### PR TITLE
Updated the 3DS2 SDK version to 2.2.0.

### DIFF
--- a/Adyen/Components/Await/AwaitComponent.swift
+++ b/Adyen/Components/Await/AwaitComponent.swift
@@ -65,7 +65,7 @@ public final class AwaitComponent: AnyAwaitActionHandler {
             let presentableComponent = PresentableComponentWrapper(component: self, viewController: viewController)
             presentationDelegate.present(component: presentableComponent, disableCloseButton: false)
         } else {
-            fatalError("presentationDelegate is nil, please provide a presentation delegate to present the AwaitComponent UI.")
+            assertionFailure("presentationDelegate is nil, please provide a presentation delegate to present the AwaitComponent UI.")
         }
         
         let awaitComponentBuilder = self.awaitActionHandler ?? AwaitActionHandlerProvider(environment: environment, apiClient: nil)

--- a/AdyenCard/3DS2 Component/ThreeDS2Component.swift
+++ b/AdyenCard/3DS2 Component/ThreeDS2Component.swift
@@ -54,7 +54,7 @@ public final class ThreeDS2Component: ActionComponent {
     
     private func createFingerprint(using service: ADYService, paymentData: String) {
         do {
-            let transaction = try service.transaction(withMessageVersion: nil)
+            let transaction = try service.transaction(withMessageVersion: "2.1.0")
             self.transaction = transaction
             
             let fingerprint = try Fingerprint(authenticationRequestParameters: transaction.authenticationRequestParameters)

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "adyen/adyen-3ds2-ios" >= 2.1.0-rc.5
+github "adyen/adyen-3ds2-ios" >= 2.2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "adyen/adyen-3ds2-ios" "2.1.0-rc.5"
+github "adyen/adyen-3ds2-ios" "2.2.0"


### PR DESCRIPTION
## Summary
1. Updated the 3DS2 SDK version to 2.2.0.
2. Fixed the messageVersion to 2.1.0 to avoid mass 3DS 2 errors because issuers might not be ready for 2.2.0.
3. A small fix in AwaitComponent to avoid crashes in production.

<!-- ## Tested scenarios -->
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
1. fixed an issue where a fatal error is raised in `AwaitComponent` if `presentationDelegate` is nil.
2. Fixed the 3DS2 message version to be 2.1.0 in `ThreeDS2Component`.
