### PR TITLE
Added a dismiss function to RedirectComponent and DropInActionCompone…

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		F919DF9724E6E2810027976E /* StoredCardComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F919DF9624E6E2810027976E /* StoredCardComponent.swift */; };
 		F919DF9924EA64680027976E /* CardPublicKeyProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F919DF9824EA64680027976E /* CardPublicKeyProviderTests.swift */; };
 		F919DFA024EABCC10027976E /* StoredCardComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F919DF9F24EABCC10027976E /* StoredCardComponentTests.swift */; };
+		F919DFA224ED599D0027976E /* DropInActionComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F919DFA124ED599D0027976E /* DropInActionComponentTests.swift */; };
 		F924C072246BEEF0006DDAB8 /* CardDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F924C071246BEEF0006DDAB8 /* CardDetailsTests.swift */; };
 		F924C074246C2E0B006DDAB8 /* LazyOptional.swift in Sources */ = {isa = PBXBuildFile; fileRef = F924C073246C2E0B006DDAB8 /* LazyOptional.swift */; };
 		F924C079246C38E0006DDAB8 /* SecuredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F924C078246C38E0006DDAB8 /* SecuredViewController.swift */; };
@@ -696,6 +697,7 @@
 		F919DF9624E6E2810027976E /* StoredCardComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCardComponent.swift; sourceTree = "<group>"; };
 		F919DF9824EA64680027976E /* CardPublicKeyProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPublicKeyProviderTests.swift; sourceTree = "<group>"; };
 		F919DF9F24EABCC10027976E /* StoredCardComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCardComponentTests.swift; sourceTree = "<group>"; };
+		F919DFA124ED599D0027976E /* DropInActionComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropInActionComponentTests.swift; sourceTree = "<group>"; };
 		F924C071246BEEF0006DDAB8 /* CardDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDetailsTests.swift; sourceTree = "<group>"; };
 		F924C073246C2E0B006DDAB8 /* LazyOptional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyOptional.swift; sourceTree = "<group>"; };
 		F924C078246C38E0006DDAB8 /* SecuredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecuredViewController.swift; sourceTree = "<group>"; };
@@ -1494,6 +1496,7 @@
 				F9EDB795239663F800CFB3C9 /* PaymentComponentMock.swift */,
 				F9639B5124E29E340073F38A /* PresentationDelegateMock.swift */,
 				F9639B5724E3DB3F0073F38A /* APIClientMock.swift */,
+				F919DFA124ED599D0027976E /* DropInActionComponentTests.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2728,6 +2731,7 @@
 				E9021E042264C55E009CF7F4 /* KeyedDecodingContainerExtensionsTests.swift in Sources */,
 				F9EDB79E2397AEF400CFB3C9 /* ComponentManagerTests.swift in Sources */,
 				F9EDB7922396603F00CFB3C9 /* PaymentMethodListComponentTests.swift in Sources */,
+				F919DFA224ED599D0027976E /* DropInActionComponentTests.swift in Sources */,
 				F9639B4924E28DC80073F38A /* IntervalCalculatorMock.swift in Sources */,
 				F919DFA024EABCC10027976E /* StoredCardComponentTests.swift in Sources */,
 				F9EDB78F23964FC000CFB3C9 /* StoredCardAlertManagerTests.swift in Sources */,

--- a/Adyen/Components/Base/Component.swift
+++ b/Adyen/Components/Base/Component.swift
@@ -18,6 +18,16 @@ public protocol Component: AnyObject {
     
 }
 
