### PR TITLE
Fix bug with applePay cencelation

### DIFF
--- a/Adyen/Components/Apple Pay/ApplePayComponent.swift
+++ b/Adyen/Components/Apple Pay/ApplePayComponent.swift
@@ -261,7 +261,10 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
 extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     
     public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
-        controller.dismiss(animated: true, completion: dismissCompletion)
+        controller.dismiss(animated: true) {
+            self.delegate?.didFail(with: ComponentError.cancelled, from: self)
+            self.dismissCompletion?()
+        }
         paymentAuthorizationViewController = nil
         dismissCompletion = nil
     }


### PR DESCRIPTION
"DropInComponent.stopLoading" was not called when canceling ApplePay