### PR TITLE
Implemented client key injection into PaymentMethodsConfiguration, an…

### DIFF
--- a/Adyen/Components/Base/Component.swift
+++ b/Adyen/Components/Base/Component.swift
@@ -12,6 +12,10 @@ public protocol Component: AnyObject {
     /// Defines the environment used to make networking requests.
     var environment: Environment { get set }
     
+    /// The client key that corresponds to the webservice user you will use for initiating the payment.
+    /// See https://docs.adyen.com/user-management/client-side-authentication for more information.
+    var clientKey: String? { get set }
+    
 }
 
 public extension Component {
@@ -26,6 +30,17 @@ public extension Component {
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.environment, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+    
+    /// :nodoc:
+    var clientKey: String? {
+        get {
+            environment.clientKey
+        }
+        
+        set {
+            environment.clientKey = newValue
         }
     }
     

--- a/Adyen/Utilities/Environment.swift
+++ b/Adyen/Utilities/Environment.swift
@@ -13,7 +13,7 @@ public struct Environment: APIEnvironment {
     public var baseURL: URL
     
     /// :nodoc:
-    public var headers: [String: String] = ["Origin": "https://test.org", "Content-Type": "application/json"]
+    public var headers: [String: String] = ["Content-Type": "application/json"]
     
     /// :nodoc:
     public var queryParameters: [URLQueryItem] {

--- a/Adyen/Utilities/Environment.swift
+++ b/Adyen/Utilities/Environment.swift
@@ -16,7 +16,13 @@ public struct Environment: APIEnvironment {
     public var headers: [String: String] = ["Origin": "https://test.org", "Content-Type": "application/json"]
     
     /// :nodoc:
-    public var queryParameters: [URLQueryItem] = [URLQueryItem(name: "token", value: "test_YP5RJK3TL5EELNPAS7RHIRVRAIMYZXOH")]
+    public var queryParameters: [URLQueryItem] {
+        guard let clientKey = clientKey else { return [] }
+        return [URLQueryItem(name: "token", value: clientKey)]
+    }
+    
+    /// :nodoc:
+    public var clientKey: String?
     
     /// Adyen's test environment.
     public static let test = Environment(baseURL: URL(string: "https://checkoutshopper-test.adyen.com/")!,

--- a/AdyenDropIn/DropInActionComponent.swift
+++ b/AdyenDropIn/DropInActionComponent.swift
@@ -102,7 +102,7 @@ public final class DropInActionComponent: ActionComponent {
     private func perform(_ action: AwaitAction) {
         guard environment.clientKey != nil else {
             // swiftlint:disable:next line_length
-            assertionFailure("Failed to instantiate AwaitComponent because client key is not configured, Please supply the client key in the PaymentMethodsConfiguration if using DropInComponent, or DropInActionComponent.environment.clientKey if using DropInActionComponent separately.")
+            assertionFailure("Failed to instantiate AwaitComponent because client key is not configured. Please supply the client key in the PaymentMethodsConfiguration if using DropInComponent, or DropInActionComponent.clientKey if using DropInActionComponent separately.")
             return
         }
         let component = AwaitComponent(style: awaitComponentStyle)

--- a/AdyenDropIn/DropInActionComponent.swift
+++ b/AdyenDropIn/DropInActionComponent.swift
@@ -100,6 +100,11 @@ public final class DropInActionComponent: ActionComponent {
     }
     
     private func perform(_ action: AwaitAction) {
+        guard environment.clientKey != nil else {
+            // swiftlint:disable:next line_length
+            assertionFailure("Failed to instantiate AwaitComponent because client key is not configured, Please supply the client key in the PaymentMethodsConfiguration if using DropInComponent, or DropInActionComponent.environment.clientKey if using DropInActionComponent separately.")
+            return
+        }
         let component = AwaitComponent(style: awaitComponentStyle)
         component._isDropIn = _isDropIn
         component.delegate = delegate

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -20,6 +20,13 @@ public final class DropInComponent: NSObject, PresentableComponent {
     
     /// The title text on the first page of drop in component.
     public let title: String
+
+    /// :nodoc:
+    public var environment: Environment = .live {
+        didSet {
+            environment.clientKey = configuration.clientKey
+        }
+    }
     
     /// Initializes the drop in component.
     ///

--- a/AdyenDropIn/Models/PaymentMethodsConfiguration.swift
+++ b/AdyenDropIn/Models/PaymentMethodsConfiguration.swift
@@ -18,6 +18,10 @@ extension DropInComponent {
         /// The Apple Pay configuration.
         public var applePay = ApplePayConfiguration()
         
+        /// The client key that corresponds to the webservice user you will use for initiating the payment.
+        /// See https://docs.adyen.com/user-management/client-side-authentication for more information.
+        public var clientKey: String?
+        
         /// Indicates the localization parameters, leave it nil to use the default parameters.
         public var localizationParameters: LocalizationParameters?
         

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -135,7 +135,7 @@ internal final class ComponentManager {
     private func createMBWayComponent(_ paymentMethod: MBWayPaymentMethod) -> MBWayComponent? {
         guard configuration.clientKey != nil else {
             // swiftlint:disable:next line_length
-            adyenPrint("Failed to instantiate MBWayComponent because client key is not configured, Please supply the client key in the PaymentMethodsConfiguration.")
+            adyenPrint("Failed to instantiate MBWayComponent because client key is not configured. Please supply the client key in the PaymentMethodsConfiguration.")
             return nil
         }
         let component = MBWayComponent(paymentMethod: paymentMethod, style: style.formComponent)

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -38,7 +38,7 @@ internal final class ComponentManager {
     private func component(for paymentMethod: PaymentMethod) -> PaymentComponent? {
         let paymentComponent: PaymentComponent? = paymentMethod.buildComponent(using: self)
         
-        paymentComponent?.environment.clientKey = configuration.clientKey
+        paymentComponent?.clientKey = configuration.clientKey
         
         if var paymentComponent = paymentComponent as? Localizable {
             paymentComponent.localizationParameters = configuration.localizationParameters

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -38,6 +38,8 @@ internal final class ComponentManager {
     private func component(for paymentMethod: PaymentMethod) -> PaymentComponent? {
         let paymentComponent: PaymentComponent? = paymentMethod.buildComponent(using: self)
         
+        paymentComponent?.environment.clientKey = configuration.clientKey
+        
         if var paymentComponent = paymentComponent as? Localizable {
             paymentComponent.localizationParameters = configuration.localizationParameters
         }
@@ -130,7 +132,12 @@ internal final class ComponentManager {
         return component
     }
     
-    private func createMBWayComponent(_ paymentMethod: MBWayPaymentMethod) -> MBWayComponent {
+    private func createMBWayComponent(_ paymentMethod: MBWayPaymentMethod) -> MBWayComponent? {
+        guard configuration.clientKey != nil else {
+            // swiftlint:disable:next line_length
+            adyenPrint("Failed to instantiate MBWayComponent because client key is not configured, Please supply the client key in the PaymentMethodsConfiguration.")
+            return nil
+        }
         let component = MBWayComponent(paymentMethod: paymentMethod, style: style.formComponent)
         component.showsLargeTitle = false
         return component

--- a/AdyenTests/Adyen Tests/Core/PaymentMethodTests.swift
+++ b/AdyenTests/Adyen Tests/Core/PaymentMethodTests.swift
@@ -50,7 +50,8 @@ class PaymentMethodTests: XCTestCase {
                 bcmcMobileQR,
                 qiwiWallet,
                 weChatSDKDictionary,
-                debitCardDictionary
+                debitCardDictionary,
+                mbway
             ]
         ]
         
@@ -101,7 +102,7 @@ class PaymentMethodTests: XCTestCase {
         
         // Regular payment methods
         
-        XCTAssertEqual(paymentMethods.regular.count, 11)
+        XCTAssertEqual(paymentMethods.regular.count, 12)
         XCTAssertTrue(paymentMethods.regular[0] is CardPaymentMethod)
         XCTAssertEqual((paymentMethods.regular[0] as! CardPaymentMethod).fundingSource!, .credit)
         
@@ -154,6 +155,10 @@ class PaymentMethodTests: XCTestCase {
         
         XCTAssertTrue(paymentMethods.regular[10] is CardPaymentMethod)
         XCTAssertEqual((paymentMethods.regular[10] as! CardPaymentMethod).fundingSource!, .debit)
+
+        XCTAssertTrue(paymentMethods.regular[11] is MBWayPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[11].name, "MB WAY")
+        XCTAssertEqual(paymentMethods.regular[11].type, "mbway")
     }
     
     // MARK: - Card
@@ -313,6 +318,14 @@ class PaymentMethodTests: XCTestCase {
         XCTAssertEqual(paymentMethod.displayInformation, expectedDisplayInfo)
         XCTAssertEqual(paymentMethod.localizedDisplayInformation(using: expectedLocalizationParameters),
                        expectedBancontactCardDisplayInfo(method: paymentMethod, localizationParameters: expectedLocalizationParameters))
+    }
+
+    // MARK: - MBWay
+
+    func testDecodingMBWayPaymentMethod() throws {
+        let paymentMethod = try Coder.decode(mbway) as MBWayPaymentMethod
+        XCTAssertEqual(paymentMethod.type, "mbway")
+        XCTAssertEqual(paymentMethod.name, "MB WAY")
     }
     
     public func expectedBancontactCardDisplayInfo(method: StoredBCMCPaymentMethod, localizationParameters: LocalizationParameters?) -> DisplayInformation {

--- a/AdyenTests/Adyen Tests/Core/TestPaymentMethodsJson.swift
+++ b/AdyenTests/Adyen Tests/Core/TestPaymentMethodsJson.swift
@@ -180,6 +180,12 @@ let bcmcMobileQR = [
     "type": "bcmc_mobile_QR"
 ] as [String: Any]
 
+let mbway = [
+    "name" : "MB WAY",
+    "supportsRecurring" : true,
+    "type" : "mbway"
+] as [String: Any]
+
 let qiwiWallet = [
     "details": [
         [

--- a/AdyenUIHost/Application/Configuration.swift
+++ b/AdyenUIHost/Application/Configuration.swift
@@ -29,6 +29,8 @@ internal struct Configuration {
     
     static let additionalData = ["allow3DS2": true]
     
+    static let clientKey = "{YOUR_CLIENT_KEY}"
+    
     // swiftlint:disable:next line_length
     static let cardPublicKey = "{YOUR_CARD_PUBLIC_KEY}"
     

--- a/AdyenUIHost/Domains/Components/ComponentsViewController.swift
+++ b/AdyenUIHost/Domains/Components/ComponentsViewController.swift
@@ -91,6 +91,7 @@ internal final class ComponentsViewController: UIViewController {
     private func presentDropInComponent() {
         guard let paymentMethods = paymentMethods else { return }
         let configuration = DropInComponent.PaymentMethodsConfiguration()
+        configuration.clientKey = Configuration.clientKey
         configuration.card.publicKey = Configuration.cardPublicKey
         configuration.applePay.merchantIdentifier = Configuration.applePayMerchantIdentifier
         configuration.applePay.summaryItems = Configuration.applePaySummaryItems


### PR DESCRIPTION
## Summary
Implemented client key injection into PaymentMethodsConfiguration, and propagating the client key to DropInComponent and all the paymentMethod components, also added unit tests.

## Tested scenarios
1. Tested `ComponentManager` injecting the client key into its created components.
2. Tested MBWay payment method decoding from `paymentMethods/` endpoint response.
3. Tested `ComponentManager` scrapping `MBWayComponent` in case client key is not configured.

