### PR TITLE
fix: Fix constraints on QRCodeView and PreApplePay view not using safeAreaLayoutGuide

### DIFF
--- a/Adyen/Helpers/UIViewConstraintsHelper.swift
+++ b/Adyen/Helpers/UIViewConstraintsHelper.swift
@@ -25,16 +25,16 @@ extension AdyenScope where Base: UIView {
         return constraints
     }
 
-    /// Attach top, bottom, left and right anchores of this view to corespondent anchores inside specified view.
-    /// IMPORTANT: both view should be in the same hierarcy.
+    /// Attach top, bottom, left and right anchors of this view to corresponding anchors inside specified view.
+    /// IMPORTANT: both views should be in the same hierarcy.
     /// - Parameter view: Container view
     @discardableResult
-    public func anchor(inside margines: UILayoutGuide, with padding: UIEdgeInsets = .zero) -> [NSLayoutConstraint] {
+    public func anchor(inside margins: UILayoutGuide, with padding: UIEdgeInsets = .zero) -> [NSLayoutConstraint] {
         let constraints = [
-            base.topAnchor.constraint(equalTo: margines.topAnchor, constant: padding.top),
-            base.bottomAnchor.constraint(equalTo: margines.bottomAnchor, constant: padding.bottom),
-            base.leadingAnchor.constraint(equalTo: margines.leadingAnchor, constant: padding.left),
-            base.trailingAnchor.constraint(equalTo: margines.trailingAnchor, constant: padding.right)
+            base.topAnchor.constraint(equalTo: margins.topAnchor, constant: padding.top),
+            base.bottomAnchor.constraint(equalTo: margins.bottomAnchor, constant: padding.bottom),
+            base.leadingAnchor.constraint(equalTo: margins.leadingAnchor, constant: padding.left),
+            base.trailingAnchor.constraint(equalTo: margins.trailingAnchor, constant: padding.right)
         ]
         NSLayoutConstraint.activate(constraints)
         return constraints

--- a/AdyenActions/UI/View Controllers/QR Code/QRCodeView.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/QRCodeView.swift
@@ -55,7 +55,7 @@ internal final class QRCodeView: UIView, Localizable, Observer {
         logo.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             logo.bottomAnchor.constraint(equalTo: topAnchor, constant: -7),
-            logo.centerXAnchor.constraint(equalTo: centerXAnchor)
+            logo.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor)
         ])
     }
     
@@ -64,8 +64,8 @@ internal final class QRCodeView: UIView, Localizable, Observer {
         instructionLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             instructionLabel.topAnchor.constraint(equalTo: logo.bottomAnchor, constant: 24),
-            instructionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 37),
-            instructionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -37.0)
+            instructionLabel.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 37),
+            instructionLabel.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -37.0)
         ])
     }
     
@@ -74,7 +74,7 @@ internal final class QRCodeView: UIView, Localizable, Observer {
         progressView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             progressView.topAnchor.constraint(equalTo: instructionLabel.bottomAnchor, constant: 24.0),
-            progressView.centerXAnchor.constraint(equalTo: centerXAnchor)
+            progressView.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor)
         ])
     }
     
@@ -83,7 +83,7 @@ internal final class QRCodeView: UIView, Localizable, Observer {
         expirationLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             expirationLabel.topAnchor.constraint(equalTo: progressView.bottomAnchor, constant: 13.0),
-            expirationLabel.centerXAnchor.constraint(equalTo: centerXAnchor)
+            expirationLabel.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor)
         ])
     }
     
@@ -92,8 +92,8 @@ internal final class QRCodeView: UIView, Localizable, Observer {
         copyButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             copyButton.topAnchor.constraint(equalTo: expirationLabel.bottomAnchor, constant: 34),
-            copyButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            copyButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            copyButton.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            copyButton.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -16),
             copyButton.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -18)
         ])
     }

--- a/AdyenDropIn/Views/PreApplePayView.swift
+++ b/AdyenDropIn/Views/PreApplePayView.swift
@@ -53,8 +53,8 @@ internal final class PreApplePayView: UIView, Localizable {
         payButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             payButton.topAnchor.constraint(equalTo: topAnchor, constant: 13.0),
-            payButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16.0),
-            payButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16.0),
+            payButton.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 16.0),
+            payButton.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -16.0),
             payButton.heightAnchor.constraint(equalToConstant: 48.0)
         ])
         payButton.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "applePayButton")
@@ -66,7 +66,7 @@ internal final class PreApplePayView: UIView, Localizable {
         hintLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             hintLabel.topAnchor.constraint(equalTo: payButton.bottomAnchor, constant: 15.0),
-            hintLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            hintLabel.centerXAnchor.constraint(equalTo: payButton.centerXAnchor),
             hintLabel.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -24.0)
         ])
         hintLabel.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "hintLabel")


### PR DESCRIPTION
This PR will fix issue when QRCodeView and PreApplePayView subviews were not using `safeAreaLayoutGuide.leadingAnchor` and `safeAreaLayoutGuide.trailingAnchor`, causing them to look wrong in landscape orientation. 