### PR TITLE
Prevents apple pay call didFail on success

### DIFF
--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 /**
- /// A component that provides a form for card payments.
+  A component that provides a form for card payments.
 
  - SeeAlso:
  [Implementation guidelines](https://docs.adyen.com/payment-methods/cards/ios-component)

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -10,6 +10,9 @@ import PassKit
 
 /// A component that handles Apple Pay payments.
 public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent, Localizable, FinalizableComponent {
+
+    /// :nodoc:
+    internal var success: Bool = false
     
     /// :nodoc:
     private let payment: Payment
@@ -25,7 +28,11 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
 
     /// Apple Pay component configuration.
     internal let configuration: Configuration
+
+    /// :nodoc:
     internal var paymentAuthorizationViewController: PKPaymentAuthorizationViewController?
+
+    /// :nodoc:
     internal var paymentAuthorizationCompletion: ((PKPaymentAuthorizationStatus) -> Void)?
     
     /// The delegate of the component.
@@ -104,7 +111,9 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     /// Finalizes ApplePay payment after being processed by payment provider.
     /// - Parameter success: The status of the payment.
     public func didFinalize(with success: Bool) {
+        self.success = success
         paymentAuthorizationCompletion?(success ? .success : .failure)
+        paymentAuthorizationCompletion = nil
     }
 
     // MARK: - Private

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -8,15 +8,13 @@ import Adyen
 import Foundation
 import PassKit
 
-// MARK: - PKPaymentAuthorizationViewControllerDelegate
-
 /// :nodoc:
 extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     
     /// :nodoc:
     public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
         dismiss { [weak self] in
-            guard let self = self else { return }
+            guard let self = self, self.success == false else { return }
             self.delegate?.didFail(with: ComponentError.cancelled, from: self)
         }
     }

--- a/Demo/Common/IntegrationExample.swift
+++ b/Demo/Common/IntegrationExample.swift
@@ -92,7 +92,11 @@ internal final class IntegrationExample: APIClientAware {
 
         presenter?.dismiss { [weak self] in
             // Payment is unsuccessful. Add your code here.
-            self?.presentAlert(with: error)
+            if let componentError = (error as? ComponentError), componentError == ComponentError.cancelled {
+                self?.presentAlert(withTitle: "Cancelled")
+            } else {
+                self?.presentAlert(with: error)
+            }
         }
     }
 

--- a/Demo/Common/IntegrationExampleComponents.swift
+++ b/Demo/Common/IntegrationExampleComponents.swift
@@ -155,6 +155,7 @@ extension IntegrationExample: ActionComponentDelegate {
     }
 
     internal func didProvide(_ data: ActionComponentData, from component: ActionComponent) {
+        (component as? PresentableComponent)?.viewController.view.isUserInteractionEnabled = false
         let request = PaymentDetailsRequest(
             details: data.details,
             paymentData: data.paymentData,

--- a/Demo/Common/IntegrationExampleDropIn.swift
+++ b/Demo/Common/IntegrationExampleDropIn.swift
@@ -84,6 +84,7 @@ extension IntegrationExample: DropInComponentDelegate {
     }
 
     internal func didProvide(_ data: ActionComponentData, from component: DropInComponent) {
+        component.viewController.view.isUserInteractionEnabled = false
         let request = PaymentDetailsRequest(
             details: data.details,
             paymentData: data.paymentData,


### PR DESCRIPTION
## Open PR

### Changes

- safeguard apple-pay calling `didFail` on successful payment
- disable UI for presented payment component while `/payment/details` call