### PR TITLE
fix: PaymentMethods decoding with null values

### DIFF
--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
@@ -85,7 +85,7 @@ internal enum AnyPaymentMethodDecoder {
             let type = try container.decode(String.self, forKey: .type)
             let isStored = decoder.codingPath.contains { $0.stringValue == PaymentMethods.CodingKeys.stored.stringValue }
             let brand = try? container.decode(String.self, forKey: .brand)
-            let isIssuersList = container.contains(.issuers)
+            let isIssuersList = try container.containsValue(.issuers)
 
             if isIssuersList {
                 return try IssuerListPaymentMethodDecoder().decode(from: decoder, isStored: isStored)

--- a/Adyen/Core/Payment Methods/Abstract/PaymentMethods.swift
+++ b/Adyen/Core/Payment Methods/Abstract/PaymentMethods.swift
@@ -56,7 +56,7 @@ public struct PaymentMethods: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.regular = try container.decode([AnyPaymentMethod].self, forKey: .regular).compactMap(\.value)
         
-        if container.contains(.stored) {
+        if try container.containsValue(.stored) {
             self.stored = try container.decode([AnyPaymentMethod].self, forKey: .stored).compactMap { $0.value as? StoredPaymentMethod }
         } else {
             self.stored = []

--- a/Adyen/Helpers/KeyedDecodingContainerHelpers.swift
+++ b/Adyen/Helpers/KeyedDecodingContainerHelpers.swift
@@ -25,5 +25,13 @@ internal extension KeyedDecodingContainer {
         
         return intValue
     }
-    
+
+    /// Returns a Boolean value indicating whether the decoder contains a **non null** value
+    /// associated with the given key.
+    ///
+    /// - parameter key: The key to search for.
+    /// - returns: Whether the `Decoder` has an entry for the given key.
+    func containsValue(_ key: KeyedDecodingContainer<K>.Key) throws -> Bool {
+        try contains(key) && !decodeNil(forKey: key)
+    }
 }

--- a/Tests/AdyenTests/Adyen Tests/Core/PaymentMethodTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Core/PaymentMethodTests.swift
@@ -213,6 +213,39 @@ class PaymentMethodTests: XCTestCase {
         XCTAssertEqual(paymentMethods.regular[20].type.rawValue, "oxxo")
 
     }
+
+    func testDecodingPaymentMethodsWithNullValues() throws {
+
+        let json = """
+{
+    "storedPaymentMethods": null,
+    "paymentMethods": [
+        {
+            "brand": null,
+            "brands": [
+                "visa",
+                "mc",
+                "diners",
+                "discover",
+                "maestro"
+            ],
+            "issuers": null,
+            "configuration": null,
+            "fundingSource": null,
+            "group": null,
+            "inputDetails": null,
+            "name": "Card payment",
+            "type": "scheme"
+        }
+    ]
+}
+"""
+
+        let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(paymentMethods.regular.count, 1)
+        XCTAssertEqual(paymentMethods.stored.count, 0)
+        XCTAssertTrue(paymentMethods.regular[0] is CardPaymentMethod)
+    }
     
     func testEquality() {
         XCTAssertFalse(BLIKPaymentMethod(type: .blik, name: "blik") ==


### PR DESCRIPTION
## Summary
PaymentMethods decoding uses the `contains` function of `KeyedDecodingContainer` to check if the decoding object contains some value. The problem is that `contains` returns true even for null value, which leads to not intended behaviour. For example, if a payment method json object contains `issuers: null`, the SDK will try to parse it with the `IssuerListPaymentMethodDecoder` which is incorrect.

I've created a new extension function `containsValue` that check if there is a non null value associated with a given key.

## Tested scenarios
I've created the `testDecodingPaymentMethodsWithNullValues` test function, which check json parsing with null values.
