### PR TITLE
Check IBAN minimum length to avoid a crash on rearrange

### DIFF
--- a/Adyen/Components/SEPA Direct Debit/IBANValidator.swift
+++ b/Adyen/Components/SEPA Direct Debit/IBANValidator.swift
@@ -15,10 +15,11 @@ public final class IBANValidator: Validator {
     
     /// :nodoc:
     public func isValid(_ value: String) -> Bool {
-        guard value.count <= maximumLength(for: value) else {
+        let minimumValidLength = 4
+        guard minimumValidLength...maximumLength(for: value) ~= value.count else {
             return false
         }
-        
+
         let rearrangedValue = rearrange(value)
         let numerifiedValue = numerify(rearrangedValue)
         


### PR DESCRIPTION
Hello,

The rearrange function is expecting 4 characters, however it does not check if a string with at least 4 characters is passed to it which causes a crash.

```
/// Rearranges the string to prepare for IBAN validation.
/// The country code and check numbers (the four initial characters) are moved to the end of the string.
/// The string is expected to be at least 4 characters.
private func rearrange(_ string: String) -> String {
```

I am creating this PR because we would like to be able to rely on the validators without writing extra checks on our end to prevents crashes inside an Adyen class.

Thanks you 😄