### PR TITLE
Retains dismiss closure in Apple Pay

### DIFF
--- a/Adyen/Components/Apple Pay/ApplePayComponentExtensions.swift
+++ b/Adyen/Components/Apple Pay/ApplePayComponentExtensions.swift
@@ -14,12 +14,12 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     
     /// :nodoc:
     public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
-        controller.dismiss(animated: true) {
+        controller.dismiss(animated: true) { [dismissCompletion] in
             self.delegate?.didFail(with: ComponentError.cancelled, from: self)
-            self.dismissCompletion?()
+            dismissCompletion?()
+            self.dismissCompletion = nil
         }
-        paymentAuthorizationViewController = nil
-        dismissCompletion = nil
+        self.paymentAuthorizationViewController = nil
     }
     
     /// :nodoc:


### PR DESCRIPTION
## Summary
While implementing Apple Pay in iOS using the Drop In SDK we noticed that when calling `stopLoading(withSuccess success: Bool, completion:)` method, that our completion block was never called. This meant that we were unable to finish our transaction when the Apple Pay sheet finishes dismissing.

This fix ensures that the `dismissCompletion` closure is captured in the dismiss closure and called. As far as I can tell, the closure was being deallocated before it could be called. Capturing it in the closure prevents this from happening and our closure is called successfuly and was also subject to a potential race condition where it could be set to nil before being called inside the closure.

## Tested scenarios
We have tested this in our own application but this is a limited use case. I'd encourage testing in other applications/scenarios and assessing any other affects my code change could have as I am not familiar with the entire Adyen codebase. This change was required for us to successfuly. We call the method like so:

```
dropInComponent?.stopLoading(withSuccess: true, completion: { [weak self] in
                   /// Perform post-transaction actions
                })
```

Tested in iOS 14.1 with the Adyen SDK attached via SPM on the develop branch.

There is currently no open issue for this problem. Happy to open one for tracking purposes if required.
