### PR TITLE
Fix component view controller child view layout

### DIFF
--- a/Adyen/UI/Controller/ComponentViewController.swift
+++ b/Adyen/UI/Controller/ComponentViewController.swift
@@ -47,13 +47,6 @@ public final class ComponentViewController: UIViewController {
     }
     
     /// :nodoc:
-    public override func viewWillLayoutSubviews() {
-        super.viewWillLayoutSubviews()
-        
-        children.first?.view.frame = view.bounds
-    }
-    
-    /// :nodoc:
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
@@ -76,6 +69,13 @@ public final class ComponentViewController: UIViewController {
         
         addChild(viewController)
         view.addSubview(viewController.view)
+        viewController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+          viewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+          viewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+          viewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+          viewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+          ])
         viewController.didMove(toParent: self)
     }
 }


### PR DESCRIPTION
Hi @adyen-git-manager! We are working with CC payments and faced one issue during view controller presentation. The issue appears if any payment view controller is presented modally (which uses `ComponentViewController` inside).

We can work around it by installing payment view controller as child view controller, but fix for the issue is very simple.

Please, have a look.