### PR TITLE
chore: fixes versioning in the project and experimenting with versioned github pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,10 +1,6 @@
 name: Deploy Docs
-on: 
-  workflow_dispatch:
-    inputs:
-      versionToDeploy:
-        description: 'To which version to deploy?'
-        required: true
+on: [workflow_dispatch]
+
 jobs:
 
   Deploy:
@@ -20,12 +16,16 @@ jobs:
       with:
         xcode-version: latest-stable
 
+    - name: Set current marketing version
+      run: echo '::set-output name=MARKETING_VERSION::$(agvtool what-marketing-version -terse1)'
+      id: get-current-marketing-version
+
     - name: Deploy to current version 🚀
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/html
-        destination_dir: ./${{ github.event.inputs.versionToDeploy }}
+        destination_dir: ./${{ steps.get-current-marketing-version.outputs.MARKETING_VERSION }}
     - name: Deploy to root 🚀
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,13 +1,16 @@
-name: Generate Docs
-on: [workflow_dispatch]
+name: Deploy Docs
+on: 
+  workflow_dispatch:
+    inputs:
+      versionToDeploy:
+        description: 'To which version to deploy?'
+        required: true
 jobs:
 
-  Generate:
+  Deploy:
     runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - uses: n1hility/cancel-previous-runs@v2
       with:
         token: ${{ secrets.MANUAL_ACTION_TOKEN }}
@@ -17,13 +20,13 @@ jobs:
       with:
         xcode-version: latest-stable
 
-    - name: Deploy 🚀
+    - name: Deploy to current version 🚀
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/html
-        destination_dir: ${{ agvtool what-marketing-version -terse1 }}
-    - name: Deploy redirect 🚀
+        destination_dir: ./${{ github.event.inputs.versionToDeploy }}
+    - name: Deploy to root 🚀
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,31 @@
+name: Generate Docs
+on: [workflow_dispatch]
+jobs:
+
+  Generate:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: n1hility/cancel-previous-runs@v2
+      with:
+        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+
+    - name: Select latest Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
+    - name: Deploy 🚀
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/html
+        destination_dir: ${{ agvtool what-marketing-version -terse1 }}
+    - name: Deploy redirect 🚀
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/redirect
+        keep_files: true

--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -1,5 +1,10 @@
 name: Generate Docs
-on: [workflow_dispatch]
+on: 
+  workflow_dispatch:
+    inputs:
+      latestVersion:
+        description: 'Whats the latest version of the SDK?'
+        required: true
 jobs:
 
   Generate:
@@ -19,9 +24,9 @@ jobs:
 
     - name: Generate Docs
       run: |
-        gem install cocoapods
-        gem install jazzy
         Scripts/generate_docc_documentation.sh
+      env:
+        LATEST_VERSION: ${{ github.event.inputs.latestVersion }}
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:

--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -21,7 +21,6 @@ jobs:
       run: |
         gem install cocoapods
         gem install jazzy
-        Scripts/generate_jazzy_documentation.sh
         Scripts/generate_docc_documentation.sh
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -6377,7 +6377,7 @@
 				DEVELOPMENT_TEAM = B2NYSS5932;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.CheckoutDemoUIKit.AdyenUIHostUITests;
@@ -6398,7 +6398,7 @@
 				DEVELOPMENT_TEAM = B2NYSS5932;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.CheckoutDemoUIKit.AdyenUIHostUITests;
@@ -6414,6 +6414,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				MARKETING_VERSION = 5.0.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 6;
 			};
@@ -6423,6 +6425,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				MARKETING_VERSION = 5.0.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 6;
 			};
@@ -6463,7 +6467,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 4.7.0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -6483,6 +6487,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MARKETING_VERSION = 5.0.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -6528,7 +6533,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 4.7.0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -6542,6 +6547,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MARKETING_VERSION = 5.0.0;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -6620,7 +6626,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CURRENT_PROJECT_VERSION = 5.0.0;
+				CURRENT_PROJECT_VERSION = 1;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/AdyenTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -6629,6 +6635,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 5.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AdyenUIHost.app/AdyenUIHost";
@@ -6640,7 +6647,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CURRENT_PROJECT_VERSION = 5.0.0;
+				CURRENT_PROJECT_VERSION = 1;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/AdyenTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -6649,6 +6656,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 5.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AdyenUIHost.app/AdyenUIHost";
@@ -6717,7 +6725,7 @@
 				CODE_SIGN_ENTITLEMENTS = Demo/Shared.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B2NYSS5932;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Demo/UIKit/Info.plist;
@@ -6743,7 +6751,7 @@
 				CODE_SIGN_ENTITLEMENTS = Demo/Shared.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B2NYSS5932;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Demo/UIKit/Info.plist;
@@ -7201,7 +7209,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5.0.0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B2NYSS5932;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/AdyenSwiftUITests/Info.plist;
@@ -7211,6 +7219,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenSwiftUITests;
@@ -7225,7 +7234,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 5.0.0;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B2NYSS5932;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/AdyenSwiftUITests/Info.plist;
@@ -7235,6 +7244,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 5.0.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenSwiftUITests;

