### PR TITLE
fix: move URL extension inside the .adyen Scope

### DIFF
--- a/Adyen/Helpers/URLHelpers.swift
+++ b/Adyen/Helpers/URLHelpers.swift
@@ -7,17 +7,23 @@
 import Foundation
 
 /// :nodoc:
-public extension URL {
-    var queryParameters: [String: String] {
-        let components = URLComponents(url: self, resolvingAgainstBaseURL: true)
+extension URL: AdyenCompatible {}
+
+/// :nodoc:
+extension AdyenScope where Base == URL {
+    
+    /// :nodoc:
+    public var queryParameters: [String: String] {
+        let components = URLComponents(url: base, resolvingAgainstBaseURL: true)
         let queryItems = components?.queryItems ?? []
-        
+
         return Dictionary(uniqueKeysWithValues: queryItems.map {
             ($0.name, $0.value?.removingPercentEncoding ?? "")
         })
     }
-    
-    var isHttp: Bool {
-        scheme == "http" || scheme == "https"
+
+    /// :nodoc:
+    public var isHttp: Bool {
+        base.scheme == "http" || base.scheme == "https"
     }
 }

--- a/AdyenActions/Components/Redirect/RedirectComponent.swift
+++ b/AdyenActions/Components/Redirect/RedirectComponent.swift
@@ -51,7 +51,7 @@ public final class RedirectComponent: ActionComponent {
     public func handle(_ action: RedirectAction) {
         Analytics.sendEvent(component: componentName, flavor: _isDropIn ? .dropin : .components, context: apiContext)
         
-        if action.url.isHttp {
+        if action.url.adyen.isHttp {
             openHttpSchemeUrl(action)
         } else {
             openCustomSchemeUrl(action)

--- a/AdyenActions/Components/Redirect/RedirectDetails.swift
+++ b/AdyenActions/Components/Redirect/RedirectDetails.swift
@@ -52,7 +52,7 @@ public struct RedirectDetails: AdditionalDetails {
     }
     
     internal func extractKeyValuesFromURL() -> [(CodingKeys, String)]? {
-        let queryParameters = returnURL.queryParameters
+        let queryParameters = returnURL.adyen.queryParameters
 
         if let redirectResult = queryParameters[CodingKeys.redirectResult.rawValue]?.removingPercentEncoding {
             return [(.redirectResult, redirectResult)]

--- a/Tests/AdyenTests/Adyen Tests/Extension Tests/URLExtensionsTest.swift
+++ b/Tests/AdyenTests/Adyen Tests/Extension Tests/URLExtensionsTest.swift
@@ -11,14 +11,14 @@ class URLExtensionsTests: XCTestCase {
     
     func testQueryParametersWithNoParameters() {
         let url = URL(string: "url://")!
-        let parameters = url.queryParameters
+        let parameters = url.adyen.queryParameters
         
         XCTAssertEqual(parameters.isEmpty, true)
     }
     
     func testQueryParametersWithMultipleParameters() {
         let url = URL(string: "url://?a=aParameter&b=2&c=c")!
-        let parameters = url.queryParameters
+        let parameters = url.adyen.queryParameters
         
         XCTAssertEqual(parameters.count, 3)
         XCTAssertEqual(parameters["a"], "aParameter")


### PR DESCRIPTION
fix: move URL extension inside the .adyen Scope