### PR TITLE
Added a shouldDismissOnDidFinish property to CheckoutController 

### DIFF
--- a/Adyen/UI/Checkout/CheckoutController.swift
+++ b/Adyen/UI/Checkout/CheckoutController.swift
@@ -46,6 +46,9 @@ public final class CheckoutController {
     /// Determines whether the preselected payment method should be shown when available. Default value is `true`.
     public var showsPreselectedPaymentMethod = true
     
+    /// Determines whether the presenter should automatically dismiss when the didFinish method is called
+    public var shouldDismissOnDidFinish = true
+    
     /// Starts the checkout process and presents the checkout UI on the provided presentingViewController.
     public func start() {
         paymentController = PaymentController(delegate: self)
@@ -60,6 +63,23 @@ public final class CheckoutController {
     /// Cancels the checkout process and dismisses the checkout UI.
     public func cancel() {
         paymentController?.cancel()
+    }
+    
+    /// Publicly exposes dismiss(with result: Result<PaymentResult>?)
+    public func dismiss() {
+        dismiss(with: nil)
+    }
+    
+    /// Dismisses the presenting viewController. When the Dismisal is complete the CheckoutController resets and if a result is present calls the delegate method didFinish
+    ///
+    /// - Parameter result: PaymentResult
+    private func dismiss(with result: Result<PaymentResult>?) {
+        self.presenter.dismiss {
+            self.reset()
+            if let result = result {
+                self.delegate?.didFinish(with: result, for: self)
+            }
+        }
     }
     
     // MARK: - Private
@@ -122,8 +142,9 @@ extension CheckoutController: PaymentControllerDelegate {
         presenter.showPaymentProcessing(false)
         
         let completion = {
-            self.presenter.dismiss {
-                self.reset()
+            if self.shouldDismissOnDidFinish {
+                self.dismiss(with: result)
+            } else {
                 self.delegate?.didFinish(with: result, for: self)
             }
         }


### PR DESCRIPTION
**Rationale**
Currently the CheckoutController is dismissed before the didFinish delegate method is called.  
However, In the didFinish delegate method we still have more work to do. Such as making a call to our backend so that we can communicate with Adyen and update our records.  
Although it makes sense that CheckoutController is dismissed once it is finished.  Visually as a user it looks awkward dismissing the Adyen activity indicator before all backend communication is finished.  

**Solution**
Adding a shouldDismissOnDidFinish property that defaults to true I think should fix this issue.  
By defaulting shouldDismissOnDidFinish to true the workflow kept the same as it is now, but it gives the us the option to set to false which would allow us to dismiss the CheckoutController when see fit.
