### PR TITLE
Init Amount from a major unit Decimal

### DIFF
--- a/Adyen/Core/Payment.swift
+++ b/Adyen/Core/Payment.swift
@@ -28,6 +28,15 @@ public struct Payment {
             self.currencyCode = currencyCode
         }
         
+        /// Initializes an Amount from a `Decimal` value expressed in major units.
+        ///
+        /// - Parameters:
+        ///   - value: The value in major units.
+        ///   - currencyCode: The code of the currency.
+        public init(value: Decimal, currencyCode: String) {
+            self.value = AmountFormatter.minorUnitAmount(from: value, currencyCode: currencyCode)
+            self.currencyCode = currencyCode
+        }
     }
     
     /// The amount for this payment.

--- a/Adyen/Utilities/AmountFormatter.swift
+++ b/Adyen/Utilities/AmountFormatter.swift
@@ -34,6 +34,26 @@ public final class AmountFormatter {
         return Int(majorUnitAmount * pow(Double(10), Double(maximumFractionDigits)))
     }
     
+    /// Converts an amount in major currency unit to an amount in minor currency units.
+    ///
+    /// - Parameters:
+    ///   - majorUnitAmount: The amount in major currency units.
+    ///   - currencyCode: The code of the currency.
+    public static func minorUnitAmount(from majorUnitAmount: Decimal, currencyCode: String) -> Int {
+        let maximumFractionDigits = AmountFormatter.maximumFractionDigits(for: currencyCode)
+        
+        let roundTowardsZero = NSDecimalNumberHandler(roundingMode: majorUnitAmount.isSignMinus ? .up : .down,
+                                                      scale: 0,
+                                                      raiseOnExactness: false,
+                                                      raiseOnOverflow: false,
+                                                      raiseOnUnderflow: false,
+                                                      raiseOnDivideByZero: false)
+        
+        return (majorUnitAmount as NSDecimalNumber)
+            .multiplying(byPowerOf10: Int16(maximumFractionDigits))
+            .rounding(accordingToBehavior: roundTowardsZero).intValue
+    }
+    
     private static func decimalAmount(_ amount: Int, currencyCode: String) -> NSDecimalNumber {
         let defaultFormatter = AmountFormatter.defaultFormatter(currencyCode: currencyCode)
         let maximumFractionDigits = AmountFormatter.maximumFractionDigits(for: currencyCode)

--- a/AdyenTests/Adyen Tests/Utilities/AmountFormatterTests.swift
+++ b/AdyenTests/Adyen Tests/Utilities/AmountFormatterTests.swift
@@ -29,4 +29,23 @@ class AmountFormatterTests: XCTestCase {
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: -218521.213969269, currencyCode: "JOD"), -218521213)
     }
     
+    func testConversionFromDecimalToMinorAmounts() {
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(123.351), currencyCode: "EUR"), 12335)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-123.351), currencyCode: "EUR"), -12335)
+
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(0.239), currencyCode: "EUR"), 23)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-0.239), currencyCode: "EUR"), -23)
+        
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(111.113), currencyCode: "USD"), 11111)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-111.113), currencyCode: "USD"), -11111)
+        
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(333.119), currencyCode: "EUR"), 33311)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-333.119), currencyCode: "EUR"), -33311)
+        
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(218521.213969269), currencyCode: "EUR"), 21852121)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-218521.213969269), currencyCode: "EUR"), -21852121)
+        
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(218521.213969269), currencyCode: "JOD"), 218521213)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-218521.213969269), currencyCode: "JOD"), -218521213)
+    }
 }

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "adyen/adyen-3ds2-ios" "2.1.0-rc.5"
+github "adyen/adyen-3ds2-ios" "2.1.0-rc.6"


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

My app stores prices in major units using `Decimal`, like so:
```swift
struct Price {
    let amount: Decimal
    let currencyCode: String
}
```

It's great for correctness, but not so great when trying to initialize a `Payment.Amount` because it only accepts minor units. The issue with minor units is that Adyen and iOS disagree on what a minor unit is for certain currencies, and I don't want to have to worry about that.

This change leverages the workarounds already implemented inside `AmountFormatter` to allow for the creation of a `Payment.Amount` using a `Decimal` value specified in major units. It applies proper rounding (towards zero).

## Tested scenarios
<!-- Description of tested scenarios -->
All unit test scenarios for `AmountFormatter.minorUnitAmount(from: Double)`, but with `Decimal` values instead.
