### PR TITLE
Use TextStyle fonts on GenericVoucherView 

### DIFF
--- a/AdyenActions/UI/View Controllers/Voucher/GenericVoucherView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/GenericVoucherView.swift
@@ -52,8 +52,7 @@ internal final class GenericVoucherView: AbstractVoucherView {
     private lazy var instructionButton: UIButton = {
         let button = UIButton(style: model.instruction.style.button)
         button.setTitle(model.instruction.title, for: .normal)
-        button.heightAnchor.constraint(equalToConstant: 20).isActive = true
-        button.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        button.contentEdgeInsets = UIEdgeInsets(top: 5.0, left: 10.0, bottom: 5.0, right: 10.0)
         button.addTarget(self, action: #selector(openInstructions), for: .touchUpInside)
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: "adyen.voucher", postfix: "instructionButton")
 

--- a/AdyenActions/UI/View Controllers/Voucher/GenericVoucherViewModel.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/GenericVoucherViewModel.swift
@@ -31,7 +31,7 @@ extension GenericVoucherView {
             internal struct Style {
 
                 internal lazy var button: ButtonStyle = {
-                    var style = ButtonStyle(title: TextStyle(font: .systemFont(ofSize: 9),
+                    var style = ButtonStyle(title: TextStyle(font: .preferredFont(forTextStyle: .footnote),
                                                              color: UIColor.Adyen.defaultBlue),
                                             cornerRounding: .percent(0.5))
                     style.borderColor = UIColor.Adyen.defaultBlue
@@ -58,21 +58,25 @@ extension GenericVoucherView {
 
         internal struct Style {
 
-            internal var text = TextStyle(font: .systemFont(ofSize: 13),
-                                          color: UIColor.Adyen.componentLabel,
-                                          textAlignment: .center)
+            internal var text = TextStyle(
+                font: .preferredFont(forTextStyle: .footnote),
+                color: UIColor.Adyen.componentLabel,
+                textAlignment: .center)
 
-            internal var amount = TextStyle(font: .boldSystemFont(ofSize: 16),
-                                            color: UIColor.Adyen.componentLabel,
-                                            textAlignment: .center)
+            internal var amount = TextStyle(
+                font: UIFont.preferredFont(forTextStyle: .callout).adyen.font(with: .bold),
+                color: UIColor.Adyen.componentLabel,
+                textAlignment: .center)
 
-            internal var codeText = TextStyle(font: .boldSystemFont(ofSize: 24),
-                                              color: UIColor.Adyen.componentLabel,
-                                              textAlignment: .center)
+            internal var codeText = TextStyle(
+                font: UIFont.preferredFont(forTextStyle: .title1).adyen.font(with: .bold),
+                color: UIColor.Adyen.componentLabel,
+                textAlignment: .center)
 
-            internal var fieldValueText = TextStyle(font: .boldSystemFont(ofSize: 13),
-                                                    color: UIColor.Adyen.componentLabel,
-                                                    textAlignment: .center)
+            internal var fieldValueText = TextStyle(
+                font: UIFont.preferredFont(forTextStyle: .footnote).adyen.font(with: .semibold),
+                color: UIColor.Adyen.componentLabel,
+                textAlignment: .center)
 
             internal var mainButton: ButtonStyle
 

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherSeparatorView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherSeparatorView.swift
@@ -13,7 +13,7 @@ extension VoucherSeparatorView {
     internal struct Model {
         internal var separatorTitle: String
 
-        internal var separatorStyle = TextStyle(font: .systemFont(ofSize: 13),
+        internal var separatorStyle = TextStyle(font: .preferredFont(forTextStyle: .footnote),
                                                 color: UIColor.Adyen.componentLabel,
                                                 textAlignment: .center)
     }

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -18,11 +18,11 @@ internal enum Configuration {
 
     static let appName = "Adyen Demo"
 
-    static let amount = Payment.Amount(value: 17408, currencyCode: "IDR")
+    static let amount = Payment.Amount(value: 17408, currencyCode: "EUR")
 
     static let reference = "Test Order Reference - iOS UIHost"
     
-    static let countryCode = "ID"
+    static let countryCode = "NL"
 
     static let returnUrl = "ui-host://"
     

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -18,11 +18,11 @@ internal enum Configuration {
 
     static let appName = "Adyen Demo"
 
-    static let amount = Payment.Amount(value: 17408, currencyCode: "EUR")
+    static let amount = Payment.Amount(value: 17408, currencyCode: "IDR")
 
     static let reference = "Test Order Reference - iOS UIHost"
     
-    static let countryCode = "NL"
+    static let countryCode = "ID"
 
     static let returnUrl = "ui-host://"
     


### PR DESCRIPTION
This PR will use `TextStyle` fonts instead of hardcoded sizes in `GenericVoucherView` for better accessibility when using larger font sizes.