### PR TITLE
feature: Add support for changing the store payment method field visibility

### DIFF
--- a/Adyen/UI/Form/Items/Toggle/FormTogglechItem.swift
+++ b/Adyen/UI/Form/Items/Toggle/FormTogglechItem.swift
@@ -8,7 +8,10 @@ import Foundation
 
 /// An item in which a switch is toggled, producing a boolean value.
 /// :nodoc:
-public final class FormToggleItem: FormValueItem<Bool, FormToggleItemStyle> {
+public final class FormToggleItem: FormValueItem<Bool, FormToggleItemStyle>, Hidable {
+
+    /// :nodoc:
+    public var isHidden: Observable<Bool> = Observable(false)
     
     /// Initializes the switch item.
     ///

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -164,7 +164,10 @@ public class CardComponent: PublicKeyConsumer,
         component.payment = payment
         return component
     }()
-    
+
+    func update(storePaymentMethodFieldVisibility isVisible: Bool) {
+        cardViewController.update(storePaymentMethodFieldVisibility: isVisible)
+    }
     // MARK: - Form Items
     
     private lazy var securedViewController = SecuredViewController(child: cardViewController, style: style)

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -165,7 +165,7 @@ public class CardComponent: PublicKeyConsumer,
         return component
     }()
 
-    func update(storePaymentMethodFieldVisibility isVisible: Bool) {
+    public func update(storePaymentMethodFieldVisibility isVisible: Bool) {
         cardViewController.update(storePaymentMethodFieldVisibility: isVisible)
     }
     // MARK: - Form Items

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -10,6 +10,10 @@ import UIKit
     import AdyenEncryption
 #endif
 
+protocol CardViewControllerProtocol {
+    func update(storePaymentMethodFieldVisibility isVisible: Bool)
+}
+
 internal class CardViewController: FormViewController {
 
     private let configuration: CardComponent.Configuration
@@ -291,5 +295,12 @@ internal protocol CardViewControllerDelegate: AnyObject {
 extension FormValueItem where ValueType == String {
     internal var nonEmptyValue: String? {
         self.value.isEmpty ? nil : self.value
+    }
+}
+
+extension CardViewController: CardViewControllerProtocol {
+    func update(storePaymentMethodFieldVisibility isVisible: Bool) {
+        guard let storeDetailsItem = items.storeDetailsItem as? Hidable else { return }
+        storeDetailsItem.isVisible = isVisible
     }
 }

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -301,6 +301,7 @@ extension FormValueItem where ValueType == String {
 extension CardViewController: CardViewControllerProtocol {
     func update(storePaymentMethodFieldVisibility isVisible: Bool) {
         guard var storeDetailsItem = items.storeDetailsItem as? Hidable else { return }
+        storeDetailsItem.value = false
         storeDetailsItem.isVisible = isVisible
     }
 }

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -300,7 +300,7 @@ extension FormValueItem where ValueType == String {
 
 extension CardViewController: CardViewControllerProtocol {
     func update(storePaymentMethodFieldVisibility isVisible: Bool) {
-        guard let storeDetailsItem = items.storeDetailsItem as? Hidable else { return }
+        guard var storeDetailsItem = items.storeDetailsItem as? Hidable else { return }
         storeDetailsItem.isVisible = isVisible
     }
 }

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -301,7 +301,7 @@ extension FormValueItem where ValueType == String {
 extension CardViewController: CardViewControllerProtocol {
     func update(storePaymentMethodFieldVisibility isVisible: Bool) {
         guard var storeDetailsItem = items.storeDetailsItem as? Hidable else { return }
-        storeDetailsItem.value = false
+        items.storeDetailsItem.value = false
         storeDetailsItem.isVisible = isVisible
     }
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
There was no support for changing the visibility of the store payment method switch after the CardComponent was presented. 

Internally there was a need to be able to hide/show the store payment method field based on the card brand/type.

![162455160-9b2b518b-0a10-40f8-a799-31028b11fec7](https://user-images.githubusercontent.com/3766687/162994336-e8cf140c-e6c1-4553-ab18-81424c5de042.gif)

