### PR TITLE
Add PreferredPaymentMethodDelegate to CheckoutViewController

### DIFF
--- a/Adyen/UI/Checkout/CheckoutViewController.swift
+++ b/Adyen/UI/Checkout/CheckoutViewController.swift
@@ -42,7 +42,10 @@ public final class CheckoutViewController: UIViewController, PaymentRequestDeleg
     
     /// The delegate for payment processing.
     internal(set) public weak var delegate: CheckoutViewControllerDelegate?
-    
+
+    /// The delegate for payment method.
+    public weak var paymentMethodDelegate: PreferredPaymentMethodDelegate?
+
     /// The delegate for card scanning functionality for card payments.
     public weak var cardScanDelegate: CheckoutViewControllerCardScanDelegate?
     
@@ -115,6 +118,11 @@ public final class CheckoutViewController: UIViewController, PaymentRequestDeleg
     
     /// :nodoc:
     public func paymentRequest(_ request: PaymentRequest, requiresPaymentMethodFrom preferredMethods: [PaymentMethod]?, available availableMethods: [PaymentMethod], completion: @escaping MethodCompletion) {
+
+        if let preferredMethod = paymentMethodDelegate?.preferredMethod(self, available: availableMethods) {
+            completion(preferredMethod)
+        }
+
         paymentMethodCompletion = completion
         
         paymentMethodPickerViewController.pluginManager = request.pluginManager

--- a/Adyen/UI/Checkout/PreferredPaymentMethodDelegate.swift
+++ b/Adyen/UI/Checkout/PreferredPaymentMethodDelegate.swift
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2018 Oktawian Chojnacki
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+/// The `PreferredPaymentMethodDelegate` protocol defines the methods that a paymentMethodDelegate of `CheckoutViewController` should implement to provide preffered payment method.
+
+public protocol PreferredPaymentMethodDelegate: class {
+    /// Invoked when the payment methods are available and client can select the preffered one to continue with.
+    ///
+    /// - Parameters:
+    ///   - controller: The checkout view controller that finished the payment flow.
+    ///   - available: Available payment methods.
+    /// - Returns: Preferred payment method or nil then selection will be presented.
+    func preferredMethod(_ controller: CheckoutViewController, available availableMethods: [PaymentMethod]) -> PaymentMethod?
+}


### PR DESCRIPTION
Should partially solve the Issue https://github.com/Adyen/adyen-ios/issues/21

# 🤔 Rationale

- Server can send payment setup with only one available payment method, this way we can save the user one useless tap
- Use case: preferred payment method is preselected before Adyen payment was initiated but we want to use Quick Integration
- We can accept only one payment type ex. Apple Pay

# 💻 Getting there

While this PR is a first step to have single payment method flow using Quick Integration I think we need something much better.

I need more time to propose changes to the codebase giving us the ultimate solution to this problem but in the mean time this addition is an improvement and would not break compatibility. In the final soultion the public API won't change so the faster we introduce it, the better.

# ⚙️ How to use it?

Implement the delegate:


```swift
extension PaymentInteractionMediator: PreferredPaymentMethodDelegate {
    func preferredMethod(_ controller: CheckoutViewController, available availableMethods: [Adyen.PaymentMethod]) -> Adyen.PaymentMethod? {
        return availableMethods.first // Why not? ;)
    }
}
```

Set a delegate:

```swift
checkoutViewController.paymentMethodDelegate = paymentInteractionMediator
```

That's it.