+/// A component that has UI that can be dismissed.
+public protocol DismissableComponent: Component {
+    
+    /// Dismiss any `ViewController` presented by the component, for example when payment has concluded.
+    ///
+    /// - Parameter animated: A boolean indicating whether to dismiss with animation or not.
+    /// - Parameter completion: A closure to execute when dismissal animation has completed.
+    func dismiss(_ animated: Bool, completion: (() -> Void)?)
+}
+
 public extension Component {
     
     /// :nodoc:

--- a/Adyen/Components/Redirect/RedirectComponent.swift
+++ b/Adyen/Components/Redirect/RedirectComponent.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 /// A component that handles a redirect action. Supports external websites, apps and universal links.
-public final class RedirectComponent: ActionComponent {
+public final class RedirectComponent: ActionComponent, DismissableComponent {
     
     /// Describes the types of errors that can be returned by the component.
     public enum Error: Swift.Error {
@@ -38,6 +38,11 @@ public final class RedirectComponent: ActionComponent {
         Analytics.sendEvent(component: componentName, flavor: _isDropIn ? .dropin : .components, environment: environment)
         
         universalRedirectComponent.handle(action)
+    }
+    
+    /// :nodoc:
+    public func dismiss(_ animated: Bool, completion: (() -> Void)?) {
+        universalRedirectComponent.dismiss(animated, completion: completion)
     }
     
     /// This function should be invoked from the application's delegate when the application is opened through a URL.

--- a/Adyen/Components/Redirect/UniversalRedirectComponent.swift
+++ b/Adyen/Components/Redirect/UniversalRedirectComponent.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Handles any redirect Url whether its a web url, an App custom scheme url, or an app universal link.
-internal final class UniversalRedirectComponent: ActionComponent {
+internal final class UniversalRedirectComponent: ActionComponent, DismissableComponent {
     
     /// :nodoc:
     internal weak var delegate: ActionComponentDelegate?
@@ -49,6 +49,11 @@ internal final class UniversalRedirectComponent: ActionComponent {
         } else {
             openCustomSchemeUrl(action)
         }
+    }
+    
+    /// :nodoc:
+    internal func dismiss(_ animated: Bool, completion: (() -> Void)?) {
+        redirectComponent?.viewController.dismiss(animated: animated, completion: completion)
     }
     
     // MARK: - Http link handling

--- a/AdyenDropIn/DropInActionComponent.swift
+++ b/AdyenDropIn/DropInActionComponent.swift
@@ -48,6 +48,14 @@ public final class DropInActionComponent: ActionComponent {
         }
     }
     
+    /// Dismiss any `DismissableComponent` managed by the `DropInActionComponent`, for example when payment has concluded.
+    ///
+    /// - Parameter animated: A boolean indicating whether to dismiss with animation or not.
+    /// - Parameter completion: A closure to execute when dismissal animation has completed.
+    internal func dismiss(_ animated: Bool, completion: (() -> Void)?) {
+        redirectComponent?.dismiss(animated, completion: completion)
+    }
+    
     // MARK: - Private
     
     private var redirectComponent: RedirectComponent?

--- a/AdyenTests/Adyen Tests/Components/DropInActionComponentTests.swift
+++ b/AdyenTests/Adyen Tests/Components/DropInActionComponentTests.swift
@@ -1,0 +1,44 @@
+//
+//  DropInActionComponentTests.swift
+//  AdyenTests
+//
+//  Created by Mohamed Eldoheiri on 8/19/20.
+//  Copyright © 2020 Adyen. All rights reserved.
+//
+
+import XCTest
+@testable import AdyenDropIn
+import SafariServices
+
+class DropInActionComponentTests: XCTestCase {
+
+    func testRedirectToHttpWebLink() {
+        let sut = DropInActionComponent()
+        let delegate = ActionComponentDelegateMock()
+        sut.delegate = delegate
+
+        delegate.onDidOpenExternalApplication = { _ in
+            XCTFail("delegate.didOpenExternalApplication() must not to be called")
+        }
+
+        let action = Action.redirect(RedirectAction(url: URL(string: "https://www.adyen.com")!, paymentData: "test_data"))
+        sut.perform(action)
+
+        let waitExpectation = expectation(description: "Expect in app browser to be presented and then dismissed")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(2)) {
+
+            let topPresentedViewController = UIViewController.findTopPresenter()
+            XCTAssertNotNil(topPresentedViewController as? SFSafariViewController)
+
+            sut.dismiss(true) {
+                let topPresentedViewController = UIViewController.findTopPresenter()
+                XCTAssertNil(topPresentedViewController as? SFSafariViewController)
+
+                waitExpectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
+}

--- a/AdyenTests/Adyen Tests/Components/Redirect/RedirectComponentTests.swift
+++ b/AdyenTests/Adyen Tests/Components/Redirect/RedirectComponentTests.swift
@@ -144,7 +144,7 @@ class RedirectComponentTests: XCTestCase {
         waitForExpectations(timeout: 10, handler: nil)
     }
 
-    func testOpenHttpLinkSuccess() {
+    func testOpenHttpWebLink() {
         let sut = RedirectComponent()
         let delegate = ActionComponentDelegateMock()
         sut.delegate = delegate

--- a/AdyenTests/Adyen Tests/Components/Redirect/RedirectComponentTests.swift
+++ b/AdyenTests/Adyen Tests/Components/Redirect/RedirectComponentTests.swift
@@ -143,5 +143,44 @@ class RedirectComponentTests: XCTestCase {
         
         waitForExpectations(timeout: 10, handler: nil)
     }
+
+    func testOpenHttpLinkSuccess() {
+        let sut = RedirectComponent()
+        let delegate = ActionComponentDelegateMock()
+        sut.delegate = delegate
+        let appLauncher = AppLauncherMock()
+        sut.universalRedirectComponent.appLauncher = appLauncher
+
+        appLauncher.onOpenCustomSchemeUrl = { url, completion in
+            XCTFail("appLauncher.openCustomSchemeUrl() must not to be called")
+        }
+
+        appLauncher.onOpenUniversalAppUrl = { url, completion in
+            completion?(false)
+        }
+
+        delegate.onDidOpenExternalApplication = { _ in
+            XCTFail("delegate.didOpenExternalApplication() must not to be called")
+        }
+
+        let action = RedirectAction(url: URL(string: "https://www.adyen.com")!, paymentData: "test_data")
+        sut.handle(action)
+
+        let waitExpectation = expectation(description: "Expect in app browser to be presented and then dismissed")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(2)) {
+
+            let topPresentedViewController = UIViewController.findTopPresenter()
+            XCTAssertNotNil(topPresentedViewController as? SFSafariViewController)
+
+            sut.dismiss(true) {
+                let topPresentedViewController = UIViewController.findTopPresenter()
+                XCTAssertNil(topPresentedViewController as? SFSafariViewController)
+
+                waitExpectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
     
 }

--- a/AdyenUIHost/Application/Configuration.swift
+++ b/AdyenUIHost/Application/Configuration.swift
@@ -19,7 +19,7 @@ internal struct Configuration {
     
     static let reference = "Test Order Reference - iOS UIHost"
     
-    static let countryCode = "BE"
+    static let countryCode = "NL"
     
     static let returnUrl = "ui-host://"
     


### PR DESCRIPTION
Added a dismiss function to RedirectComponent and DropInActionComponent for merchants to be able to dismiss the presented UI in case payment is concluded

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Added a dismiss function to RedirectComponent and DropInActionCompone

## Tested scenarios
Added a test case to `RedirectComponentTests`.
Added a test case to `DropInActionComponentTests`.


**Fixed issue**:  <!-- #-prefixed issue number -->
Fixed an issue where merchants using components and redirect component alone can't dismiss the in-app browser.
