### PR TITLE
Refactor payment cancelation

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		E736413A25A73064007C10E3 /* AESGCM.swift in Sources */ = {isa = PBXBuildFile; fileRef = E732763F256845A0003D3F59 /* AESGCM.swift */; };
 		E7388D8523DB1F9A008E62B8 /* DimmingPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7388D8423DB1F9A008E62B8 /* DimmingPresentationController.swift */; };
 		E73C54E425EBD2DC00B57758 /* BrowserComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C54E325EBD2DC00B57758 /* BrowserComponent.swift */; };
+		E73C560625EE8C8D00B57758 /* APIClientHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C560525EE8C8D00B57758 /* APIClientHelper.swift */; };
+		E73C560725EE8C8D00B57758 /* APIClientHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C560525EE8C8D00B57758 /* APIClientHelper.swift */; };
 		E745256925C1C9E1006A941F /* AdyenActionComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9789C6F23F1924B000B4B2B /* AdyenActionComponent.swift */; };
 		E7484C2723B9FDF000CCF74F /* SlideInPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7484C2623B9FDF000CCF74F /* SlideInPresentationAnimator.swift */; };
 		E749FD1E23CF4998000D18BA /* NavigationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E749FD1D23CF4998000D18BA /* NavigationStyle.swift */; };
@@ -840,6 +842,7 @@
 		E7388D9423E08BF9008E62B8 /* nb-NO */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "nb-NO"; path = "nb-NO.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		E7388D9523E08BF9008E62B8 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E73C54E325EBD2DC00B57758 /* BrowserComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserComponent.swift; sourceTree = "<group>"; };
+		E73C560525EE8C8D00B57758 /* APIClientHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientHelper.swift; sourceTree = "<group>"; };
 		E7484C2623B9FDF000CCF74F /* SlideInPresentationAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideInPresentationAnimator.swift; sourceTree = "<group>"; };
 		E749FD1D23CF4998000D18BA /* NavigationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStyle.swift; sourceTree = "<group>"; };
 		E74D918225AF3FE600743B0C /* CardBrandProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardBrandProviderTests.swift; sourceTree = "<group>"; };
@@ -1424,6 +1427,7 @@
 			isa = PBXGroup;
 			children = (
 				E24FED0C2270915A00A65122 /* CodingHelpers.swift */,
+				E73C560525EE8C8D00B57758 /* APIClientHelper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -3954,6 +3958,7 @@
 				F9A53C442549887F009000A7 /* DefaultAPIClient.swift in Sources */,
 				E24FED0D2270915A00A65122 /* CodingHelpers.swift in Sources */,
 				E757F03925D2ED57007C813D /* APIClientMock.swift in Sources */,
+				E73C560625EE8C8D00B57758 /* APIClientHelper.swift in Sources */,
 				F9A53C4A2549887F009000A7 /* Environment.swift in Sources */,
 				F9620D7B23C36082005209FC /* Configuration.swift in Sources */,
 				E24FECF5226EF9AB00A65122 /* ComponentsViewController.swift in Sources */,
@@ -4100,6 +4105,7 @@
 				F9A53D6325499B13009000A7 /* Configuration.swift in Sources */,
 				F95B6D9A2527454E002C9062 /* SceneDelegate.swift in Sources */,
 				F95B6DD6252B4654002C9062 /* ComponentsItem.swift in Sources */,
+				E73C560725EE8C8D00B57758 /* APIClientHelper.swift in Sources */,
 				E7D18A1125D44769006AD3B7 /* IntegrationExampleComponents.swift in Sources */,
 				E757F03A25D2ED58007C813D /* APIClientMock.swift in Sources */,
 				F95B6DB525274DFF002C9062 /* CodingHelpers.swift in Sources */,

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		E73C54E425EBD2DC00B57758 /* BrowserComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C54E325EBD2DC00B57758 /* BrowserComponent.swift */; };
 		E73C560625EE8C8D00B57758 /* APIClientHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C560525EE8C8D00B57758 /* APIClientHelper.swift */; };
 		E73C560725EE8C8D00B57758 /* APIClientHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C560525EE8C8D00B57758 /* APIClientHelper.swift */; };
+		E73C567F25EFCC4200B57758 /* IssuerListComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C567E25EFCC4200B57758 /* IssuerListComponentTests.swift */; };
 		E745256925C1C9E1006A941F /* AdyenActionComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9789C6F23F1924B000B4B2B /* AdyenActionComponent.swift */; };
 		E7484C2723B9FDF000CCF74F /* SlideInPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7484C2623B9FDF000CCF74F /* SlideInPresentationAnimator.swift */; };
 		E749FD1E23CF4998000D18BA /* NavigationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E749FD1D23CF4998000D18BA /* NavigationStyle.swift */; };
@@ -843,6 +844,7 @@
 		E7388D9523E08BF9008E62B8 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E73C54E325EBD2DC00B57758 /* BrowserComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserComponent.swift; sourceTree = "<group>"; };
 		E73C560525EE8C8D00B57758 /* APIClientHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientHelper.swift; sourceTree = "<group>"; };
+		E73C567E25EFCC4200B57758 /* IssuerListComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuerListComponentTests.swift; sourceTree = "<group>"; };
 		E7484C2623B9FDF000CCF74F /* SlideInPresentationAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideInPresentationAnimator.swift; sourceTree = "<group>"; };
 		E749FD1D23CF4998000D18BA /* NavigationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationStyle.swift; sourceTree = "<group>"; };
 		E74D918225AF3FE600743B0C /* CardBrandProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardBrandProviderTests.swift; sourceTree = "<group>"; };
@@ -2702,6 +2704,7 @@
 			children = (
 				F96A25422371AB75007DBF0B /* PaymentComponentDelegateMock.swift */,
 				F90FB7BD2446EBB9005BFE0E /* BrowserInfoTests.swift */,
