### PR TITLE
feature: display unsupported brands on card number entry

### DIFF
--- a/Adyen/Assets/Generated/LocalizationKey.swift
+++ b/Adyen/Assets/Generated/LocalizationKey.swift
@@ -71,6 +71,10 @@ public struct LocalizationKey {
     public static let cardStoredMessage = LocalizationKey(key: "adyen.card.stored.message")
     /// Expires %@
     public static let cardStoredExpires = LocalizationKey(key: "adyen.card.stored.expires")
+    /// %@ isn't supported
+    public static let cardNumberItemUnsupportedBrand = LocalizationKey(key: "adyen.card.numberItem.unsupportedBrand")
+    /// The entered card brand isn't supported
+    public static let cardNumberItemUnknownBrand = LocalizationKey(key: "adyen.card.numberItem.unknownBrand")
     /// Confirm %@ payment
     public static let dropInStoredTitle = LocalizationKey(key: "adyen.dropIn.stored.title")
     /// Change Payment Method
@@ -257,12 +261,19 @@ public struct LocalizationKey {
     public static let voucherShopperReference = LocalizationKey(key: "adyen.voucher.shopperReference")
     /// Alternative Reference
     public static let voucherAlternativeReference = LocalizationKey(key: "adyen.voucher.alternativeReference")
+    /// Number of installments
     public static let cardInstallmentsNumberOfInstallments = LocalizationKey(key: "adyen.card.installments.numberOfInstallments")
+    /// One time payment
     public static let cardInstallmentsOneTime = LocalizationKey(key: "adyen.card.installments.oneTime")
+    /// Installments payment
     public static let cardInstallmentsTitle = LocalizationKey(key: "adyen.card.installments.title")
+    /// Revolving payment
     public static let cardInstallmentsRevolving = LocalizationKey(key: "adyen.card.installments.revolving")
+    /// %@x %@
     public static let cardInstallmentsMonthsAndPrice = LocalizationKey(key: "adyen.card.installments.monthsAndPrice")
+    /// %@ months
     public static let cardInstallmentsMonths = LocalizationKey(key: "adyen.card.installments.months")
+    /// Method of payment
     public static let cardInstallmentsPlan = LocalizationKey(key: "adyen.card.installments.plan")
     
     internal let key: String

--- a/Adyen/Assets/ar.lproj/Localizable.strings
+++ b/Adyen/Assets/ar.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "التحقق من بطاقتك";
 "adyen.card.stored.message" = "يُرجى إدخال رمز CVC للبطاقة %@";
 "adyen.card.stored.expires" = "تنتهي في %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "تأكيد الدفع باستخدام %@";
 "adyen.dropIn.preselected.openAll.title" = "تغيير طريقة الدفع";
 "adyen.continueTo" = "متابعة إلى %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "الدفع الدوري";
 "adyen.card.installments.monthsAndPrice" = "%@ x %@";
 "adyen.card.installments.months" = "%@ أشهر";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "طريقة الدفع";

--- a/Adyen/Assets/cs-CZ.lproj/Localizable.strings
+++ b/Adyen/Assets/cs-CZ.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Ověřte svou kartu";
 "adyen.card.stored.message" = "Zadejte prosím kód CVC karty %@";
 "adyen.card.stored.expires" = "Vyprší %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Potvrdit platbu";
 "adyen.dropIn.preselected.openAll.title" = "Změnit způsob platby";
 "adyen.continueTo" = "Pokračovat k %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Opakující se platba";
 "adyen.card.installments.monthsAndPrice" = "%@× %@";
 "adyen.card.installments.months" = "%@ měsíců";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Způsob platby";

--- a/Adyen/Assets/da-DK.lproj/Localizable.strings
+++ b/Adyen/Assets/da-DK.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Kontrollér dit kort";
 "adyen.card.stored.message" = "Du skal indtaste CVC-koden for %@";
 "adyen.card.stored.expires" = "Udløber %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Bekræft %@-betaling";
 "adyen.dropIn.preselected.openAll.title" = "Skift betalingsmåde";
 "adyen.continueTo" = "Fortsæt til %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Løbende betaling";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ måneder";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Betalingsmetode";

--- a/Adyen/Assets/de-DE.lproj/Localizable.strings
+++ b/Adyen/Assets/de-DE.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Karte verifizieren";
 "adyen.card.stored.message" = "Bitte CVC-Code für %@ eingeben.";
 "adyen.card.stored.expires" = "Gültig bis %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Bestätige %@ Zahlung";
 "adyen.dropIn.preselected.openAll.title" = "Zahlungsmethode wechseln";
 "adyen.continueTo" = "Weiter zu %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Ratenzahlung";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ Monate";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Zahlungsmethode";

--- a/Adyen/Assets/el-GR.lproj/Localizable.strings
+++ b/Adyen/Assets/el-GR.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Επαληθεύστε την κάρτα σας";
 "adyen.card.stored.message" = "Εισαγάγετε τον κωδικό CVC της κάρτας %@";
 "adyen.card.stored.expires" = "Λήξη: %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Επιβεβαίωση πληρωμής μέσω %@";
 "adyen.dropIn.preselected.openAll.title" = "Αλλαγή τρόπου πληρωμής";
 "adyen.continueTo" = "Μετάβαση στην %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Ανακυκλούμενη πληρωμή";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ μήνες";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Τρόπος πληρωμής";

--- a/Adyen/Assets/en-US.lproj/Localizable.strings
+++ b/Adyen/Assets/en-US.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Verify your card";
 "adyen.card.stored.message" = "Please enter the CVC code for %@";
 "adyen.card.stored.expires" = "Expires %@";
+"adyen.card.numberItem.unsupportedBrand" = "%@ isn't supported";
+"adyen.card.numberItem.unknownBrand" = "The entered card brand isn't supported";
 "adyen.dropIn.stored.title" = "Confirm %@ payment";
 "adyen.dropIn.preselected.openAll.title" = "Change Payment Method";
 "adyen.continueTo" = "Continue to %@";

--- a/Adyen/Assets/es-ES.lproj/Localizable.strings
+++ b/Adyen/Assets/es-ES.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Verifique su tarjeta";
 "adyen.card.stored.message" = "Introduzca el código de verificación de %@";
 "adyen.card.stored.expires" = "Expira el %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Confirmar pago de %@";
 "adyen.dropIn.preselected.openAll.title" = "Cambiar método de pago";
 "adyen.continueTo" = "Continuar a %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Pago rotativo";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ meses";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Método de pago";

--- a/Adyen/Assets/fi.lproj/Localizable.strings
+++ b/Adyen/Assets/fi.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Määritä korttisi";
 "adyen.card.stored.message" = "Syötä CVC-koodisi %@ varten";
 "adyen.card.stored.expires" = "Vanhenee %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Vahvista %@ maksu";
 "adyen.dropIn.preselected.openAll.title" = "Muuta maksutapaa";
 "adyen.continueTo" = "Jatka kohteeseen %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Toistuva maksu";
 "adyen.card.installments.monthsAndPrice" = "%@ x%@";
 "adyen.card.installments.months" = "%@ kuukautta";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Maksutapa";

--- a/Adyen/Assets/fr-FR.lproj/Localizable.strings
+++ b/Adyen/Assets/fr-FR.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Vérifiez votre carte";
 "adyen.card.stored.message" = "Entrez votre CVC code pour %@ s'il vous plaît.";
 "adyen.card.stored.expires" = "Expire le %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Confirmer paiement de %@";
 "adyen.dropIn.preselected.openAll.title" = "Changer de moyen de paiement";
 "adyen.continueTo" = "Poursuivre vers %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Paiement en plusieurs fois";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ mois";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Méthode de paiement";

--- a/Adyen/Assets/hr-HR.lproj/Localizable.strings
+++ b/Adyen/Assets/hr-HR.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Potvrdite svoju karticu";
 "adyen.card.stored.message" = "Unesite CVC kôd za %@";
 "adyen.card.stored.expires" = "Istječe %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Potvrdite plaćanje: % @";
 "adyen.dropIn.preselected.openAll.title" = "Promijeni način plaćanja";
 "adyen.continueTo" = "Nastavi na %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Obnovljivo plaćanje";
 "adyen.card.installments.monthsAndPrice" = "%@ x %@";
 "adyen.card.installments.months" = "Mjeseci: %@";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Način plaćanja";

--- a/Adyen/Assets/hu-HU.lproj/Localizable.strings
+++ b/Adyen/Assets/hu-HU.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Kártya ellenőrzése";
 "adyen.card.stored.message" = "Adja meg a %@ CVC-kódját";
 "adyen.card.stored.expires" = "Lejár: %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "%@ használatával történő fizetés jóváhagyása";
 "adyen.dropIn.preselected.openAll.title" = "Fizetési mód módosítása";
 "adyen.continueTo" = "Folytatás a következővel: %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Többösszegű fizetés";
 "adyen.card.installments.monthsAndPrice" = "%@ x %@";
 "adyen.card.installments.months" = "%@ hónap";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Fizetési mód";

--- a/Adyen/Assets/it-IT.lproj/Localizable.strings
+++ b/Adyen/Assets/it-IT.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Verifica la Carta";
 "adyen.card.stored.message" = "Inserire il codice CVC per %@";
 "adyen.card.stored.expires" = "Scade il: %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Conferma il pagamento di %@";
 "adyen.dropIn.preselected.openAll.title" = "Cambia metodo di pagamento";
 "adyen.continueTo" = "Procedi verso %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Pagamento ricorrente";
 "adyen.card.installments.monthsAndPrice" = "%@ x%@";
 "adyen.card.installments.months" = "%@ mesi";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Metodo di pagamento";

--- a/Adyen/Assets/ja-JP.lproj/Localizable.strings
+++ b/Adyen/Assets/ja-JP.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "カード情報を確認して下さい。";
 "adyen.card.stored.message" = "%@のためセキュリティーコードをご入力下さい";
 "adyen.card.stored.expires" = "%@ に期限が切れます";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "%@のお支払いをご確認下さい";
 "adyen.dropIn.preselected.openAll.title" = "お支払方法を変更する";
 "adyen.continueTo" = "次へ進む：%@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "リボ払い";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@か月";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "支払方法";

--- a/Adyen/Assets/ko.lproj/Localizable.strings
+++ b/Adyen/Assets/ko.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "카드 확인";
 "adyen.card.stored.message" = "%@에 대한 CVC 코드를 입력하세요.";
 "adyen.card.stored.expires" = "만료: %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "%@ 결제 확인";
 "adyen.dropIn.preselected.openAll.title" = "결제 수단 변경";
 "adyen.continueTo" = "다음으로 계속: %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "리볼빙 결제";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@개월";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "결제 수단";

--- a/Adyen/Assets/nb-NO.lproj/Localizable.strings
+++ b/Adyen/Assets/nb-NO.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Bekreft kortet ditt";
 "adyen.card.stored.message" = "Vennligst oppgi CVC-koden for %@";
 "adyen.card.stored.expires" = "Utløper %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Bekreft betaling med %@";
 "adyen.dropIn.preselected.openAll.title" = "Endre betalingsmetode";
 "adyen.continueTo" = "Fortsett til %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Gjentakende betaling";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ måneder";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Betalingsmetode";

--- a/Adyen/Assets/nl-NL.lproj/Localizable.strings
+++ b/Adyen/Assets/nl-NL.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Verifieer uw kaart";
 "adyen.card.stored.message" = "Voer de verificatiecode in voor %@";
 "adyen.card.stored.expires" = "Verloopt op %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Bevestig %@ betaling";
 "adyen.dropIn.preselected.openAll.title" = "Betalingsmethode wijzigen";
 "adyen.continueTo" = "Doorgaan naar %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Terugkerende betaling";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ maanden";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Betaalmethode";

--- a/Adyen/Assets/pl-PL.lproj/Localizable.strings
+++ b/Adyen/Assets/pl-PL.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Zweryfikuj kartę";
 "adyen.card.stored.message" = "Proszę wprowadzić kod CVC dla %@";
 "adyen.card.stored.expires" = "Wygasa %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Potwierdź płatność %@";
 "adyen.dropIn.preselected.openAll.title" = "Zmień metodę płatności";
 "adyen.continueTo" = "Przejdź do %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Płatność odnawialna";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ miesięcy";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Metoda płatności";

--- a/Adyen/Assets/pt-BR.lproj/Localizable.strings
+++ b/Adyen/Assets/pt-BR.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Verifique seu cartão";
 "adyen.card.stored.message" = "Por favor insira o código CVC para %@";
 "adyen.card.stored.expires" = "Expira em %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Confirmar pagamento %@";
 "adyen.dropIn.preselected.openAll.title" = "Alterar método de pagamento";
 "adyen.continueTo" = "Continuar para %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Pagamento rotativo";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ meses";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Método de pagamento";

--- a/Adyen/Assets/ro-RO.lproj/Localizable.strings
+++ b/Adyen/Assets/ro-RO.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Verificați-vă cardul";
 "adyen.card.stored.message" = "Vă rugăm să introduceți codul CVC pentru %@";
 "adyen.card.stored.expires" = "Expiră la %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Confirmați plata %@";
 "adyen.dropIn.preselected.openAll.title" = "Schimbare metodă de plată";
 "adyen.continueTo" = "Continuați către %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Plată recurentă";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ luni";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Metodă de plată";

--- a/Adyen/Assets/ru-RU.lproj/Localizable.strings
+++ b/Adyen/Assets/ru-RU.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Подтвердить карту";
 "adyen.card.stored.message" = "Введите код CVC карты %@";
 "adyen.card.stored.expires" = "Действительно до %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Подтвердить оплату %@";
 "adyen.dropIn.preselected.openAll.title" = "Изменить способ оплаты";
 "adyen.continueTo" = "Перейти к %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Повторяющаяся оплата";
 "adyen.card.installments.monthsAndPrice" = "%@× %@";
 "adyen.card.installments.months" = "%@ мес.";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Способ оплаты";

--- a/Adyen/Assets/sk-SK.lproj/Localizable.strings
+++ b/Adyen/Assets/sk-SK.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Overte kartu";
 "adyen.card.stored.message" = "Zadajte kód CVC pre kartu s číslom %@";
 "adyen.card.stored.expires" = "Platnosť vyprší %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Potvrďte platbu pomocou %@";
 "adyen.dropIn.preselected.openAll.title" = "Zmeniť spôsob platby";
 "adyen.continueTo" = "Pokračovať do %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Revolvingová platba";
 "adyen.card.installments.monthsAndPrice" = "%@ x %@";
 "adyen.card.installments.months" = "%@ mesiace/-ov";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Spôsob platby";

--- a/Adyen/Assets/sl-SI.lproj/Localizable.strings
+++ b/Adyen/Assets/sl-SI.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Preverite podatke o kartici";
 "adyen.card.stored.message" = "Vnesite kodo CVC za kartico, ki se konča na %@";
 "adyen.card.stored.expires" = "Potek veljavnosti %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Potrdite plačilo: %@";
 "adyen.dropIn.preselected.openAll.title" = "Spremeni način plačila";
 "adyen.continueTo" = "Nadaljujte na %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Revolving plačilo";
 "adyen.card.installments.monthsAndPrice" = "%@ × %@";
 "adyen.card.installments.months" = "Št. mesecev: %@";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Način plačila";

--- a/Adyen/Assets/sv-SE.lproj/Localizable.strings
+++ b/Adyen/Assets/sv-SE.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "Verifiera ditt kort";
 "adyen.card.stored.message" = "Vänligen fyll i CVC kod för %@";
 "adyen.card.stored.expires" = "Utgår %@";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "Bekräfta %@-betalning";
 "adyen.dropIn.preselected.openAll.title" = "Ändra betalningssätt";
 "adyen.continueTo" = "Fortsätt till %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "Uppdelad betalning";
 "adyen.card.installments.monthsAndPrice" = "%@ x %@";
 "adyen.card.installments.months" = "%@ månader";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "Betalningssätt";

--- a/Adyen/Assets/zh-CN.lproj/Localizable.strings
+++ b/Adyen/Assets/zh-CN.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "验证您的卡片";
 "adyen.card.stored.message" = "请输入 %@ 的 CVC 码";
 "adyen.card.stored.expires" = "%@过期";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "确认 %@ 支付";
 "adyen.dropIn.preselected.openAll.title" = "更改支付方式";
 "adyen.continueTo" = "继续至 %@";
@@ -129,4 +131,4 @@
 "adyen.card.installments.revolving" = "循环支付";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "%@ 个月";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "付款方式";

--- a/Adyen/Assets/zh-TW.lproj/Localizable.strings
+++ b/Adyen/Assets/zh-TW.lproj/Localizable.strings
@@ -30,6 +30,8 @@
 "adyen.card.stored.title" = "驗證您的信用卡";
 "adyen.card.stored.message" = "請輸入 %@ 的信用卡驗證碼";
 "adyen.card.stored.expires" = "%@ 到期";
+"adyen.card.numberItem.unsupportedBrand" = "";
+"adyen.card.numberItem.unknownBrand" = "";
 "adyen.dropIn.stored.title" = "確認 %@ 付款";
 "adyen.dropIn.preselected.openAll.title" = "變更付款方式";
 "adyen.continueTo" = "繼續前往 %@";
@@ -126,4 +128,4 @@
 "adyen.card.installments.revolving" = "延期付款";
 "adyen.card.installments.monthsAndPrice" = "%@x %@";
 "adyen.card.installments.months" = "％{times} 個月";
-"adyen.card.installments.plan" = "";
+"adyen.card.installments.plan" = "付款方式";

--- a/Adyen/UI/Form/Items/Text/FormTextItem.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextItem.swift
@@ -20,8 +20,8 @@ open class FormTextItem: FormValueItem<String, FormTextItemStyle>, ValidatableFo
     /// The validator to use for validating the text in the text field.
     public var validator: Validator?
 
-    /// A message that is displayed when validation fails.
-    public var validationFailureMessage: String?
+    /// A message that is displayed when validation fails. Observable.
+    @Observable(nil) public var validationFailureMessage: String?
 
     /// The auto-capitalization style for the text field.
     public var autocapitalizationType: UITextAutocapitalizationType = .sentences
@@ -34,6 +34,9 @@ open class FormTextItem: FormValueItem<String, FormTextItemStyle>, ValidatableFo
 
     /// The type of content for autofill.
     public var contentType: UITextContentType?
+    
+    /// Determines whether the validation can occur while editing is active.
+    public var allowsValidationWhileEditing: Bool = false
 
     public init(style: FormTextItemStyle) {
         super.init(value: "", style: style)

--- a/Adyen/UI/Form/Items/Text/FormTextItemView.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextItemView.swift
@@ -49,6 +49,10 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValueItemView<String, F
         
         addSubview(textStackView)
         configureConstraints()
+        
+        observe(item.$validationFailureMessage) { [weak self] newValue in
+            self?.alertLabel.text = newValue
+        }
     }
     
     /// :nodoc:
@@ -266,7 +270,9 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValueItemView<String, F
     /// :nodoc:
     open func updateValidationStatus(forced: Bool = false) {
         let textFieldNotEmpty = textField.text.map(\.isEmpty) == false
-        let forceShowValidationStatus = (forced || textFieldNotEmpty) && !isEditing
+        // if validation check is allowed during editing, ignore editing check
+        let forceShowValidationStatus = (forced || textFieldNotEmpty)
+            && (item.allowsValidationWhileEditing || !isEditing)
         if item.isValid(), forceShowValidationStatus {
             accessory = .valid
             hideAlertLabel(true)

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -145,11 +145,19 @@ internal class CardViewController: FormViewController {
 
         let kcpItemsHidden = shouldHideKcpItems(with: binInfo.issuingCountryCode)
 
-        items.numberItem.validator = CardNumberValidator(isLuhnCheckEnabled: brands.luhnCheckRequired)
+        let firstBrand = firstSupportedBrand(from: brands)
+        items.numberItem.luhnCheckEnabled = brands.luhnCheckRequired
+        items.numberItem.update(currentBrand: firstBrand)
         items.additionalAuthPasswordItem.isHidden.wrappedValue = kcpItemsHidden
         items.additionalAuthCodeItem.isHidden.wrappedValue = kcpItemsHidden
         items.socialSecurityNumberItem.isHidden.wrappedValue = shouldHideSocialSecurityItem(with: brands)
-        items.installmentsItem?.update(cardType: brands.first?.type) // choose first until dual brand selection feature
+        items.installmentsItem?.update(cardType: firstBrand?.type) // choose first until dual brand selection feature
+    }
+    
+    /// Returns the first supported brand in a multi(dual) brand sitation. If neither brand is supported, returns the first brand.
+    private func firstSupportedBrand(from brands: [CardBrand]) -> CardBrand? {
+        guard !brands.isEmpty else { return nil }
+        return brands.first { $0.isSupported } ?? brands.first
     }
 
     // MARK: Private methods

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -144,8 +144,8 @@ internal class CardViewController: FormViewController {
         }
 
         let kcpItemsHidden = shouldHideKcpItems(with: binInfo.issuingCountryCode)
-
         let firstBrand = firstSupportedBrand(from: brands)
+        
         items.numberItem.luhnCheckEnabled = brands.luhnCheckRequired
         items.numberItem.update(currentBrand: firstBrand)
         items.additionalAuthPasswordItem.isHidden.wrappedValue = kcpItemsHidden

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -21,11 +21,18 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
         accessory = .customView(cardTypeLogosView)
         textField.textContentType = .creditCardNumber
         textField.returnKeyType = .default
+        
+        observe(item.$currentBrand) { [weak self] _ in
+            self?.updateValidationStatus(forced: true)
+        }
     }
     
     override internal func textFieldDidBeginEditing(_ text: UITextField) {
         super.textFieldDidBeginEditing(text)
-        accessory = .customView(cardTypeLogosView)
+        // change accessory back only if brand is supported or empty
+        if item.currentBrand?.isSupported ?? true {
+            accessory = .customView(cardTypeLogosView)
+        }
     }
     
     override internal func textFieldDidEndEditing(_ text: UITextField) {

--- a/AdyenCard/Utilities/CardType/FallbackCardBrandProvider.swift
+++ b/AdyenCard/Utilities/CardType/FallbackCardBrandProvider.swift
@@ -12,7 +12,7 @@ internal final class FallbackBinInfoProvider: AnyBinInfoProvider {
 
     /// :nodoc:
     internal func provide(for bin: String, supportedTypes: [CardType], completion: @escaping (BinLookupResponse) -> Void) {
-        let result: [CardBrand] = supportedTypes.adyen.types(forCardNumber: bin).map { type in
+        let result: [CardBrand] = CardType.allCases.adyen.types(forCardNumber: bin).map { type in
 
             let cvcPolicy: CardBrand.RequirementPolicy
             switch type {
@@ -28,7 +28,7 @@ internal final class FallbackBinInfoProvider: AnyBinInfoProvider {
                 cvcPolicy = .required
             }
 
-            return CardBrand(type: type, cvcPolicy: cvcPolicy)
+            return CardBrand(type: type, isSupported: supportedTypes.contains(type), cvcPolicy: cvcPolicy)
         }
         completion(BinLookupResponse(brands: result))
     }

--- a/AdyenCard/Utilities/CardType/FallbackCardBrandProvider.swift
+++ b/AdyenCard/Utilities/CardType/FallbackCardBrandProvider.swift
@@ -12,7 +12,7 @@ internal final class FallbackBinInfoProvider: AnyBinInfoProvider {
 
     /// :nodoc:
     internal func provide(for bin: String, supportedTypes: [CardType], completion: @escaping (BinLookupResponse) -> Void) {
-        let result: [CardBrand] = CardType.allCases.adyen.types(forCardNumber: bin).map { type in
+        let result: [CardBrand] = supportedTypes.adyen.types(forCardNumber: bin).map { type in
 
             let cvcPolicy: CardBrand.RequirementPolicy
             switch type {
@@ -28,7 +28,7 @@ internal final class FallbackBinInfoProvider: AnyBinInfoProvider {
                 cvcPolicy = .required
             }
 
-            return CardBrand(type: type, isSupported: supportedTypes.contains(type), cvcPolicy: cvcPolicy)
+            return CardBrand(type: type, cvcPolicy: cvcPolicy)
         }
         completion(BinLookupResponse(brands: result))
     }

--- a/AdyenCard/Validators/CardNumberValidator.swift
+++ b/AdyenCard/Validators/CardNumberValidator.swift
@@ -14,13 +14,18 @@ public final class CardNumberValidator: Validator {
     /// Indicates whether to validate for luhn check
     private let isLuhnCheckEnabled: Bool
     
+    /// Indicates whether the detected brand is supported or not.
+    private let isEnteredBrandSupported: Bool
+    
     /// :nodoc:
-    public init(isLuhnCheckEnabled: Bool) {
+    public init(isLuhnCheckEnabled: Bool, isEnteredBrandSupported: Bool) {
         self.isLuhnCheckEnabled = isLuhnCheckEnabled
+        self.isEnteredBrandSupported = isEnteredBrandSupported
     }
     
     /// :nodoc:
     public func isValid(_ value: String) -> Bool {
+        guard isEnteredBrandSupported else { return false }
         let minimumValidCardLength = 12
         let isValid = value.count >= minimumValidCardLength && (!isLuhnCheckEnabled || luhnCheck(value))
         

--- a/Tests/AdyenTests/Card Tests/CardComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/CardComponentTests.swift
@@ -1138,16 +1138,44 @@ class CardComponentTests: XCTestCase {
                                 configuration: config)
 
         let cardNumberItem = sut.cardViewController.items.numberItem
-        cardNumberItem.validator = CardNumberValidator(isLuhnCheckEnabled: allEnabledLuhns.luhnCheckRequired)
+        cardNumberItem.luhnCheckEnabled = allEnabledLuhns.luhnCheckRequired
         cardNumberItem.value = "4111 1111 1111"
         XCTAssertFalse(cardNumberItem.isValid())
         cardNumberItem.value = "4111 1111 1111 1111"
         XCTAssertTrue(cardNumberItem.isValid())
 
-        cardNumberItem.validator = CardNumberValidator(isLuhnCheckEnabled: atLeastOneDisabledLuhn.luhnCheckRequired)
+        cardNumberItem.luhnCheckEnabled = atLeastOneDisabledLuhn.luhnCheckRequired
         XCTAssertTrue(cardNumberItem.isValid())
         cardNumberItem.value = "4111 1111 1111"
         XCTAssertTrue(cardNumberItem.isValid())
+    }
+    
+    func testUnSupportedBrands() {
+        let method = CardPaymentMethod(type: "bcmc", name: "Test name", fundingSource: .credit, brands: ["visa", "amex", "mc", "elo"])
+        var config = CardComponent.Configuration()
+        config.excludedCardTypes = [.americanExpress]
+
+        let sut = CardComponent(paymentMethod: method,
+                                apiContext: Dummy.context,
+                                configuration: config,
+                                style: .init())
+        
+        fillCard(on: sut.viewController.view, with: Dummy.visaCard)
+        let cardNumberItem = sut.cardViewController.items.numberItem
+        var binResponse = BinLookupResponse(brands: [CardBrand(type: .visa, isSupported: true)])
+        sut.cardViewController.update(binInfo: binResponse)
+        XCTAssertFalse(cardNumberItem.allowsValidationWhileEditing)
+        XCTAssertTrue(cardNumberItem.isValid())
+        
+        fillCard(on: sut.viewController.view, with: Dummy.amexCard)
+        binResponse = BinLookupResponse(brands: [CardBrand(type: .americanExpress, isSupported: false)])
+        sut.cardViewController.update(binInfo: binResponse)
+        XCTAssertTrue(cardNumberItem.allowsValidationWhileEditing)
+        XCTAssertFalse(cardNumberItem.isValid())
+        
+        binResponse = BinLookupResponse(brands: [])
+        sut.cardViewController.update(binInfo: binResponse)
+        XCTAssertFalse(cardNumberItem.allowsValidationWhileEditing)
     }
 
     func testCVCOptionality() {

--- a/Tests/AdyenTests/Card Tests/Validators/CardNumberValidatorTests.swift
+++ b/Tests/AdyenTests/Card Tests/Validators/CardNumberValidatorTests.swift
@@ -10,7 +10,7 @@ import XCTest
 class CardNumberValidatorTests: XCTestCase {
     
     func testValidCards() {
-        let validator = CardNumberValidator(isLuhnCheckEnabled: true)
+        let validator = CardNumberValidator(isLuhnCheckEnabled: true, isEnteredBrandSupported: true)
         
         CardNumbers.valid.forEach { cardNumber in
             XCTAssertTrue(validator.isValid(cardNumber))
@@ -18,15 +18,21 @@ class CardNumberValidatorTests: XCTestCase {
     }
     
     func testInvalidCards() {
-        let validator = CardNumberValidator(isLuhnCheckEnabled: true)
+        let validator = CardNumberValidator(isLuhnCheckEnabled: true, isEnteredBrandSupported: true)
         
         CardNumbers.invalid.forEach { cardNumber in
             XCTAssertFalse(validator.isValid(cardNumber))
         }
     }
     
+    func testUnsupportedCard() {
+        let validator = CardNumberValidator(isLuhnCheckEnabled: true, isEnteredBrandSupported: false)
+        
+        CardNumbers.valid.forEach { XCTAssertFalse(validator.isValid($0)) }
+    }
+    
     func testNonLuhnCheckCards() {
-        let validator = CardNumberValidator(isLuhnCheckEnabled: false)
+        let validator = CardNumberValidator(isLuhnCheckEnabled: false, isEnteredBrandSupported: true)
         XCTAssertTrue(validator.isValid("4111111111111112"))
         XCTAssertTrue(validator.isValid("370000000000000"))
         XCTAssertFalse(validator.isValid("37000000000"))


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
In card number field, after detecting a card number's brand, display a failed validation message if it's among the unsupported types given in the configuration.
- Missing the brand name (to be added in binlookup first)
