### PR TITLE
Change Card Validators and CardType enum access level to public

### DIFF
--- a/AdyenCard/Utilities/CardExpiryValidator.swift
+++ b/AdyenCard/Utilities/CardExpiryValidator.swift
@@ -4,13 +4,15 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-class CardExpiryValidator: NumericValidator {
+public class CardExpiryValidator: NumericValidator {
     
-    func isMaxLength(_ string: String) -> Bool {
+    public init() {}
+    
+    public func isMaxLength(_ string: String) -> Bool {
         return sanitize(string).count >= maxLength
     }
     
-    func isValid(_ string: String) -> Bool {
+    public func isValid(_ string: String) -> Bool {
         let sanitizedString = sanitize(string)
         
         guard sanitizedString.count == maxLength else {
@@ -46,7 +48,7 @@ class CardExpiryValidator: NumericValidator {
         return isValid
     }
     
-    func format(_ string: String) -> String {
+    public func format(_ string: String) -> String {
         let separator = "/"
         
         let sanitizedString = sanitize(string)

--- a/AdyenCard/Utilities/CardNameValidator.swift
+++ b/AdyenCard/Utilities/CardNameValidator.swift
@@ -4,9 +4,11 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-class CardNameValidator: Validator {
+public class CardNameValidator: Validator {
     
-    func isMaxLength(_ string: String) -> Bool {
+    public init() {}
+    
+    public func isMaxLength(_ string: String) -> Bool {
         return string.count >= 26
     }
 }

--- a/AdyenCard/Utilities/CardNumberValidator.swift
+++ b/AdyenCard/Utilities/CardNumberValidator.swift
@@ -6,9 +6,11 @@
 
 import UIKit
 
-class CardNumberValidator: NumericValidator {
+public class CardNumberValidator: NumericValidator {
     
-    func isValid(_ string: String) -> Bool {
+    public init() {}
+    
+    public func isValid(_ string: String) -> Bool {
         let sanitizedCardNumber = sanitize(string)
         let minimumValidCardLength = 12
         let isValid = sanitizedCardNumber.count >= minimumValidCardLength && luhnCheck(sanitizedCardNumber)
@@ -16,11 +18,11 @@ class CardNumberValidator: NumericValidator {
         return isValid
     }
     
-    func isMaxLength(_ string: String) -> Bool {
+    public func isMaxLength(_ string: String) -> Bool {
         return string.count >= 23
     }
     
-    func format(_ string: String) -> String {
+    public func format(_ string: String) -> String {
         let sanitizedCardNumber = sanitize(string)
         let formattedCardNumber = sanitizedCardNumber.grouped(length: 4)
         return formattedCardNumber

--- a/AdyenCard/Utilities/CardSecurityCodeValidator.swift
+++ b/AdyenCard/Utilities/CardSecurityCodeValidator.swift
@@ -4,20 +4,22 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-class CardSecurityCodeValidator: NumericValidator {
+public class CardSecurityCodeValidator: NumericValidator {
     
-    func isMaxLength(_ string: String) -> Bool {
+    public init() {}
+    
+    public func isMaxLength(_ string: String) -> Bool {
         return string.count >= maxLength
     }
     
-    func isValid(_ string: String) -> Bool {
+    public func isValid(_ string: String) -> Bool {
         let sanitized = sanitize(string)
         let minLength = 3
         let isValid = sanitized.count >= minLength && sanitized.count <= maxLength
         return isValid
     }
     
-    func format(_ string: String) -> String {
+    public func format(_ string: String) -> String {
         return sanitize(string)
     }
     

--- a/AdyenCard/Utilities/CardType.swift
+++ b/AdyenCard/Utilities/CardType.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Enum containing most known types of credit and debit cards.
-internal enum CardType: String {
+public enum CardType: String {
     /// Accel
     case accel
     
@@ -195,7 +195,7 @@ internal extension CardType {
     }
 }
 
-internal extension CardType {
+public extension CardType {
     func matches(cardNumber: String) -> Bool {
         guard let pattern = regex else {
             return false


### PR DESCRIPTION
**Intention**
Before v2.x.x update there was a public `CardValidator` class.
It's useful in case somebody needs to customise card input screen but still intends to use Adyen validators.
Also `CardType` have been public before v2.x.x allowing to have custom logic for a specific card type.

**Solution**
Would like to bring back a public access level for `Card Validators` and `CardType`  with this PR.