### PR TITLE
Conditionally compile ViewControllerPresenter.swift file

### DIFF
--- a/Adyen/UI/SwiftUI/Present View Controller/ViewControllerPresenter.swift
+++ b/Adyen/UI/SwiftUI/Present View Controller/ViewControllerPresenter.swift
@@ -6,100 +6,102 @@
 
 import SwiftUI
 
-/// :nodoc:
-@available(iOS 13.0, *)
-extension View {
+#if canImport(SwiftUI) && canImport(Combine)
+    /// :nodoc:
+    @available(iOS 13.0, *)
+    public extension View {
 
-    /// Present a `ViewController` modally.
-    ///
-    /// - Parameter viewController: A `Binding<UIViewController?>` instance,
-    /// set the `wrappedValue` to a view controller instance to dismiss the previous view controller if it had previously a value
-    /// and presents the new one,
-    /// set it to `nil` to dismiss the previous view Controller if any.
-    public func present(viewController: Binding<UIViewController?>) -> some View {
-        modifier(ViewControllerPresenter(viewController: viewController))
-    }
-}
-
-/// :nodoc:
-@available(iOS 13.0, *)
-internal struct ViewControllerPresenter: ViewModifier {
-
-    @Binding internal var viewController: UIViewController?
-
-    internal func body(content: Content) -> some View {
-        ZStack {
-            FullScreenView(viewController: $viewController)
-            content
-        }
-    }
-}
-
-/// :nodoc:
-@available(iOS 13.0, *)
-internal final class FullScreenView: UIViewControllerRepresentable {
-
-    @Binding internal var viewController: UIViewController?
-
-    internal init(viewController: Binding<UIViewController?>) {
-        self._viewController = viewController
-    }
-
-    internal final class Coordinator {
-
-        fileprivate var currentlyPresentedViewController: UIViewController?
-    }
-
-    internal func makeUIViewController(context: UIViewControllerRepresentableContext<FullScreenView>) -> UIViewController {
-        return UIViewController()
-    }
-
-    internal func makeCoordinator() -> Coordinator {
-        Coordinator()
-    }
-
-    internal func updateUIViewController(_ uiViewController: UIViewController, context: UIViewControllerRepresentableContext<FullScreenView>) {
-        if let viewController = viewController, viewController !== context.coordinator.currentlyPresentedViewController {
-
-            dismissIfNeededThenPresent(viewController: viewController, presenter: uiViewController, context: context)
-
-        } else if context.coordinator.currentlyPresentedViewController != nil, viewController == nil {
-
-            dismiss(presenter: uiViewController, context: context, completion: nil)
+        /// Present a `ViewController` modally.
+        ///
+        /// - Parameter viewController: A `Binding<UIViewController?>` instance,
+        /// set the `wrappedValue` to a view controller instance to dismiss the previous view controller if it had previously a value
+        /// and presents the new one,
+        /// set it to `nil` to dismiss the previous view Controller if any.
+        func present(viewController: Binding<UIViewController?>) -> some View {
+            modifier(ViewControllerPresenter(viewController: viewController))
         }
     }
 
-    private func dismissIfNeededThenPresent(viewController: UIViewController,
-                                            presenter: UIViewController,
-                                            context: UIViewControllerRepresentableContext<FullScreenView>) {
-        if context.coordinator.currentlyPresentedViewController != nil {
+    /// :nodoc:
+    @available(iOS 13.0, *)
+    internal struct ViewControllerPresenter: ViewModifier {
 
-            dismiss(presenter: presenter, context: context) { [weak self] in
-                self?.present(viewController: viewController, presenter: presenter, context: context)
+        @Binding internal var viewController: UIViewController?
+
+        internal func body(content: Content) -> some View {
+            ZStack {
+                FullScreenView(viewController: $viewController)
+                content
             }
-        } else {
-            present(viewController: viewController, presenter: presenter, context: context)
         }
     }
 
-    private func present(viewController: UIViewController,
-                         presenter: UIViewController,
-                         context: UIViewControllerRepresentableContext<FullScreenView>) {
-        guard !viewController.isBeingPresented, !viewController.isBeingDismissed else { return }
-        presenter.present(viewController, animated: true) {
-            context.coordinator.currentlyPresentedViewController = viewController
+    /// :nodoc:
+    @available(iOS 13.0, *)
+    internal final class FullScreenView: UIViewControllerRepresentable {
+
+        @Binding internal var viewController: UIViewController?
+
+        internal init(viewController: Binding<UIViewController?>) {
+            self._viewController = viewController
+        }
+
+        internal final class Coordinator {
+
+            fileprivate var currentlyPresentedViewController: UIViewController?
+        }
+
+        internal func makeUIViewController(context: UIViewControllerRepresentableContext<FullScreenView>) -> UIViewController {
+            return UIViewController()
+        }
+
+        internal func makeCoordinator() -> Coordinator {
+            Coordinator()
+        }
+
+        internal func updateUIViewController(_ uiViewController: UIViewController, context: UIViewControllerRepresentableContext<FullScreenView>) {
+            if let viewController = viewController, viewController !== context.coordinator.currentlyPresentedViewController {
+
+                dismissIfNeededThenPresent(viewController: viewController, presenter: uiViewController, context: context)
+
+            } else if context.coordinator.currentlyPresentedViewController != nil, viewController == nil {
+
+                dismiss(presenter: uiViewController, context: context, completion: nil)
+            }
+        }
+
+        private func dismissIfNeededThenPresent(viewController: UIViewController,
+                                                presenter: UIViewController,
+                                                context: UIViewControllerRepresentableContext<FullScreenView>) {
+            if context.coordinator.currentlyPresentedViewController != nil {
+
+                dismiss(presenter: presenter, context: context) { [weak self] in
+                    self?.present(viewController: viewController, presenter: presenter, context: context)
+                }
+            } else {
+                present(viewController: viewController, presenter: presenter, context: context)
+            }
+        }
+
+        private func present(viewController: UIViewController,
+                             presenter: UIViewController,
+                             context: UIViewControllerRepresentableContext<FullScreenView>) {
+            guard !viewController.isBeingPresented, !viewController.isBeingDismissed else { return }
+            presenter.present(viewController, animated: true) {
+                context.coordinator.currentlyPresentedViewController = viewController
+            }
+        }
+
+        private func dismiss(presenter: UIViewController,
+                             context: UIViewControllerRepresentableContext<FullScreenView>,
+                             completion: (() -> Void)?) {
+            guard let viewController = context.coordinator.currentlyPresentedViewController else { return }
+            guard !viewController.isBeingPresented, !viewController.isBeingDismissed else { return }
+
+            presenter.dismiss(animated: true) {
+                context.coordinator.currentlyPresentedViewController = nil
+                completion?()
+            }
         }
     }
-
-    private func dismiss(presenter: UIViewController,
-                         context: UIViewControllerRepresentableContext<FullScreenView>,
-                         completion: (() -> Void)?) {
-        guard let viewController = context.coordinator.currentlyPresentedViewController else { return }
-        guard !viewController.isBeingPresented, !viewController.isBeingDismissed else { return }
-
-        presenter.dismiss(animated: true) {
-            context.coordinator.currentlyPresentedViewController = nil
-            completion?()
-        }
-    }
-}
+#endif


### PR DESCRIPTION
## Summary
Conditionally compile ViewControllerPresenter.swift file only in case the project is iOS 13+ and compiler can import SwiftUI and Combine

## Tested scenarios
 Tested archiving a release build of the SDK


**Fixed issue**: 
Fixed the issue where release builds are failing because we have minimum deployment target 10, but ViewControllerPresenter.swift requires iOS 13+, SwiftUI and Combine framework.
