### PR TITLE
fix: Treat BCMC_Mobile as RedirectAction instead of QRCodeAction

### DIFF
--- a/AdyenActions/Actions/Action.swift
+++ b/AdyenActions/Actions/Action.swift
@@ -57,7 +57,17 @@ public enum Action: Decodable {
         case .voucher:
             self = .voucher(try VoucherAction(from: decoder))
         case .qrCode:
-            self = .qrCode(try QRCodeAction(from: decoder))
+            self = try Self.handleQRCodeType(from: decoder)
+        }
+    }
+    
+    /// :nodoc:
+    private static func handleQRCodeType(from decoder: Decoder) throws -> Action {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if (try? container.decode(QRCodePaymentMethod.self, forKey: .paymentMethodType)) != nil {
+            return .qrCode(try QRCodeAction(from: decoder))
+        } else {
+            return .redirect(try RedirectAction(from: decoder))
         }
     }
     
@@ -74,6 +84,7 @@ public enum Action: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case type
+        case paymentMethodType
     }
     
 }

--- a/AdyenActions/Actions/QRCodeAction.swift
+++ b/AdyenActions/Actions/QRCodeAction.swift
@@ -12,6 +12,7 @@ public enum QRCodePaymentMethod: String, Codable, CaseIterable {
 
     /// PIX
     case pix
+    
 }
 
 /// Describes any QR code action.

--- a/Tests/AdyenTests/Adyen Tests/Core/ActionTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Core/ActionTests.swift
@@ -31,6 +31,52 @@ class ActionTests: XCTestCase {
         XCTAssertEqual(redirectAction?.paymentData, "example_data")
     }
     
+    func testQRCodeActionDecoding() {
+        let json =
+            """
+            {
+                "type": "qrCode",
+                "qrCodeData": "example_data",
+                "paymentData": "example_data",
+                "paymentMethodType": "pix"
+            }
+            """
+        
+        let action = try? JSONDecoder().decode(Action.self, from: json.data(using: .utf8)!)
+        
+        var qrCodeAction: QRCodeAction?
+        if case let .qrCode(qrCode)? = action {
+            qrCodeAction = qrCode
+        }
+
+        XCTAssertNotNil(qrCodeAction)
+        XCTAssertEqual(qrCodeAction?.paymentData, "example_data")
+        XCTAssertTrue(qrCodeAction?.paymentMethodType == .some(.pix))
+    }
+    
+    func testQRCodeToRedirectActionDecoding() {
+        let json =
+            """
+            {
+                "type": "qrCode",
+                "url": "https://example.org/",
+                "paymentData": "example_data",
+                "paymentMethodType": "bcmc_mobile"
+            }
+            """
+        
+        let action = try? JSONDecoder().decode(Action.self, from: json.data(using: .utf8)!)
+        
+        var qrToRedirectAction: RedirectAction?
+        if case let .redirect(redirect)? = action {
+            qrToRedirectAction = redirect
+        }
+        
+        XCTAssertNotNil(qrToRedirectAction)
+        XCTAssertEqual(qrToRedirectAction?.url.absoluteString, "https://example.org/")
+        XCTAssertEqual(qrToRedirectAction?.paymentData, "example_data")
+    }
+    
     func test3DS2FingerprintActionDecoding() {
         let json =
             """


### PR DESCRIPTION
This PR will fix the issue when BCMC_Mobile was treated as a `QRCodeAction`. Instead it will be parsed into a `RedirectAction` and handled appropriately.