### PR TITLE
fix: removing keyboard observers

### DIFF
--- a/Adyen/UI/Form/FormViewController.swift
+++ b/Adyen/UI/Form/FormViewController.swift
@@ -65,7 +65,7 @@ open class FormViewController: UIViewController, Localizable, KeyboardObserver, 
 
     /// :nodoc:
     public func startObserving() {
-        keyboardObserver = startObserving { [weak self] in
+        startObserving { [weak self] in
             self?.keyboardRect = $0
             self?.didUpdatePreferredContentSize()
         }

--- a/AdyenDropIn/Presentation/DropInNavigationController.swift
+++ b/AdyenDropIn/Presentation/DropInNavigationController.swift
@@ -32,7 +32,7 @@ internal final class DropInNavigationController: UINavigationController, Keyboar
     }
 
     internal func startObserving() {
-        keyboardObserver = startObserving { [weak self] in
+        startObserving { [weak self] in
             self?.keyboardRect = $0
             self?.updateTopViewControllerIfNeeded()
         }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Keyboard observers were not being removed on deinit since they are re-assigned as `void`s in the calling classes instead of NSObverservers as the initial assignment.

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
