### PR TITLE
Allow ApplePay to run onboarding when no supported network

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -54,7 +54,7 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
             throw Error.deviceDoesNotSupportApplyPay
         }
         let supportedNetworks = paymentMethod.supportedNetworks
-        guard PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: supportedNetworks) else {
+        guard configuration.allowOnboarding || Self.canMakePaymentWith(supportedNetworks) else {
             throw Error.userCannotMakePayment
         }
         guard CountryCodeValidator().isValid(payment.countryCode) else {
@@ -136,6 +136,11 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
         
         return paymentAuthorizationViewController
     }
+
+    private static func canMakePaymentWith(_ networks: [PKPaymentNetwork]) -> Bool {
+        PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: networks)
+    }
+
 }
 
 extension ApplePayComponent {

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -64,6 +64,10 @@ extension ApplePayComponent {
         /// A prepopulated billing address.
         public var billingContact: PKContact?
 
+        /// The flag to toggle available cards in the whallet check.
+        /// When `true` - will ignore networks check and allow fallback to "Apple Pay card onboarding".
+        public var allowOnboarding: Bool
+
         /// Initializes the configuration.
         ///
         /// - Parameter summaryItems: The line items for this payment.
@@ -74,16 +78,19 @@ extension ApplePayComponent {
         /// A list of fields that you need for a shipping contact in order to process the transaction. Ignored on iOS 10.*.
         /// - Parameter requiredShippingContactFields: The excluded card brands.
         /// - Parameter billingContact: A prepopulated billing address.
+        /// - Parameter allowOnboarding: The flag to toggle available cards in the whallet check.
         public init(summaryItems: [PKPaymentSummaryItem],
                     merchantIdentifier: String,
                     requiredBillingContactFields: Set<PKContactField> = [],
                     requiredShippingContactFields: Set<PKContactField> = [],
-                    billingContact: PKContact? = nil) {
+                    billingContact: PKContact? = nil,
+                    allowOnboarding: Bool = false) {
             self.summaryItems = summaryItems
             self.merchantIdentifier = merchantIdentifier
             self.requiredBillingContactFields = requiredBillingContactFields
             self.requiredShippingContactFields = requiredShippingContactFields
             self.billingContact = billingContact
+            self.allowOnboarding = allowOnboarding
         }
 
         internal func createPaymentRequest(payment: Payment,

--- a/Demo/Common/IntegrationExampleComponents.swift
+++ b/Demo/Common/IntegrationExampleComponents.swift
@@ -48,7 +48,8 @@ extension IntegrationExample {
     internal func presentApplePayComponent() {
         guard let paymentMethod = paymentMethods?.paymentMethod(ofType: ApplePayPaymentMethod.self) else { return }
         let config = ApplePayComponent.Configuration(summaryItems: ConfigurationConstants.applePaySummaryItems,
-                                                     merchantIdentifier: ConfigurationConstants.applePayMerchantIdentifier)
+                                                     merchantIdentifier: ConfigurationConstants.applePayMerchantIdentifier,
+                                                     allowOnboarding: true)
         let component = try? ApplePayComponent(paymentMethod: paymentMethod,
                                                apiContext: apiContext,
                                                payment: payment,


### PR DESCRIPTION
## Open PR

### Changes

* add `allowOnboarding` flag to ApplePayConfig that allows bypassing supported networks check on ApplePayComponent to open ApplePay onboarding flow