### PR TITLE
feature: disable luhn check if flag is false in binlookup

### DIFF
--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -170,6 +170,7 @@ internal class CardViewController: FormViewController {
             isHidden = !configuration.showAdditionalAuthenticationFields(for: binInfo.issuingCountryCode)
         }
 
+        numberItem.validator = CardNumberValidator(isLuhnCheckEnabled: brands.luhnCheckRequired)
         additionalAuthPasswordItem.isHidden.wrappedValue = isHidden
         additionalAuthCodeItem.isHidden.wrappedValue = isHidden
         socialSecurityNumberItem.isHidden.wrappedValue = !brands.socialSecurityNumberRequired

--- a/AdyenCard/Form/FormCardNumberItem.swift
+++ b/AdyenCard/Form/FormCardNumberItem.swift
@@ -44,7 +44,7 @@ internal final class FormCardNumberItem: FormTextItem, Observer {
         observe(publisher) { [weak self] value in self?.valueDidChange(value) }
         
         title = localizedString(.cardNumberItemTitle, localizationParameters)
-        validator = CardNumberValidator()
+        validator = CardNumberValidator(isLuhnCheckEnabled: true)
         formatter = cardNumberFormatter
         placeholder = localizedString(.cardNumberItemPlaceholder, localizationParameters)
         validationFailureMessage = localizedString(.cardNumberItemInvalid, localizationParameters)

--- a/AdyenCard/Form/FormCardSecurityCodeItem.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItem.swift
@@ -73,4 +73,9 @@ extension Array where Element == CardBrand {
     var socialSecurityNumberRequired: Bool {
         contains { $0.showsSocialSecurityNumber }
     }
+    
+    /// If any of the brands requires to skip luhn check, returns `false`. Otherwise `true`.
+    var luhnCheckRequired: Bool {
+        contains { !$0.isLuhnCheckEnabled }
+    }
 }

--- a/AdyenCard/Utilities/CardType/CardBrand.swift
+++ b/AdyenCard/Utilities/CardType/CardBrand.swift
@@ -48,6 +48,7 @@ public struct CardBrand: Decodable {
     ///   - cvcPolicy: Indicates the cvc policy of the brand.
     ///   - isLuhnCheckEnabled: Indicates whether Luhn check applies to card numbers of this brand.
     ///   - showsExpiryDate: Indicates whether to show the expiry date field.
+    ///   - showsSocialSecurityNumber: Indicates whether to show social security number field or not.
     internal init(type: CardType,
                   isSupported: Bool = true,
                   cvcPolicy: CVCPolicy = .required,

--- a/AdyenCard/Validators/CardNumberValidator.swift
+++ b/AdyenCard/Validators/CardNumberValidator.swift
@@ -11,13 +11,18 @@ import Foundation
 /// The input is expected to be sanitized.
 public final class CardNumberValidator: Validator {
     
+    /// Indicates whether to validate for luhn check
+    private let isLuhnCheckEnabled: Bool
+    
     /// :nodoc:
-    public init() {}
+    public init(isLuhnCheckEnabled: Bool) {
+        self.isLuhnCheckEnabled = isLuhnCheckEnabled
+    }
     
     /// :nodoc:
     public func isValid(_ value: String) -> Bool {
         let minimumValidCardLength = 12
-        let isValid = value.count >= minimumValidCardLength && luhnCheck(value)
+        let isValid = value.count >= minimumValidCardLength && (!isLuhnCheckEnabled || luhnCheck(value))
         
         return isValid
     }

--- a/Tests/AdyenTests/Card Tests/Validators/CardNumberValidatorTests.swift
+++ b/Tests/AdyenTests/Card Tests/Validators/CardNumberValidatorTests.swift
@@ -10,7 +10,7 @@ import XCTest
 class CardNumberValidatorTests: XCTestCase {
     
     func testValidCards() {
-        let validator = CardNumberValidator()
+        let validator = CardNumberValidator(isLuhnCheckEnabled: true)
         
         CardNumbers.valid.forEach { cardNumber in
             XCTAssertTrue(validator.isValid(cardNumber))
@@ -18,10 +18,18 @@ class CardNumberValidatorTests: XCTestCase {
     }
     
     func testInvalidCards() {
-        let validator = CardNumberValidator()
+        let validator = CardNumberValidator(isLuhnCheckEnabled: true)
         
         CardNumbers.invalid.forEach { cardNumber in
             XCTAssertFalse(validator.isValid(cardNumber))
         }
+    }
+    
+    func testNonLuhnCheckCards() {
+        let validator = CardNumberValidator(isLuhnCheckEnabled: false)
+        XCTAssertTrue(validator.isValid("4111111111111112"))
+        XCTAssertTrue(validator.isValid("370000000000000"))
+        XCTAssertFalse(validator.isValid("37000000000"))
+        XCTAssertFalse(validator.isValid("0"))
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Check for enableLuhnCheck flag in BinLookupResponse brands to allow for luhn check validation.


**Fixed issue**:  [COIOS-472](https://youtrack.is.adyen.com/issue/COIOS-472)
