### PR TITLE
fix: Use returnUrlQueryString for entire URL query

### DIFF
--- a/AdyenActions/Components/Redirect/RedirectDetails.swift
+++ b/AdyenActions/Components/Redirect/RedirectDetails.swift
@@ -54,15 +54,15 @@ public struct RedirectDetails: AdditionalDetails {
     internal func extractKeyValuesFromURL() -> [(CodingKeys, String)]? {
         let queryParameters = returnURL.queryParameters
 
-        if let queryString = queryParameters["pp"]?.removingPercentEncoding {
-            return [(.queryString, queryString)]
-        } else if let redirectResult = queryParameters[CodingKeys.redirectResult.rawValue]?.removingPercentEncoding {
+        if let redirectResult = queryParameters[CodingKeys.redirectResult.rawValue]?.removingPercentEncoding {
             return [(.redirectResult, redirectResult)]
         } else if let payload = queryParameters[CodingKeys.payload.rawValue]?.removingPercentEncoding {
             return [(.payload, payload)]
         } else if let paymentResponse = queryParameters[CodingKeys.paymentResponse.rawValue]?.removingPercentEncoding,
                   let merchantData = queryParameters[CodingKeys.merchantData.rawValue]?.removingPercentEncoding {
             return [(.paymentResponse, paymentResponse), (.merchantData, merchantData)]
+        } else if let queryString = returnURL.query {
+            return [(.queryString, queryString)]
         }
         
         return nil

--- a/Tests/AdyenTests/Adyen Tests/Components/Redirect Tests/RedirectDetailsTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Redirect Tests/RedirectDetailsTests.swift
@@ -73,7 +73,7 @@ class RedirectDetailsTests: XCTestCase {
         XCTAssertNotNil(try? JSONEncoder().encode(details))
     }
 
-    func testExtrationFromURLWithoutQuery() {
+    func testExtractionFromURLWithoutQuery() {
         let url = URL(string: "url://")!
         let details = RedirectDetails(returnURL: url)
         

--- a/Tests/AdyenTests/Adyen Tests/Components/Redirect Tests/RedirectDetailsTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Redirect Tests/RedirectDetailsTests.swift
@@ -49,31 +49,6 @@ class RedirectDetailsTests: XCTestCase {
         XCTAssertNotNil(try? JSONEncoder().encode(details))
     }
     
-    func testPaResExtractionWithoutMDFromURL() {
-        let url = URL(string: "url://?param1=abc&PaRes=some")!
-        let details = RedirectDetails(returnURL: url)
-        
-        XCTAssertNil(details.extractKeyValuesFromURL())
-
-        XCTAssertThrowsError(try JSONEncoder().encode(details)) { _ in }
-    }
-    
-    func testMDExtractionWithoutPaResFromURL() {
-        let url = URL(string: "url://?param1=abc&MD=some")!
-        let details = RedirectDetails(returnURL: url)
-        
-        XCTAssertNil(details.extractKeyValuesFromURL())
-        XCTAssertThrowsError(try JSONEncoder().encode(details)) { _ in }
-    }
-    
-    func testExtractionFromURLWithInvalidParameters() {
-        let url = URL(string: "url://?param1=abc&param2=3")!
-        let details = RedirectDetails(returnURL: url)
-        
-        XCTAssertNil(details.extractKeyValuesFromURL())
-        XCTAssertThrowsError(try JSONEncoder().encode(details)) { _ in }
-    }
-    
     func testRedirectResultExtractionFromURLWithEncodedParameter() {
         let url = URL(string: "url://?param1=abc&redirectResult=encoded%21%20%40%20%24&param2=3")!
         let details = RedirectDetails(returnURL: url)
@@ -93,9 +68,17 @@ class RedirectDetailsTests: XCTestCase {
 
         XCTAssertEqual(keyValues.count, 1)
         XCTAssertEqual(keyValues[0].0, RedirectDetails.CodingKeys.queryString)
-        XCTAssertEqual(keyValues[0].1, "H7j5+pwnbNk8uKpS/m67rDp/K+AiJbQ==")
+        XCTAssertEqual(keyValues[0].1, "param1=abc&pp=H7j5+pwnbNk8uKpS/m67rDp/K+AiJbQ==&param2=3")
 
         XCTAssertNotNil(try? JSONEncoder().encode(details))
+    }
+
+    func testExtrationFromURLWithoutQuery() {
+        let url = URL(string: "url://")!
+        let details = RedirectDetails(returnURL: url)
+        
+        XCTAssertNil(details.extractKeyValuesFromURL())
+        XCTAssertThrowsError(try JSONEncoder().encode(details)) { _ in }
     }
 
     func testEncoding() {


### PR DESCRIPTION
## Summary
This submits `returnUrlQueryString` if no known values are found in the redirect parameters. This adds support for direct issuer links.