### PR TITLE
chore: fix warning caused by a redundant iOS version check

### DIFF
--- a/Tests/AdyenTests/Card Tests/Utilities/CardEncryptorCardTests.swift
+++ b/Tests/AdyenTests/Card Tests/Utilities/CardEncryptorCardTests.swift
@@ -209,16 +209,15 @@ class CardEncryptorCardTests: XCTestCase {
         XCTAssertEqual(payload, expected)
     }
 
-    @available(iOS 13.0, *)
     func testAESGCM() {
-        let data = NSData(base64Encoded: "eyJleHBpcnlZZWFyIjoiMTk3MiIsImN2YyI6IjY2NiIsImV4cGlyeU1vbnRoIjoiNyIsImhvbGRlck5hbWUiOiJLdW4gamUgZGl0IGxlemVuPyIsIm51bWJlciI6IjA2NTU1OTAzMDAiLCJnZW5lcmF0aW9udGltZSI6IjIwMTMtMDgtMjFUMTI6MDE6MzQuMjQ5WiJ9")!
-        let key = NSData(base64Encoded: "Xjmy/REE0Unnzc4+kATHkQtN2+t1xUd/enXOB9IH8Sg=")!
-        let iv = NSData(base64Encoded: "2Mk9bTtPn1jdnMr/")!
-        let result = Cryptor.AES.GCM.encrypt(data: data, withKey: key, initVector: iv)
-
-        var payload = Data()
-        let expected: Data
         if #available(iOS 13.0, *) {
+            let data = NSData(base64Encoded: "eyJleHBpcnlZZWFyIjoiMTk3MiIsImN2YyI6IjY2NiIsImV4cGlyeU1vbnRoIjoiNyIsImhvbGRlck5hbWUiOiJLdW4gamUgZGl0IGxlemVuPyIsIm51bWJlciI6IjA2NTU1OTAzMDAiLCJnZW5lcmF0aW9udGltZSI6IjIwMTMtMDgtMjFUMTI6MDE6MzQuMjQ5WiJ9")!
+            let key = NSData(base64Encoded: "Xjmy/REE0Unnzc4+kATHkQtN2+t1xUd/enXOB9IH8Sg=")!
+            let iv = NSData(base64Encoded: "2Mk9bTtPn1jdnMr/")!
+            let result = Cryptor.AES.GCM.encrypt(data: data, withKey: key, initVector: iv)
+            
+            var payload = Data()
+            let expected: Data
             payload.append(contentsOf: iv as Data)
             payload.append(result.cipher!)
             payload.append(result.atag!)
@@ -227,12 +226,8 @@ class CardEncryptorCardTests: XCTestCase {
             XCTAssertNotNil(result.atag)
             XCTAssertEqual(result.atag, Data(base64Encoded: "qJ/43FDTLDE+dUa+4d9ahg=="))
             XCTAssertEqual(result.cipher, Data(base64Encoded: "Z0tDqFGd16KdRNFKIyqR4bgQFjPzyAbxlRT0vn0Mh9CPrhmp4NYYEBYPZz9ZyLd/pihSWqz99Bs8/am6+OeQeeUQlQvX9OeabajgLa6id2HiAjLOR1ANpxLvXtqlZsQaIeIii7EgTZwz789hiQFKwFz8ia8/E6RJEVGZrw+ZQPrd8w1+9454Agm32L1mcOVC52uQOIJq"))
-        } else {
-            payload.append(contentsOf: iv as Data)
-            payload.append(result.cipher!)
-            expected = Data(base64Encoded: "2Mk9bTtPn1jdnMr/u/K1o0+81LFIFCGKZCYvS0briKpA53nDEoj/Igqr6XitnBe7FpamUkttm0VY+ZGAhMRCahd6uF/OT9CLw96GAlC48JLX8Jp5ul1OQwzcvsV4Oqn/P9jmiXaFvfpIZ9nfMQRmOWTokDcC6Ga7ihuRC9zunwvcNZsDqVf7chpZz++PBYazRgGbfvIZ9p++Zd1QgWhT3OPT4rNlUKP9VqQ=")!
+            
+            XCTAssertEqual(payload.base64EncodedString(), expected.base64EncodedString())
         }
-
-        XCTAssertEqual(payload.base64EncodedString(), expected.base64EncodedString())
     }
 }


### PR DESCRIPTION
This PR fixes a warning caused by an `if #available(iOS 13.0, *)` check inside an `if #available(iOS 13.0, *)` check.