### PR TITLE
Stop Polling when the await component cancel button is clicked by the…

### DIFF
--- a/Adyen/Components/Await/AwaitComponent.swift
+++ b/Adyen/Components/Await/AwaitComponent.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// A component that handles Await action's.
-internal protocol AnyAwaitActionHandler: ActionComponent {
+internal protocol AnyAwaitActionHandler: ActionComponent, Cancellable {
     func handle(_ action: AwaitAction)
 }
 
@@ -74,6 +74,11 @@ public final class AwaitComponent: AnyAwaitActionHandler {
         paymentMethodSpecificAwaitComponent?.delegate = delegate
         
         paymentMethodSpecificAwaitComponent?.handle(action)
+    }
+    
+    /// :nodoc:
+    public func didCancel() {
+        paymentMethodSpecificAwaitComponent?.didCancel()
     }
     
     /// :nodoc:

--- a/Adyen/Components/Await/PollingAwaitComponent.swift
+++ b/Adyen/Components/Await/PollingAwaitComponent.swift
@@ -99,6 +99,10 @@ internal final class PollingAwaitComponent: AnyAwaitActionHandler {
     /// - Parameter result: The request result.
     /// - Parameter paymentData: The payment data.
     private func handle(finalResult result: Result<PaymentStatusResponse, Error>, paymentData: String) {
+        guard !isCancelled else {
+            delegate?.didFail(with: ComponentError.cancelled, from: self)
+            return
+        }
         switch result {
         case let .success(response):
             deliverData(response, paymentData: paymentData)

--- a/Adyen/Components/Base/PresentableComponent.swift
+++ b/Adyen/Components/Base/PresentableComponent.swift
@@ -13,8 +13,17 @@ public protocol Localizable {
     var localizationParameters: LocalizationParameters? { get set }
 }
 
+/// :nodoc:
+/// Represents any object than can handle a cancel event.
+public protocol Cancellable {
+    
+    /// :nodoc:
+    /// Called when the user cancels the component.
+    func didCancel()
+}
+
 /// A component that provides a view controller for the shopper to fill payment details.
-public protocol PresentableComponent: Component {
+public protocol PresentableComponent: Component, Cancellable {
     
     /// The payment information.
     var payment: Payment? { get set }
@@ -70,6 +79,9 @@ public extension PresentableComponent {
     func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
         completion?()
     }
+    
+    /// :nodoc:
+    func didCancel() {}
     
 }
 

--- a/Adyen/Components/Base/PresentableComponent.swift
+++ b/Adyen/Components/Base/PresentableComponent.swift
@@ -80,7 +80,7 @@ public extension PresentableComponent {
         completion?()
     }
     
-    /// :nodoc:
+    /// Notifies the component that the user has dismissed it.
     func didCancel() {}
     
 }

--- a/Adyen/Components/PresentableComponentWrapper.swift
+++ b/Adyen/Components/PresentableComponentWrapper.swift
@@ -23,4 +23,10 @@ internal final class PresentableComponentWrapper: PresentableComponent {
         self.component = component
         self.viewController = viewController
     }
+    
+    /// :nodoc:
+    internal func didCancel() {
+        guard let component = component as? Cancellable else { return }
+        component.didCancel()
+    }
 }

--- a/Adyen/Components/PresentableComponentWrapper.swift
+++ b/Adyen/Components/PresentableComponentWrapper.swift
@@ -15,6 +15,9 @@ internal final class PresentableComponentWrapper: PresentableComponent {
     /// The wrapped component.
     internal let component: Component
     
+    /// :nodoc:
+    internal var requiresModalPresentation: Bool = true
+    
     /// Initializes the wrapper component.
     ///
     /// - Parameter component: The wrapped component.

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -20,7 +20,7 @@ public final class DropInComponent: NSObject, PresentableComponent {
     
     /// The title text on the first page of drop in component.
     public let title: String
-
+    
     /// :nodoc:
     public var environment: Environment = .live {
         didSet {
@@ -159,8 +159,9 @@ public final class DropInComponent: NSObject, PresentableComponent {
         }
     }
     
-    private func didSelectCancelButton(isRoot: Bool, component: PaymentComponent?) {
+    private func didSelectCancelButton(isRoot: Bool, component: PresentableComponent) {
         guard !paymentInProgress else { return }
+        component.didCancel()
         if isRoot {
             self.delegate?.didFail(with: ComponentError.cancelled, from: self)
         } else {

--- a/AdyenDropIn/Presentation/DropInNavigationController.swift
+++ b/AdyenDropIn/Presentation/DropInNavigationController.swift
@@ -6,7 +6,7 @@
 
 internal final class DropInNavigationController: UINavigationController {
     
-    internal typealias CancelHandler = (Bool, PaymentComponent?) -> Void
+    internal typealias CancelHandler = (Bool, PresentableComponent) -> Void
     
     private let cancelHandler: CancelHandler?
     
@@ -63,7 +63,7 @@ internal final class DropInNavigationController: UINavigationController {
     private func wrapInModalController(component: PresentableComponent, isRoot: Bool) -> WrapperViewController {
         let modal = ModalViewController(rootViewController: component.viewController,
                                         style: style) { [weak self] modal in
-            self?.cancelHandler?(modal, component as? PaymentComponent)
+            self?.cancelHandler?(modal, component)
         }
         modal.isRoot = isRoot
         let container = WrapperViewController(child: modal)

--- a/AdyenTests/Adyen Tests/Components/APIClientMock.swift
+++ b/AdyenTests/Adyen Tests/Components/APIClientMock.swift
@@ -23,15 +23,16 @@ final class APIClientMock: APIClientProtocol {
 
     func perform<R>(_ request: R, completionHandler: @escaping (Result<R.ResponseType, Error>) -> Void) where R : Request {
         counter += 1
+        DispatchQueue.main.async {
+            let nextResult = self.mockedResults.removeFirst()
 
-        let nextResult = mockedResults.removeFirst()
-
-        switch nextResult {
-        case let .success(response):
-            guard let response = response as? R.ResponseType else { return }
-            completionHandler(.success(response))
-        case let .failure(error):
-            completionHandler(.failure(error))
+            switch nextResult {
+            case let .success(response):
+                guard let response = response as? R.ResponseType else { return }
+                completionHandler(.success(response))
+            case let .failure(error):
+                completionHandler(.failure(error))
+            }
         }
     }
 

--- a/AdyenTests/Adyen Tests/Components/Await Component/AwaitComponentTests.swift
+++ b/AdyenTests/Adyen Tests/Components/Await Component/AwaitComponentTests.swift
@@ -18,6 +18,12 @@ final class AwaitActionHandlerMock: AnyAwaitActionHandler {
     func handle(_ action: AwaitAction) {
         onHandle?(action)
     }
+
+    var onDidCancel: (() -> Void)?
+
+    func didCancel() {
+        onDidCancel?()
+    }
 }
 
 struct AwaitActionHandlerProviderMock: AnyAwaitActionHandlerProvider {

--- a/AdyenTests/Adyen Tests/Components/Await Component/PollingAwaitComponentTests.swift
+++ b/AdyenTests/Adyen Tests/Components/Await Component/PollingAwaitComponentTests.swift
@@ -278,23 +278,18 @@ class PollingAwaitComponentTests: XCTestCase {
         let sut = PollingAwaitComponent(apiClient: retryApiClient)
 
         let delegate = ActionComponentDelegateMock()
-        delegate.onDidFail = { _, _ in
-            XCTFail()
-        }
 
-        let onDidProvideExpectation = expectation(description: "ActionComponentDelegate.didProvide must be called.")
-        onDidProvideExpectation.assertForOverFulfill = true
-        delegate.onDidProvide = { data, component in
+        let onDidFailExpectation = expectation(description: "ActionComponentDelegate.didFail must be called.")
+        delegate.onDidFail = { error, component in
             XCTAssertTrue(component === sut)
 
-            XCTAssertEqual(data.paymentData, "data")
-            XCTAssertNotNil(data.details as? AwaitActionDetails)
+            XCTAssertEqual(error as? ComponentError, ComponentError.cancelled)
 
-            let details = data.details as! AwaitActionDetails
+            onDidFailExpectation.fulfill()
+        }
 
-            XCTAssertEqual(details.payload, "pay load")
-
-            onDidProvideExpectation.fulfill()
+        delegate.onDidProvide = { _, _ in
+            XCTFail()
         }
 
         sut.delegate = delegate

--- a/AdyenUIHost/Domains/Components/ComponentsViewController.swift
+++ b/AdyenUIHost/Domains/Components/ComponentsViewController.swift
@@ -36,7 +36,8 @@ internal final class ComponentsViewController: UIViewController {
             [
                 ComponentsItem(title: "Card", selectionHandler: presentCardComponent),
                 ComponentsItem(title: "iDEAL", selectionHandler: presentIdealComponent),
-                ComponentsItem(title: "SEPA Direct Debit", selectionHandler: presentSEPADirectDebitComponent)
+                ComponentsItem(title: "SEPA Direct Debit", selectionHandler: presentSEPADirectDebitComponent),
+                ComponentsItem(title: "MB WAY", selectionHandler: presentMBWayComponent)
             ]
         ]
         
@@ -49,11 +50,15 @@ internal final class ComponentsViewController: UIViewController {
         let handler = DropInActionComponent()
         handler.redirectComponentStyle = dropInComponentStyle.redirectComponent
         handler.delegate = self
+        handler.presentationDelegate = self
+        handler.environment = environment
+        handler.clientKey = Configuration.clientKey
         return handler
     }()
     
     private func present(_ component: PresentableComponent) {
         component.environment = environment
+        component.clientKey = Configuration.clientKey
         component.payment = payment
         
         if let paymentComponent = component as? PaymentComponent {
@@ -73,15 +78,15 @@ internal final class ComponentsViewController: UIViewController {
         component.viewController.navigationItem.leftBarButtonItem = .init(barButtonSystemItem: .cancel,
                                                                           target: self,
                                                                           action: #selector(cancelDidPress))
-        present(navigation, animated: true)
+        adyen.topPresenter.present(navigation, animated: true)
     }
     
     @objc private func cancelDidPress() {
-        guard let paymentComponent = self.currentComponent as? PaymentComponent else {
-            self.dismiss(animated: true, completion: nil)
-            return
+        currentComponent?.didCancel()
+        
+        if let paymentComponent = self.currentComponent as? PaymentComponent {
+            paymentComponent.delegate?.didFail(with: ComponentError.cancelled, from: paymentComponent)
         }
-        paymentComponent.delegate?.didFail(with: ComponentError.cancelled, from: paymentComponent)
     }
     
     // MARK: - DropIn Component
@@ -129,6 +134,14 @@ internal final class ComponentsViewController: UIViewController {
         present(component)
     }
     
+    private func presentMBWayComponent() {
+        guard let paymentMethod = paymentMethods?.paymentMethod(ofType: MBWayPaymentMethod.self) else { return }
+        let component = MBWayComponent(paymentMethod: paymentMethod,
+                                       style: dropInComponentStyle.formComponent)
+        component.delegate = self
+        present(component)
+    }
+    
     // MARK: - Networking
     
     private lazy var apiClient = DefaultAPIClient()
@@ -159,6 +172,7 @@ internal final class ComponentsViewController: UIViewController {
         switch result {
         case let .success(response):
             if let action = response.action {
+                currentComponent?.stopLoading()
                 handle(action)
             } else {
                 finish(with: response.resultCode)
@@ -272,5 +286,11 @@ extension ComponentsViewController: CardComponentDelegate {
     
     internal func didChangeCardType(_ value: [CardType]?, component: CardComponent) {
         print("Current card type: \((value ?? []).reduce("") { "\($0), \($1)" })")
+    }
+}
+
+extension ComponentsViewController: PresentationDelegate {
+    internal func present(component: PresentableComponent, disableCloseButton: Bool) {
+        present(component)
     }
 }


### PR DESCRIPTION

## Summary
Implemented stoping polling once the user cancels the `AwaitComponent`.

## Tested scenarios
Testing calling `didCancel()` on `PollingAwaitComponent` in `PollingAwaitComponentTests`


**Fixed issue**:  <!-- #-prefixed issue number -->
Fixed the case when the user clicks the cancel button of the `AwaitComponent`, and stop polling

