### PR TITLE
Option to skip payment list on dropin when single regular method

### DIFF
--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -22,7 +22,7 @@ extension DropInComponent: PaymentMethodListComponentDelegate {
     
     internal func didSelect(_ component: PaymentComponent,
                             in paymentMethodListComponent: PaymentMethodListComponent) {
-        rootComponent.startLoading(for: component)
+        (rootComponent as? ComponentLoader)?.startLoading(for: component)
         didSelect(component)
     }
     
@@ -95,7 +95,7 @@ extension DropInComponent: ActionComponentDelegate {
 extension DropInComponent: PreselectedPaymentMethodComponentDelegate {
 
     internal func didProceed(with component: PaymentComponent) {
-        rootComponent.startLoading(for: component)
+        (rootComponent as? ComponentLoader)?.startLoading(for: component)
         didSelect(component)
     }
     

--- a/AdyenDropIn/Models/DropInConfiguration.swift
+++ b/AdyenDropIn/Models/DropInConfiguration.swift
@@ -40,11 +40,17 @@ public extension DropInComponent {
         /// The payment information.
         public var payment: Adyen.Payment?
         
+        /// Determines whether to enable skipping payment list step
+        /// when there is only one non-instant payment method.
+        public let allowsSkippingPaymentList: Bool
+        
         /// Initializes the drop in configuration.
         /// - Parameters:
         ///   - apiContext: The API context used to retrieve internal resources.
-        public init(apiContext: APIContext) {
+        ///   - allowsSkippingPaymentList: Boolean to enable skipping payment list when there is only one one non-instant payment method.
+        public init(apiContext: APIContext, allowsSkippingPaymentList: Bool = false) {
             self.apiContext = apiContext
+            self.allowsSkippingPaymentList = allowsSkippingPaymentList
         }
 
     }

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -102,6 +102,21 @@ internal final class ComponentManager {
 
     internal lazy var paidComponents = paymentMethods.paid.compactMap(component(for:))
     
+    /// Returns the only regular component that is not an instant payment,
+    /// when no other payment method exists.
+    internal var singleRegularComponent: (PaymentComponent & PresentableComponent)? {
+        guard storedComponents.isEmpty,
+              paidComponents.isEmpty,
+              regularComponents.count == 1,
+              let regularComponent = regularComponents.first else { return nil }
+        let cannotSkipPaymentList = regularComponent is InstantPaymentComponent
+        if cannotSkipPaymentList {
+            return nil
+        } else {
+            return regularComponent as? (PaymentComponent & PresentableComponent)
+        }
+    }
+    
     // MARK: - Private
     
     private func component(for paymentMethod: PaymentMethod) -> PaymentComponent? {

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -108,13 +108,8 @@ internal final class ComponentManager {
         guard storedComponents.isEmpty,
               paidComponents.isEmpty,
               regularComponents.count == 1,
-              let regularComponent = regularComponents.first else { return nil }
-        let cannotSkipPaymentList = regularComponent is InstantPaymentComponent
-        if cannotSkipPaymentList {
-            return nil
-        } else {
-            return regularComponent as? (PaymentComponent & PresentableComponent)
-        }
+              let regularComponent = regularComponents.first as? (PaymentComponent & PresentableComponent) else { return nil }
+        return regularComponent
     }
     
     // MARK: - Private


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Added a configuration flag to allow skipping payment list on drop in when there is only one non-instant payment method.
