### PR TITLE
fix: use the dynamic messageVersion passed with the three DS 2 fingerprint token

### DIFF
--- a/AdyenCard/3DS2 Component/ThreeDS2Component.swift
+++ b/AdyenCard/3DS2 Component/ThreeDS2Component.swift
@@ -46,16 +46,20 @@ public final class ThreeDS2Component: ActionComponent {
             serviceParameters.directoryServerPublicKey = token.directoryServerPublicKey
             
             ADYService.service(with: serviceParameters, appearanceConfiguration: appearanceConfiguration) { service in
-                self.createFingerprint(using: service, paymentData: action.paymentData)
+                self.createFingerprint(using: service,
+                                       messageVersion: token.threeDSMessageVersion,
+                                       paymentData: action.paymentData)
             }
         } catch {
             didFail(with: error)
         }
     }
     
-    private func createFingerprint(using service: ADYService, paymentData: String) {
+    private func createFingerprint(using service: ADYService,
+                                   messageVersion: String,
+                                   paymentData: String) {
         do {
-            let transaction = try service.transaction(withMessageVersion: "2.1.0")
+            let transaction = try service.transaction(withMessageVersion: messageVersion)
             self.transaction = transaction
             
             let fingerprint = try Fingerprint(authenticationRequestParameters: transaction.authenticationRequestParameters)

--- a/AdyenCard/3DS2 Component/ThreeDS2ComponentFingerprintToken.swift
+++ b/AdyenCard/3DS2 Component/ThreeDS2ComponentFingerprintToken.swift
@@ -12,10 +12,12 @@ internal extension ThreeDS2Component {
         
         internal let directoryServerIdentifier: String
         internal let directoryServerPublicKey: String
+        internal let threeDSMessageVersion: String
         
         private enum CodingKeys: String, CodingKey {
             case directoryServerIdentifier = "directoryServerId"
             case directoryServerPublicKey
+            case threeDSMessageVersion
         }
     }
     


### PR DESCRIPTION
## Summary
 fix: use the dynamic messageVersion passed with the three DS 2 fingerprint token message version and not hardcoding the message version to 2.1.0

