### PR TITLE
Feature/preferred payment in quick integration improved ux

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A64D0B32094C71600448864 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A64D0B12094C71600448864 /* LoadingViewController.swift */; };
+		1A64D0B42094C71600448864 /* PreferredPaymentMethodDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A64D0B22094C71600448864 /* PreferredPaymentMethodDelegate.swift */; };
 		53C0FEFC4B5CD9400E89E4CA /* Pods_AdyenTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3BE1722DC859E029DDBCF09 /* Pods_AdyenTests.framework */; };
 		7C62EBEC1F3C793700C9D67E /* PaymentMethodExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C62EBEB1F3C793700C9D67E /* PaymentMethodExtensions.swift */; };
 		7D7AD12FB4E950056731EEB6 /* Pods_Adyen.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7AEC312DF920BCC1C4BC1C0 /* Pods_Adyen.framework */; };
@@ -176,6 +178,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1A64D0B12094C71600448864 /* LoadingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
+		1A64D0B22094C71600448864 /* PreferredPaymentMethodDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferredPaymentMethodDelegate.swift; sourceTree = "<group>"; };
 		20191199750F47C401152B90 /* Pods-Adyen.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Adyen.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Adyen/Pods-Adyen.debug.xcconfig"; sourceTree = "<group>"; };
 		36FCC0F6EB491A052CC61D81 /* Pods_AdyenUIHost.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdyenUIHost.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		39B692648B2F9A2E64860876 /* Pods-Adyen.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Adyen.release.xcconfig"; path = "Pods/Target Support Files/Pods-Adyen/Pods-Adyen.release.xcconfig"; sourceTree = "<group>"; };
@@ -673,6 +677,8 @@
 		E27DA5331F28D0DA008487D5 /* Checkout */ = {
 			isa = PBXGroup;
 			children = (
+				1A64D0B12094C71600448864 /* LoadingViewController.swift */,
+				1A64D0B22094C71600448864 /* PreferredPaymentMethodDelegate.swift */,
 				E27DA5351F28D0DA008487D5 /* CheckoutViewController.swift */,
 				E27DA5361F28D0DA008487D5 /* CheckoutViewControllerDelegate.swift */,
 			);
@@ -1194,6 +1200,7 @@
 				E25038271F175A1300DCFD38 /* SEPADirectDebitFormViewController.swift in Sources */,
 				E20AD0701EFAB0E00065B70E /* PaymentRequestResult.swift in Sources */,
 				E25038481F17641700DCFD38 /* CardPaymentFieldManager.swift in Sources */,
+				1A64D0B42094C71600448864 /* PreferredPaymentMethodDelegate.swift in Sources */,
 				E27DA5481F28D0DA008487D5 /* UITableViewControllerExtensions.swift in Sources */,
 				E27DA5791F28D48C008487D5 /* PaymentDetailsPresenter.swift in Sources */,
 				E275BB301FC2C54D00C7719E /* PaymentRequestToken.swift in Sources */,
@@ -1224,6 +1231,7 @@
 				E27DA5871F28D4BE008487D5 /* FormView.swift in Sources */,
 				E250381E1F1759B100DCFD38 /* IBANSpecification.swift in Sources */,
 				E23AE02D1F98BF6100FF10AD /* CheckoutButton.swift in Sources */,
+				1A64D0B32094C71600448864 /* LoadingViewController.swift in Sources */,
 				E250382F1F175D0800DCFD38 /* ApplePayDetailsPresenter.swift in Sources */,
 				E2BA22391FD96CEB00AC982E /* PickerViewCell.swift in Sources */,
 				E27DA5461F28D0DA008487D5 /* CheckoutViewControllerDelegate.swift in Sources */,

--- a/Adyen/CoreUI/Plugins/PaymentDetailsPresenter.swift
+++ b/Adyen/CoreUI/Plugins/PaymentDetailsPresenter.swift
@@ -6,9 +6,22 @@
 
 import Foundation
 
+/// How to present payment details.
+internal enum NavigationMode {
+
+    /// Push
+    case push
+
+    /// Present modally (including in current view)
+    case present
+}
+
 /// Instances of conforming types present an interface to fill in payment details.
 internal protocol PaymentDetailsPresenter: class {
-    
+
+    /// How to present payment detals.
+    var navigationMode: NavigationMode { get set }
+
     /// The delegate of the details presenter.
     var delegate: PaymentDetailsPresenterDelegate? { get set }
     

--- a/Adyen/Plugins/ApplePay/ApplePayDetailsPresenter.swift
+++ b/Adyen/Plugins/ApplePay/ApplePayDetailsPresenter.swift
@@ -8,6 +8,9 @@ import Foundation
 import PassKit
 
 internal class ApplePayDetailsPresenter: NSObject, PaymentDetailsPresenter {
+
+    /// Ignored in this presenter.
+    var navigationMode: NavigationMode = .present
     
     private let hostViewController: UINavigationController
     

--- a/Adyen/Plugins/Cards/CardFormDetailsPresenter.swift
+++ b/Adyen/Plugins/Cards/CardFormDetailsPresenter.swift
@@ -8,7 +8,9 @@ import Foundation
 import AdyenCSE
 
 internal class CardFormDetailsPresenter: PaymentDetailsPresenter {
-    
+
+    var navigationMode: NavigationMode = .push
+
     // MARK: - Public
     
     internal weak var delegate: PaymentDetailsPresenterDelegate?
@@ -37,9 +39,25 @@ internal class CardFormDetailsPresenter: PaymentDetailsPresenter {
         formViewController.cardDetailsHandler = { cardInputData in
             self.submit(cardInputData: cardInputData)
         }
-        hostViewController.pushViewController(formViewController, animated: true)
+        
+        present(formViewController)
     }
-    
+
+    private func present(_ viewController: UIViewController) {
+        switch navigationMode {
+        case .present:
+            hostViewController.viewControllers = [viewController]
+            viewController.navigationItem.hidesBackButton = true
+            viewController.navigationItem.leftBarButtonItem = AppearanceConfiguration.shared.cancelButtonItem(target: self, selector: #selector(didSelect(cancelButtonItem:)))
+        case .push:
+            hostViewController.pushViewController(viewController, animated: true)
+        }
+    }
+
+    @objc private func didSelect(cancelButtonItem: Any) {
+        hostViewController.dismiss(animated: true, completion: nil)
+    }
+
     // MARK: - Private
     
     private let hostViewController: UINavigationController

--- a/Adyen/Plugins/Cards/CardOneClickDetailsPresenter.swift
+++ b/Adyen/Plugins/Cards/CardOneClickDetailsPresenter.swift
@@ -7,7 +7,9 @@
 import Foundation
 
 internal class CardOneClickDetailsPresenter: PaymentDetailsPresenter {
-    
+
+    var navigationMode: NavigationMode = .present
+
     private let hostViewController: UINavigationController
     
     private let pluginConfiguration: PluginConfiguration

--- a/Adyen/Plugins/Ideal/IdealDetailsPresenter.swift
+++ b/Adyen/Plugins/Ideal/IdealDetailsPresenter.swift
@@ -7,7 +7,9 @@
 import Foundation
 
 internal class IdealDetailsPresenter: PaymentDetailsPresenter {
-    
+
+    var navigationMode: NavigationMode = .push
+
     private let hostViewController: UINavigationController
     
     private let pluginConfiguration: PluginConfiguration
@@ -24,7 +26,22 @@ internal class IdealDetailsPresenter: PaymentDetailsPresenter {
         let pickerViewController = PickerViewController(items: pickerItems)
         pickerViewController.title = pluginConfiguration.paymentMethod.name
         pickerViewController.delegate = self
-        hostViewController.pushViewController(pickerViewController, animated: true)
+        present(pickerViewController)
+    }
+
+    private func present(_ viewController: UIViewController) {
+        switch navigationMode {
+        case .present:
+            hostViewController.viewControllers = [viewController]
+            viewController.navigationItem.hidesBackButton = true
+            viewController.navigationItem.leftBarButtonItem = AppearanceConfiguration.shared.cancelButtonItem(target: self, selector: #selector(didSelect(cancelButtonItem:)))
+        case .push:
+            hostViewController.pushViewController(viewController, animated: true)
+        }
+    }
+
+    @objc private func didSelect(cancelButtonItem: Any) {
+        hostViewController.dismiss(animated: true, completion: nil)
     }
     
     private func submit(issuerIdentifier: String) {

--- a/Adyen/Plugins/MOLPay/MOLPayDetailsPresenter.swift
+++ b/Adyen/Plugins/MOLPay/MOLPayDetailsPresenter.swift
@@ -7,7 +7,9 @@
 import Foundation
 
 internal class MOLPayDetailsPresenter: PaymentDetailsPresenter {
-    
+
+    var navigationMode: NavigationMode = .push
+
     private let hostViewController: UINavigationController
     
     private let pluginConfiguration: PluginConfiguration
@@ -24,7 +26,18 @@ internal class MOLPayDetailsPresenter: PaymentDetailsPresenter {
         let pickerViewController = PickerViewController(items: pickerItems)
         pickerViewController.title = pluginConfiguration.paymentMethod.name
         pickerViewController.delegate = self
-        hostViewController.pushViewController(pickerViewController, animated: true)
+        present(pickerViewController)
+    }
+
+    private func present(_ viewController: UIViewController) {
+        switch navigationMode {
+        case .present:
+            hostViewController.viewControllers = [viewController]
+            viewController.navigationItem.hidesBackButton = true
+            viewController.navigationItem.leftBarButtonItem = AppearanceConfiguration.shared.cancelButtonItem(target: self, selector: #selector(didSelect(cancelButtonItem:)))
+        case .push:
+            hostViewController.pushViewController(viewController, animated: true)
+        }
     }
     
     private func submit(issuerIdentifier: String) {

--- a/Adyen/Plugins/SEPADirectDebit/SEPADirectDebitDetailsPresenter.swift
+++ b/Adyen/Plugins/SEPADirectDebit/SEPADirectDebitDetailsPresenter.swift
@@ -7,7 +7,9 @@
 import Foundation
 
 internal class SEPADirectDebitDetailsPresenter: PaymentDetailsPresenter {
-    
+
+    var navigationMode: NavigationMode = .push
+
     private let hostViewController: UINavigationController
     
     private let pluginConfiguration: PluginConfiguration
@@ -26,7 +28,22 @@ internal class SEPADirectDebitDetailsPresenter: PaymentDetailsPresenter {
         formViewController.title = pluginConfiguration.paymentMethod.name
         formViewController.payButtonTitle = AppearanceConfiguration.shared.payActionTitle(forAmount: paymentSetup.amount, currencyCode: paymentSetup.currencyCode)
         formViewController.delegate = self
-        hostViewController.pushViewController(formViewController, animated: true)
+        present(formViewController)
+    }
+
+    private func present(_ viewController: UIViewController) {
+        switch navigationMode {
+        case .present:
+            hostViewController.viewControllers = [viewController]
+            viewController.navigationItem.hidesBackButton = true
+            viewController.navigationItem.leftBarButtonItem = AppearanceConfiguration.shared.cancelButtonItem(target: self, selector: #selector(didSelect(cancelButtonItem:)))
+        case .push:
+            hostViewController.pushViewController(viewController, animated: true)
+        }
+    }
+
+    @objc private func didSelect(cancelButtonItem: Any) {
+        hostViewController.dismiss(animated: true, completion: nil)
     }
     
     fileprivate func submit(iban: String, name: String) {

--- a/Adyen/UI/Checkout/CheckoutViewController.swift
+++ b/Adyen/UI/Checkout/CheckoutViewController.swift
@@ -42,7 +42,10 @@ public final class CheckoutViewController: UIViewController, PaymentRequestDeleg
     
     /// The delegate for payment processing.
     internal(set) public weak var delegate: CheckoutViewControllerDelegate?
-    
+
+    /// The delegate for payment method.
+    public weak var paymentMethodDelegate: PreferredPaymentMethodDelegate?
+
     /// The delegate for card scanning functionality for card payments.
     public weak var cardScanDelegate: CheckoutViewControllerCardScanDelegate?
     
@@ -115,6 +118,11 @@ public final class CheckoutViewController: UIViewController, PaymentRequestDeleg
     
     /// :nodoc:
     public func paymentRequest(_ request: PaymentRequest, requiresPaymentMethodFrom preferredMethods: [PaymentMethod]?, available availableMethods: [PaymentMethod], completion: @escaping MethodCompletion) {
+
+        if let preferredMethod = paymentMethodDelegate?.preferredMethod(self, available: availableMethods) {
+            completion(preferredMethod)
+        }
+
         paymentMethodCompletion = completion
         
         paymentMethodPickerViewController.pluginManager = request.pluginManager

--- a/Adyen/UI/Checkout/LoadingViewController.swift
+++ b/Adyen/UI/Checkout/LoadingViewController.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2018 Oktawian Chojnacki
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import UIKit
+
+final class LoadingViewController: UIViewController {
+
+    var didCancelClosure: (()-> Void)?
+
+    internal init() {
+        super.init(nibName: nil, bundle: nil)
+
+        navigationItem.leftBarButtonItem = AppearanceConfiguration.shared.cancelButtonItem(target: self, selector: #selector(didSelect(cancelButtonItem:)))
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        let activity = UIActivityIndicatorView(activityIndicatorStyle: .white)
+        navigationItem.titleView = activity
+        activity.startAnimating()
+    }
+
+    @objc private func didSelect(cancelButtonItem: Any) {
+        didCancelClosure?()
+    }
+}

--- a/Adyen/UI/Checkout/PreferredPaymentMethodDelegate.swift
+++ b/Adyen/UI/Checkout/PreferredPaymentMethodDelegate.swift
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2018 Oktawian Chojnacki
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+/// The `PreferredPaymentMethodDelegate` protocol defines the methods that a paymentMethodDelegate of `CheckoutViewController` should implement to provide preffered payment method.
+
+public protocol PreferredPaymentMethodDelegate: class {
+    /// Invoked when the payment methods are available and client can select the preffered one to continue with.
+    ///
+    /// - Parameters:
+    ///   - controller: The checkout view controller that finished the payment flow.
+    ///   - available: Available payment methods.
+    /// - Returns: Preferred payment method or nil then selection will be presented.
+    func preferredMethod(_ controller: CheckoutViewController, available availableMethods: [PaymentMethod]) -> PaymentMethod?
+}


### PR DESCRIPTION
Should solve the Issue https://github.com/Adyen/adyen-ios/issues/21

# 🤔 Rationale

- Server can send payment setup with only one available payment method, this way we can save the user one useless tap
- Use case: preferred payment method is preselected before Adyen payment was initiated but we want to use Quick Integration
- We can accept only one payment type ex. Apple Pay

# ⚙️ How to use it?

Implement the delegate:

```swift
extension PaymentInteractionMediator: PreferredPaymentMethodDelegate {
    func preferredMethod(_ controller: CheckoutViewController, available availableMethods: [Adyen.PaymentMethod]) -> Adyen.PaymentMethod? {
        return availableMethods.first // Why not? ;)
    }
}
```

Set a delegate:

```swift
checkoutViewController.paymentMethodDelegate = paymentInteractionMediator
```

That's it.

# 🤔 Caveats?

Some payment plugins can present instead of push, internal logic can suggest otherwise but for example ApplePay plugin will ignore the navigation mode.