+				E73C567E25EFCC4200B57758 /* IssuerListComponentTests.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -3897,6 +3900,7 @@
 				E757EFFE25D2ECDB007C813D /* APIClientMock.swift in Sources */,
 				F9DC6BA623AA293500863F3A /* ListViewControllerTests.swift in Sources */,
 				F90FB7BE2446EBB9005BFE0E /* BrowserInfoTests.swift in Sources */,
+				E73C567F25EFCC4200B57758 /* IssuerListComponentTests.swift in Sources */,
 				E9E3DAC6221ECF6300697074 /* CardNumberValidatorTests.swift in Sources */,
 				F9D644E424D2FA310059CBE3 /* EmailValidatorTests.swift in Sources */,
 				F9639B4D24E298C70073F38A /* SimpleSchedulerTests.swift in Sources */,

--- a/Adyen/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponentExtensions.swift
+++ b/Adyen/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponentExtensions.swift
@@ -21,7 +21,7 @@ extension AbstractPersonalInformationComponent: FormViewControllerDelegate {
 extension AbstractPersonalInformationComponent: LoadingComponent {
 
     /// :nodoc:
-    public func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
+    public func stopLoading(completion: (() -> Void)?) {
         button.showsActivityIndicator = false
         formViewController.view.isUserInteractionEnabled = true
         completion?()

--- a/Adyen/Components/Base/Component.swift
+++ b/Adyen/Components/Base/Component.swift
@@ -28,6 +28,14 @@ public protocol DismissableComponent: Component {
     func dismiss(_ animated: Bool, completion: (() -> Void)?)
 }
 
+/// A component that needs to be aware of the result of the payment.
+public protocol FinalizableComponent: Component {
+
+    /// Finalizes payment after being proccessed by payment provider.
+    /// - Parameter success: The status of the payment.
+    func didFinalize(with success: Bool)
+}
+
 public extension Component {
     
     /// :nodoc:

--- a/Adyen/Components/Base/Component.swift
+++ b/Adyen/Components/Base/Component.swift
@@ -18,16 +18,6 @@ public protocol Component: AnyObject {
     
 }
 
-/// A component that has UI that can be dismissed.
-public protocol DismissableComponent: Component {
-    
-    /// Dismiss any `ViewController` presented by the component, for example when payment has concluded.
-    ///
-    /// - Parameter animated: A boolean indicating whether to dismiss with animation or not.
-    /// - Parameter completion: A closure to execute when dismissal animation has completed.
-    func dismiss(_ animated: Bool, completion: (() -> Void)?)
-}
-
 /// A component that needs to be aware of the result of the payment.
 public protocol FinalizableComponent: Component {
 
@@ -56,7 +46,7 @@ public extension Component {
     /// :nodoc:
     var clientKey: String? {
         get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.clientKey) as? String
+            objc_getAssociatedObject(self, &AssociatedKeys.clientKey) as? String
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.clientKey, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)

--- a/Adyen/Components/Base/LoadingComponent.swift
+++ b/Adyen/Components/Base/LoadingComponent.swift
@@ -19,7 +19,6 @@ public protocol LoadingComponent {
     /// Stops any processing animation that the view controller is running.
     ///
     /// - Parameters:
-    ///   - success: Boolean indicating the component should go to a success or failure state.
     ///   - completion: Completion block to be called when animations are finished.
-    func stopLoading(withSuccess success: Bool, completion: (() -> Void)?)
+    func stopLoading(completion: (() -> Void)?)
 }

--- a/Adyen/Components/Base/PresentableComponent.swift
+++ b/Adyen/Components/Base/PresentableComponent.swift
@@ -24,7 +24,7 @@ public protocol Cancellable: AnyObject {
 }
 
 /// A component that provides a view controller for the shopper to fill payment details.
-public protocol PresentableComponent: DismissableComponent {
+public protocol PresentableComponent: Component {
     
     /// Indicates whether `viewController` expected to be presented modally,
     /// hence it can not handle it's own presentation and dismissal.
@@ -38,12 +38,5 @@ public extension PresentableComponent {
     
     /// :nodoc:
     var requiresModalPresentation: Bool { false }
-    
-    /// Notifies the component that the user has dismissed it.
-    func dismiss(_ animated: Bool, completion: (() -> Void)?) {
-        viewController.dismiss(animated: animated) {
-            completion?()
-        }
-    }
     
 }

--- a/Adyen/Core/APIClient/APIClient.swift
+++ b/Adyen/Core/APIClient/APIClient.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// :nodoc:
 /// Describes any API Client.
-public protocol APIClientProtocol {
+public protocol APIClientProtocol: AnyObject {
     
     /// :nodoc:
     typealias CompletionHandler<T> = (Result<T, Error>) -> Void

--- a/Adyen/Core/Core Protocols/PresentableComponentWrapper.swift
+++ b/Adyen/Core/Core Protocols/PresentableComponentWrapper.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// :nodoc:
 /// A component that wraps any `Component` to make it a `PresentableComponent`.
-public final class PresentableComponentWrapper: PresentableComponent {
+public final class PresentableComponentWrapper: PresentableComponent, Cancellable {
     
     /// :nodoc:
     public let viewController: UIViewController

--- a/Adyen/Core/Core Protocols/PresentationDelegate.swift
+++ b/Adyen/Core/Core Protocols/PresentationDelegate.swift
@@ -10,5 +10,5 @@ import Foundation
 public protocol PresentationDelegate: AnyObject {
     
     /// Asks the delegate to present a `PresentableComponent` as the `delegate` sees fit.
-    func present(component: PresentableComponent, disableCloseButton: Bool)
+    func present(component: PresentableComponent)
 }

--- a/Adyen/UI/Form/Items/Button/FormButtonItemView.swift
+++ b/Adyen/UI/Form/Items/Button/FormButtonItemView.swift
@@ -32,7 +32,7 @@ internal final class FormButtonItemView: FormItemView<FormButtonItem>, Observer 
     
     // MARK: - Submit Button
     
-    private lazy var submitButton: SubmitButton = {
+    internal lazy var submitButton: SubmitButton = {
         
         let submitButton = SubmitButton(style: item.style.button)
         

--- a/AdyenActions/Components/Await/AwaitComponent.swift
+++ b/AdyenActions/Components/Await/AwaitComponent.swift
@@ -65,7 +65,7 @@ public final class AwaitComponent: AnyAwaitActionHandler {
         
         if let presentationDelegate = presentationDelegate {
             let presentableComponent = PresentableComponentWrapper(component: self, viewController: viewController)
-            presentationDelegate.present(component: presentableComponent, disableCloseButton: false)
+            presentationDelegate.present(component: presentableComponent)
         } else {
             assertionFailure("presentationDelegate is nil, please provide a presentation delegate to present the AwaitComponent UI.")
         }

--- a/AdyenActions/Components/Redirect/RedirectComponent.swift
+++ b/AdyenActions/Components/Redirect/RedirectComponent.swift
@@ -82,7 +82,7 @@ public final class RedirectComponent: ActionComponent {
         let component = BrowserComponent(url: action.url, style: style)
         component.delegate = self
         browserComponent = component
-        presentationDelegate?.present(component: component, disableCloseButton: false)
+        presentationDelegate?.present(component: component)
     }
     
     // MARK: - Custom scheme link handling

--- a/AdyenActions/Components/Redirect/RedirectComponent.swift
+++ b/AdyenActions/Components/Redirect/RedirectComponent.swift
@@ -117,7 +117,7 @@ extension RedirectComponent: BrowserComponentDelegate {
 
     /// :nodoc:
     internal func didCancel() {
-        browserComponent?.dismiss(true) {
+        if browserComponent != nil {
             self.browserComponent = nil
             self.delegate?.didFail(with: ComponentError.cancelled, from: self)
         }

--- a/AdyenActions/Components/Voucher/VoucherComponent.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponent.swift
@@ -67,7 +67,7 @@ public final class VoucherComponent: AnyVoucherActionHandler {
 
         if let presentationDelegate = presentationDelegate {
             let presentableComponent = PresentableComponentWrapper(component: self, viewController: viewController)
-            presentationDelegate.present(component: presentableComponent, disableCloseButton: false)
+            presentationDelegate.present(component: presentableComponent)
         } else {
             assertionFailure("presentationDelegate is nil, please provide a presentation delegate to present the VoucherComponent UI.")
         }

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -168,7 +168,7 @@ public class CardComponent: PaymentComponent, PresentableComponent, Localizable,
     public var localizationParameters: LocalizationParameters?
     
     /// :nodoc:
-    public func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
+    public func stopLoading(completion: (() -> Void)?) {
         button.showsActivityIndicator = false
         formViewController.view.isUserInteractionEnabled = true
         completion?()

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -25,6 +25,7 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     public weak var delegate: PaymentComponentDelegate?
     
     /// Initializes the component.
+    /// - Warning: didFInalize() must be called before dismissing this component.
     ///
     /// - Parameter configuration: Apple Pay component configuration
     /// - Throws: `ApplePayComponent.Error.userCannotMakePayment`.
@@ -86,6 +87,18 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     public func didFinalize(with success: Bool) {
         paymentAuthorizationCompletion?(success ? .success : .failure)
     }
+
+    /// Dismiss `PKPaymentAuthorizationViewController` presented by the component, for example when payment has concluded.
+    ///
+    /// - Parameter animated: A boolean indicating whether to dismiss with animation or not.
+    /// - Parameter completion: A closure to execute when dismissal animation has completed.
+    public func dismiss(_ animated: Bool, completion: (() -> Void)?) {
+        paymentAuthorizationViewController?.dismiss(animated: true) { [weak self] in
+            guard let self = self else { return }
+            self.paymentAuthorizationViewController = nil
+            completion?()
+        }
+    }
     
     // MARK: - Private
     
@@ -106,14 +119,6 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
         }
         
         return paymentAuthorizationViewController
-    }
-
-    public func dismiss(_ animated: Bool, completion: (() -> Void)?) {
-        paymentAuthorizationViewController?.dismiss(animated: true) { [weak self] in
-            guard let self = self else { return }
-            self.paymentAuthorizationViewController = nil
-            completion?()
-        }
     }
 }
 

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -24,7 +24,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     public func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController,
                                                    didAuthorizePayment payment: PKPayment,
                                                    completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
-        
+        paymentAuthorizationCompletion = completion
         let token = String(data: payment.token.paymentData, encoding: .utf8) ?? ""
         let network = payment.token.paymentMethod.network?.rawValue ?? ""
         let billingContact = payment.billingContact

--- a/AdyenComponents/BLIK/BLIKComponent.swift
+++ b/AdyenComponents/BLIK/BLIKComponent.swift
@@ -41,7 +41,7 @@ public final class BLIKComponent: PaymentComponent, PresentableComponent, Locali
     }
 
     /// :nodoc:
-    public func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
+    public func stopLoading(completion: (() -> Void)?) {
         button.showsActivityIndicator = false
         formViewController.view.isUserInteractionEnabled = true
         completion?()

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -40,9 +40,8 @@ public final class IssuerListComponent: PaymentComponent, PresentableComponent, 
         listViewController
     }
     
-    public func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
+    public func stopLoading(completion: (() -> Void)?) {
         listViewController.stopLoading()
-        
         completion?()
     }
     

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -13,7 +13,9 @@ import UIKit
 public final class IssuerListComponent: PaymentComponent, PresentableComponent, LoadingComponent {
     
     /// The issuer list payment method.
-    public let paymentMethod: PaymentMethod
+    public var paymentMethod: PaymentMethod {
+        issuerListPaymentMethod
+    }
     
     /// The delegate of the component.
     public weak var delegate: PaymentComponentDelegate?
@@ -27,7 +29,6 @@ public final class IssuerListComponent: PaymentComponent, PresentableComponent, 
     /// - Parameter style: The Component's UI style..
     public init(paymentMethod: IssuerListPaymentMethod,
                 style: ListComponentStyle = ListComponentStyle()) {
-        self.paymentMethod = paymentMethod
         self.issuerListPaymentMethod = paymentMethod
         self.style = style
     }

--- a/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
+++ b/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
@@ -46,10 +46,9 @@ public final class SEPADirectDebitComponent: PaymentComponent, PresentableCompon
     public var localizationParameters: LocalizationParameters?
     
     /// :nodoc:
-    public func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
+    public func stopLoading(completion: (() -> Void)?) {
         button.showsActivityIndicator = false
         formViewController.view.isUserInteractionEnabled = true
-        
         completion?()
     }
     

--- a/AdyenDropIn/Components/PaymentMethodListComponent.swift
+++ b/AdyenDropIn/Components/PaymentMethodListComponent.swift
@@ -91,7 +91,7 @@ internal final class PaymentMethodListComponent: ComponentLoader, PresentableCom
     }
     
     /// :nodoc:
-    internal func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
+    internal func stopLoading(completion: (() -> Void)?) {
         listViewController.stopLoading()
         completion?()
     }

--- a/AdyenDropIn/Components/PreselectedPaymentMethodComponent.swift
+++ b/AdyenDropIn/Components/PreselectedPaymentMethodComponent.swift
@@ -110,7 +110,7 @@ internal final class PreselectedPaymentMethodComponent: ComponentLoader,
         openAllButtonItem.enabled = false
     }
     
-    internal func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
+    internal func stopLoading(completion: (() -> Void)?) {
         submitButtonItem.showsActivityIndicator = false
         openAllButtonItem.enabled = true
         completion?()

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -171,7 +171,7 @@ public final class DropInComponent: NSObject,
     }
     
     private func didSelectCancelButton(isRoot: Bool, component: PresentableComponent) {
-        guard !paymentInProgress else { return }
+        guard !paymentInProgress || component is Cancellable else { return }
         
         if isRoot {
             self.delegate?.didFail(with: ComponentError.cancelled, from: self)

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -60,15 +60,14 @@ public final class DropInComponent: NSObject,
     }
     
     /// :nodoc:
-    public func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {
-        paymentInProgress = false
+    public func stopLoading(completion: (() -> Void)?) {
         let rootComponent = self.rootComponent
         if let topComponent = selectedPaymentComponent as? LoadingComponent {
-            topComponent.stopLoading(withSuccess: success) {
-                rootComponent.stopLoading(withSuccess: success, completion: completion)
+            topComponent.stopLoading {
+                rootComponent.stopLoading(completion: completion)
             }
         } else {
-            rootComponent.stopLoading(withSuccess: success, completion: completion)
+            rootComponent.stopLoading(completion: completion)
         }
     }
 
@@ -178,15 +177,19 @@ public final class DropInComponent: NSObject,
             self.delegate?.didFail(with: ComponentError.cancelled, from: self)
         } else {
             navigationController.popViewController(animated: true)
-            stopLoading(withSuccess: true, completion: nil)
             userDidCancel(component)
         }
     }
 
     private func userDidCancel(_ component: Component) {
+        stopLoading(completion: nil)
         (component as? Cancellable)?.didCancel()
-        guard let component = (component as? PaymentComponent) ?? selectedPaymentComponent else { return }
-        delegate?.didCancel(component: component, from: self)
+
+        if let component = (component as? PaymentComponent) ?? selectedPaymentComponent, paymentInProgress {
+            delegate?.didCancel(component: component, from: self)
+        }
+
+        paymentInProgress = false
     }
 }
 
@@ -212,9 +215,7 @@ extension DropInComponent: PaymentComponentDelegate {
     
     /// :nodoc:
     public func didFail(with error: Error, from component: PaymentComponent) {
-        paymentInProgress = false
         if case ComponentError.cancelled = error {
-            stopLoading(withSuccess: false, completion: nil)
             userDidCancel(component)
         } else {
             delegate?.didFail(with: error, from: self)
@@ -228,7 +229,7 @@ extension DropInComponent: ActionComponentDelegate {
     
     /// :nodoc:
     public func didOpenExternalApplication(_ component: ActionComponent) {
-        stopLoading(withSuccess: true, completion: nil)
+        stopLoading(completion: nil)
     }
 
     /// :nodoc:
@@ -239,8 +240,6 @@ extension DropInComponent: ActionComponentDelegate {
     /// :nodoc:
     public func didFail(with error: Error, from component: ActionComponent) {
         if case ComponentError.cancelled = error {
-            paymentInProgress = false
-            stopLoading(withSuccess: false, completion: nil)
             userDidCancel(component)
         } else {
             delegate?.didFail(with: error, from: self)
@@ -278,8 +277,7 @@ extension DropInComponent: PreselectedPaymentMethodComponentDelegate {
 }
 
 extension DropInComponent: PresentationDelegate {
-    public func present(component: PresentableComponent, disableCloseButton: Bool) {
-        paymentInProgress = disableCloseButton
+    public func present(component: PresentableComponent) {
         navigationController.present(asModal: component)
     }
 }

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -180,7 +180,7 @@ public final class DropInComponent: NSObject,
     }
 
     /// :nodoc:
-    private func stopLoading() {
+    private func stopLoading(completion: (() -> Void)? = nil) {
         let rootComponent = self.rootComponent
         if let topComponent = selectedPaymentComponent as? LoadingComponent {
             topComponent.stopLoading {
@@ -282,9 +282,15 @@ extension DropInComponent: PresentationDelegate {
 }
 
 extension DropInComponent: FinalizableComponent {
+
+    /// Stops loading and finalise DropIn's selected payment if nececery.
+    /// This method must be called after certan payment methods (e.x. ApplePay)
+    /// - Parameter success: Status of the payment.
     public func didFinalize(with success: Bool) {
-        guard let topComponent = selectedPaymentComponent as? FinalizableComponent else { return }
-        topComponent.didFinalize(with: success)
+        stopLoading { [weak self] in
+            guard let topComponent = self?.selectedPaymentComponent as? FinalizableComponent else { return }
+            topComponent.didFinalize(with: success)
+        }
     }
 }
 

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -123,13 +123,13 @@ internal final class ComponentManager {
         let requiredShippingContactFields = configuration.applePay.requiredShippingContactFields
         
         do {
-            let configuration = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+            let configuration = ApplePayComponent.Configuration(payment: payment,
+                                                                paymentMethod: paymentMethod,
                                                                 summaryItems: summaryItems,
                                                                 merchantIdentifier: identfier,
                                                                 requiredBillingContactFields: requiredBillingContactFields,
                                                                 requiredShippingContactFields: requiredShippingContactFields)
-            return try ApplePayComponent(payment: payment,
-                                         configuration: configuration)
+            return try ApplePayComponent(configuration: configuration)
         } catch {
             adyenPrint("Failed to instantiate ApplePayComponent because of error: \(error.localizedDescription)")
             return nil

--- a/Demo/Common/Helpers/APIClientHelper.swift
+++ b/Demo/Common/Helpers/APIClientHelper.swift
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2021 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+
+import Adyen
+
+protocol APIClientAware {
+    var apiClient: APIClientProtocol { get }
+}
+
+extension APIClientAware {
+
+    var apiClient: APIClientProtocol {
+        if let apiClient = getApiClient() {
+            return apiClient
+        }
+
+        let apiClient = generateApiClient()
+        setApiClient(apiClient)
+        return apiClient
+    }
+
+    private func getApiClient() -> APIClientProtocol? {
+        objc_getAssociatedObject(self, &AssociatedKeys.apiClient) as? APIClientProtocol
+    }
+
+    private func setApiClient(_ newValue: APIClientProtocol) {
+        objc_setAssociatedObject(self, &AssociatedKeys.apiClient, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    private func generateApiClient() -> APIClientProtocol {
+        if CommandLine.arguments.contains("-UITests") {
+            guard
+                let url = Bundle.main.url(forResource: "payment_methods_response", withExtension: "json"),
+                let data = try? Data(contentsOf: url),
+                let response = try? JSONDecoder().decode(PaymentMethodsResponse.self, from: data) else { return DefaultAPIClient() }
+
+            let apiClient = APIClientMock()
+            apiClient.mockedResults = [.success(response)]
+            return apiClient
+        }
+
+        return DefaultAPIClient()
+    }
+}
+
+private enum AssociatedKeys {
+    internal static var apiClient = "apiClient"
+}
+

--- a/Demo/Common/IntegrationExample.swift
+++ b/Demo/Common/IntegrationExample.swift
@@ -22,7 +22,7 @@ internal protocol Presenter: AnyObject {
     func presentAlert(with error: Error, retryHandler: (() -> Void)?)
 }
 
-internal final class IntegrationExample {
+internal final class IntegrationExample: APIClientAware {
     internal let payment = Payment(amount: Configuration.amount, countryCode: Configuration.countryCode)
     internal let environment = Configuration.componentsEnvironment
 
@@ -46,20 +46,6 @@ internal final class IntegrationExample {
 
     // MARK: - Networking
 
-    // swiftlint:disable:enable force_try
-    internal lazy var apiClient: APIClientProtocol = {
-        if CommandLine.arguments.contains("-UITests") {
-            let apiClient = APIClientMock()
-            let data = try! Data(contentsOf: Bundle.main.url(forResource: "payment_methods_response", withExtension: "json")!)
-            let response = try! JSONDecoder().decode(PaymentMethodsResponse.self, from: data)
-            apiClient.mockedResults = [.success(response)]
-            return apiClient
-        } else {
-            return DefaultAPIClient()
-        }
-    }()
-    // swiftlint:disable:disable force_try
-
     internal func requestPaymentMethods() {
         let request = PaymentMethodsRequest()
         apiClient.perform(request) { [weak self] result in
@@ -74,30 +60,18 @@ internal final class IntegrationExample {
     }
 
     internal func finish(with resultCode: PaymentsResponse.ResultCode) {
-        let success = resultCode == .authorised || resultCode == .received || resultCode == .pending
-
-        stopLoadingIfNeeded(success) { [weak self] in
-            self?.presenter?.dismiss { [weak self] in
-                self?.presentAlert(withTitle: resultCode.rawValue)
-            }
+        presenter?.dismiss { [weak self] in
+            // Payment is processed. Add your code here.
+            self?.presentAlert(withTitle: resultCode.rawValue)
         }
     }
 
     internal func finish(with error: Error) {
         let isCancelled = ((error as? ComponentError) == .cancelled)
 
-        stopLoadingIfNeeded(false) { [weak self] in
-            self?.presenter?.dismiss { [weak self] in
-                if !isCancelled { self?.presentAlert(with: error) }
-            }
-        }
-    }
-
-    private func stopLoadingIfNeeded(_ success: Bool, completion: (() -> Void)?) {
-        if let currentComponent = currentComponent as? LoadingComponent {
-            currentComponent.stopLoading(withSuccess: success, completion: completion)
-        } else {
-            completion?()
+        presenter?.dismiss { [weak self] in
+            // Payment is unsuccessful. Add your code here.
+            if !isCancelled { self?.presentAlert(with: error) }
         }
     }
 

--- a/Demo/Common/IntegrationExample.swift
+++ b/Demo/Common/IntegrationExample.swift
@@ -60,6 +60,11 @@ internal final class IntegrationExample: APIClientAware {
     }
 
     internal func finish(with resultCode: PaymentsResponse.ResultCode) {
+        if let finalizableComponent = currentComponent as? FinalizableComponent {
+            let success = resultCode == .authorised || resultCode == .received || resultCode == .pending
+            finalizableComponent.didFinalize(with: success)
+        }
+
         presenter?.dismiss { [weak self] in
             // Payment is processed. Add your code here.
             self?.presentAlert(withTitle: resultCode.rawValue)

--- a/Demo/Common/IntegrationExample.swift
+++ b/Demo/Common/IntegrationExample.swift
@@ -28,7 +28,6 @@ internal final class IntegrationExample: APIClientAware {
 
     internal var paymentMethods: PaymentMethods?
     internal var currentComponent: PresentableComponent?
-    internal var paymentInProgress: Bool = false
 
     internal weak var presenter: Presenter?
 

--- a/Demo/Common/IntegrationExample.swift
+++ b/Demo/Common/IntegrationExample.swift
@@ -72,7 +72,10 @@ internal final class IntegrationExample: APIClientAware {
     }
 
     internal func finish(with error: Error) {
-        let isCancelled = ((error as? ComponentError) == .cancelled)
+        let isCancelled = (error as? ComponentError) == .cancelled
+        if let finalizableComponent = currentComponent as? FinalizableComponent {
+            finalizableComponent.didFinalize(with: false)
+        }
 
         presenter?.dismiss { [weak self] in
             // Payment is unsuccessful. Add your code here.

--- a/Demo/Common/IntegrationExampleComponents.swift
+++ b/Demo/Common/IntegrationExampleComponents.swift
@@ -55,10 +55,11 @@ extension IntegrationExample {
 
     internal func presentApplePayComponent() {
         guard let paymentMethod = paymentMethods?.paymentMethod(ofType: ApplePayPaymentMethod.self) else { return }
-        let config = ApplePayComponent.Configuration(paymentMethod: paymentMethod,
+        let config = ApplePayComponent.Configuration(payment: payment,
+                                                     paymentMethod: paymentMethod,
                                                      summaryItems: Configuration.applePaySummaryItems,
                                                      merchantIdentifier: Configuration.applePayMerchantIdentifier)
-        let component = try? ApplePayComponent(payment: payment, configuration: config)
+        let component = try? ApplePayComponent(configuration: config)
         component?.delegate = self
         guard let presentableComponent = component else { return }
         present(presentableComponent)
@@ -170,7 +171,7 @@ extension IntegrationExample: CardComponentDelegate {
 }
 
 extension IntegrationExample: PresentationDelegate {
-    internal func present(component: PresentableComponent, disableCloseButton: Bool) {
+    internal func present(component: PresentableComponent) {
         present(component)
     }
 }

--- a/Demo/Common/IntegrationExampleComponents.swift
+++ b/Demo/Common/IntegrationExampleComponents.swift
@@ -119,7 +119,6 @@ extension IntegrationExample {
     }
 
     private func handle(_ action: Action) {
-        guard paymentInProgress else { return }
         actionComponent.perform(action)
     }
 
@@ -128,13 +127,11 @@ extension IntegrationExample {
 extension IntegrationExample: PaymentComponentDelegate {
 
     internal func didSubmit(_ data: PaymentComponentData, from component: PaymentComponent) {
-        paymentInProgress = true
         let request = PaymentsRequest(data: data)
         apiClient.perform(request, completionHandler: paymentResponseHandler)
     }
 
     internal func didFail(with error: Error, from component: PaymentComponent) {
-        paymentInProgress = false
         finish(with: error)
     }
 
@@ -143,12 +140,10 @@ extension IntegrationExample: PaymentComponentDelegate {
 extension IntegrationExample: ActionComponentDelegate {
 
     internal func didFail(with error: Error, from component: ActionComponent) {
-        paymentInProgress = false
         finish(with: error)
     }
 
     internal func didComplete(from component: ActionComponent) {
-        paymentInProgress = false
         finish(with: .authorised)
     }
 

--- a/Demo/Common/IntegrationExampleDropIn.swift
+++ b/Demo/Common/IntegrationExampleDropIn.swift
@@ -50,7 +50,6 @@ extension IntegrationExample {
     }
 
     private func handle(_ action: Action) {
-        guard paymentInProgress else { return }
         (currentComponent as? DropInComponent)?.handle(action)
     }
 }
@@ -58,7 +57,6 @@ extension IntegrationExample {
 extension IntegrationExample: DropInComponentDelegate {
 
     internal func didSubmit(_ data: PaymentComponentData, from component: DropInComponent) {
-        paymentInProgress = true
         let request = PaymentsRequest(data: data)
         apiClient.perform(request, completionHandler: paymentResponseHandler)
     }
@@ -71,12 +69,10 @@ extension IntegrationExample: DropInComponentDelegate {
     }
 
     internal func didComplete(from component: DropInComponent) {
-        paymentInProgress = false
         finish(with: .authorised)
     }
 
     internal func didFail(with error: Error, from component: DropInComponent) {
-        paymentInProgress = false
         finish(with: error)
     }
 

--- a/Demo/UIKit/ComponentsViewController.swift
+++ b/Demo/UIKit/ComponentsViewController.swift
@@ -96,7 +96,7 @@ internal final class ComponentsViewController: UIViewController, Presenter {
     }
 
     internal func present(viewController: UIViewController, completion: (() -> Void)?) {
-        present(viewController, animated: true, completion: completion)
+        adyen.topPresenter.present(viewController, animated: true, completion: completion)
     }
 
     internal func dismiss(completion: (() -> Void)?) {

--- a/Tests/AdyenTests/Adyen Tests/Components/AdyenActionComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/AdyenActionComponentTests.swift
@@ -162,7 +162,7 @@ class AdyenActionComponentTests: XCTestCase {
 }
 
 extension UIViewController: PresentationDelegate {
-    public func present(component: PresentableComponent, disableCloseButton: Bool) {
+    public func present(component: PresentableComponent) {
         self.present(component.viewController, animated: true, completion: nil)
     }
 }

--- a/Tests/AdyenTests/Adyen Tests/Components/Await Component/AwaitComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Await Component/AwaitComponentTests.swift
@@ -54,7 +54,7 @@ class AwaitComponentTests: XCTestCase {
         sut.presentationDelegate = presentationDelegate
 
         let presentationExpectation = expectation(description: "expect presentation delegate to be called")
-        presentationDelegate.doPresent = { component, _ in
+        presentationDelegate.doPresent = { component in
             let messageLabel: UILabel! = component.viewController.view.findView(by: "messageLabel")
             let spinnerLabel: UILabel! = component.viewController.view.findView(by: "spinnerTitleLabel")
 
@@ -104,7 +104,7 @@ class AwaitComponentTests: XCTestCase {
 
         let presentationDelegate = PresentationDelegateMock()
         let waitExpectation = expectation(description: "Wait for the presentationDelegate to be called.")
-        presentationDelegate.doPresent = { component, disableCloseButton in
+        presentationDelegate.doPresent = { component in
             XCTAssertNotNil(component.viewController as? AwaitViewController)
             let viewController = component.viewController as! AwaitViewController
 

--- a/Tests/AdyenTests/Adyen Tests/Components/BLIK Component/BLIKComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/BLIK Component/BLIKComponentTests.swift
@@ -146,9 +146,9 @@ class BLIKComponentTests: XCTestCase {
             let data = data.paymentMethod as! BLIKDetails
             XCTAssertEqual(data.blikCode, "123456")
 
-            self.sut.stopLoading(withSuccess: true, completion: {
+            self.sut.stopLoading {
                 delegateExpectation.fulfill()
-            })
+            }
             XCTAssertEqual(self.sut.viewController.view.isUserInteractionEnabled, true)
             XCTAssertEqual(self.sut.button.showsActivityIndicator, false)
         }

--- a/Tests/AdyenTests/Adyen Tests/Components/Base/IssuerListComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Base/IssuerListComponentTests.swift
@@ -1,0 +1,37 @@
+//
+// Copyright © 2020 Adyen. All rights reserved.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@testable import Adyen
+@testable import AdyenComponents
+import XCTest
+
+class IssuerListComponentTests: XCTestCase {
+
+    func testStartStopLoading() {
+        let paymentMethod = try! Coder.decode(issuerListDictionary) as IssuerListPaymentMethod
+        let sut = IssuerListComponent(paymentMethod: paymentMethod)
+
+        let expectation = XCTestExpectation(description: "Dummy Expectation")
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+
+        let listViewController = sut.viewController as? ListViewController
+        XCTAssertNotNil(listViewController)
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
+            let item = listViewController!.sections[0].items[0]
+            let cell = listViewController!.tableView.visibleCells[0] as! ListCell
+            XCTAssertFalse(cell.showsActivityIndicator)
+            listViewController?.startLoading(for: item)
+            XCTAssertTrue(cell.showsActivityIndicator)
+            sut.stopLoading {
+                XCTAssertFalse(cell.showsActivityIndicator)
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 5)
+    }
+
+}

--- a/Tests/AdyenTests/Adyen Tests/Components/Doku/DokuComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Doku/DokuComponentTests.swift
@@ -157,9 +157,9 @@ class DokuComponentTests: XCTestCase {
             XCTAssertEqual(data.lastName, "Smith")
             XCTAssertEqual(data.emailAddress, "mohamed.smith@domain.com")
 
-            sut.stopLoading(withSuccess: true, completion: {
+            sut.stopLoading {
                 delegateExpectation.fulfill()
-            })
+            }
             XCTAssertEqual(sut.viewController.view.isUserInteractionEnabled, true)
             XCTAssertEqual(sut.button.showsActivityIndicator, false)
         }

--- a/Tests/AdyenTests/Adyen Tests/Components/MB Way/MBWayComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/MB Way/MBWayComponentTests.swift
@@ -116,9 +116,9 @@ class MBWayComponentTests: XCTestCase {
             let data = data.paymentMethod as! MBWayDetails
             XCTAssertEqual(data.telephoneNumber, "+3511233456789")
 
-            sut.stopLoading(withSuccess: true, completion: {
+            sut.stopLoading {
                 delegateExpectation.fulfill()
-            })
+            }
             XCTAssertEqual(sut.viewController.view.isUserInteractionEnabled, true)
             XCTAssertEqual(sut.button.showsActivityIndicator, false)
         }

--- a/Tests/AdyenTests/Adyen Tests/Components/PresentationDelegateMock.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/PresentationDelegateMock.swift
@@ -11,10 +11,10 @@ import Foundation
 
 final class PresentationDelegateMock: PresentationDelegate {
 
-    var doPresent: ((_ component: PresentableComponent, _ disableCloseButton: Bool) -> Void)?
+    var doPresent: ((_ component: PresentableComponent) -> Void)?
 
-    func present(component: PresentableComponent, disableCloseButton: Bool) {
-        doPresent?(component, disableCloseButton)
+    func present(component: PresentableComponent) {
+        doPresent?(component)
     }
 
 }

--- a/Tests/AdyenTests/Adyen Tests/Components/Qiwi Wallet/QiwiWalletComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Qiwi Wallet/QiwiWalletComponentTests.swift
@@ -164,9 +164,9 @@ class QiwiWalletComponentTests: XCTestCase {
             XCTAssertEqual(data.phonePrefix, "+3")
             XCTAssertEqual(data.phoneNumber, "7455573152")
 
-            sut.stopLoading(withSuccess: true, completion: {
+            sut.stopLoading {
                 delegateExpectation.fulfill()
-            })
+            }
             XCTAssertEqual(sut.viewController.view.isUserInteractionEnabled, true)
             XCTAssertEqual(sut.button.showsActivityIndicator, false)
         }

--- a/Tests/AdyenTests/Adyen Tests/Components/SEPA Tests/SEPADirectDebitComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/SEPA Tests/SEPADirectDebitComponentTests.swift
@@ -169,5 +169,23 @@ class SEPADirectDebitComponentTests: XCTestCase {
         let sut = SEPADirectDebitComponent(paymentMethod: sepaPaymentMethod)
         XCTAssertEqual(sut.requiresModalPresentation, true)
     }
+
+    func testStopLoading() {
+        let sepaPaymentMethod = SEPADirectDebitPaymentMethod(type: "bcmc", name: "Test name")
+        let sut = SEPADirectDebitComponent(paymentMethod: sepaPaymentMethod)
+
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+
+        let expectation = XCTestExpectation(description: "Dummy Expectation")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
+            XCTAssertFalse(sut.button.showsActivityIndicator)
+            sut.button.showsActivityIndicator = true
+            sut.stopLoading {
+                XCTAssertFalse(sut.button.showsActivityIndicator)
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 5)
+    }
     
 }

--- a/Tests/AdyenTests/Adyen Tests/Components/Voucher Component/VoucherComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Voucher Component/VoucherComponentTests.swift
@@ -32,7 +32,7 @@ class VoucherComponentTests: XCTestCase {
         }
 
         let presentationDelegateExpectation = expectation(description: "Expect presentationDelegate.present() to be called.")
-        presentationDelegate.doPresent = { component, disableCloseButton in
+        presentationDelegate.doPresent = { component in
             let component = component as! PresentableComponentWrapper
             XCTAssertEqual(component.viewController.title, "test_title")
             XCTAssertTrue(component.viewController === expectedViewContoller)

--- a/Tests/AdyenTests/Adyen Tests/UI/PreselectedPaymentComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/UI/PreselectedPaymentComponentTests.swift
@@ -77,6 +77,23 @@ class PreselectedPaymentComponentTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 5)
     }
+
+    func testSubmitButtonLoading() {
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton.button")
+        XCTAssertFalse(button.showsActivityIndicator)
+        sut.startLoading(for: component)
+
+        let expectation = XCTestExpectation(description: "Dummy Expectation")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
+            XCTAssertTrue(button.showsActivityIndicator)
+            self.sut.stopLoading {
+                XCTAssertFalse(button.showsActivityIndicator)
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 5)
+    }
     
     func testPressOpenAllButton() {
         let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.openAllButton.button")

--- a/Tests/AdyenTests/Adyen Tests/UI/PresentableComponentMock.swift
+++ b/Tests/AdyenTests/Adyen Tests/UI/PresentableComponentMock.swift
@@ -17,7 +17,7 @@ class PresentableComponentMock: PresentableComponent {
         return controll
     }
     
-    func stopLoading(withSuccess success: Bool, completion: (() -> Void)?) {}
+    func stopLoading(completion: (() -> Void)?) {}
     
     var environment: Environment = .test
 }

--- a/Tests/AdyenTests/Adyen Tests/Utilities/ComponentManagerTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Utilities/ComponentManagerTests.swift
@@ -61,7 +61,7 @@ class ComponentManagerTests: XCTestCase {
         XCTAssertEqual(sut.components.stored.filter { $0.environment.clientKey == "client_key" }.count, 4)
         XCTAssertEqual(sut.components.regular.filter { $0.environment.clientKey == "client_key" }.count, 12)
 
-        XCTAssertEqual(sut.components.regular.filter { $0 is LoadingComponent }.count, 10)
+        XCTAssertEqual(sut.components.regular.filter { $0 is LoadingComponent }.count, 9)
         XCTAssertEqual(sut.components.regular.filter { $0 is Localizable }.count, 8)
         XCTAssertEqual(sut.components.regular.filter { $0 is PresentableComponent }.count, 10)
     }

--- a/Tests/AdyenTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/BCMCComponentTests.swift
@@ -176,7 +176,7 @@ class BCMCComponentTests: XCTestCase {
             XCTAssertNotNil(resultJson["encryptedSecurityCode"] as? String)
             XCTAssertNotNil(resultJson["encryptedExpiryMonth"] as? String)
 
-            sut.stopLoading(withSuccess: true) {
+            sut.stopLoading {
                 didSubmitExpectation.fulfill()
             }
         }

--- a/Tests/AdyenTests/Card Tests/CardComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/CardComponentTests.swift
@@ -667,9 +667,9 @@ class CardComponentTests: XCTestCase {
             XCTAssertTrue(component === sut)
             XCTAssertTrue(data.paymentMethod is CardDetails)
 
-            sut.stopLoading(withSuccess: true, completion: {
+            sut.stopLoading {
                 delegateExpectation.fulfill()
-            })
+            }
             XCTAssertEqual(sut.viewController.view.isUserInteractionEnabled, true)
             XCTAssertEqual(sut.button.showsActivityIndicator, false)
         }


### PR DESCRIPTION
## Open PR

### Changes

* simplify ApplePay flow
* simplify DropIn state management
* add FinalizableComponent

### Code cleanup

* remove `withSuccess success: Bool` from `LoadingComponent.stopLoad(completion: (() -> Void)?)`
* `disableCloseButton: Bool` from  `presentationDelegate.present(component: presentableComponent)`