### PR TITLE
v3: add new networks to Apple pay

### DIFF
--- a/Adyen/Components/Apple Pay/ApplePayComponentExtensions.swift
+++ b/Adyen/Components/Apple Pay/ApplePayComponentExtensions.swift
@@ -86,9 +86,18 @@ extension ApplePayComponent {
         
         internal var supportedNetworks: [PKPaymentNetwork] {
             var networks: [PKPaymentNetwork] = [.visa, .masterCard, .amex, .discover, .interac]
+
+            if #available(iOS 14.0, *) {
+                networks.append(.girocard)
+            }
             
+            if #available(iOS 12.1.1, *) {
+                networks.append(.elo)
+            }
+
             if #available(iOS 12.0, *) {
                 networks.append(.maestro)
+                networks.append(.electron)
             }
             
             if #available(iOS 10.1, *) {

--- a/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTest.swift
+++ b/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTest.swift
@@ -249,8 +249,17 @@ class ApplePayComponentTest: XCTestCase {
     private var supportedNetworks: [PKPaymentNetwork] {
         var networks: [PKPaymentNetwork] = [.visa, .masterCard, .amex, .discover, .interac]
         
+        if #available(iOS 14.0, *) {
+            networks.append(.girocard)
+        }
+
+        if #available(iOS 12.1.1, *) {
+            networks.append(.elo)
+        }
+
         if #available(iOS 12.0, *) {
             networks.append(.maestro)
+            networks.append(.electron)
         }
 
         if #available(iOS 10.1, *) {


### PR DESCRIPTION
## Open

## Changes

* add girocard, elo, electron to Apple Pay