### PR TITLE
Fix: Call completion in `IssuerListComponent.stopLoading`

### DIFF
--- a/Adyen/Components/Issuer List/IssuerListComponent.swift
+++ b/Adyen/Components/Issuer List/IssuerListComponent.swift
@@ -35,6 +35,8 @@ public final class IssuerListComponent: PaymentComponent, PresentableComponent {
     
     public func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
         listViewController.stopLoading()
+
+        completion?()
     }
     
     // MARK: - Private


### PR DESCRIPTION
Completion is called on `stopLoading` of any `PresentableComponent` but `IssuerListComponent`. 
Therefore it's just not possible to rely  on completion being called and will lead to a potentially broken app flow, if nonetheless doing so.