### PR TITLE
chore: safe range access on string extension

### DIFF
--- a/Adyen/Helpers/StringHelpers.swift
+++ b/Adyen/Helpers/StringHelpers.swift
@@ -107,25 +107,53 @@ public extension AdyenScope where Base == String {
     }
     
     /// Get the substring from a given open range.
+    /// If the range does not overlap with the base string at all, returns an empty string.
     ///
     /// - Parameter range: The range of the desired substring.
     /// - Returns: A string with the substring of the given range.
     subscript(range: Range<Int>) -> String {
-        let lowerBound = base.index(base.startIndex, offsetBy: range.lowerBound)
-        let upperBound = base.index(lowerBound, offsetBy: range.upperBound - range.lowerBound)
-        
-        return String(base[lowerBound..<upperBound])
+        guard let safe = safeRange(from: range) else { return "" }
+        return String(base[safe])
     }
     
     /// Get the substring from a given closed range.
+    /// If the range does not overlap with the base string at all, returns an empty string.
     ///
     /// - Parameter range: The closed range of the desired substring.
     /// - Returns: A string with the substring of the given closed range.
     subscript(range: ClosedRange<Int>) -> String {
-        let lowerBound = base.index(base.startIndex, offsetBy: range.lowerBound)
-        let upperBound = base.index(lowerBound, offsetBy: range.upperBound - range.lowerBound)
+        guard let safeRange = safeClosedRange(from: range) else { return "" }
+        return String(base[safeRange])
+    }
+    
+    /// Returns an open range from the given range that is within the `base`'s bounds, to prevent out of bounds access.
+    /// - Parameter range: The desired range to access in the `base`.
+    /// - Returns: A new open range that is within the `base`'s bounds, or nil when there is no overlap.
+    internal func safeRange(from range: Range<Int>) -> Range<String.Index>? {
+        guard !base.isEmpty else { return nil }
+        let baseRange = 0..<base.count
+        guard baseRange.overlaps(range) else { return nil }
+        let clampedRange = baseRange.clamped(to: range)
         
-        return String(base[lowerBound...upperBound])
+        let lowerIndex = base.index(base.startIndex, offsetBy: clampedRange.lowerBound)
+        let upperIndex = base.index(lowerIndex, offsetBy: clampedRange.upperBound - clampedRange.lowerBound)
+        
+        return lowerIndex..<upperIndex
+    }
+    
+    /// Returns a closed range from the given range that is within the `base`'s bounds, to prevent out of bounds access.
+    /// - Parameter range: The desired range to access in the `base`.
+    /// - Returns: A new closed range that is within the `base'`s bounds, or nil when there is no overlap.
+    internal func safeClosedRange(from range: ClosedRange<Int>) -> ClosedRange<String.Index>? {
+        guard !base.isEmpty else { return nil }
+        let baseRange = 0...base.count - 1
+        guard baseRange.overlaps(range) else { return nil }
+        let clampedRange = baseRange.clamped(to: range)
+        
+        let lowerIndex = base.index(base.startIndex, offsetBy: clampedRange.lowerBound)
+        let upperIndex = base.index(lowerIndex, offsetBy: clampedRange.upperBound - clampedRange.lowerBound)
+        
+        return lowerIndex...upperIndex
     }
 }
 

--- a/Tests/AdyenTests/Adyen Tests/Extension Tests/StringExtensionsTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Extension Tests/StringExtensionsTests.swift
@@ -53,4 +53,48 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("abc".adyen[1...2], "bc")
     }
     
+    func testClosedRanges() {
+        let testString = "012345"
+        XCTAssertEqual(testString.adyen[0...2], "012")
+        XCTAssertEqual(testString.adyen[0...5], "012345")
+        XCTAssertEqual(testString.adyen[3...6], "345")
+        XCTAssertEqual(testString.adyen[2...3], "23")
+        XCTAssertEqual(testString.adyen[2...2], "2")
+        XCTAssertEqual(testString.adyen[1...4], "1234")
+        XCTAssertEqual(testString.adyen[6...8], "")
+        XCTAssertEqual(testString.adyen[-6...8], "012345")
+        
+        let empty = ""
+        XCTAssertEqual(empty.adyen[0...2], "")
+        XCTAssertEqual(empty.adyen[0...5], "")
+        XCTAssertEqual(empty.adyen[3...6], "")
+        XCTAssertEqual(empty.adyen[2...3], "")
+        XCTAssertEqual(empty.adyen[2...2], "")
+        XCTAssertEqual(empty.adyen[1...4], "")
+        XCTAssertEqual(empty.adyen[6...8], "")
+        XCTAssertEqual(empty.adyen[-6...8], "")
+    }
+    
+    func testOpenRanges() {
+        let testString = "012345"
+        XCTAssertEqual(testString.adyen[0..<2], "01")
+        XCTAssertEqual(testString.adyen[0..<5], "01234")
+        XCTAssertEqual(testString.adyen[3..<6], "345")
+        XCTAssertEqual(testString.adyen[2..<3], "2")
+        XCTAssertEqual(testString.adyen[2..<2], "")
+        XCTAssertEqual(testString.adyen[1..<4], "123")
+        XCTAssertEqual(testString.adyen[6..<8], "")
+        XCTAssertEqual(testString.adyen[-6..<8], "012345")
+        
+        let empty = ""
+        XCTAssertEqual(empty.adyen[0..<2], "")
+        XCTAssertEqual(empty.adyen[0..<5], "")
+        XCTAssertEqual(empty.adyen[3..<6], "")
+        XCTAssertEqual(empty.adyen[2..<3], "")
+        XCTAssertEqual(empty.adyen[2..<2], "")
+        XCTAssertEqual(empty.adyen[1..<4], "")
+        XCTAssertEqual(empty.adyen[6..<8], "")
+        XCTAssertEqual(empty.adyen[-6..<8], "")
+    }
+    
 }

--- a/Tests/AdyenTests/Card Tests/CardComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/CardComponentTests.swift
@@ -1161,15 +1161,23 @@ class CardComponentTests: XCTestCase {
         XCTAssertFalse(expDateItem.isValid())
         expDateItem.value = "1"
         XCTAssertFalse(expDateItem.isValid())
+        XCTAssertEqual(sut.cardViewController.card.expiryYear, "20")
+        XCTAssertEqual(sut.cardViewController.card.expiryMonth, "1")
         expDateItem.value = "0224"
         XCTAssertTrue(expDateItem.isValid())
+        XCTAssertEqual(sut.cardViewController.card.expiryYear, "2024")
+        XCTAssertEqual(sut.cardViewController.card.expiryMonth, "02")
         
         expDateItem.isOptional = optionalBrands.isExpiryDateOptional
         XCTAssertTrue(expDateItem.isValid())
         expDateItem.value = "1"
+        XCTAssertEqual(sut.cardViewController.card.expiryYear, "20")
+        XCTAssertEqual(sut.cardViewController.card.expiryMonth, "1")
         XCTAssertFalse(expDateItem.isValid())
         // no value or correct value (3-4 digits) is valid
         expDateItem.value = ""
+        XCTAssertNil(sut.cardViewController.card.expiryYear)
+        XCTAssertNil(sut.cardViewController.card.expiryMonth)
         XCTAssertTrue(expDateItem.isValid())
     }
     


### PR DESCRIPTION
Prevent out of bonds access on string subscript via ranges

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Safety checks of ranges on the public subscript string extensions for open/closed ranges to prevent out of bonds crashes.

## Tested scenarios
Tested with all possible ranges with non-empty & empty strings.

