### PR TITLE
Fail challenge if there is no existing transaction

### DIFF
--- a/Adyen/Components/Base/ComponentError.swift
+++ b/Adyen/Components/Base/ComponentError.swift
@@ -12,7 +12,7 @@ public enum ComponentError: Error {
     /// Indicates the component was cancelled by the user.
     case cancelled
 
-    /// Indicates the component failed to perform the intended action.
-    case failed
+    /// Indicates the component failed since there was not active transaction.
+    case noActiveTransaction
     
 }

--- a/Adyen/Components/Base/ComponentError.swift
+++ b/Adyen/Components/Base/ComponentError.swift
@@ -11,5 +11,8 @@ public enum ComponentError: Error {
     
     /// Indicates the component was cancelled by the user.
     case cancelled
+
+    /// Indicates the component failed to perform the intended action.
+    case failed
     
 }

--- a/AdyenCard/3DS2 Component/ThreeDS2Component.swift
+++ b/AdyenCard/3DS2 Component/ThreeDS2Component.swift
@@ -64,7 +64,7 @@ public final class ThreeDS2Component: ActionComponent {
     /// - Parameter action: The challenge action as received from the Checkout API.
     public func handle(_ action: ThreeDS2ChallengeAction) {
         guard let transaction = transaction else {
-            didFail(with: ComponentError.failed)
+            didFail(with: ComponentError.noActiveTransaction)
             return
         }
         

--- a/AdyenCard/3DS2 Component/ThreeDS2Component.swift
+++ b/AdyenCard/3DS2 Component/ThreeDS2Component.swift
@@ -63,7 +63,10 @@ public final class ThreeDS2Component: ActionComponent {
     ///
     /// - Parameter action: The challenge action as received from the Checkout API.
     public func handle(_ action: ThreeDS2ChallengeAction) {
-        guard let transaction = transaction else { return }
+        guard let transaction = transaction else {
+            didFail(with: ComponentError.failed)
+            return
+        }
         
         Analytics.sendEvent(component: challengeEventName, flavor: _isDropIn ? .dropin : .components, environment: environment)
         


### PR DESCRIPTION
Added calling `ActionComponentDelegate.didFail(_)` incase there is no valid transaction when trying to call the handle Challenge method.

### Motivation and Context
We had this situation 
 - Tried to authorize a payment 
 - First, got the request to perform IdentifyShopper (good)
 - Performed and send back the result 
 - Second, requested to perform `ChallengeShopper` (expected)
 - Performed and send back the result and now things got weird
 - Third, requested again to perform `ChallengeShopper` ( 😕)
 - Calling SDK's `handle(_ action: ThreeDS2ChallengeAction)` on ThreeDS2Component just returned
 - The app keeps waiting for a callback to happen, but nothing ( 😞)

Wouldn't it be good if the call fails? ( 🤔)

### Where to start reviewing
- I am not sure if the `ComponentError.noActiveTransaction` is the best name for this scenario
