### PR TITLE
chore: Use continuous curve by default when rounding corners

### DIFF
--- a/Adyen/Helpers/UIViewRoundingHelpers.swift
+++ b/Adyen/Helpers/UIViewRoundingHelpers.swift
@@ -50,6 +50,10 @@ public extension AdyenScope where Base: UIView {
     /// - Parameters:
     ///   - radius: The radius of each corner oval.
     func round(using rounding: CornerRounding) {
+        if #available(iOS 13.0, *) {
+            base.layer.cornerCurve = .continuous
+        }
+        
         switch rounding {
         case let .fixed(value):
             base.layer.cornerRadius = value


### PR DESCRIPTION
This PR ensures we use `.continuous` rounded corner style by default as per Apple's design guidelines. 