### PR TITLE
New ApplePay flow

### DIFF
--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -267,7 +267,7 @@ public final class DropInComponent: NSObject, PresentableComponent {
         (component as? CardComponent)?.cardComponentDelegate = cardComponentDelegate
         (component as? PartialPaymentComponent)?.partialPaymentDelegate = partialPaymentDelegate
         (component as? PartialPaymentComponent)?.readyToSubmitComponentDelegate = self
-        (component as? PreApplePayComponent)?.presentationDelegate = self
+        (component as? PreApplePayComponent)?.navigationDelegate = self
         
         component._isDropIn = true
         component.payment = configuration.payment

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -110,12 +110,18 @@ extension DropInComponent: PreselectedPaymentMethodComponentDelegate {
     }
 }
 
-extension DropInComponent: PresentationDelegate {
+extension DropInComponent: NavigationDelegate {
+
+        /// :nodoc:
+    internal func dismiss() {
+        navigationController.dismiss(animated: true, completion: nil)
+    }
 
     /// :nodoc:
     public func present(component: PresentableComponent) {
         navigationController.present(asModal: component)
     }
+
 }
 
 extension DropInComponent: FinalizableComponent {

--- a/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTests.swift
@@ -41,30 +41,6 @@ class ApplePayComponentTest: XCTestCase {
         UIApplication.shared.keyWindow!.rootViewController = emptyVC
     }
 
-    func testApplePayViewControllerIsDismissedFromInside() {
-        guard Available.iOS12 else { return }
-        let dummyExpectation = expectation(description: "Wait stop dismissing")
-
-        mockDelegate.onDidFail = { error, component in
-            XCTFail("should not call didFail")
-        }
-
-        let viewController = sut.viewController
-        UIApplication.shared.keyWindow!.rootViewController = emptyVC
-        UIApplication.shared.keyWindow!.rootViewController!.present(self.sut.viewController, animated: false)
-        
-        wait(for: .seconds(1))
-        
-        self.sut.dismiss {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                dummyExpectation.fulfill()
-            }
-        }
-
-        waitForExpectations(timeout: 10)
-        XCTAssertTrue(viewController !== self.sut.viewController)
-    }
-
     func testApplePayViewControllerShouldCallDelegateDidFail() {
         guard Available.iOS12 else { return }
         let viewController = sut!.viewController
@@ -82,8 +58,6 @@ class ApplePayComponentTest: XCTestCase {
         self.sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
 
         waitForExpectations(timeout: 10)
-
-        XCTAssertTrue(viewController !== self.sut.viewController)
     }
 
     func testInvalidCurrencyCode() {

--- a/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/PreApplePayComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/PreApplePayComponentTests.swift
@@ -63,7 +63,6 @@ class PreApplePayComponentTests: XCTestCase {
     
     func testApplePayPresented() {
         guard Available.iOS12 else { return }
-        let dummyExpectation = expectation(description: "Dummy Expectation")
         
         UIApplication.shared.keyWindow?.rootViewController = sut.viewController
         
@@ -71,7 +70,7 @@ class PreApplePayComponentTests: XCTestCase {
         presentationMock.doPresent = { component in
             UIApplication.shared.keyWindow?.rootViewController?.present(component: component)
         }
-        sut.presentationDelegate = presentationMock
+        sut.navigationDelegate = presentationMock
         
         let applePayButton = self.sut.viewController.view.findView(by: "applePayButton") as? PKPaymentButton
         
@@ -79,31 +78,21 @@ class PreApplePayComponentTests: XCTestCase {
         
         applePayButton?.sendActions(for: .touchUpInside)
         
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            XCTAssertTrue(UIApplication.shared.keyWindow?.rootViewController?.presentedViewController is PKPaymentAuthorizationViewController)
-            UIApplication.shared.keyWindow?.rootViewController?.presentedViewController?.dismiss(animated: false, completion: nil)
-            dummyExpectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 10, handler: nil)
+        wait(for: .seconds(1))
+
+        XCTAssertTrue(UIApplication.shared.keyWindow?.rootViewController?.presentedViewController is PKPaymentAuthorizationViewController)
+        UIApplication.shared.keyWindow?.rootViewController?.presentedViewController?.dismiss(animated: false, completion: nil)
     }
     
     func testHintLabelAmount() {
         UIApplication.shared.keyWindow?.rootViewController = UIViewController()
         UIApplication.shared.keyWindow?.rootViewController?.present(component: sut)
-        
-        let dummyExpectation = expectation(description: "Dummy Expectation")
 
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            let hintLabel = self.sut.viewController.view.findView(by: "hintLabel") as? UILabel
-            
-            XCTAssertNotNil(hintLabel)
-            XCTAssertEqual(hintLabel?.text, self.amount.formatted)
-            
-            dummyExpectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 10, handler: nil)
+        wait(for: .seconds(1))
+        let hintLabel = self.sut.viewController.view.findView(by: "hintLabel") as? UILabel
+
+        XCTAssertNotNil(hintLabel)
+        XCTAssertEqual(hintLabel?.text, self.amount.formatted)
     }
     
     private func createTestSummaryItems() -> [PKPaymentSummaryItem] {

--- a/Tests/AdyenTests/Adyen Tests/Components/PresentationDelegateMock.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/PresentationDelegateMock.swift
@@ -1,12 +1,14 @@
 //
 
 import Adyen
+@testable import AdyenDropIn
 import Foundation
 
-final class PresentationDelegateMock: PresentationDelegate {
+final class PresentationDelegateMock: NavigationDelegate {
 
     // MARK: - presentComponent
 
+    var dismissComponentCallsCount = 0
     var presentComponentCallsCount = 0
     var presentComponentCalled: Bool {
         presentComponentCallsCount > 0
@@ -19,6 +21,13 @@ final class PresentationDelegateMock: PresentationDelegate {
         presentComponentCallsCount += 1
         presentComponentReceivedComponent = component
         doPresent?(component)
+    }
+
+    var doDismiss: (() -> Void)?
+
+    func dismiss() {
+        dismissComponentCallsCount += 1
+        doDismiss?()
     }
 
 }


### PR DESCRIPTION
## Open PR

### Changes

* always execute Apple Pay callback when token present
* adopt Component live-cycle to a new flow
* fix PreApplePayComponent: now can be opened multiple time 