### PR TITLE
Fix: improve card type detection visualisation

### DIFF
--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -36,7 +36,7 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
     
     // MARK: - Card Type Logos View
     
-    private lazy var cardTypeLogosView: UIView = {
+    internal lazy var cardTypeLogosView: UIView = {
         let cardTypeLogosView = CardsView(logos: item.cardTypeLogos, style: item.style)
         cardTypeLogosView.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "cardTypeLogos")
         cardTypeLogosView.backgroundColor = item.style.backgroundColor
@@ -47,13 +47,13 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
 
 // MARK: - FormCardNumberItemView.CardTypeLogoView
 
-private extension FormCardNumberItemView {
+extension FormCardNumberItemView {
     
-    private class CardsView: UIStackView, Observer {
+    internal class CardsView: UIStackView, Observer {
         
         private let maxCount: Int
         
-        init(logos: [FormCardNumberItem.CardTypeLogo], style: FormTextItemStyle, max count: Int = 4) {
+        internal init(logos: [FormCardNumberItem.CardTypeLogo], style: FormTextItemStyle, max count: Int = 4) {
             maxCount = count
             super.init(frame: .zero)
             axis = .horizontal
@@ -70,16 +70,16 @@ private extension FormCardNumberItemView {
             }
         }
         
-        required init(coder: NSCoder) {
+        internal required init(coder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
         
-        override func layoutSubviews() {
+        override internal func layoutSubviews() {
             invalidateIntrinsicContentSize()
             super.layoutSubviews()
         }
         
-        override var intrinsicContentSize: CGSize {
+        override internal var intrinsicContentSize: CGSize {
             let cardsCount = CGFloat(arrangedSubviews.filter { !$0.isHidden }.count)
             let width = FormCardNumberItemView.cardSize.width * cardsCount + FormCardNumberItemView.cardSpacing * max(cardsCount - 1, 0)
             return .init(width: max(width, FormCardNumberItemView.cardSpacing), height: FormCardNumberItemView.cardSize.height)
@@ -89,9 +89,9 @@ private extension FormCardNumberItemView {
     
 }
 
-private extension FormCardNumberItemView {
+extension FormCardNumberItemView {
     
-    private class CardTypeLogoView: NetworkImageView {
+    class CardTypeLogoView: NetworkImageView {
         
         private let rounding: CornerRounding
         

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -91,7 +91,7 @@ extension FormCardNumberItemView {
 
 extension FormCardNumberItemView {
     
-    class CardTypeLogoView: NetworkImageView {
+    private class CardTypeLogoView: NetworkImageView {
         
         private let rounding: CornerRounding
         
@@ -115,7 +115,7 @@ extension FormCardNumberItemView {
             return cardSize
         }
         
-        override func layoutSubviews() {
+        override internal func layoutSubviews() {
             super.layoutSubviews()
             self.adyen.round(using: rounding)
         }

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -52,7 +52,6 @@ private extension FormCardNumberItemView {
     private class CardsView: UIStackView, Observer {
         
         private let maxCount: Int
-        private var cardLogos: [CardTypeLogoView] = []
         
         init(logos: [FormCardNumberItem.CardTypeLogo], style: FormTextItemStyle, max count: Int = 4) {
             maxCount = count
@@ -60,16 +59,14 @@ private extension FormCardNumberItemView {
             axis = .horizontal
             spacing = FormCardNumberItemView.cardSpacing
             
-            logos.forEach { logo in
+            for logo in logos {
                 let imageView = CardTypeLogoView(cardTypeLogo: logo, style: style.icon)
                 imageView.backgroundColor = style.backgroundColor
-                cardLogos.append(imageView)
-                
-                observe(logo.$isHidden) { [unowned imageView, weak self] isHidden in
-                    self?.set(view: imageView, hidden: isHidden)
+                self.addArrangedSubview(imageView)
+
+                observe(logo.$isHidden) { [unowned imageView] isHidden in
+                    imageView.isHidden = isHidden
                 }
-                
-                logo.$isHidden.publish(false)
             }
         }
         
@@ -86,14 +83,6 @@ private extension FormCardNumberItemView {
             let cardsCount = CGFloat(arrangedSubviews.filter { !$0.isHidden }.count)
             let width = FormCardNumberItemView.cardSize.width * cardsCount + FormCardNumberItemView.cardSpacing * max(cardsCount - 1, 0)
             return .init(width: max(width, FormCardNumberItemView.cardSpacing), height: FormCardNumberItemView.cardSize.height)
-        }
-        
-        private func set(view: UIView, hidden: Bool) {
-            if hidden {
-                view.removeFromSuperview()
-            } else if arrangedSubviews.count < maxCount {
-                addArrangedSubview(view)
-            }
         }
         
     }

--- a/AdyenCard/Utilities/CardType/CardTypeProvider.swift
+++ b/AdyenCard/Utilities/CardType/CardTypeProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 /// :nodoc:
 internal protocol AnyCardTypeProvider: Component {
     /// :nodoc:
-    func requestCardType(for bin: String, supported cardType: [CardType], completion: @escaping ([CardType]) -> Void)
+    func requestCardTypes(for bin: String, supported cardType: [CardType], completion: @escaping ([CardType]) -> Void)
 }
 
 /// Provide cardType detection based on BinLookup API.
@@ -38,7 +38,7 @@ internal final class CardTypeProvider: AnyCardTypeProvider {
     /// - Parameters:
     ///   - bin: Card's BIN number. If longer than `minBinLength` - calls API, otherwise check local Regex,
     ///   - completion:  Callback to notify about results.
-    internal func requestCardType(for bin: String, supported cardType: [CardType], completion: @escaping ([CardType]) -> Void) {
+    internal func requestCardTypes(for bin: String, supported cardType: [CardType], completion: @escaping ([CardType]) -> Void) {
         guard bin.count > CardTypeProvider.minBinLength else {
             return completion(cardType.adyen.types(forCardNumber: bin))
         }

--- a/AdyenTests/Card Tests/BCMCComponentTests.swift
+++ b/AdyenTests/Card Tests/BCMCComponentTests.swift
@@ -125,12 +125,13 @@ class BCMCComponentTests: XCTestCase {
         UIApplication.shared.keyWindow?.rootViewController = sut.viewController
         
         let expectation = XCTestExpectation(description: "Dummy Expectation")
+        let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.numberItem")
+        XCTAssertNotNil(cardNumberItemView)
+
+        let cardNumberItem = cardNumberItemView!.item
+        self.populate(textItemView: cardNumberItemView!, with: "00000")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.numberItem")
-            XCTAssertNotNil(cardNumberItemView)
-            
-            let cardNumberItem = cardNumberItemView!.item
-            cardNumberItem.didChange(detectedCards: [], for: "12345")
+
             XCTAssertTrue(cardNumberItem.cardTypeLogos.allSatisfy { $0.isHidden })
             
             expectation.fulfill()

--- a/AdyenTests/Card Tests/CardComponentTests.swift
+++ b/AdyenTests/Card Tests/CardComponentTests.swift
@@ -446,6 +446,91 @@ class CardComponentTests: XCTestCase {
         XCTAssertNotNil(sut.viewController as? UIAlertController)
         XCTAssertNotNil(sut.storedCardComponent)
     }
+
+    func testShouldShow4CardTypesOnInit() {
+        let method = CardPaymentMethod(type: "bcmc", name: "Test name", fundingSource: .credit, brands: ["visa", "amex", "mc", "cup", "maestro", "jcb"])
+        let sut = CardComponent(paymentMethod: method,
+                                clientKey: "test_client_key")
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+
+        let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.numberItem")
+        XCTAssertNotNil(cardNumberItemView)
+        let textItemView: FormTextItemView<FormCardNumberItem>? = cardNumberItemView!.findView(with: "AdyenCard.CardComponent.numberItem")
+        XCTAssertNotNil(textItemView)
+        let cardLogoView = cardNumberItemView!.cardTypeLogosView as! FormCardNumberItemView.CardsView
+        XCTAssertNotNil(cardLogoView)
+        let cardNumberItem = cardNumberItemView!.item
+
+        let expectation = XCTestExpectation(description: "Dummy Expectation")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
+            XCTAssertEqual(cardNumberItem.cardTypeLogos.count, 6)
+            XCTAssertEqual(cardLogoView.subviews.count, 6)
+            XCTAssertEqual(cardLogoView.arrangedSubviews.filter{ !$0.isHidden }.count, 4)
+
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 8)
+    }
+
+    func testShouldShowNoCardTypesOnInvalidPANEnter() {
+        let method = CardPaymentMethod(type: "bcmc", name: "Test name", fundingSource: .credit, brands: ["visa", "amex", "mc"])
+        let sut = CardComponent(paymentMethod: method,
+                                clientKey: "test_client_key")
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+
+        let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.numberItem")
+        XCTAssertNotNil(cardNumberItemView)
+        let textItemView: FormTextItemView<FormCardNumberItem>? = cardNumberItemView!.findView(with: "AdyenCard.CardComponent.numberItem")
+        XCTAssertNotNil(textItemView)
+        let cardLogoView = cardNumberItemView!.cardTypeLogosView as! FormCardNumberItemView.CardsView
+        XCTAssertNotNil(cardLogoView)
+        let cardNumberItem = cardNumberItemView!.item
+
+        let expectation = XCTestExpectation(description: "Dummy Expectation")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
+
+            self.populate(textItemView: cardNumberItemView!, with: "1231")
+
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
+                XCTAssertEqual(cardNumberItem.cardTypeLogos.count, 3)
+                XCTAssertEqual(cardLogoView.subviews.count, 3)
+                XCTAssertTrue(cardLogoView.arrangedSubviews.allSatisfy { $0.isHidden })
+
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 8)
+    }
+
+    func testShouldShowCardTypesOnPANEnter() {
+        let method = CardPaymentMethod(type: "bcmc", name: "Test name", fundingSource: .credit, brands: ["visa", "amex", "mc"])
+        let sut = CardComponent(paymentMethod: method,
+                                clientKey: "test_client_key")
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+
+        let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.numberItem")
+        XCTAssertNotNil(cardNumberItemView)
+        let textItemView: FormTextItemView<FormCardNumberItem>? = cardNumberItemView!.findView(with: "AdyenCard.CardComponent.numberItem")
+        XCTAssertNotNil(textItemView)
+        let cardLogoView = cardNumberItemView!.cardTypeLogosView as! FormCardNumberItemView.CardsView
+        XCTAssertNotNil(cardLogoView)
+        let cardNumberItem = cardNumberItemView!.item
+
+        let expectation = XCTestExpectation(description: "Dummy Expectation")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
+
+            self.populate(textItemView: cardNumberItemView!, with: "3400")
+
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
+                XCTAssertEqual(cardNumberItem.cardTypeLogos.count, 3)
+                XCTAssertEqual(cardLogoView.subviews.count, 3)
+                XCTAssertEqual(cardLogoView.arrangedSubviews.filter{ !$0.isHidden }.count, 1)
+
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 8)
+    }
     
     private func focus<T: FormTextItem, U: FormTextItemView<T>>(textItemView: U) {
         textItemView.textField.becomeFirstResponder()

--- a/AdyenTests/Card Tests/Form/FormCardNumberItemTests.swift
+++ b/AdyenTests/Card Tests/Form/FormCardNumberItemTests.swift
@@ -46,8 +46,8 @@ class FormCardNumberItemTests: XCTestCase {
         
         // When typing unknown combination, all logos should be hidden.
         item.value = "5"
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
             XCTAssertEqual(visa.isHidden, true)
             XCTAssertEqual(mc.isHidden, true)
             XCTAssertEqual(amex.isHidden, true)
@@ -57,8 +57,8 @@ class FormCardNumberItemTests: XCTestCase {
         
         // When typing Maestro pattern, only Maestro should be visible.
         item.value = "56"
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
             XCTAssertEqual(visa.isHidden, true)
             XCTAssertEqual(mc.isHidden, true)
             XCTAssertEqual(amex.isHidden, true)
@@ -68,8 +68,8 @@ class FormCardNumberItemTests: XCTestCase {
         
         // When typing Mastercard pattern, only Mastercard should be visible.
         item.value = "55"
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
             XCTAssertEqual(visa.isHidden, true)
             XCTAssertEqual(mc.isHidden, false)
             XCTAssertEqual(amex.isHidden, true)
@@ -79,8 +79,8 @@ class FormCardNumberItemTests: XCTestCase {
         
         // When continuing to type, Mastercard should remain visible.
         item.value = "5555"
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
             XCTAssertEqual(visa.isHidden, true)
             XCTAssertEqual(mc.isHidden, false)
             XCTAssertEqual(amex.isHidden, true)
@@ -90,19 +90,19 @@ class FormCardNumberItemTests: XCTestCase {
         
         // Clearing the field should bring back both logos.
         item.value = ""
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
-            XCTAssertEqual(visa.isHidden, false)
-            XCTAssertEqual(mc.isHidden, false)
-            XCTAssertEqual(amex.isHidden, false)
-            XCTAssertEqual(cup.isHidden, false)
-            XCTAssertEqual(maestro.isHidden, false)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
+            XCTAssertEqual(visa.isHidden, true)
+            XCTAssertEqual(mc.isHidden, true)
+            XCTAssertEqual(amex.isHidden, true)
+            XCTAssertEqual(cup.isHidden, true)
+            XCTAssertEqual(maestro.isHidden, true)
         }
         
         // When typing VISA pattern, only VISA should be visible.
         item.value = "4"
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
             XCTAssertEqual(visa.isHidden, false)
             XCTAssertEqual(mc.isHidden, true)
             XCTAssertEqual(amex.isHidden, true)
@@ -112,8 +112,8 @@ class FormCardNumberItemTests: XCTestCase {
         
         // When typing Amex pattern, only Amex should be visible.
         item.value = "34"
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
             XCTAssertEqual(visa.isHidden, true)
             XCTAssertEqual(mc.isHidden, true)
             XCTAssertEqual(amex.isHidden, false)
@@ -123,8 +123,8 @@ class FormCardNumberItemTests: XCTestCase {
         
         // When typing common pattern, all matching cards should be visible.
         item.value = "62"
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
             XCTAssertEqual(visa.isHidden, true)
             XCTAssertEqual(mc.isHidden, true)
             XCTAssertEqual(amex.isHidden, true)
@@ -148,8 +148,8 @@ class FormCardNumberItemTests: XCTestCase {
         let maestro = item.cardTypeLogos[4]
 
         item.value = "1234567890"
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
             XCTAssertEqual(visa.isHidden, true)
             XCTAssertEqual(mc.isHidden, true)
             XCTAssertEqual(amex.isHidden, true)
@@ -173,8 +173,8 @@ class FormCardNumberItemTests: XCTestCase {
 
         // When entering PAN, Mastercard should remain visible.
         item.value = "5577000055770004"
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
             XCTAssertEqual(visa.isHidden, true)
             XCTAssertEqual(mc.isHidden, false)
             XCTAssertEqual(amex.isHidden, true)
@@ -184,8 +184,8 @@ class FormCardNumberItemTests: XCTestCase {
 
         // When entering too long PAN, all logos should be hidden.
         item.value = "55770000557700040"
-        cardTypeProvider.requestCardType(for: item.value, supported: supportedCardTypes) { response in
-            item.didChange(detectedCards: response, for: item.value)
+        cardTypeProvider.requestCardTypes(for: item.value, supported: supportedCardTypes) { response in
+            item.showLogos(for: response)
             XCTAssertEqual(visa.isHidden, true)
             XCTAssertEqual(mc.isHidden, true)
             XCTAssertEqual(amex.isHidden, true)

--- a/AdyenTests/Card Tests/Mocks/CardTypeProviderMock.swift
+++ b/AdyenTests/Card Tests/Mocks/CardTypeProviderMock.swift
@@ -10,7 +10,7 @@ final class CardTypeProviderMock: AnyCardTypeProvider {
 
     var onFetch: ((_ completion: @escaping ([CardType]) -> Void) -> Void)?
 
-    func requestCardType(for bin: String, supported cardType: [CardType], completion caller: @escaping ([CardType]) -> Void) {
+    func requestCardTypes(for bin: String, supported cardType: [CardType], completion caller: @escaping ([CardType]) -> Void) {
         onFetch?(caller)
     }
 }

--- a/AdyenTests/Card Tests/Utilities/CardTypeProviderTests.swift
+++ b/AdyenTests/Card Tests/Utilities/CardTypeProviderTests.swift
@@ -33,7 +33,7 @@ class CardTypeProviderTests: XCTestCase {
         apiClientMock.onExecute = {
             XCTFail("Shoul not call APIClient")
         }
-        sut.requestCardType(for: "56", supported: [.masterCard, .visa, .maestro]) { result in
+        sut.requestCardTypes(for: "56", supported: [.masterCard, .visa, .maestro]) { result in
             XCTAssertEqual(result, [.maestro])
         }
     }
@@ -41,7 +41,7 @@ class CardTypeProviderTests: XCTestCase {
     func testRemoteCardTypeFetch() {
         cardPublicKeyProvider.onFetch = { $0(.success(Dummy.dummyPublicKey)) }
         apiClientMock.mockedResults = [.success(BinLookupResponse(detectedBrands: [.solo]))]
-        sut.requestCardType(for: "5656565656565656", supported: [.masterCard, .visa, .maestro]) { result in
+        sut.requestCardTypes(for: "5656565656565656", supported: [.masterCard, .visa, .maestro]) { result in
             XCTAssertEqual(result, [.solo])
         }
     }
@@ -49,7 +49,7 @@ class CardTypeProviderTests: XCTestCase {
     func testLocalCardTypeFetchWhenPublicKeyFailure() {
         cardPublicKeyProvider.onFetch = { $0(.failure(Dummy.dummyError)) }
         apiClientMock.onExecute = { XCTFail("Shoul not call APIClient") }
-        sut.requestCardType(for: "56", supported: [.masterCard, .visa, .maestro]) { result in
+        sut.requestCardTypes(for: "56", supported: [.masterCard, .visa, .maestro]) { result in
             XCTAssertEqual(result, [.maestro])
         }
     }
@@ -57,7 +57,7 @@ class CardTypeProviderTests: XCTestCase {
     func testRemoteCardTypeFetchWhenPublicKeyFailure() {
         cardPublicKeyProvider.onFetch = { $0(.failure(Dummy.dummyError)) }
         apiClientMock.onExecute = { XCTFail("Shoul not call APIClient") }
-        sut.requestCardType(for: "5656565656565656", supported: [.masterCard, .visa, .maestro]) { result in
+        sut.requestCardTypes(for: "5656565656565656", supported: [.masterCard, .visa, .maestro]) { result in
             XCTAssertEqual(result, [.maestro])
         }
     }

--- a/AdyenUIHost/Application/Configuration.swift
+++ b/AdyenUIHost/Application/Configuration.swift
@@ -8,7 +8,7 @@ import Adyen
 import Foundation
 import PassKit
 
-internal struct Configuration {
+internal enum Configuration {
     // swiftlint:disable explicit_acl
     
     static let environment = DemoServerEnvironment.test


### PR DESCRIPTION
## Open PR

### Changes

* CardNumberItem is no longer responsible for card type logo presentation logic - simply shows what is in there. All logic for limiting of max card type logos shown, invalid and empty states are moved to CardComponent. 
* rename some internal API
* refactor some internal logic