### PR TITLE
chore: fixes the Adyen.podspec to M1 macbooks simulator builds

### DIFF
--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -15,8 +15,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.1'
   s.frameworks = 'Foundation'
   s.default_subspecs = 'Core', 'Components', 'Actions', 'Card', 'Encryption', 'DropIn'
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64', 'SWIFT_SUPPRESS_WARNINGS' => 'YES' }
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 
   s.subspec 'DropIn' do |plugin|
     plugin.source_files = 'AdyenDropIn/**/*.swift'


### PR DESCRIPTION
chore: fixes the Adyen.podspec to M1 macbooks simulator builds