### PR TITLE
fix: set minimum required TLS version to 1.2

### DIFF
--- a/Adyen/Core/APIClient/APIClient.swift
+++ b/Adyen/Core/APIClient/APIClient.swift
@@ -117,9 +117,16 @@ public final class APIClient: APIClientProtocol {
     
     /// :nodoc:
     private lazy var urlSession: URLSession = {
-        let conf = URLSessionConfiguration.ephemeral
-        conf.urlCache = nil
-        return URLSession(configuration: conf, delegate: nil, delegateQueue: .main)
+        let config = URLSessionConfiguration.ephemeral
+        config.urlCache = nil
+
+        if #available(iOS 13.0, *) {
+            config.tlsMinimumSupportedProtocolVersion = .TLSv12
+        } else {
+            config.tlsMinimumSupportedProtocol = .tlsProtocol12
+        }
+
+        return URLSession(configuration: config, delegate: nil, delegateQueue: .main)
     }()
     
     /// :nodoc:


### PR DESCRIPTION
This sets a minimum TLS version to 1.2. Using `#available` here, can be dropped when support iOS 13+
