### PR TITLE
chore: change alpha of supported card logos if brand is detected

### DIFF
--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -152,7 +152,7 @@ internal class CardViewController: FormViewController {
     internal func update(binInfo: BinLookupResponse) {
         let brands = binInfo.brands ?? []
         issuingCountryCode = binInfo.issuingCountryCode
-        items.numberContainerItem.numberItem.update(brands: brands)
+        items.numberContainerItem.update(brands: brands)
     }
     
     /// Observe the current brand changes to update all other fields.

--- a/AdyenCard/Form/FormCardLogosItemView.swift
+++ b/AdyenCard/Form/FormCardLogosItemView.swift
@@ -32,6 +32,10 @@ internal final class FormCardLogosItemView: FormItemView<FormCardLogosItem> {
         collectionView.adyen.anchor(inside: self, with: UIEdgeInsets(top: 4, left: 16, bottom: -8, right: -16))
         collectionView.register(CardLogoCell.self, forCellWithReuseIdentifier: CardLogoCell.reuseIdentifier)
         collectionView.dataSource = self
+        
+        observe(item.$alpha) { [weak self] alpha in
+            self?.collectionView.alpha = alpha
+        }
     }
     
 }

--- a/AdyenCard/Form/FormCardNumberContainerItem.swift
+++ b/AdyenCard/Form/FormCardNumberContainerItem.swift
@@ -53,6 +53,13 @@ internal final class FormCardNumberContainerItem: FormItem, Observer {
     internal func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
+    
+    internal func update(brands: [CardBrand]) {
+        // reduce alpha of supported card icons if brand is detected
+        let supportedBrands = brands.filter(\.isSupported)
+        supportedCardLogosItem.alpha = supportedBrands.isEmpty ? 1 : 0.3
+        numberItem.update(brands: brands)
+    }
 }
 
 /// Form item to display multiple card logos.
@@ -67,6 +74,9 @@ internal final class FormCardLogosItem: FormItem, Hidable {
     internal let cardLogos: [CardTypeLogo]
     
     internal let style: FormTextItemStyle
+    
+    /// Observable property to update the owner view's alpha.
+    @Observable(1) internal var alpha: CGFloat
     
     internal init(cardLogos: [CardTypeLogo], style: FormTextItemStyle) {
         self.cardLogos = cardLogos

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -99,13 +99,7 @@ extension FormCardNumberItemView {
         
         private let selectedViewAlpha: CGFloat = 1
         
-        private var unselectedViewAlpha: CGFloat {
-            if #available(iOS 12.0, *), traitCollection.userInterfaceStyle == .dark {
-                return 0.5
-            } else {
-                return 0.2
-            }
-        }
+        private let unselectedViewAlpha: CGFloat = 0.3
         
         internal init(style: ImageStyle, onBrandSelection: @escaping ((Int) -> Void)) {
             self.style = style

--- a/Tests/AdyenTests/Card Tests/CardComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/CardComponentTests.swift
@@ -1426,6 +1426,31 @@ class CardComponentTests: XCTestCase {
         wait(for: .seconds(1))
         XCTAssertFalse(logoItemView!.isHidden)
     }
+    
+    func testSupportedCardLogoAlpha() {
+        let method = CardPaymentMethod(type: "bcmc", name: "Test name", fundingSource: .credit, brands: ["visa", "amex", "mc", "elo"])
+        let config = CardComponent.Configuration(socialSecurityNumberMode: .show)
+
+        let sut = CardComponent(paymentMethod: method,
+                                apiContext: Dummy.context,
+                                configuration: config,
+                                style: .init())
+        
+        let logoItem = sut.cardViewController.items.numberContainerItem.supportedCardLogosItem
+        XCTAssertEqual(logoItem.alpha, 1)
+        
+        var binResponse = BinLookupResponse(brands: [CardBrand(type: .americanExpress)])
+        sut.cardViewController.update(binInfo: binResponse)
+        XCTAssertEqual(logoItem.alpha, 0.3)
+        
+        binResponse = BinLookupResponse(brands: [])
+        sut.cardViewController.update(binInfo: binResponse)
+        XCTAssertEqual(logoItem.alpha, 1)
+        
+        binResponse = BinLookupResponse(brands: [CardBrand(type: .americanExpress, isSupported: false)])
+        sut.cardViewController.update(binInfo: binResponse)
+        XCTAssertEqual(logoItem.alpha, 1)
+    }
 
     func testClearShouldResetPostalCodeItemToEmptyValue() throws {
         // Given


### PR DESCRIPTION
Add an alpha for the card logos based on brand is detected or not.