### PR TITLE
Fixes localization warning when using SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Adyen",
-    defaultLocalization: "en-US",
+    defaultLocalization: "en-us",
     platforms: [
         .iOS(.v11)
     ],


### PR DESCRIPTION
## Summary
This PR tackles the issue described in #369 where compiling the Adyen SDK using Swift Package Manager results in a warning about a missing localization file.

## Background
At this time, I do believe this to be a bug with the way Apple has implemented the `defaultLocalization` parameter in Swift Package Manager. Apple's own documentation states that `defaultLocalization` should be a [LanguageTag](https://developer.apple.com/documentation/swift_packages/languagetag) which is an IETF language tag, in conformance with [RFC5654](https://tools.ietf.org/html/rfc5646).

The documentation of RFC5646 states that language tags should be case insensitive but does recommend capitalising the country code. Unfortunately it seems that Swift Package Manager does differentiate between upper and lower case characters and has some sort of issue identifying a language if you specify an upper case country code. Thankfully, simply lowercasing the entire string removes the warning.

I have run the unit tests on the project and everything passed so as far as I can tell, the change is harmless and simply fixes the issue. I suspect that Apple simply never tested it with a language-country code and only expected a fallback to be a top level language code.

## Tested scenarios
All project unit tests run and passed successfully. I suspect you may want to run some manual tests your side though before merging this.

**Fixed issue**:  #369 
