### PR TITLE
Swift 4.2 support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ disabled_rules:
   - unused_closure_parameter
   - todo
   - fallthrough
+  - identifier_name
 
   #Review:
   - large_tuple

--- a/Adyen/CoreUI/Appearance/AppearanceConfiguration.swift
+++ b/Adyen/CoreUI/Appearance/AppearanceConfiguration.swift
@@ -25,10 +25,18 @@ public final class AppearanceConfiguration {
     // MARK: - Configuring the Navigation Bar Title Text Appearance
     
     /// The attributes used for the navigation bar's title.
+    #if swift(>=4.2)
+    public var navigationBarTitleTextAttributes: [NSAttributedString.Key: Any]?
+    #else
     public var navigationBarTitleTextAttributes: [NSAttributedStringKey: Any]?
+    #endif
     
     /// The attributes used for the navigation bar's large title. Only has an effect on iOS 11 and higher.
+    #if swift(>=4.2)
+    public var navigationBarLargeTitleTextAttributes: [NSAttributedString.Key: Any]?
+    #else
     public var navigationBarLargeTitleTextAttributes: [NSAttributedStringKey: Any]?
+    #endif
     
     /// Display modes for the large title in a navigation bar.
     public enum NavigationBarLargeTitleDisplayMode {
@@ -114,7 +122,11 @@ public final class AppearanceConfiguration {
     
     // MARK: - Internal
     
+    #if swift(>=4.2)
+    internal var internalCheckoutButtonTitleTextAttributes: [NSAttributedString.Key: Any]? // swiftlint:disable:this identifier_name
+    #else
     internal var internalCheckoutButtonTitleTextAttributes: [NSAttributedStringKey: Any]? // swiftlint:disable:this identifier_name
+    #endif
     
     internal var internalCheckoutButtonTitleEdgeInsets: UIEdgeInsets?
     
@@ -163,8 +175,9 @@ extension AppearanceConfiguration: NSCopying {
 public extension AppearanceConfiguration {
     
     /// The attributes used for the checkout button's title. Only used when `checkoutButtonType` is the default.
+    #if swift(>=4.2)
     @available(*, deprecated, message: "Provide a custom button via checkoutButtonType instead.")
-    public var checkoutButtonTitleTextAttributes: [NSAttributedStringKey: Any]? {
+    public var checkoutButtonTitleTextAttributes: [NSAttributedString.Key: Any]? {
         get {
             return internalCheckoutButtonTitleTextAttributes
         }
@@ -173,6 +186,18 @@ public extension AppearanceConfiguration {
             internalCheckoutButtonTitleTextAttributes = newValue
         }
     }
+    #else
+    @available(*, deprecated, message: "Provide a custom button via checkoutButtonType instead.")
+    public var checkoutButtonTitleTextAttributes: [NSAttributedStringKey: Any]? {
+        get {
+            return internalCheckoutButtonTitleTextAttributes
+        }
+    
+        set {
+            internalCheckoutButtonTitleTextAttributes = newValue
+        }
+    }
+    #endif
     
     /// The insets from the edges of the checkout button to the title. Only used when `checkoutButtonType` the default.
     @available(*, deprecated, message: "Provide a custom button via checkoutButtonType instead.")

--- a/Adyen/CoreUI/Cells/LoadingTableViewCell.swift
+++ b/Adyen/CoreUI/Cells/LoadingTableViewCell.swift
@@ -7,7 +7,11 @@
 import UIKit
 
 class LoadingTableViewCell: UITableViewCell {
+    #if swift(>=4.2)
+    private let loadingIndicator = UIActivityIndicatorView(style: .gray)
+    #else
     private let loadingIndicator = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+    #endif
     
     var isShowingLoadingIndicator: Bool {
         return loadingIndicator.isAnimating

--- a/Adyen/CoreUI/Cells/PaymentMethodTableViewCell.swift
+++ b/Adyen/CoreUI/Cells/PaymentMethodTableViewCell.swift
@@ -9,8 +9,13 @@ import UIKit
 class PaymentMethodTableViewCell: LoadingTableViewCell {
     
     // MARK: - Initializing
+    #if swift(>=4.2)
+    typealias Style = UITableViewCell.CellStyle
+    #else
+    typealias Style = UITableViewCellStyle
+    #endif
     
-    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+    override init(style: Style, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
         commonInit()
@@ -102,7 +107,11 @@ class PaymentMethodTableViewCell: LoadingTableViewCell {
         contentView.addSubview(logoView)
         contentView.addSubview(nameLabel)
         
+        #if swift(>=4.2)
+        accessibilityTraits.insert(.button)
+        #else
         accessibilityTraits |= UIAccessibilityTraitButton
+        #endif
         
         configureConstraints()
     }

--- a/Adyen/CoreUI/Checkout Button/CheckoutButton.swift
+++ b/Adyen/CoreUI/Checkout Button/CheckoutButton.swift
@@ -33,8 +33,13 @@ internal class CheckoutButton: UIButton {
     }
     
     // MARK: - Title
+    #if swift(>=4.2)
+    typealias ControlState = UIControl.State
+    #else
+    typealias ControlState = UIControlState
+    #endif
     
-    internal override func setTitle(_ title: String?, for state: UIControlState) {
+    internal override func setTitle(_ title: String?, for state: ControlState) {
         guard let title = title else {
             setAttributedTitle(nil, for: state)
             

--- a/Adyen/CoreUI/Extensions/UIButtonExtensions.swift
+++ b/Adyen/CoreUI/Extensions/UIButtonExtensions.swift
@@ -40,7 +40,11 @@ internal extension UIButton {
             return activityIndicatorView
         }
         
+        #if swift(>=4.2)
+        let activityIndicatorView = UIActivityIndicatorView(style: .white)
+        #else
         let activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle: .white)
+        #endif
         activityIndicatorView.color = activityIndicatorViewColor
         activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
         objc_setAssociatedObject(self, &AssociatedObjectKeys.activityIndicatorView, activityIndicatorView, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)

--- a/Adyen/CoreUI/Form/FormCheckmarkButton.swift
+++ b/Adyen/CoreUI/Form/FormCheckmarkButton.swift
@@ -18,7 +18,12 @@ internal class FormCheckmarkButton: UIControl {
         configureConstraints()
         
         isAccessibilityElement = true
+        
+        #if swift(>=4.2)
+        accessibilityTraits = UIAccessibilityTraits.button
+        #else
         accessibilityTraits = UIAccessibilityTraitButton
+        #endif
     }
     
     required init(coder: NSCoder) {
@@ -90,11 +95,19 @@ internal class FormCheckmarkButton: UIControl {
         didSet {
             imageView.image = isSelected ? selectedImage : image
             
+            #if swift(>=4.2)
+            if isSelected {
+                accessibilityTraits = [.button, .selected]
+            } else {
+                accessibilityTraits = .button
+            }
+            #else
             if isSelected {
                 accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitSelected
             } else {
                 accessibilityTraits = UIAccessibilityTraitButton
             }
+            #endif
         }
     }
     

--- a/Adyen/CoreUI/Form/FormTextField.swift
+++ b/Adyen/CoreUI/Form/FormTextField.swift
@@ -133,10 +133,18 @@ internal extension FormTextField {
         }
         
         set {
+            #if swift(>=4.2)
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: 18.0),
+                .foregroundColor: UIColor.black
+            ]
+            #else
             let attributes: [NSAttributedStringKey: Any] = [
                 .font: UIFont.systemFont(ofSize: 18.0),
                 .foregroundColor: UIColor.black
             ]
+            #endif
+            
             textField.attributedText = NSAttributedString(string: newValue ?? "", attributes: attributes)
         }
     }
@@ -147,10 +155,17 @@ internal extension FormTextField {
         }
         
         set {
+            #if swift(>=4.2)
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: 18.0),
+                .foregroundColor: #colorLiteral(red: 0.7450980392, green: 0.7450980392, blue: 0.7450980392, alpha: 1)
+            ]
+            #else
             let attributes: [NSAttributedStringKey: Any] = [
                 .font: UIFont.systemFont(ofSize: 18.0),
                 .foregroundColor: #colorLiteral(red: 0.7450980392, green: 0.7450980392, blue: 0.7450980392, alpha: 1)
             ]
+            #endif
             textField.attributedPlaceholder = NSAttributedString(string: newValue ?? "", attributes: attributes)
         }
     }

--- a/Adyen/CoreUI/Form/FormViewController.swift
+++ b/Adyen/CoreUI/Form/FormViewController.swift
@@ -19,7 +19,12 @@ internal class FormViewController: ContainerViewController {
         contentView = formView
         
         let notificationCenter = NotificationCenter.default
+        
+        #if swift(>=4.2)
+        notificationCenter.addObserver(self, selector: #selector(keyboardWillChangeFrame(_:)), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+        #else
         notificationCenter.addObserver(self, selector: #selector(keyboardWillChangeFrame(_:)), name: .UIKeyboardWillChangeFrame, object: nil)
+        #endif
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -50,7 +55,13 @@ internal class FormViewController: ContainerViewController {
     // MARK: - Keyboard
     
     @objc private func keyboardWillChangeFrame(_ notification: NSNotification) {
-        guard let bounds = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect else {
+        #if swift(>=4.2)
+        let key = UIResponder.keyboardFrameEndUserInfoKey
+        #else
+        let key = UIKeyboardFrameEndUserInfoKey
+        #endif
+        
+        guard let bounds = notification.userInfo?[key] as? CGRect else {
             return
         }
         

--- a/Adyen/CoreUI/Picker/PickerViewCell.swift
+++ b/Adyen/CoreUI/Picker/PickerViewCell.swift
@@ -7,8 +7,13 @@
 import UIKit
 
 internal final class PickerViewCell: UITableViewCell {
+    #if swift(>=4.2)
+    typealias Style = UITableViewCell.CellStyle
+    #else
+    typealias Style = UITableViewCellStyle
+    #endif
     
-    internal override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+    internal override init(style: Style, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
         contentView.addSubview(customImageView)
@@ -107,6 +112,10 @@ internal final class PickerViewCell: UITableViewCell {
         }
     }
     
+    #if swift(>=4.2)
+    private lazy var activityIndicatorView = UIActivityIndicatorView(style: .gray)
+    #else
     private lazy var activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+    #endif
     
 }

--- a/Adyen/Plugins/Cards/CardFormViewController.swift
+++ b/Adyen/Plugins/Cards/CardFormViewController.swift
@@ -149,7 +149,12 @@ class CardFormViewController: UIViewController, CheckoutPaymentFieldDelegate {
         if cardScanButtonHandler == nil {
             cardNumberWidthConstraint.constant = 0
         }
+        
+        #if swift(>=4.2)
+        cardNumberScanButton.setImage(UIImage.bundleImage("camera_icon"), for: UIControl.State())
+        #else
         cardNumberScanButton.setImage(UIImage.bundleImage("camera_icon"), for: UIControlState())
+        #endif
         
         cardNumberLogoImageView.image = UIImage.bundleImage("credit_card_icon")
         storeDetailsButton.setImage(UIImage.bundleImage("checkbox_inactive"), for: .normal)
@@ -204,8 +209,16 @@ class CardFormViewController: UIViewController, CheckoutPaymentFieldDelegate {
     }
     
     private func setupKeyboard() {
-        _ = NotificationCenter.default.addObserver(forName: .UIKeyboardWillShow, object: nil, queue: OperationQueue.main) { notification in
-            if let bounds = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect {
+        #if swift(>=4.2)
+        let notificationName = UIResponder.keyboardWillShowNotification
+        let userInfoKey = UIResponder.keyboardFrameEndUserInfoKey
+        #else
+        let notificationName = NSNotification.Name.UIKeyboardWillShow
+        let userInfoKey = UIKeyboardFrameEndUserInfoKey
+        #endif
+        
+        _ = NotificationCenter.default.addObserver(forName: notificationName, object: nil, queue: OperationQueue.main) { notification in
+            if let bounds = notification.userInfo?[userInfoKey] as? CGRect {
                 var inset = self.scrollView.contentInset
                 inset.bottom = bounds.size.height
                 self.scrollView.contentInset = inset

--- a/Adyen/UI/Checkout/CheckoutViewController.swift
+++ b/Adyen/UI/Checkout/CheckoutViewController.swift
@@ -155,7 +155,13 @@ public final class CheckoutViewController: UIViewController, PaymentRequestDeleg
             
             if #available(iOS 10.0, *) {
                 // Try to open the URL as a universal link.
-                UIApplication.shared.open(url, options: [UIApplicationOpenURLOptionUniversalLinksOnly: true]) { [weak self] success in
+                #if swift(>=4.2)
+                let options = [UIApplication.OpenExternalURLOptionsKey.universalLinksOnly: true]
+                #else
+                let options = [UIApplicationOpenURLOptionUniversalLinksOnly: true]
+                #endif
+                
+                UIApplication.shared.open(url, options: options) { [weak self] success in
                     // If opening the URL as a universal link was not possible, open it as a website instead.
                     if !success {
                         self?.presentWebPage(with: url)
@@ -264,14 +270,22 @@ public final class CheckoutViewController: UIViewController, PaymentRequestDeleg
     
     private var rootViewController: UIViewController? {
         willSet {
+            #if swift(>=4.2)
+            rootViewController?.removeFromParent()
+            #else
             rootViewController?.removeFromParentViewController()
+            #endif
             rootViewController?.viewIfLoaded?.removeFromSuperview()
         }
         
         didSet {
             guard let rootViewController = rootViewController else { return }
             
+            #if swift(>=4.2)
+            addChild(rootViewController)
+            #else
             addChildViewController(rootViewController)
+            #endif
             viewIfLoaded?.addSubview(rootViewController.view)
         }
     }

--- a/Adyen/UI/Extensions/UITableViewControllerExtensions.swift
+++ b/Adyen/UI/Extensions/UITableViewControllerExtensions.swift
@@ -33,7 +33,11 @@ internal extension UITableViewController {
             return activityIndicatorView
         }
         
+        #if swift(>=4.2)
+        let activityIndicatorView = UIActivityIndicatorView(style: .gray)
+        #else
         let activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+        #endif
         activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
         objc_setAssociatedObject(self, &AssociatedObjectKeys.activityIndicatorView, activityIndicatorView, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         

--- a/Adyen/UI/Payment Method Picker/PaymentMethodPickerViewController.swift
+++ b/Adyen/UI/Payment Method Picker/PaymentMethodPickerViewController.swift
@@ -189,7 +189,12 @@ extension PaymentMethodPickerViewController {
     }
     
     /// :nodoc:
-    public override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+    #if swift(>=4.2)
+    typealias EditingStyle = UITableViewCell.EditingStyle
+    #else
+    typealias EditingStyle = UITableViewCellEditingStyle
+    #endif
+    public override func tableView(_ tableView: UITableView, commit editingStyle: EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
             //  Deletion is allowed only for preferred methods (section == 0).
             if indexPath.section != 0 {


### PR DESCRIPTION
Add support for Swift 4.2 syntax.

All modifications are protected by #if swift(>=4.2) to also support for the current versions of Swift.