### PR TITLE
fix: Prevent URLSession response from being cached

### DIFF
--- a/Adyen/Core/APIClient/APIClient.swift
+++ b/Adyen/Core/APIClient/APIClient.swift
@@ -117,7 +117,7 @@ public final class APIClient: APIClientProtocol {
     
     /// :nodoc:
     private lazy var urlSession: URLSession = {
-        URLSession(configuration: .ephemeral, delegate: self, delegateQueue: .main)
+        URLSession(configuration: .ephemeral, delegate: nil, delegateQueue: .main)
     }()
     
     /// :nodoc:

--- a/Adyen/Core/APIClient/APIClient.swift
+++ b/Adyen/Core/APIClient/APIClient.swift
@@ -22,7 +22,7 @@ public protocol APIClientProtocol: AnyObject {
 
 /// :nodoc:
 /// The Basic API Client.
-public final class APIClient: NSObject, APIClientProtocol {
+public final class APIClient: APIClientProtocol {
     
     /// :nodoc:
     public typealias CompletionHandler<T> = (Result<T, Error>) -> Void
@@ -117,7 +117,7 @@ public final class APIClient: NSObject, APIClientProtocol {
     
     /// :nodoc:
     private lazy var urlSession: URLSession = {
-        URLSession(configuration: .default, delegate: self, delegateQueue: .main)
+        URLSession(configuration: .ephemeral, delegate: self, delegateQueue: .main)
     }()
     
     /// :nodoc:
@@ -128,19 +128,6 @@ public final class APIClient: NSObject, APIClientProtocol {
         }
     }
     
-}
-
-extension APIClient: URLSessionDataDelegate {
-
-    /// :nodoc:
-    public func urlSession(
-        _ session: URLSession,
-        dataTask: URLSessionDataTask,
-        willCacheResponse proposedResponse: CachedURLResponse,
-        completionHandler: @escaping (CachedURLResponse?) -> Void
-    ) {
-        completionHandler(nil)
-    }
 }
 
 internal func printAsJSON(_ data: Data) {

--- a/Adyen/Core/APIClient/APIClient.swift
+++ b/Adyen/Core/APIClient/APIClient.swift
@@ -22,7 +22,7 @@ public protocol APIClientProtocol: AnyObject {
 
 /// :nodoc:
 /// The Basic API Client.
-public final class APIClient: APIClientProtocol {
+public final class APIClient: NSObject, APIClientProtocol {
     
     /// :nodoc:
     public typealias CompletionHandler<T> = (Result<T, Error>) -> Void
@@ -117,7 +117,7 @@ public final class APIClient: APIClientProtocol {
     
     /// :nodoc:
     private lazy var urlSession: URLSession = {
-        URLSession(configuration: .default, delegate: nil, delegateQueue: .main)
+        URLSession(configuration: .default, delegate: self, delegateQueue: .main)
     }()
     
     /// :nodoc:
@@ -128,6 +128,19 @@ public final class APIClient: APIClientProtocol {
         }
     }
     
+}
+
+extension APIClient: URLSessionDataDelegate {
+
+    /// :nodoc:
+    public func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        willCacheResponse proposedResponse: CachedURLResponse,
+        completionHandler: @escaping (CachedURLResponse?) -> Void
+    ) {
+        completionHandler(nil)
+    }
 }
 
 internal func printAsJSON(_ data: Data) {

--- a/Adyen/Core/APIClient/APIClient.swift
+++ b/Adyen/Core/APIClient/APIClient.swift
@@ -117,7 +117,9 @@ public final class APIClient: APIClientProtocol {
     
     /// :nodoc:
     private lazy var urlSession: URLSession = {
-        URLSession(configuration: .ephemeral, delegate: nil, delegateQueue: .main)
+        let conf = URLSessionConfiguration.ephemeral
+        conf.urlCache = nil
+        return URLSession(configuration: conf, delegate: nil, delegateQueue: .main)
     }()
     
     /// :nodoc:


### PR DESCRIPTION
### Changes

Prevents caching of URLSession response by implementing a method from `URLSessionDataDelegate`.
**Note:** Implementing this requires `APIClient` to inherit from `NSObject`, which might impact performance. Another possible solution would be a separate delegate class, that only implements this method and is a property of `APIClient`
