### PR TITLE
chore: disable spell check on push github action make it only for PR's

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-  push:
-    branches:
-    - master
-    - develop
-
 jobs:
 
   setup:


### PR DESCRIPTION
chore: disable spell check on push github action make it only for PR's