### PR TITLE
Supported networks Apple Pay from paymentMethods

### DIFF
--- a/Adyen/Core/Payment Methods/ApplePayPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/ApplePayPaymentMethod.swift
@@ -14,6 +14,9 @@ public struct ApplePayPaymentMethod: PaymentMethod {
     
     /// :nodoc:
     public let name: String
+
+    /// :nodoc:
+    public let brands: [String]?
     
     /// :nodoc:
     public func buildComponent(using builder: PaymentComponentBuilder) -> PaymentComponent? {

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -10,56 +10,25 @@ import PassKit
 
 /// A component that handles Apple Pay payments.
 public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent, Localizable {
-    
-    /// Describes the error that can occur during Apple Pay payment.
-    public enum Error: Swift.Error, LocalizedError {
-        /// Indicates that the user can't make payments on any of the payment request’s supported networks.
-        case userCannotMakePayment
-        
-        /// Indicates that the current device's hardware doesn't support ApplePay.
-        case deviceDoesNotSupportApplyPay
-        
-        /// Indicates that the summaryItems array is empty.
-        case emptySummaryItems
-        
-        /// Indicates that the grand total summary item is a negative value.
-        case negativeGrandTotal
-        
-        /// Indicates that at least one of the summary items has an invalid amount.
-        case invalidSummaryItem
-        
-        /// Indicates that the country code is invalid.
-        case invalidCountryCode
-        
-        /// Indicates that the currency code is invalid.
-        case invalidCurrencyCode
-        
-        /// :nodoc:
-        public var errorDescription: String? {
-            switch self {
-            case .userCannotMakePayment:
-                return "The user can’t make payments on any of the payment request’s supported networks."
-            case .deviceDoesNotSupportApplyPay:
-                return "The current device's hardware doesn't support ApplePay."
-            case .emptySummaryItems:
-                return "The summaryItems array is empty."
-            case .negativeGrandTotal:
-                return "The grand total summary item should be greater than or equal to zero."
-            case .invalidSummaryItem:
-                return "At least one of the summary items has an invalid amount."
-            case .invalidCountryCode:
-                return "The country code is invalid."
-            case .invalidCurrencyCode:
-                return "The currency code is invalid."
-            }
-        }
-    }
+
+    /// Apple Pay component configuration.
+    internal let configuration: Configuration
+
+    /// Flag to indicate that component wasn't stopped by the merchant's code.
+    /// By default all cancelations assumed to be initiated by the user.
+    /// :nodoc:
+    internal var isUserCancel = true
+    internal var paymentAuthorizationCompletion: ((PKPaymentAuthorizationStatus) -> Void)?
+    internal var paymentAuthorizationViewController: PKPaymentAuthorizationViewController?
+    internal var dismissCompletion: (() -> Void)?
     
     /// The delegate of the component.
     public weak var delegate: PaymentComponentDelegate?
     
     /// The Apple Pay payment method.
-    public let paymentMethod: PaymentMethod
+    public var paymentMethod: PaymentMethod {
+        configuration.paymentMethod
+    }
     
     /// The line items for this payment.
     public var summaryItems: [PKPaymentSummaryItem] {
@@ -78,24 +47,10 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
         configuration.requiredShippingContactFields
     }
     
-    /// The merchant identifier for apple pay.
-    private var merchantIdentifier: String {
-        configuration.merchantIdentifier
-    }
-    
-    /// Apple Pay component configuration.
-    private let configuration: Configuration
-
-    /// Flag to indicate that component wasn't stopped by the merchant's code.
-    /// By default all cancelations assumed to be initiated by the user.
-    /// :nodoc:
-    internal var isUserCancel = true
-    
     /// Initializes the component.
     ///
     /// - Warning: `stopLoading()` must be called before dismissing this component.
     ///
-    /// - Parameter paymentMethod: The Apple Pay payment method.
     /// - Parameter payment: A description of the payment. Must include an amount and country code.
     /// - Parameter configuration: Apple Pay component configuration.
     /// - Parameter cancelHandler: Being called on cancel, e.g. when the user taps "cancel".
@@ -107,8 +62,7 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
     /// - Throws: `ApplePayComponent.Error.invalidSummaryItem` if at least one of the summary items has an invalid amount.
     /// - Throws: `ApplePayComponent.Error.invalidCountryCode` if the `payment.countryCode` is not a valid ISO country code.
     /// - Throws: `ApplePayComponent.Error.invalidCurrencyCode` if the `payment.amount.currencyCode` is not a valid ISO currency code.
-    public init(paymentMethod: ApplePayPaymentMethod,
-                payment: Payment,
+    public init(payment: Payment,
                 configuration: Configuration,
                 cancelHandler: (() -> Void)? = nil) throws {
         guard PKPaymentAuthorizationViewController.canMakePayments() else {
@@ -133,17 +87,12 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
             throw Error.invalidSummaryItem
         }
         
-        self.paymentMethod = paymentMethod
-        self.applePayPaymentMethod = paymentMethod
         self.configuration = configuration
         self.dismissCompletion = cancelHandler
-        
         super.init()
-        
+
         self.payment = payment
     }
-    
-    internal let applePayPaymentMethod: ApplePayPaymentMethod
     
     // MARK: - Presentable Component Protocol
     
@@ -164,10 +113,6 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
     
     // MARK: - Private
     
-    internal var paymentAuthorizationCompletion: ((PKPaymentAuthorizationStatus) -> Void)?
-    
-    internal var dismissCompletion: (() -> Void)?
-    
     private lazy var errorAlertController: UIAlertController = {
         let alertController = UIAlertController(title: ADYLocalizedString("adyen.error.title", localizationParameters),
                                                 message: ADYLocalizedString("adyen.error.unknown", localizationParameters),
@@ -183,8 +128,6 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
         alertController.addAction(dismissAction)
         return alertController
     }()
-    
-    internal var paymentAuthorizationViewController: PKPaymentAuthorizationViewController?
     
     private func getPaymentAuthorizationViewController() -> PKPaymentAuthorizationViewController? {
         if paymentAuthorizationViewController == nil {
@@ -208,7 +151,7 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
         let paymentRequest = PKPaymentRequest()
         
         paymentRequest.countryCode = payment?.countryCode ?? ""
-        paymentRequest.merchantIdentifier = merchantIdentifier
+        paymentRequest.merchantIdentifier = configuration.merchantIdentifier
         paymentRequest.currencyCode = payment?.amount.currencyCode ?? ""
         paymentRequest.supportedNetworks = configuration.supportedNetworks
         paymentRequest.merchantCapabilities = .capability3DS
@@ -236,4 +179,52 @@ public class ApplePayComponent: NSObject, PaymentComponent, PresentableComponent
             self.dismissCompletion = nil
         }
     }
+}
+
+extension ApplePayComponent {
+
+    /// Describes the error that can occur during Apple Pay payment.
+    public enum Error: Swift.Error, LocalizedError {
+        /// Indicates that the user can't make payments on any of the payment request’s supported networks.
+        case userCannotMakePayment
+
+        /// Indicates that the current device's hardware doesn't support ApplePay.
+        case deviceDoesNotSupportApplyPay
+
+        /// Indicates that the summaryItems array is empty.
+        case emptySummaryItems
+
+        /// Indicates that the grand total summary item is a negative value.
+        case negativeGrandTotal
+
+        /// Indicates that at least one of the summary items has an invalid amount.
+        case invalidSummaryItem
+
+        /// Indicates that the country code is invalid.
+        case invalidCountryCode
+
+        /// Indicates that the currency code is invalid.
+        case invalidCurrencyCode
+
+        /// :nodoc:
+        public var errorDescription: String? {
+            switch self {
+            case .userCannotMakePayment:
+                return "The user can’t make payments on any of the payment request’s supported networks."
+            case .deviceDoesNotSupportApplyPay:
+                return "The current device's hardware doesn't support ApplePay."
+            case .emptySummaryItems:
+                return "The summaryItems array is empty."
+            case .negativeGrandTotal:
+                return "The grand total summary item should be greater than or equal to zero."
+            case .invalidSummaryItem:
+                return "At least one of the summary items has an invalid amount."
+            case .invalidCountryCode:
+                return "The country code is invalid."
+            case .invalidCurrencyCode:
+                return "The currency code is invalid."
+            }
+        }
+    }
+
 }

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -64,9 +64,6 @@ extension ApplePayComponent {
         /// Ignored on iOS 10.*.
         public var requiredShippingContactFields: Set<PKContactField> = []
 
-        /// The excluded card brands.
-        public var excludedCardNetworks: [PKPaymentNetwork] = []
-
         // :nodoc:
         internal var supportedNetworks: [PKPaymentNetwork] {
             var networks = ApplePayComponent.defaultNetworks
@@ -76,7 +73,7 @@ extension ApplePayComponent {
                 networks = networks.filter { brandsSet.contains($0.adyenName) }
             }
 
-            return networks.filter { !excludedCardNetworks.contains($0) }
+            return networks
         }
         
         /// Initializes the configuration.
@@ -93,14 +90,12 @@ extension ApplePayComponent {
                     summaryItems: [PKPaymentSummaryItem],
                     merchantIdentifier: String,
                     requiredBillingContactFields: Set<PKContactField> = [],
-                    requiredShippingContactFields: Set<PKContactField> = [],
-                    excludedCardNetworks: [PKPaymentNetwork] = []) {
+                    requiredShippingContactFields: Set<PKContactField> = []) {
             self.paymentMethod = paymentMethod
             self.summaryItems = summaryItems
             self.merchantIdentifier = merchantIdentifier
             self.requiredBillingContactFields = requiredBillingContactFields
             self.requiredShippingContactFields = requiredShippingContactFields
-            self.excludedCardNetworks = excludedCardNetworks
         }
     }
 

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -30,7 +30,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         let network = payment.token.paymentMethod.network?.rawValue ?? ""
         let billingContact = payment.billingContact
         let shippingContact = payment.shippingContact
-        let details = ApplePayDetails(paymentMethod: applePayPaymentMethod,
+        let details = ApplePayDetails(paymentMethod: configuration.paymentMethod,
                                       token: token,
                                       network: network,
                                       billingContact: billingContact,
@@ -46,6 +46,9 @@ extension ApplePayComponent {
     
     /// Apple Pay component configuration.
     public struct Configuration {
+
+        /// The payment method for Apple Pay.
+        public let paymentMethod: ApplePayPaymentMethod
         
         /// The public key used for encrypting card details.
         public var summaryItems: [PKPaymentSummaryItem]
@@ -63,9 +66,22 @@ extension ApplePayComponent {
 
         /// The excluded card brands.
         public var excludedCardNetworks: [PKPaymentNetwork] = []
+
+        // :nodoc:
+        internal var supportedNetworks: [PKPaymentNetwork] {
+            var networks = ApplePayComponent.defaultNetworks
+            
+            if let brands = paymentMethod.brands {
+                let brandsSet = Set(brands)
+                networks = networks.filter { brandsSet.contains($0.adyenName) }
+            }
+
+            return networks.filter { !excludedCardNetworks.contains($0) }
+        }
         
         /// Initializes the configuration.
         ///
+        /// - Parameter paymentMethod: The Apple Pay payment method.
         /// - Parameter summaryItems: The line items for this payment.
         /// - Parameter merchantIdentifier: The merchant identifier.
         /// - Parameter requiredBillingContactFields:
@@ -73,31 +89,52 @@ extension ApplePayComponent {
         /// - Parameter requiredShippingContactFields:
         /// A list of fields that you need for a shipping contact in order to process the transaction. Ignored on iOS 10.*.
         /// - Parameter requiredShippingContactFields: The excluded card brands.
-        public init(summaryItems: [PKPaymentSummaryItem],
+        public init(paymentMethod: ApplePayPaymentMethod,
+                    summaryItems: [PKPaymentSummaryItem],
                     merchantIdentifier: String,
                     requiredBillingContactFields: Set<PKContactField> = [],
                     requiredShippingContactFields: Set<PKContactField> = [],
                     excludedCardNetworks: [PKPaymentNetwork] = []) {
+            self.paymentMethod = paymentMethod
             self.summaryItems = summaryItems
             self.merchantIdentifier = merchantIdentifier
             self.requiredBillingContactFields = requiredBillingContactFields
             self.requiredShippingContactFields = requiredShippingContactFields
             self.excludedCardNetworks = excludedCardNetworks
         }
-        
-        internal var supportedNetworks: [PKPaymentNetwork] {
-            var networks: [PKPaymentNetwork] = [.visa, .masterCard, .amex, .discover, .interac]
-            
-            if #available(iOS 12.0, *) {
-                networks.append(.maestro)
-            }
-            
-            if #available(iOS 10.1, *) {
-                networks.append(.JCB)
-            }
-            
-            return networks.filter { !excludedCardNetworks.contains($0) }
+    }
+
+    // Adyen supports: interac, visa, mc, electron, maestro, amex, jcb, discover, elodebit, elo.
+    // Will support girocard in future versions
+    internal static var defaultNetworks: [PKPaymentNetwork] {
+        var networks: [PKPaymentNetwork] = [.visa, .masterCard, .amex, .discover, .interac]
+
+        if #available(iOS 14.0, *) {
+            networks.append(.girocard)
         }
         
+        if #available(iOS 12.1.1, *) {
+            networks.append(.elo)
+        }
+
+        if #available(iOS 12.0, *) {
+            networks.append(.maestro)
+            networks.append(.electron)
+        }
+
+        if #available(iOS 10.1, *) {
+            networks.append(.JCB)
+        }
+
+        return networks
     }
+}
+
+extension PKPaymentNetwork {
+
+    internal var adyenName: String {
+        if self == .masterCard { return "mc" }
+        return self.rawValue.lowercased()
+    }
+
 }

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -133,13 +133,13 @@ internal final class ComponentManager {
         let excludedCardNetworks = configuration.applePay.excludedCardNetworks
         
         do {
-            let configuration = ApplePayComponent.Configuration(summaryItems: summaryItems,
+            let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+                                                                summaryItems: summaryItems,
                                                                 merchantIdentifier: identfier,
                                                                 requiredBillingContactFields: requiredBillingContactFields,
                                                                 requiredShippingContactFields: requiredShippingContactFields,
                                                                 excludedCardNetworks: excludedCardNetworks)
-            return try ApplePayComponent(paymentMethod: paymentMethod,
-                                         payment: payment,
+            return try ApplePayComponent(payment: payment,
                                          configuration: configuration)
         } catch {
             adyenPrint("Failed to instantiate ApplePayComponent because of error: \(error.localizedDescription)")

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -130,15 +130,13 @@ internal final class ComponentManager {
         
         let requiredBillingContactFields = configuration.applePay.requiredBillingContactFields
         let requiredShippingContactFields = configuration.applePay.requiredShippingContactFields
-        let excludedCardNetworks = configuration.applePay.excludedCardNetworks
         
         do {
             let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
                                                                 summaryItems: summaryItems,
                                                                 merchantIdentifier: identfier,
                                                                 requiredBillingContactFields: requiredBillingContactFields,
-                                                                requiredShippingContactFields: requiredShippingContactFields,
-                                                                excludedCardNetworks: excludedCardNetworks)
+                                                                requiredShippingContactFields: requiredShippingContactFields)
             return try ApplePayComponent(payment: payment,
                                          configuration: configuration)
         } catch {

--- a/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTest.swift
+++ b/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTest.swift
@@ -13,13 +13,15 @@ class ApplePayComponentTest: XCTestCase {
 
     var mockDelegate: PaymentComponentDelegateMock!
     var sut: ApplePayComponent!
+    lazy var amount = Payment.Amount(value: 2, currencyCode: getRandomCurrencyCode())
+    lazy var payment = Payment(amount: amount, countryCode: getRandomCountryCode())
 
     override func setUp() {
-        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name")
-        let amount = Payment.Amount(value: 2, currencyCode: getRandomCurrencyCode())
-        let payment = Payment(amount: amount, countryCode: getRandomCountryCode())
-        let configuration = ApplePayComponent.Configuration(summaryItems: createTestSummaryItems(), merchantIdentifier: "test_id")
-        sut = try? ApplePayComponent(paymentMethod: paymentMethod, payment: payment, configuration: configuration)
+        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: nil)
+        let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+                                                            summaryItems: createTestSummaryItems(),
+                                                            merchantIdentifier: "test_id")
+        sut = try? ApplePayComponent(payment: payment, configuration: configuration)
         mockDelegate = PaymentComponentDelegateMock()
         sut.delegate = mockDelegate
     }
@@ -104,11 +106,13 @@ class ApplePayComponentTest: XCTestCase {
     }
 
     func testInvalidCurrencyCode() {
-        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name")
+        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: nil)
         let amount = Payment.Amount(value: 2, currencyCode: "wqedf")
         let payment = Payment(amount: amount, countryCode: getRandomCountryCode())
-        let configuration = ApplePayComponent.Configuration(summaryItems: createTestSummaryItems(), merchantIdentifier: "test_id")
-        XCTAssertThrowsError(try ApplePayComponent(paymentMethod: paymentMethod, payment: payment, configuration: configuration)) { error in
+        let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+                                                            summaryItems: createTestSummaryItems(),
+                                                            merchantIdentifier: "test_id")
+        XCTAssertThrowsError(try ApplePayComponent(payment: payment, configuration: configuration)) { error in
             XCTAssertTrue(error is ApplePayComponent.Error)
             XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidCurrencyCode)
             XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The currency code is invalid.")
@@ -116,11 +120,12 @@ class ApplePayComponentTest: XCTestCase {
     }
     
     func testInvalidCountryCode() {
-        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name")
-        let amount = Payment.Amount(value: 2, currencyCode: getRandomCurrencyCode())
+        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: nil)
         let payment = Payment(amount: amount, countryCode: "asda")
-        let configuration = ApplePayComponent.Configuration(summaryItems: createTestSummaryItems(), merchantIdentifier: "test_id")
-        XCTAssertThrowsError(try ApplePayComponent(paymentMethod: paymentMethod, payment: payment, configuration: configuration)) { error in
+        let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+                                                            summaryItems: createTestSummaryItems(),
+                                                            merchantIdentifier: "test_id")
+        XCTAssertThrowsError(try ApplePayComponent(payment: payment, configuration: configuration)) { error in
             XCTAssertTrue(error is ApplePayComponent.Error)
             XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidCountryCode)
             XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The country code is invalid.")
@@ -128,11 +133,11 @@ class ApplePayComponentTest: XCTestCase {
     }
     
     func testEmptySummaryItems() {
-        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name")
-        let amount = Payment.Amount(value: 2, currencyCode: getRandomCurrencyCode())
-        let payment = Payment(amount: amount, countryCode: getRandomCountryCode())
-        let configuration = ApplePayComponent.Configuration(summaryItems: [], merchantIdentifier: "test_id")
-        XCTAssertThrowsError(try ApplePayComponent(paymentMethod: paymentMethod, payment: payment, configuration: configuration)) { error in
+        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: nil)
+        let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+                                                            summaryItems: [],
+                                                            merchantIdentifier: "test_id")
+        XCTAssertThrowsError(try ApplePayComponent(payment: payment, configuration: configuration)) { error in
             XCTAssertTrue(error is ApplePayComponent.Error)
             XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.emptySummaryItems)
             XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The summaryItems array is empty.")
@@ -140,11 +145,11 @@ class ApplePayComponentTest: XCTestCase {
     }
     
     func testGrandTotalIsNegative() {
-        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name")
-        let amount = Payment.Amount(value: 2, currencyCode: getRandomCurrencyCode())
-        let payment = Payment(amount: amount, countryCode: getRandomCountryCode())
-        let configuration = ApplePayComponent.Configuration(summaryItems: createInvalidGrandTotalTestSummaryItems(), merchantIdentifier: "test_id")
-        XCTAssertThrowsError(try ApplePayComponent(paymentMethod: paymentMethod, payment: payment, configuration: configuration)) { error in
+        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: nil)
+        let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+                                                            summaryItems: createInvalidGrandTotalTestSummaryItems(),
+                                                            merchantIdentifier: "test_id")
+        XCTAssertThrowsError(try ApplePayComponent(payment: payment, configuration: configuration)) { error in
             XCTAssertTrue(error is ApplePayComponent.Error)
             XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.negativeGrandTotal)
             XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The grand total summary item should be greater than or equal to zero.")
@@ -152,11 +157,11 @@ class ApplePayComponentTest: XCTestCase {
     }
     
     func testOneItemWithZeroAmount() {
-        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name")
-        let amount = Payment.Amount(value: 2, currencyCode: getRandomCurrencyCode())
-        let payment = Payment(amount: amount, countryCode: getRandomCountryCode())
-        let configuration = ApplePayComponent.Configuration(summaryItems: createTestSummaryItemsWithZeroAmount(), merchantIdentifier: "test_id")
-        XCTAssertThrowsError(try ApplePayComponent(paymentMethod: paymentMethod, payment: payment, configuration: configuration)) { error in
+        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: nil)
+        let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+                                                            summaryItems: createTestSummaryItemsWithZeroAmount(),
+                                                            merchantIdentifier: "test_id")
+        XCTAssertThrowsError(try ApplePayComponent(payment: payment, configuration: configuration)) { error in
             XCTAssertTrue(error is ApplePayComponent.Error)
             XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidSummaryItem)
             XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "At least one of the summary items has an invalid amount.")
@@ -172,23 +177,23 @@ class ApplePayComponentTest: XCTestCase {
     }
     
     func testPaymentRequest() {
-        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name")
+        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: nil)
         let countryCode = getRandomCountryCode()
-        let amount = Payment.Amount(value: 2, currencyCode: getRandomCurrencyCode())
         let payment = Payment(amount: amount, countryCode: countryCode)
         let expectedSummaryItems = createTestSummaryItems()
         let expectedRequiredBillingFields = getRandomContactFieldSet()
         let expectedRequiredShippingFields = getRandomContactFieldSet()
-        let configuration = ApplePayComponent.Configuration(summaryItems: expectedSummaryItems,
+        let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+                                                            summaryItems: expectedSummaryItems,
                                                             merchantIdentifier: "test_id",
                                                             requiredBillingContactFields: expectedRequiredBillingFields,
                                                             requiredShippingContactFields: expectedRequiredShippingFields,
                                                             excludedCardNetworks: [.visa])
-        let sut = try? ApplePayComponent(paymentMethod: paymentMethod,
-                                         payment: payment,
+        let sut = try? ApplePayComponent(payment: payment,
                                          configuration: configuration)
         let paymentRequest = sut!.createPaymentRequest()
         XCTAssertEqual(paymentRequest.paymentSummaryItems, expectedSummaryItems)
+            
         XCTAssertEqual(paymentRequest.merchantCapabilities, PKMerchantCapability.capability3DS)
         XCTAssertEqual(paymentRequest.supportedNetworks, self.supportedNetworks.filter { $0 != .visa })
         XCTAssertEqual(paymentRequest.currencyCode, amount.currencyCode)
@@ -197,6 +202,23 @@ class ApplePayComponentTest: XCTestCase {
         if #available(iOS 11.0, *) {
             XCTAssertEqual(paymentRequest.requiredBillingContactFields, expectedRequiredBillingFields)
             XCTAssertEqual(paymentRequest.requiredShippingContactFields, expectedRequiredShippingFields)
+        }
+    }
+
+    func testBrandsFiltering() {
+        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: ["mc", "visa", "elo", "unknown_network"])
+        let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+                                                            summaryItems: createTestSummaryItems(),
+                                                            merchantIdentifier: "test_id",
+                                                            excludedCardNetworks: [.visa])
+        let sut = try? ApplePayComponent(payment: payment,
+                                         configuration: configuration)
+        let paymentRequest = sut!.createPaymentRequest()
+
+        if #available(iOS 12.1.1, *) {
+            XCTAssertEqual(paymentRequest.supportedNetworks, [.masterCard, .elo])
+        } else {
+            XCTAssertEqual(paymentRequest.supportedNetworks, [.masterCard])
         }
     }
     
@@ -250,8 +272,17 @@ class ApplePayComponentTest: XCTestCase {
     private var supportedNetworks: [PKPaymentNetwork] {
         var networks: [PKPaymentNetwork] = [.visa, .masterCard, .amex, .discover, .interac]
         
+        if #available(iOS 14.0, *) {
+            networks.append(.girocard)
+        }
+
+        if #available(iOS 12.1.1, *) {
+            networks.append(.elo)
+        }
+
         if #available(iOS 12.0, *) {
             networks.append(.maestro)
+            networks.append(.electron)
         }
 
         if #available(iOS 10.1, *) {

--- a/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTest.swift
+++ b/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTest.swift
@@ -187,15 +187,14 @@ class ApplePayComponentTest: XCTestCase {
                                                             summaryItems: expectedSummaryItems,
                                                             merchantIdentifier: "test_id",
                                                             requiredBillingContactFields: expectedRequiredBillingFields,
-                                                            requiredShippingContactFields: expectedRequiredShippingFields,
-                                                            excludedCardNetworks: [.visa])
+                                                            requiredShippingContactFields: expectedRequiredShippingFields)
         let sut = try? ApplePayComponent(payment: payment,
                                          configuration: configuration)
         let paymentRequest = sut!.createPaymentRequest()
         XCTAssertEqual(paymentRequest.paymentSummaryItems, expectedSummaryItems)
             
         XCTAssertEqual(paymentRequest.merchantCapabilities, PKMerchantCapability.capability3DS)
