### PR TITLE
chore: add backticks to await case in advance of ios15 async/await

### DIFF
--- a/AdyenActions/Actions/Action.swift
+++ b/AdyenActions/Actions/Action.swift
@@ -78,7 +78,7 @@ public enum Action: Decodable {
         case threeDS2
         case sdk
         case qrCode
-        case await
+        case `await`
         case voucher
     }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Added backticks to the `await` case of the `Action` enum to prevent issues with iOS 15s new async/await keywords
