### PR TITLE
chore: Set rounded corners for PIX logo

### DIFF
--- a/AdyenActions/Components/QRCode/QRCodeComponent.swift
+++ b/AdyenActions/Components/QRCode/QRCodeComponent.swift
@@ -149,6 +149,7 @@ internal final class QRCodeComponent: ActionComponent, Localizable, Cancellable 
                 instructionLabel: style.instructionLabel,
                 progressView: style.progressView,
                 expirationLabel: style.expirationLabel,
+                logoCornerRounding: style.logoCornerRounding,
                 backgroundColor: style.backgroundColor
             )
         )

--- a/AdyenActions/UI/UI Style/QRCodeComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/QRCodeComponentStyle.swift
@@ -28,6 +28,9 @@ public struct QRCodeComponentStyle: ViewStyle {
     
     /// The expiration label style.
     public var expirationLabel = TextStyle(font: .preferredFont(forTextStyle: .footnote), color: UIColor.Adyen.componentSecondaryLabel)
+    
+    /// The corner rounding for the logo
+    public var logoCornerRounding: CornerRounding = .fixed(5)
         
     /// :nodoc:
     public var backgroundColor: UIColor = UIColor.Adyen.componentBackground

--- a/AdyenActions/UI/View Controllers/QR Code/QRCodeView.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/QRCodeView.swift
@@ -110,8 +110,11 @@ internal final class QRCodeView: UIView, Localizable, Observer {
     private lazy var logo: NetworkImageView = {
         let logo = NetworkImageView()
         let logoSize = CGSize(width: 74.0, height: 48.0)
+        logo.adyen.round(using: model.style.logoCornerRounding)
+        logo.clipsToBounds = true
         logo.widthAnchor.constraint(equalToConstant: logoSize.width).isActive = true
         logo.heightAnchor.constraint(equalToConstant: logoSize.height).isActive = true
+        logo.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "logo")
         
         logo.imageURL = model.logoUrl
         

--- a/AdyenActions/UI/View Controllers/QR Code/QRCodeViewModel.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/QRCodeViewModel.swift
@@ -31,6 +31,8 @@ extension QRCodeView {
             
             internal let expirationLabel: TextStyle
             
+            internal let logoCornerRounding: CornerRounding
+            
             internal let backgroundColor: UIColor
         }
         

--- a/Tests/AdyenTests/Adyen Tests/Components/PIX/QRCodeComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/PIX/QRCodeComponentTests.swift
@@ -39,6 +39,8 @@ class QRCodeComponentTests: XCTestCase {
             color: .blue, textAlignment: .right
         )
         
+        style.logoCornerRounding = .fixed(10)
+        
         style.backgroundColor = UIColor.Adyen.componentSeparator
         
         let sut = QRCodeComponent(style: style)
@@ -56,6 +58,7 @@ class QRCodeComponentTests: XCTestCase {
                 let instructionLabel: UILabel? = viewController.view.findView(by: "instructionLabel")
                 let progressView: UIProgressView? = viewController.view.findView(by: "progressView")
                 let expirationLabel: UILabel? = viewController.view.findView(by: "expirationLabel")
+                let logo: UIImageView? = viewController.view.findView(by: "logo")
                 
                 // Test copy button
                 XCTAssertEqual(copyButton?.backgroundColor, style.copyButton.backgroundColor)
@@ -74,6 +77,9 @@ class QRCodeComponentTests: XCTestCase {
                 XCTAssertEqual(expirationLabel?.font, style.expirationLabel.font)
                 XCTAssertEqual(expirationLabel?.textColor, style.expirationLabel.color)
                 XCTAssertEqual(expirationLabel?.textAlignment, style.expirationLabel.textAlignment)
+                
+                // Test logo
+                XCTAssertEqual(logo?.layer.cornerRadius, 10)
                 
                 dummyExpectation.fulfill()
             }
@@ -219,7 +225,7 @@ class QRCodeComponentTests: XCTestCase {
         
         sut.handle(action)
         
-        waitForExpectations(timeout: 60, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
     
     func testCopyButton() {


### PR DESCRIPTION
This PR adds rounded corners to PIX logo so it looks better in dark mode