### PR TITLE
ApplePay delegate.didFail fix

### DIFF
--- a/Adyen/Components/Apple Pay/ApplePayComponent.swift
+++ b/Adyen/Components/Apple Pay/ApplePayComponent.swift
@@ -251,6 +251,7 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
     private func getPaymentAuthorizationViewController() -> PKPaymentAuthorizationViewController? {
         if paymentAuthorizationViewController == nil {
             paymentAuthorizationViewController = newPaymentAuthorizationViewController()
+            isSuccessfull = false
         }
         return paymentAuthorizationViewController
     }

--- a/Adyen/Components/Apple Pay/ApplePayComponent.swift
+++ b/Adyen/Components/Apple Pay/ApplePayComponent.swift
@@ -84,6 +84,10 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
     
     /// Apple Pay component configuration.
     private let configuration: Configuration
+
+    /// Flag to verify if ApplePay is successfully finished.
+    /// :nodoc:
+    internal var isSuccessfull = false
     
     /// Initializes the component.
     ///
@@ -215,6 +219,7 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
     
     /// :nodoc:
     public func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
+        isSuccessfull = success
         paymentAuthorizationCompletion?(success ? .success : .failure)
         dismiss(callback: completion)
     }

--- a/Adyen/Components/Apple Pay/ApplePayComponent.swift
+++ b/Adyen/Components/Apple Pay/ApplePayComponent.swift
@@ -85,9 +85,9 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
     /// Apple Pay component configuration.
     private let configuration: Configuration
 
-    /// Flag to verify if ApplePay is successfully finished.
+    /// Flag to indicate that component wasn't stopped by the merchant's code. By default all cancelations assumed to be initiated by the user.
     /// :nodoc:
-    internal var isSuccessfull = false
+    internal var isUserCancel = true
     
     /// Initializes the component.
     ///
@@ -219,7 +219,7 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
     
     /// :nodoc:
     public func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
-        isSuccessfull = success
+        isUserCancel = false
         paymentAuthorizationCompletion?(success ? .success : .failure)
         dismiss(callback: completion)
     }
@@ -251,7 +251,7 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
     private func getPaymentAuthorizationViewController() -> PKPaymentAuthorizationViewController? {
         if paymentAuthorizationViewController == nil {
             paymentAuthorizationViewController = newPaymentAuthorizationViewController()
-            isSuccessfull = false
+            isUserCancel = true
         }
         return paymentAuthorizationViewController
     }

--- a/Adyen/Components/Apple Pay/ApplePayComponentExtensions.swift
+++ b/Adyen/Components/Apple Pay/ApplePayComponentExtensions.swift
@@ -14,7 +14,9 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     
     /// :nodoc:
     public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
-        self.delegate?.didFail(with: ComponentError.cancelled, from: self)
+        if !isSuccessfull {
+            self.delegate?.didFail(with: ComponentError.cancelled, from: self)
+        }
     }
     
     /// :nodoc:

--- a/Adyen/Components/Apple Pay/ApplePayComponentExtensions.swift
+++ b/Adyen/Components/Apple Pay/ApplePayComponentExtensions.swift
@@ -14,7 +14,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     
     /// :nodoc:
     public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
-        if !isSuccessfull {
+        if isUserCancel {
             self.delegate?.didFail(with: ComponentError.cancelled, from: self)
         }
     }

--- a/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTest.swift
+++ b/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTest.swift
@@ -68,6 +68,22 @@ class ApplePayComponentTest: XCTestCase {
         sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
         waitForExpectations(timeout: 2)
     }
+
+    func testApplePayViewControllerDoNotCallsDelgateDidFailWhenStopLoadingComponent() {
+        let viewController = sut!.viewController
+        let onDidFailExpectation = expectation(description: "Wait for delegate call")
+        mockDelegate.onDidFail = { error, component in
+            XCTFail("Should not call delegate")
+        }
+
+        UIApplication.shared.keyWindow?.rootViewController = UINavigationController(rootViewController: UIViewController())
+        UIApplication.shared.keyWindow?.rootViewController?.present(viewController, animated: true)
+
+        sut.stopLoading(withSuccess: true) { onDidFailExpectation.fulfill() }
+        sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
+
+        waitForExpectations(timeout: 5)
+    }
     
     func testApplePayViewControllerIsResetAfterAuthorization() {
         let viewController = sut!.viewController

--- a/Common Example code/Domains/Components/ComponentsViewController.swift
+++ b/Common Example code/Domains/Components/ComponentsViewController.swift
@@ -34,6 +34,7 @@ internal final class ComponentsViewController: UIViewController, Presenter {
             ],
             [
                 ComponentsItem(title: "Card", selectionHandler: presentCardComponent),
+                ComponentsItem(title: "ApplePay", selectionHandler: presentApplePayComponent),
                 ComponentsItem(title: "iDEAL", selectionHandler: presentIdealComponent),
                 ComponentsItem(title: "SEPA Direct Debit", selectionHandler: presentSEPADirectDebitComponent),
                 ComponentsItem(title: "MB WAY", selectionHandler: presentMBWayComponent)
@@ -63,6 +64,10 @@ internal final class ComponentsViewController: UIViewController, Presenter {
 
     internal func presentMBWayComponent() {
         controller.presentMBWayComponent()
+    }
+
+    internal func presentApplePayComponent() {
+        controller.presentApplePayComponent()
     }
 
     internal func requestPaymentMethods() {

--- a/Common Example code/PaymentsController.swift
+++ b/Common Example code/PaymentsController.swift
@@ -131,6 +131,20 @@ internal final class PaymentsController {
         present(component)
     }
 
+    internal func presentApplePayComponent() {
+        guard let paymentMethod = paymentMethods?.paymentMethod(ofType: ApplePayPaymentMethod.self) else { return }
+        let config = ApplePayComponent.Configuration(summaryItems: Configuration.applePaySummaryItems,
+                                                     merchantIdentifier: Configuration.applePayMerchantIdentifier)
+        let component = try? ApplePayComponent(paymentMethod: paymentMethod,
+                                               payment: payment,
+                                               configuration: config) {
+            print("ApplePay dismissed")
+        }
+        component?.delegate = self
+        guard let presentableComponent = component else { return }
+        present(presentableComponent)
+    }
+
     // MARK: - Networking
 
     private lazy var apiClient: APIClientProtocol = {


### PR DESCRIPTION
## Open PR

### Changes

* prevent ApplePay calling `delegate.didFail` on success
* add ApplePay component integration to ComponentsController

