### PR TITLE
v4: Correct name for cartebancaire on ApplePay

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -179,6 +179,7 @@ extension PKPaymentNetwork {
 
     internal var adyenName: String {
         if self == .masterCard { return "mc" }
+        if #available(iOS 11.2, *), self == .cartesBancaires { return "cartebancaire" }
         return self.rawValue.lowercased()
     }
 


### PR DESCRIPTION
## Open PR

### Changes

* correct name for cartebancaire on Apple Pay