### PR TITLE
Rename TextField to less common name TextFieldAdyen

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -303,7 +303,7 @@
 		E9E3DB062226B3B200697074 /* CoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DB052226B3B200697074 /* CoderTests.swift */; };
 		F90FB7BC2446E8C8005BFE0E /* BrowserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90FB7BB2446E8C8005BFE0E /* BrowserInfo.swift */; };
 		F90FB7BE2446EBB9005BFE0E /* BrowserInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90FB7BD2446EBB9005BFE0E /* BrowserInfoTests.swift */; };
-		F90FB7C02448587C005BFE0E /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90FB7BF2448587C005BFE0E /* TextField.swift */; };
+		F90FB7C02448587C005BFE0E /* TextFieldAdyen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90FB7BF2448587C005BFE0E /* TextFieldAdyen.swift */; };
 		F913B3ED26B7FAA8008F6CD2 /* AdyenNetworking in Frameworks */ = {isa = PBXBuildFile; productRef = F913B3EC26B7FAA8008F6CD2 /* AdyenNetworking */; };
 		F913B3F126B80D4E008F6CD2 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F913B3F026B80D4E008F6CD2 /* APIRequest.swift */; };
 		F91664F023E41D7300C10738 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91664EF23E41D7300C10738 /* AnyEncodable.swift */; };
@@ -1226,7 +1226,7 @@
 		E9E3DB052226B3B200697074 /* CoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoderTests.swift; sourceTree = "<group>"; };
 		F90FB7BB2446E8C8005BFE0E /* BrowserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserInfo.swift; sourceTree = "<group>"; };
 		F90FB7BD2446EBB9005BFE0E /* BrowserInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserInfoTests.swift; sourceTree = "<group>"; };
-		F90FB7BF2448587C005BFE0E /* TextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextField.swift; sourceTree = "<group>"; };
+		F90FB7BF2448587C005BFE0E /* TextFieldAdyen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldAdyen.swift; sourceTree = "<group>"; };
 		F913B3F026B80D4E008F6CD2 /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
 		F91664EF23E41D7300C10738 /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		F91664F823E460CD00C10738 /* WeChatPaySDKData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeChatPaySDKData.swift; sourceTree = "<group>"; };
@@ -1806,7 +1806,7 @@
 			children = (
 				E216D3BD221AAB710013CBCF /* FormTextItem.swift */,
 				E2C0E0B9220B2966008616F6 /* FormTextItemView.swift */,
-				F90FB7BF2448587C005BFE0E /* TextField.swift */,
+				F90FB7BF2448587C005BFE0E /* TextFieldAdyen.swift */,
 				F96F44D423BDED4400871C1F /* FormTextItemStyle.swift */,
 				E76EC6872412581E009C6E2F /* FormTextInputItem.swift */,
 				E76EC6962417F36A009C6E2F /* FormTextInputItemView.swift */,
@@ -4614,7 +4614,7 @@
 				5AD40EEF26303C830090E01C /* UIButtonHelpers.swift in Sources */,
 				E2D12C07221ED15F00EF682F /* FormTogglechItem.swift in Sources */,
 				F917308E26491ED900985310 /* InstantPaymentComponent.swift in Sources */,
-				F90FB7C02448587C005BFE0E /* TextField.swift in Sources */,
+				F90FB7C02448587C005BFE0E /* TextFieldAdyen.swift in Sources */,
 				E224088D22B0FD220058923E /* StoredPayPalPaymentMethod.swift in Sources */,
 				F99D2F0A266136A700BB5B2F /* AppleWalletPassResponse.swift in Sources */,
 				F9639B3524DD97A30073F38A /* PaymentStatusResponse.swift in Sources */,

--- a/Adyen/UI/Form/Items/Text/FormTextItemView.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextItemView.swift
@@ -96,8 +96,8 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValueItemView<String, F
     
     // MARK: - Text Field
     
-    public lazy var textField: TextField = {
-        let textField = TextField()
+    public lazy var textField: TextFieldAdyen = {
+        let textField = TextFieldAdyen()
         textField.font = item.style.text.font
         textField.adjustsFontForContentSizeCategory = true
         textField.textColor = item.style.text.color

--- a/Adyen/UI/Form/Items/Text/TextFieldAdyen.swift
+++ b/Adyen/UI/Form/Items/Text/TextFieldAdyen.swift
@@ -12,7 +12,7 @@ import UIKit
 /// So in order to prevent this behaviour,
 /// accessibilityValue is overriden to return an empty string in case the text var is nil or empty string.
 /// :nodoc:
-public final class TextField: UITextField {
+public final class TextFieldAdyen: UITextField {
     
     private var heightConstraint: NSLayoutConstraint?
     
@@ -45,7 +45,7 @@ public final class TextField: UITextField {
     }
 }
 
-extension TextField {
+extension TextFieldAdyen {
 
     public func apply(placeholderText: String?, with style: TextStyle?) {
         if let text = placeholderText, let style = style {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
My proposal is to use less common name for custom textfields, i.e. TextField .
Because if you have i.e. **Material** library in your project, they have TextField custom class from UITextField
Adyen also have class named TextField.
I See  XCode error during compiling:
**"'TextField' has different definitions in different modules; first difference is definition in module Adyen.Swift'"**

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  627
