### PR TITLE
made init public

### DIFF
--- a/Adyen/Components/Redirect/RedirectDetails.swift
+++ b/Adyen/Components/Redirect/RedirectDetails.swift
@@ -16,7 +16,7 @@ public struct RedirectDetails: AdditionalDetails {
     ///
     /// - Parameter:
     ///   - returnURL: The URL through which the user returned to the app after a redirect.
-    internal init(returnURL: URL) {
+    public init(returnURL: URL) {
         self.returnURL = returnURL
     }
     


### PR DESCRIPTION
There are a few structures that are public but their initialisers are internal. 

We needed to create a RedirectComponent based on a WKWebView as we want control on how it looks like on screen. 

To parse the data from the returnURL we need to initialise a RedirectDetails Object but the init was internal instead of public. 

This is to fix the issue.