--- a/Adyen/Info.plist
+++ b/Adyen/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AdyenActions/Info.plist
+++ b/AdyenActions/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AdyenCard/Info.plist
+++ b/AdyenCard/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AdyenComponents/Info.plist
+++ b/AdyenComponents/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AdyenDropIn/Info.plist
+++ b/AdyenDropIn/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AdyenEncryption/Info.plist
+++ b/AdyenEncryption/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AdyenSwiftUI/Info.plist
+++ b/AdyenSwiftUI/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/AdyenWeChatPay/Info.plist
+++ b/AdyenWeChatPay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Demo/SwiftUI/Info.plist
+++ b/Demo/SwiftUI/Info.plist
@@ -43,7 +43,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Demo/UIKit/Info.plist
+++ b/Demo/UIKit/Info.plist
@@ -43,7 +43,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Scripts/generate_docc_documentation.sh
+++ b/Scripts/generate_docc_documentation.sh
@@ -15,6 +15,8 @@ FINAL_DOCC_ARCHIVE_PATH=$DOCS_ROOT/docc_archive
 
 rm -rf $TEMP_PROJECT_FOLDER
 
+rm -rf $DOCS_ROOT
+
 mkdir -p $DOCS_ROOT
 
 mkdir -p $TEMP_PROJECT_FOLDER $TEMP_PROJECT_PATH $FINAL_DOCC_ARCHIVE_PATH
@@ -148,5 +150,5 @@ mkdir -p $REDIRECT_FOLDER
 cd $REDIRECT_FOLDER
 
 echo "<head>
-  <meta http-equiv=\"Refresh\" content=\"0; url='/adyen-ios/$CURRENT_MARKETING_VERSION'\" />
+  <meta http-equiv=\"Refresh\" content=\"0; url='/adyen-ios/$LATEST_VERSION/documentation/adyen'\" />
 </head>" > index.html

--- a/Scripts/generate_docc_documentation.sh
+++ b/Scripts/generate_docc_documentation.sh
@@ -10,11 +10,14 @@ set -e
 TEMP_PROJECT_FOLDER=TempProject
 TEMP_PROJECT_PATH=$TEMP_PROJECT_FOLDER/Adyen
 FRAMEWORK_NAME=Adyen
-FINAL_DOC_PATH=Docc_archive
+DOCS_ROOT=docs
+FINAL_DOCC_ARCHIVE_PATH=$DOCS_ROOT/docc_archive
 
 rm -rf $TEMP_PROJECT_FOLDER
 
-mkdir -p $TEMP_PROJECT_FOLDER $TEMP_PROJECT_PATH $FINAL_DOC_PATH
+mkdir -p $DOCS_ROOT
+
+mkdir -p $TEMP_PROJECT_FOLDER $TEMP_PROJECT_PATH $FINAL_DOCC_ARCHIVE_PATH
 
 cd $TEMP_PROJECT_PATH
  
@@ -122,16 +125,28 @@ xcodebuild docbuild \
 cd ../../
 
 # Delete old DocC archive
-rm -rf $FINAL_DOC_PATH/$FRAMEWORK_NAME.doccarchive
+rm -rf $FINAL_DOCC_ARCHIVE_PATH/$FRAMEWORK_NAME.doccarchive
 
 # Move the new DocC archive to the its final place
-mv $TEMP_PROJECT_PATH/$DERIVED_DATA_PATH/Build/Products/Release-iphonesimulator/$FRAMEWORK_NAME.doccarchive $FINAL_DOC_PATH/$FRAMEWORK_NAME.doccarchive
+mv $TEMP_PROJECT_PATH/$DERIVED_DATA_PATH/Build/Products/Release-iphonesimulator/$FRAMEWORK_NAME.doccarchive $FINAL_DOCC_ARCHIVE_PATH/$FRAMEWORK_NAME.doccarchive
+
+CURRENT_MARKETING_VERSION=$(agvtool what-marketing-version -terse1)
 
 # Generate the DocC html pages
 $(xcrun --find docc) process-archive \
-transform-for-static-hosting $FINAL_DOC_PATH/$FRAMEWORK_NAME.doccarchive \
---output-path docs \
---hosting-base-path /adyen-ios
+transform-for-static-hosting $FINAL_DOCC_ARCHIVE_PATH/$FRAMEWORK_NAME.doccarchive \
+--output-path $DOCS_ROOT/html \
+--hosting-base-path /adyen-ios/$CURRENT_MARKETING_VERSION
 
 # Clean up.
 rm -rf $TEMP_PROJECT_FOLDER
+
+REDIRECT_FOLDER=$DOCS_ROOT/redirect
+
+mkdir -p $REDIRECT_FOLDER
+
+cd $REDIRECT_FOLDER
+
+echo "<head>
+  <meta http-equiv=\"Refresh\" content=\"0; url='/adyen-ios/$CURRENT_MARKETING_VERSION'\" />
+</head>" > index.html

--- a/Tests/AdyenSwiftUITests/Info.plist
+++ b/Tests/AdyenSwiftUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Tests/AdyenTests/Info.plist
+++ b/Tests/AdyenTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>5.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
chore: fixes versioning in the project and made GitHub pages documentation versioned

Now with v5.0.0 GitHub pages will be deployed from the new branch `gh-pages` and with each new version the html docs for that version will be deployed to a new folder with version as name e.g 5.2.1, 5.0.0 ...etc, and the githubpages root will have an index.html that redirects to the latest version 