### PR TITLE
Brand-protected icons for payment methods

### DIFF
--- a/Adyen/Helpers/UIViewHelpers.swift
+++ b/Adyen/Helpers/UIViewHelpers.swift
@@ -61,7 +61,7 @@ public extension AdyenScope where Base: UIView {
             let radius = value * min(base.bounds.height, base.bounds.width)
             base.layer.cornerRadius = radius
         case .none:
-            break
+            base.layer.cornerRadius = 0
         }
     }
     

--- a/Adyen/UI/List/ListItem.swift
+++ b/Adyen/UI/List/ListItem.swift
@@ -31,6 +31,9 @@ public class ListItem: FormItem {
     /// An identifier for the `ListItem`,
     /// that is set to the `ListItemView.accessibilityIdentifier`.
     public var identifier: String?
+
+    /// The flag to indicate if an icon is a custom image that should not be tempered.
+    public let canModifyIcon: Bool
     
     /// Initializes the list item.
     ///
@@ -41,16 +44,19 @@ public class ListItem: FormItem {
     ///   - showsDisclosureIndicator: A boolean value indicating whether a disclosure indicator
     ///                               should be shown in the item's cell.
     ///   - selectionHandler: The closure to execute when an item is selected.
+    ///   - canModifyIcon: The flag to indicate that image could be tampered.
     public init(title: String,
                 imageURL: URL? = nil,
                 style: ListItemStyle = ListItemStyle(),
                 showsDisclosureIndicator: Bool = true,
-                selectionHandler: (() -> Void)? = nil) {
+                selectionHandler: (() -> Void)? = nil,
+                canModifyIcon: Bool = true) {
         self.title = title
         self.imageURL = imageURL
         self.style = style
         self.showsDisclosureIndicator = showsDisclosureIndicator
         self.selectionHandler = selectionHandler
+        self.canModifyIcon = canModifyIcon
     }
     
     public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {

--- a/Adyen/UI/List/ListItemView.swift
+++ b/Adyen/UI/List/ListItemView.swift
@@ -82,6 +82,10 @@ public final class ListItemView: UIView, AnyFormItemView {
     
     private func updateImageView(style: ListItemStyle) {
         imageView.contentMode = style.image.contentMode
+        guard item?.canModifyIcon == true else {
+            return imageView.layer.borderWidth = 0
+        }
+
         imageView.clipsToBounds = style.image.clipsToBounds
         imageView.layer.borderWidth = style.image.borderWidth
         imageView.layer.borderColor = style.image.borderColor?.cgColor
@@ -99,7 +103,12 @@ public final class ListItemView: UIView, AnyFormItemView {
     
     override public func layoutSubviews() {
         super.layoutSubviews()
-        imageView.adyen.round(using: item?.style.image.cornerRounding ?? .fixed(4))
+
+        guard item?.canModifyIcon == true else {
+            return imageView.adyen.round(using: .none)
+        }
+
+        imageView.adyen.round(using: item?.style.image.cornerRounding ?? .fixed(8))
     }
     
     // MARK: - Title Label
@@ -164,6 +173,10 @@ public final class ListItemView: UIView, AnyFormItemView {
     override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         
+        guard item?.canModifyIcon == true else {
+            return imageView.layer.borderColor = nil
+        }
+
         imageView.layer.borderColor = item?.style.image.borderColor?.cgColor ?? UIColor.AdyenCore.componentSeparator.cgColor
     }
     

--- a/AdyenDropIn/Components/PaymentMethodListComponent.swift
+++ b/AdyenDropIn/Components/PaymentMethodListComponent.swift
@@ -39,13 +39,18 @@ internal final class PaymentMethodListComponent: LoadingComponent, Localizable {
     
     /// :nodoc:
     internal var viewController: UIViewController { listViewController }
+
+    private let brandProtectedComponents: Set = ["applepay"]
     
     internal lazy var listViewController: ListViewController = {
         func item(for component: PaymentComponent) -> ListItem {
             let showsDisclosureIndicator = (component as? PresentableComponent)?.requiresModalPresentation == true
             
             let displayInformation = component.paymentMethod.localizedDisplayInformation(using: localizationParameters)
-            let listItem = ListItem(title: displayInformation.title, style: style.listItem)
+            let isProtected = brandProtectedComponents.contains(component.paymentMethod.type)
+            let listItem = ListItem(title: displayInformation.title,
+                                    style: style.listItem,
+                                    canModifyIcon: !isProtected)
             listItem.identifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: listItem.title)
             listItem.imageURL = LogoURLProvider.logoURL(for: component.paymentMethod, environment: environment)
             listItem.subtitle = displayInformation.subtitle


### PR DESCRIPTION
## Open PR

### Changes

* add custom icon for ApplePay
* allow brand protected icons remain untampered on DropIn