-        XCTAssertEqual(paymentRequest.supportedNetworks, self.supportedNetworks.filter { $0 != .visa })
+        XCTAssertEqual(paymentRequest.supportedNetworks, self.supportedNetworks)
         XCTAssertEqual(paymentRequest.currencyCode, amount.currencyCode)
         XCTAssertEqual(paymentRequest.merchantIdentifier, "test_id")
         XCTAssertEqual(paymentRequest.countryCode, countryCode)
@@ -206,11 +205,10 @@ class ApplePayComponentTest: XCTestCase {
     }
 
     func testBrandsFiltering() {
-        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: ["mc", "visa", "elo", "unknown_network"])
+        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: ["mc", "elo", "unknown_network"])
         let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
                                                             summaryItems: createTestSummaryItems(),
-                                                            merchantIdentifier: "test_id",
-                                                            excludedCardNetworks: [.visa])
+                                                            merchantIdentifier: "test_id")
         let sut = try? ApplePayComponent(payment: payment,
                                          configuration: configuration)
         let paymentRequest = sut!.createPaymentRequest()

--- a/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayDetailsTest.swift
+++ b/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayDetailsTest.swift
@@ -11,7 +11,7 @@ import XCTest
 class ApplePayDetailsTest: XCTestCase {
     
     func testSerialisation() throws {
-        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name")
+        let paymentMethod = ApplePayPaymentMethod(type: "test_type", name: "test_name", brands: nil)
         let sut = ApplePayDetails(paymentMethod: paymentMethod,
                                   token: "test_token",
                                   network: "test_network",

--- a/Common Example code/Networking/Environment.swift
+++ b/Common Example code/Networking/Environment.swift
@@ -22,7 +22,7 @@ internal enum DemoServerEnvironment: APIEnvironment {
         }
     }
 
-    internal var version: Int { 65 }
+    internal var version: Int { 67 }
 
     internal var headers: [String: String] {
         [

--- a/Common Example code/PaymentsController.swift
+++ b/Common Example code/PaymentsController.swift
@@ -138,10 +138,10 @@ internal final class PaymentsController {
 
     internal func presentApplePayComponent() {
         guard let paymentMethod = paymentMethods?.paymentMethod(ofType: ApplePayPaymentMethod.self) else { return }
-        let config = ApplePayComponent.Configuration(summaryItems: Configuration.applePaySummaryItems,
+        let config = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+                                                     summaryItems: Configuration.applePaySummaryItems,
                                                      merchantIdentifier: Configuration.applePayMerchantIdentifier)
-        let component = try? ApplePayComponent(paymentMethod: paymentMethod,
-                                               payment: payment,
+        let component = try? ApplePayComponent(payment: payment,
                                                configuration: config) {
             print("ApplePay dismissed")
         }


### PR DESCRIPTION
## Open PR

### Changes

* get list of supported networks for Applepay from paymentMethods
* ~~deprecate~~ remove excludedCardNetworks