### PR TITLE
chore: added the COCOAPODS_TRUNK_TOKEN for publishing the Adyen.podspec

### DIFF
--- a/.github/workflows/publich_podspec.yml
+++ b/.github/workflows/publich_podspec.yml
@@ -16,3 +16,5 @@ jobs:
       run: |
         gem install cocoapods
         pod trunk push Adyen.podspec --allow-warnings
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
chore: added the COCOAPODS_TRUNK_TOKEN for publishing the Adyen.podspec.