### PR TITLE
Dismiss the checkout all together when a web redirect is canceled

### DIFF
--- a/Adyen/UI/Checkout/CheckoutPresenter.swift
+++ b/Adyen/UI/Checkout/CheckoutPresenter.swift
@@ -192,6 +192,9 @@ extension CheckoutPresenter: SFSafariViewControllerDelegate {
     /// :nodoc:
     public func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
         showPaymentProcessing(false)
+
+        // Dismiss the whole checkout.
+        delegate?.didSelectCancel(in: self)
     }
     
 }

--- a/Adyen/UI/Form/FormViewController.swift
+++ b/Adyen/UI/Form/FormViewController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// :nodoc:
-open class FormViewController: UIViewController {
+open class FormViewController: UIViewController, PaymentProcessingElement {
     
     public init(appearance: Appearance) {
         self.appearance = appearance
@@ -79,6 +79,16 @@ open class FormViewController: UIViewController {
         
         view.endEditing(true)
         formView.payButton.showsActivityIndicator = true
+    }
+
+    // MARK: - PaymentProcessingElement
+
+    func startProcessing() {
+        formView.payButton.showsActivityIndicator = true
+    }
+
+    func stopProcessing() {
+        formView.payButton.showsActivityIndicator = false
     }
     
     // MARK: - Private

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ platform :ios, '9.0'
 use_frameworks!
 
 target 'AdyenUIHost' do
-    
+
   pod 'SwiftLint'
   pod 'SwiftFormat/CLI'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,20 @@
 PODS:
-  - SwiftFormat/CLI (0.35.6)
-  - SwiftLint (0.27.0)
+  - SwiftFormat/CLI (0.46.3)
+  - SwiftLint (0.40.3)
 
 DEPENDENCIES:
   - SwiftFormat/CLI
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - SwiftFormat
     - SwiftLint
 
 SPEC CHECKSUMS:
-  SwiftFormat: 92cd208b201c0a44dd65657280df42c37950261b
-  SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
+  SwiftFormat: b639417da9e024b9e782f917bc9a080cf75bcb37
+  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
 
-PODFILE CHECKSUM: 3bd657701fe159132dcc8ba92cfe2bac80f5e70c
+PODFILE CHECKSUM: 056c56e506ea41f44119a876dec69324f7dd7274
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.9.3


### PR DESCRIPTION
## Summary
in cases:

1. Any payment method form that trigger a redirect (e.g Card form that trigger 3ds1 redirect).
2. Any redirect payment method like paypal for example.

and then the shopper cancel the safari screen.

Then:

dismiss the checkout all together.
