### PR TITLE
Include checkoutAttemptId as a parameter in payments call.

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -151,6 +151,8 @@
 		C97C16AA28059A5A00534419 /* TelemetryTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97C16A928059A5A00534419 /* TelemetryTrackerTests.swift */; };
 		C97C16AC280702B200534419 /* TelemetryFlavorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97C16AB280702B200534419 /* TelemetryFlavorTests.swift */; };
 		C97C16AD2807076400534419 /* AnalyticsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C0005B280468E100CE2EEC /* AnalyticsProviderMock.swift */; };
+		C981254E2851E9AF006D1374 /* PaymentComponentSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = C981254C2851E903006D1374 /* PaymentComponentSubject.swift */; };
+		C98125502851E9E4006D1374 /* PaymentComponentSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C981254F2851E9E4006D1374 /* PaymentComponentSubjectTests.swift */; };
 		C982FFD826946F0800AED849 /* AffirmComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C982FFD726946F0800AED849 /* AffirmComponent.swift */; };
 		C982FFDC2694792F00AED849 /* AffirmPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = C982FFDB2694792F00AED849 /* AffirmPaymentMethod.swift */; };
 		C9B6683527C7CB7A006950B9 /* TelemetryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B6683427C7CB7A006950B9 /* TelemetryTracker.swift */; };
@@ -1188,6 +1190,8 @@
 		C978F5EE2732CD6A00F59B3C /* FormCardSecurityCodeItemViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardSecurityCodeItemViewTests.swift; sourceTree = "<group>"; };
 		C97C16A928059A5A00534419 /* TelemetryTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryTrackerTests.swift; sourceTree = "<group>"; };
 		C97C16AB280702B200534419 /* TelemetryFlavorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryFlavorTests.swift; sourceTree = "<group>"; };
+		C981254C2851E903006D1374 /* PaymentComponentSubject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentComponentSubject.swift; sourceTree = "<group>"; };
+		C981254F2851E9E4006D1374 /* PaymentComponentSubjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentComponentSubjectTests.swift; sourceTree = "<group>"; };
 		C982FFD726946F0800AED849 /* AffirmComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AffirmComponent.swift; sourceTree = "<group>"; };
 		C982FFDB2694792F00AED849 /* AffirmPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AffirmPaymentMethod.swift; sourceTree = "<group>"; };
 		C9B6683427C7CB7A006950B9 /* TelemetryTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryTracker.swift; sourceTree = "<group>"; };
@@ -2292,6 +2296,15 @@
 			path = CardSecurityCodeItem;
 			sourceTree = "<group>";
 		};
+		C981254B2851E8E2006D1374 /* PaymentComponent */ = {
+			isa = PBXGroup;
+			children = (
+				C981254C2851E903006D1374 /* PaymentComponentSubject.swift */,
+				C981254F2851E9E4006D1374 /* PaymentComponentSubjectTests.swift */,
+			);
+			path = PaymentComponent;
+			sourceTree = "<group>";
+		};
 		C982FFD626945FCE00AED849 /* Affirm */ = {
 			isa = PBXGroup;
 			children = (
@@ -3239,6 +3252,7 @@
 		E97B9717229D533B00505476 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				C981254B2851E8E2006D1374 /* PaymentComponent */,
 				F919DFA124ED599D0027976E /* AdyenActionComponentTests.swift */,
 				A009837B279859BE007E68C4 /* ACH Direct Debit */,
 				C96688BD26A6F72900DC7297 /* Affirm */,
@@ -5635,6 +5649,7 @@
 				C9338020276A09E7005B66CD /* BACSDirectDebitComponentTrackerProtocolMock.swift in Sources */,
 				E9E3DABB221EA22F00697074 /* CardExpiryDateFormatterTests.swift in Sources */,
 				F9639B5624E3DB190073F38A /* PollingComponentTests.swift in Sources */,
+				C98125502851E9E4006D1374 /* PaymentComponentSubjectTests.swift in Sources */,
 				F9976BB526D90C6700D2D7CE /* MultibancoShareableVoucherViewProviderTests.swift in Sources */,
 				E7877803282409FF004A6366 /* ApplePayDelegateMock.swift in Sources */,
 				F99F08642383F2B000EBB948 /* FormTextItemViewTests.swift in Sources */,
@@ -5731,6 +5746,7 @@
 				F9885435272C17BD00F34557 /* PaymentMethodListComponentDelegateMock.swift in Sources */,
 				F9BA21BF246D36AC00D36A63 /* LazyOptionalTests.swift in Sources */,
 				E9021DF2225CC6D0009CF7F4 /* RedirectDetailsTests.swift in Sources */,
+				C981254E2851E9AF006D1374 /* PaymentComponentSubject.swift in Sources */,
 				F96F44E123BF5C2000871C1F /* LocalizationTests.swift in Sources */,
 				007D79232823BE7800382D31 /* UIApplicationExtension.swift in Sources */,
 				F9D5750E237475DB009C18B5 /* CardEncryptorCardTests.swift in Sources */,

--- a/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
+++ b/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
@@ -32,6 +32,7 @@ internal final class AnalyticsProvider: AnalyticsProviderProtocol {
 
     internal let apiClient: APIClientProtocol
     internal let configuration: AnalyticsConfiguration
+    internal var checkoutAttemptId: String?
     private let uniqueAssetAPIClient: UniqueAssetAPIClient<CheckoutAttemptIdResponse>
 
     // MARK: - Initializers
@@ -50,9 +51,10 @@ internal final class AnalyticsProvider: AnalyticsProviderProtocol {
 
         let checkoutAttemptIdRequest = CheckoutAttemptIdRequest()
 
-        uniqueAssetAPIClient.perform(checkoutAttemptIdRequest) { result in
+        uniqueAssetAPIClient.perform(checkoutAttemptIdRequest) { [weak self] result in
             switch result {
             case let .success(response):
+                self?.checkoutAttemptId = response.identifier
                 completion(response.identifier)
             case .failure:
                 completion(nil)

--- a/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
+++ b/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
@@ -24,7 +24,11 @@ public struct AnalyticsConfiguration {
 }
 
 @_spi(AdyenInternal)
-public protocol AnalyticsProviderProtocol: TelemetryTrackerProtocol {}
+public protocol AnalyticsProviderProtocol: TelemetryTrackerProtocol {
+
+    /// :nodoc:
+    var checkoutAttemptId: String? { get }
+}
 
 internal final class AnalyticsProvider: AnalyticsProviderProtocol {
 

--- a/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
+++ b/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
@@ -36,7 +36,7 @@ internal final class AnalyticsProvider: AnalyticsProviderProtocol {
 
     internal let apiClient: APIClientProtocol
     internal let configuration: AnalyticsConfiguration
-    internal var checkoutAttemptId: String?
+    internal private(set) var checkoutAttemptId: String?
     private let uniqueAssetAPIClient: UniqueAssetAPIClient<CheckoutAttemptIdResponse>
 
     // MARK: - Initializers

--- a/Adyen/Core/AdyenContext/AdyenContext.swift
+++ b/Adyen/Core/AdyenContext/AdyenContext.swift
@@ -8,7 +8,6 @@ import AdyenNetworking
 import Foundation
 
 /// A class that defines the behavior of the components in a payment flow.
-/// Create an `AdyenContext` instance for each payment flow and use it for all the components.
 public final class AdyenContext {
 
     // MARK: - Properties

--- a/Adyen/Core/AdyenContext/AdyenContext.swift
+++ b/Adyen/Core/AdyenContext/AdyenContext.swift
@@ -7,8 +7,8 @@
 import AdyenNetworking
 import Foundation
 
-/// A class that defines the behavior of the components in a payment session.
-/// Create an `AdyenContext` instance for each payment session and use it for all the components.
+/// A class that defines the behavior of the components in a payment flow.
+/// Create an `AdyenContext` instance for each payment flow and use it for all the components.
 public final class AdyenContext {
 
     // MARK: - Properties

--- a/Adyen/Core/AdyenContext/AdyenContext.swift
+++ b/Adyen/Core/AdyenContext/AdyenContext.swift
@@ -7,8 +7,8 @@
 import AdyenNetworking
 import Foundation
 
-/// A class that defines a set of attributes to set the behaviour for all components in a payment.
-/// An `AdyenContext` instance should be created per payment session.
+/// A class that defines the behavior of the components in a payment session.
+/// Create an `AdyenContext` instance for each payment session and use it for all the components.
 public final class AdyenContext {
 
     // MARK: - Properties

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -28,6 +28,7 @@ public protocol PaymentComponent: PaymentAwareComponent, PaymentMethodAware {
 extension PaymentComponent {
     
     public func submit(data: PaymentComponentData, component: PaymentComponent? = nil) {
+        // data.checkoutAttemptId = component?.context.analyticsProvider
         guard data.browserInfo == nil else {
             delegate?.didSubmit(data, from: component ?? self)
             return

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -28,14 +28,14 @@ public protocol PaymentComponent: PaymentAwareComponent, PaymentMethodAware {
 extension PaymentComponent {
     
     public func submit(data: PaymentComponentData, component: PaymentComponent? = nil) {
-        var mutableData = data
-        mutableData.checkoutAttemptId = component?.context.analyticsProvider.checkoutAttemptId
+        var updatedData = data
+        updatedData.checkoutAttemptId = component?.context.analyticsProvider.checkoutAttemptId
 
-        guard data.browserInfo == nil else {
-            delegate?.didSubmit(data, from: component ?? self)
+        guard updatedData.browserInfo == nil else {
+            delegate?.didSubmit(updatedData, from: component ?? self)
             return
         }
-        data.dataByAddingBrowserInfo { [weak self] in
+        updatedData.dataByAddingBrowserInfo { [weak self] in
             guard let self = self else { return }
             self.delegate?.didSubmit($0, from: component ?? self)
         }

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -30,13 +30,20 @@ extension PaymentComponent {
     public func submit(data: PaymentComponentData, component: PaymentComponent? = nil) {
         let component = component ?? self
         let checkoutAttemptId = component.context.analyticsProvider.checkoutAttemptId
-        let updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
+        var updatedData: PaymentComponentData
+
+        if data.checkoutAttemptId == checkoutAttemptId {
+            updatedData = data
+        } else {
+            updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
                                                amount: data.amount,
                                                order: data.order,
                                                storePaymentMethod: data.storePaymentMethod,
                                                browserInfo: data.browserInfo,
                                                checkoutAttemptId: checkoutAttemptId,
                                                installments: data.installments)
+
+        }
 
         guard updatedData.browserInfo == nil else {
             delegate?.didSubmit(updatedData, from: component)

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -28,7 +28,9 @@ public protocol PaymentComponent: PaymentAwareComponent, PaymentMethodAware {
 extension PaymentComponent {
     
     public func submit(data: PaymentComponentData, component: PaymentComponent? = nil) {
-        // data.checkoutAttemptId = component?.context.analyticsProvider
+        var mutableData = data
+        mutableData.checkoutAttemptId = component?.context.analyticsProvider.checkoutAttemptId
+
         guard data.browserInfo == nil else {
             delegate?.didSubmit(data, from: component ?? self)
             return

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -28,16 +28,23 @@ public protocol PaymentComponent: PaymentAwareComponent, PaymentMethodAware {
 extension PaymentComponent {
     
     public func submit(data: PaymentComponentData, component: PaymentComponent? = nil) {
-        var updatedData = data
-        updatedData.checkoutAttemptId = component?.context.analyticsProvider.checkoutAttemptId
+        let component = component ?? self
+        let checkoutAttemptId = component.context.analyticsProvider.checkoutAttemptId
+        let updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
+                                               amount: data.amount,
+                                               order: data.order,
+                                               storePaymentMethod: data.storePaymentMethod,
+                                               browserInfo: data.browserInfo,
+                                               checkoutAttemptId: checkoutAttemptId,
+                                               installments: data.installments)
 
         guard updatedData.browserInfo == nil else {
-            delegate?.didSubmit(updatedData, from: component ?? self)
+            delegate?.didSubmit(updatedData, from: component)
             return
         }
         updatedData.dataByAddingBrowserInfo { [weak self] in
             guard let self = self else { return }
-            self.delegate?.didSubmit($0, from: component ?? self)
+            self.delegate?.didSubmit($0, from: component)
         }
     }
 }

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -50,6 +50,9 @@ public struct PaymentComponentData {
     /// Indicates the device default browser info.
     public let browserInfo: BrowserInfo?
 
+    // TODO: - Document checkoutAttemptId
+    public let checkoutAttemptId: String?
+
     /// The billing address information.
     public var billingAddress: PostalAddress? {
         guard let shopperInfo = paymentMethod as? ShopperInformation else { return nil }
@@ -77,6 +80,7 @@ public struct PaymentComponentData {
     ///   - order: The partial payment order if any.
     ///   - storePaymentMethod: Whether the user has chosen to store the payment method.
     ///   - browserInfo: The device default browser info.
+    ///   - checkoutAttemptId: The checkoutAttempt identifier.
     ///   - installments: Installments selection if specified.
     @_spi(AdyenInternal)
     public init(paymentMethodDetails: PaymentMethodDetails,
@@ -84,12 +88,14 @@ public struct PaymentComponentData {
                 order: PartialPaymentOrder?,
                 storePaymentMethod: Bool = false,
                 browserInfo: BrowserInfo? = nil,
+                checkoutAttemptId: String? = nil,
                 installments: Installments? = nil) {
         self.paymentMethod = paymentMethodDetails
+        self.amount = amount
+        self.order = order
         self.storePaymentMethod = storePaymentMethod
         self.browserInfo = browserInfo
-        self.order = order
-        self.amount = amount
+        self.checkoutAttemptId = checkoutAttemptId
         self.installments = installments
     }
 

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -50,7 +50,7 @@ public struct PaymentComponentData {
     /// Indicates the device default browser info.
     public let browserInfo: BrowserInfo?
 
-    // TODO: - Document checkoutAttemptId
+    /// A unique ID that identifies the current transaction.
     public let checkoutAttemptId: String?
 
     /// The billing address information.

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -50,7 +50,7 @@ public struct PaymentComponentData {
     /// Indicates the device default browser info.
     public let browserInfo: BrowserInfo?
 
-    /// A unique ID that identifies the current transaction.
+    /// A unique identifier for a checkout attempt.
     public let checkoutAttemptId: String?
 
     /// The billing address information.

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -51,7 +51,7 @@ public struct PaymentComponentData {
     public let browserInfo: BrowserInfo?
 
     // TODO: - Document checkoutAttemptId
-    public internal(set) var checkoutAttemptId: String?
+    public let checkoutAttemptId: String?
 
     /// The billing address information.
     public var billingAddress: PostalAddress? {
@@ -132,6 +132,7 @@ public struct PaymentComponentData {
                                             order: order,
                                             storePaymentMethod: storePaymentMethod,
                                             browserInfo: $0,
+                                            checkoutAttemptId: checkoutAttemptId,
                                             installments: installments))
         }
     }

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -51,7 +51,7 @@ public struct PaymentComponentData {
     public let browserInfo: BrowserInfo?
 
     // TODO: - Document checkoutAttemptId
-    public let checkoutAttemptId: String?
+    public internal(set) var checkoutAttemptId: String?
 
     /// The billing address information.
     public var billingAddress: PostalAddress? {

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -245,6 +245,7 @@ public final class GiftCardComponent: PresentableComponent,
                              paymentData: paymentData)
         } else {
             delegate?.didSubmit(paymentData, from: self)
+            submit(data: paymentData, component: self)
         }
         return .success(())
     }

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -244,7 +244,6 @@ public final class GiftCardComponent: PresentableComponent,
                              remainingAmount: remainingAmount,
                              paymentData: paymentData)
         } else {
-            delegate?.didSubmit(paymentData, from: self)
             submit(data: paymentData, component: self)
         }
         return .success(())

--- a/AdyenComponents/Boleto/BoletoComponent.swift
+++ b/AdyenComponents/Boleto/BoletoComponent.swift
@@ -193,7 +193,7 @@ extension BoletoComponent: ViewControllerDelegate {
 extension BoletoComponent: PaymentComponentDelegate {
     
     public func didSubmit(_ data: PaymentComponentData, from component: PaymentComponent) {
-        delegate?.didSubmit(data, from: self)
+        submit(data: data, component: self)
     }
     
     public func didFail(with error: Error, from component: PaymentComponent) {

--- a/AdyenDropIn/Components/PreApplePayComponent.swift
+++ b/AdyenDropIn/Components/PreApplePayComponent.swift
@@ -93,20 +93,13 @@ extension PreApplePayComponent: PaymentComponentDelegate {
     
     internal func didSubmit(_ data: PaymentComponentData, from component: PaymentComponent) {
         let checkoutAttemptId = component.context.analyticsProvider.checkoutAttemptId
-        var updatedData: PaymentComponentData
-
-        if data.checkoutAttemptId == checkoutAttemptId {
-            updatedData = data
-        } else {
-            updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
+        let updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
                                                amount: data.amount,
                                                order: data.order,
                                                storePaymentMethod: data.storePaymentMethod,
                                                browserInfo: data.browserInfo,
                                                checkoutAttemptId: checkoutAttemptId,
                                                installments: data.installments)
-        }
-
         submit(data: updatedData, component: self)
     }
     

--- a/AdyenDropIn/Components/PreApplePayComponent.swift
+++ b/AdyenDropIn/Components/PreApplePayComponent.swift
@@ -93,13 +93,20 @@ extension PreApplePayComponent: PaymentComponentDelegate {
     
     internal func didSubmit(_ data: PaymentComponentData, from component: PaymentComponent) {
         let checkoutAttemptId = component.context.analyticsProvider.checkoutAttemptId
-        let updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
+        var updatedData: PaymentComponentData
+
+        if data.checkoutAttemptId == checkoutAttemptId {
+            updatedData = data
+        } else {
+            updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
                                                amount: data.amount,
                                                order: data.order,
                                                storePaymentMethod: data.storePaymentMethod,
                                                browserInfo: data.browserInfo,
                                                checkoutAttemptId: checkoutAttemptId,
                                                installments: data.installments)
+        }
+
         submit(data: updatedData, component: self)
     }
     

--- a/AdyenDropIn/Components/PreApplePayComponent.swift
+++ b/AdyenDropIn/Components/PreApplePayComponent.swift
@@ -92,7 +92,15 @@ internal final class PreApplePayComponent: PresentableComponent,
 extension PreApplePayComponent: PaymentComponentDelegate {
     
     internal func didSubmit(_ data: PaymentComponentData, from component: PaymentComponent) {
-        delegate?.didSubmit(data, from: self)
+        let checkoutAttemptId = component.context.analyticsProvider.checkoutAttemptId
+        let updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
+                                               amount: data.amount,
+                                               order: data.order,
+                                               storePaymentMethod: data.storePaymentMethod,
+                                               browserInfo: data.browserInfo,
+                                               checkoutAttemptId: checkoutAttemptId,
+                                               installments: data.installments)
+        delegate?.didSubmit(updatedData, from: self)
     }
     
     internal func didFail(with error: Error, from component: PaymentComponent) {

--- a/AdyenDropIn/Components/PreApplePayComponent.swift
+++ b/AdyenDropIn/Components/PreApplePayComponent.swift
@@ -100,7 +100,7 @@ extension PreApplePayComponent: PaymentComponentDelegate {
                                                browserInfo: data.browserInfo,
                                                checkoutAttemptId: checkoutAttemptId,
                                                installments: data.installments)
-        delegate?.didSubmit(updatedData, from: self)
+        submit(data: updatedData, component: self)
     }
     
     internal func didFail(with error: Error, from component: PaymentComponent) {

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -51,7 +51,17 @@ extension DropInComponent: PaymentComponentDelegate {
     
     public func didSubmit(_ data: PaymentComponentData, from component: PaymentComponent) {
         paymentInProgress = true
-        delegate?.didSubmit(data, from: component, in: self)
+
+        let checkoutAttemptId = component.context.analyticsProvider.checkoutAttemptId
+        let updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
+                                               amount: data.amount,
+                                               order: data.order,
+                                               storePaymentMethod: data.storePaymentMethod,
+                                               browserInfo: data.browserInfo,
+                                               checkoutAttemptId: checkoutAttemptId,
+                                               installments: data.installments)
+
+        delegate?.didSubmit(updatedData, from: component, in: self)
     }
     
     public func didFail(with error: Error, from component: PaymentComponent) {

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -53,13 +53,19 @@ extension DropInComponent: PaymentComponentDelegate {
         paymentInProgress = true
 
         let checkoutAttemptId = component.context.analyticsProvider.checkoutAttemptId
-        let updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
+        var updatedData: PaymentComponentData
+
+        if data.checkoutAttemptId == checkoutAttemptId {
+            updatedData = data
+        } else {
+            updatedData = PaymentComponentData(paymentMethodDetails: data.paymentMethod,
                                                amount: data.amount,
                                                order: data.order,
                                                storePaymentMethod: data.storePaymentMethod,
                                                browserInfo: data.browserInfo,
                                                checkoutAttemptId: checkoutAttemptId,
                                                installments: data.installments)
+        }
 
         delegate?.didSubmit(updatedData, from: component, in: self)
     }

--- a/AdyenSession/API/Payments/PaymentsRequest.swift
+++ b/AdyenSession/API/Payments/PaymentsRequest.swift
@@ -50,6 +50,7 @@ internal struct PaymentsRequest: APIRequest {
         try container.encodeIfPresent(data.deliveryAddress, forKey: .deliveryAddress)
         try container.encodeIfPresent(data.socialSecurityNumber, forKey: .socialSecurityNumber)
         try container.encodeIfPresent(data.browserInfo, forKey: .browserInfo)
+        try container.encodeIfPresent(data.checkoutAttemptId, forKey: .checkoutAttemptId)
         try container.encodeIfPresent(data.order?.compactOrder, forKey: .order)
     }
     
@@ -59,6 +60,7 @@ internal struct PaymentsRequest: APIRequest {
         case storePaymentMethod
         case shopperEmail
         case browserInfo
+        case checkoutAttemptId
         case shopperName
         case telephoneNumber
         case billingAddress

--- a/Demo/Common/IntegrationExample.swift
+++ b/Demo/Common/IntegrationExample.swift
@@ -54,7 +54,9 @@ internal final class IntegrationExample: APIClientAware {
     // MARK: - Initializers
 
     internal init() {
-        self.context = AdyenContext(apiContext: ConfigurationConstants.apiContext, analyticsConfiguration: .init())
+        var analyticsConfiguration = AnalyticsConfiguration()
+        analyticsConfiguration.isEnabled = true
+        self.context = AdyenContext(apiContext: ConfigurationConstants.apiContext, analyticsConfiguration: analyticsConfiguration)
     }
 
     // MARK: - Networking

--- a/Demo/Common/Networking/PaymentsRequest.swift
+++ b/Demo/Common/Networking/PaymentsRequest.swift
@@ -41,6 +41,7 @@ internal struct PaymentsRequest: APIRequest {
         try container.encodeIfPresent(data.socialSecurityNumber, forKey: .socialSecurityNumber)
         try container.encode(Locale.current.identifier, forKey: .shopperLocale)
         try container.encodeIfPresent(data.browserInfo, forKey: .browserInfo)
+        try container.encodeIfPresent(data.checkoutAttemptId, forKey: .checkoutAttemptId)
         try container.encode("iOS", forKey: .channel)
         try container.encode(amount, forKey: .amount)
         try container.encode(ConfigurationConstants.reference, forKey: .reference)
@@ -67,6 +68,7 @@ internal struct PaymentsRequest: APIRequest {
         case additionalData
         case merchantAccount
         case browserInfo
+        case checkoutAttemptId
         case shopperName
         case telephoneNumber
         case shopperLocale

--- a/Tests/AdyenTests/Adyen Tests/Analytics/AnalyticsProviderMock.swift
+++ b/Tests/AdyenTests/Adyen Tests/Analytics/AnalyticsProviderMock.swift
@@ -11,6 +11,14 @@ import Foundation
 
 class AnalyticsProviderMock: AnalyticsProviderProtocol {
 
+    // MARK: - checkoutAttemptId
+
+    var checkoutAttemptId: String? {
+        get { return underlyingCheckoutAttemptId }
+        set(value) { underlyingCheckoutAttemptId = value }
+    }
+    var underlyingCheckoutAttemptId: String?
+
     // MARK: - sendTelemetryEvent
 
     var sendTelemetryEventCallsCount = 0

--- a/Tests/AdyenTests/Adyen Tests/Analytics/AnalyticsProviderTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Analytics/AnalyticsProviderTests.swift
@@ -107,7 +107,7 @@ class AnalyticsProviderTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testFetchCheckoutAttemptIdWhenCheckoutAttemptIdIsEnabledGivenFailureShouldCallCompletionWithNilValue() throws {
+    func testFetchCheckoutAttemptIdWhenAnalyticsIsEnabledGivenFailureShouldCallCompletionWithNilValue() throws {
         // Given
         var analyticsConfiguration = AnalyticsConfiguration()
         analyticsConfiguration.isEnabled = true
@@ -128,6 +128,44 @@ class AnalyticsProviderTests: XCTestCase {
         }
 
         waitForExpectations(timeout: 1)
+    }
+
+    func testFetchCheckoutAttemptIdWhenAnalyticsIsEnabledShouldSetCheckoutAttemptIdProperty() throws {
+        // Given
+        var analyticsConfiguration = AnalyticsConfiguration()
+        analyticsConfiguration.isEnabled = true
+        sut = AnalyticsProvider(apiClient: apiClient, configuration: analyticsConfiguration)
+
+        let expectedCheckoutAttemptId = checkoutAttemptIdMockValue
+
+        let checkoutAttemptIdResponse = CheckoutAttemptIdResponse(identifier: expectedCheckoutAttemptId)
+        let checkoutAttemptIdResult: Result<Response, Error> = .success(checkoutAttemptIdResponse)
+        apiClient.mockedResults = [checkoutAttemptIdResult]
+
+        // When
+        sut.fetchCheckoutAttemptId { _ in
+
+            // Then
+            XCTAssertEqual(expectedCheckoutAttemptId, self.sut.checkoutAttemptId)
+        }
+    }
+
+    func testFetchCheckoutAttemptIdWhenAnalyticsIsDisabledShouldNotSetCheckoutAttemptIdProperty() throws {
+        // Given
+        var analyticsConfiguration = AnalyticsConfiguration()
+        analyticsConfiguration.isEnabled = false
+        sut = AnalyticsProvider(apiClient: apiClient, configuration: analyticsConfiguration)
+
+        let checkoutAttemptIdResponse = CheckoutAttemptIdResponse(identifier: checkoutAttemptIdMockValue)
+        let checkoutAttemptIdResult: Result<Response, Error> = .success(checkoutAttemptIdResponse)
+        apiClient.mockedResults = [checkoutAttemptIdResult]
+
+        // When
+        sut.fetchCheckoutAttemptId { _ in
+
+            // Then
+            XCTAssertNil(self.sut.checkoutAttemptId)
+        }
     }
 
     // MARK - Private

--- a/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/PreApplePayComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/PreApplePayComponentTests.swift
@@ -144,7 +144,7 @@ class PreApplePayComponentTests: XCTestCase {
 
         // When
         XCTAssertNil(paymentComponentData.checkoutAttemptId)
-        sut.submit(data: paymentComponentData, component: sut)
+        sut.didSubmit(paymentComponentData, from: sut)
 
         // Then
         paymentComponentDelegate.onDidSubmit = { data, _ in
@@ -167,7 +167,7 @@ class PreApplePayComponentTests: XCTestCase {
 
         // When
         XCTAssertNil(paymentComponentData.checkoutAttemptId)
-        sut.submit(data: paymentComponentData, component: sut)
+        sut.didSubmit(paymentComponentData, from: sut)
 
         // Then
         paymentComponentDelegate.onDidSubmit = { data, _ in

--- a/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/PreApplePayComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/PreApplePayComponentTests.swift
@@ -11,20 +11,44 @@ import PassKit
 import XCTest
 
 class PreApplePayComponentTests: XCTestCase {
-    
+
+    var analyticsProviderMock: AnalyticsProviderMock!
+    var amount: Amount!
+    var paymentMethod: ApplePayPaymentMethod!
+    var context: AdyenContext!
+    var paymentComponentDelegate: PaymentComponentDelegateMock!
     var sut: PreApplePayComponent!
     lazy var applePayPayment = Dummy.createTestApplePayPayment()
 
-    override func setUp() {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        amount = Amount(value: 100, currencyCode: "USD")
+        paymentMethod = ApplePayPaymentMethod(type: .applePay, name: "test_name", brands: nil)
+
+        analyticsProviderMock = AnalyticsProviderMock()
+        context = AdyenContext(apiContext: Dummy.apiContext, analyticsProvider: analyticsProviderMock)
+        paymentComponentDelegate = PaymentComponentDelegateMock()
+
         let configuration = ApplePayComponent.Configuration(payment: applePayPayment,
                                                             merchantIdentifier: "test_id")
         var applePayStyle = ApplePayStyle()
         applePayStyle.paymentButtonType = .inStore
         let preApplePayConfig = PreApplePayComponent.Configuration(style: applePayStyle)
         sut = try! PreApplePayComponent(paymentMethod: ApplePayPaymentMethod(type: .applePay, name: "test_name", brands: nil),
-                                                context: Dummy.context,
+                                        context: Dummy.context,
                                         configuration: preApplePayConfig,
                                         applePayConfiguration: configuration)
+        sut.delegate = paymentComponentDelegate
+    }
+
+    override func tearDownWithError() throws {
+        analyticsProviderMock = nil
+        amount = nil
+        paymentMethod = nil
+        context = nil
+        paymentComponentDelegate = nil
+        sut = nil
+        try super.tearDownWithError()
     }
     
     func testUIConfiguration() {
@@ -104,4 +128,50 @@ class PreApplePayComponentTests: XCTestCase {
         XCTAssertEqual(hintLabel?.text, self.applePayPayment.payment.amount.formatted)
     }
 
+    func testSubmitWithAnalyticsEnabledShouldSetCheckoutAttemptIdInPaymentComponentData() throws {
+        // Given
+        let expectedCheckoutAttemptId = "d06da733-ec41-4739-a532-5e8deab1262e16547639430681e1b021221a98c4bf13f7366b30fec4b376cc8450067ff98998682dd24fc9bda"
+        analyticsProviderMock.underlyingCheckoutAttemptId = expectedCheckoutAttemptId
+        let paymentMethodDetails = ApplePayDetails(paymentMethod: paymentMethod,
+                                                   token: "test_token",
+                                                   network: "test_network",
+                                                   billingContact: nil,
+                                                   shippingContact: nil,
+                                                   shippingMethod: nil)
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails,
+                                                        amount: amount,
+                                                        order: nil)
+
+        // When
+        XCTAssertNil(paymentComponentData.checkoutAttemptId)
+        sut.submit(data: paymentComponentData, component: sut)
+
+        // Then
+        paymentComponentDelegate.onDidSubmit = { data, _ in
+            XCTAssertEqual(expectedCheckoutAttemptId, data.checkoutAttemptId)
+        }
+    }
+
+    func testSubmitWithAnalyticsDisabledShouldNotSetCheckoutAttemptIdInPaymentComponentData() throws {
+        // Given
+        analyticsProviderMock.underlyingCheckoutAttemptId = nil
+        let paymentMethodDetails = ApplePayDetails(paymentMethod: paymentMethod,
+                                                   token: "test_token",
+                                                   network: "test_network",
+                                                   billingContact: nil,
+                                                   shippingContact: nil,
+                                                   shippingMethod: nil)
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails,
+                                                        amount: amount,
+                                                        order: nil)
+
+        // When
+        XCTAssertNil(paymentComponentData.checkoutAttemptId)
+        sut.submit(data: paymentComponentData, component: sut)
+
+        // Then
+        paymentComponentDelegate.onDidSubmit = { data, _ in
+            XCTAssertNil(data.checkoutAttemptId)
+        }
+    }
 }

--- a/Tests/AdyenTests/Adyen Tests/Components/PaymentComponent/PaymentComponentSubject.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/PaymentComponent/PaymentComponentSubject.swift
@@ -1,0 +1,35 @@
+//
+//  PaymentComponentSubject.swift
+//  AdyenUIHost
+//
+//  Created by Naufal Aros on 09/06/2022.
+//  Copyright © 2022 Adyen. All rights reserved.
+//
+
+import Foundation
+import Adyen
+
+class PaymentComponentSubject: PaymentComponent {
+
+    // MARK: - Properties
+
+    var context: AdyenContext
+    var delegate: PaymentComponentDelegate?
+    var payment: Payment?
+    var order: PartialPaymentOrder?
+    var paymentMethod: PaymentMethod
+
+    // MARK: - Initializers
+
+    public init(context: AdyenContext,
+                delegate: PaymentComponentDelegate,
+                payment: Payment?,
+                order: PartialPaymentOrder?,
+                paymentMethod: PaymentMethod) {
+        self.context = context
+        self.delegate = delegate
+        self.payment = payment
+        self.order = order
+        self.paymentMethod = paymentMethod
+    }
+}

--- a/Tests/AdyenTests/Adyen Tests/Components/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -1,0 +1,115 @@
+//
+//  PaymentComponentSubjectTests.swift
+//  AdyenUIKitTests
+//
+//  Created by Naufal Aros on 09/06/2022.
+//  Copyright © 2022 Adyen. All rights reserved.
+//
+
+import XCTest
+@_spi(AdyenInternal) @testable import Adyen
+@_spi(AdyenInternal) @testable import AdyenComponents
+
+class PaymentComponentSubjectTests: XCTestCase {
+
+    var analyticsProviderMock: AnalyticsProviderMock!
+    var context: AdyenContext!
+    var paymentComponentDelegate: PaymentComponentDelegateMock!
+    var payment: Payment!
+    var paymentMethod: PaymentMethod!
+    var amount: Amount!
+    var sut: PaymentComponentSubject!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        analyticsProviderMock = AnalyticsProviderMock()
+        context = AdyenContext(apiContext: Dummy.apiContext, analyticsProvider: analyticsProviderMock)
+        paymentComponentDelegate = PaymentComponentDelegateMock()
+
+        amount = Amount(value: 100, currencyCode: "USD")
+        payment = .init(amount: amount, countryCode: "US")
+        paymentMethod = MBWayPaymentMethod(type: .mbWay, name: "MBWay")
+        sut = PaymentComponentSubject(context: context,
+                                      delegate: paymentComponentDelegate,
+                                      payment: payment,
+                                      order: nil,
+                                      paymentMethod: paymentMethod)
+    }
+
+    override func tearDownWithError() throws {
+        context = nil
+        paymentComponentDelegate = nil
+        payment = nil
+        paymentMethod = nil
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testSubmitWithAnalyticsProviderCheckoutAttemptIdNotNilShouldSetCheckoutAttemptIdInPaymentComponentData() throws {
+        // Given
+        let expectedCheckoutAttemptId = "d06da733-ec41-4739-a532-5e8deab1262e16547639430681e1b021221a98c4bf13f7366b30fec4b376cc8450067ff98998682dd24fc9bda"
+        analyticsProviderMock.underlyingCheckoutAttemptId = expectedCheckoutAttemptId
+        let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: amount, order: nil)
+
+        // When
+        XCTAssertNil(paymentComponentData.checkoutAttemptId)
+        sut.submit(data: paymentComponentData, component: sut)
+
+        // Then
+        paymentComponentDelegate.onDidSubmit = { data, _ in
+            XCTAssertEqual(expectedCheckoutAttemptId, data.checkoutAttemptId)
+        }
+    }
+
+    func testSubmitWithAnalyticsProviderCheckoutAttemptIdNilShouldNotSetCheckoutAttemptIdInPaymentComponentData() throws {
+        // Given
+        analyticsProviderMock.underlyingCheckoutAttemptId = nil
+        let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: amount, order: nil)
+
+        // When
+        XCTAssertNil(paymentComponentData.checkoutAttemptId)
+        sut.submit(data: paymentComponentData, component: sut)
+
+        // Then
+        paymentComponentDelegate.onDidSubmit = { data, _ in
+            XCTAssertNil(data.checkoutAttemptId)
+        }
+    }
+
+    func testSubmitWhenBrowserInfoIsNilShouldSetBrowserInfoInPaymentComponentData() throws {
+        // Given
+        let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: amount, order: nil)
+
+        // When
+        XCTAssertNil(paymentComponentData.browserInfo)
+        sut.submit(data: paymentComponentData, component: sut)
+
+        // Then
+        paymentComponentDelegate.onDidSubmit = { data, _ in
+            XCTAssertNotNil(data.browserInfo)
+        }
+    }
+
+    func testSubmitWhenBrowserInfoIsNotNilShouldNotSetBrowserInfoInPaymentComponentData() throws {
+        // Given
+        let expectedBrowserInfo = BrowserInfo(userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)")
+        let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails,
+                                                        amount: amount,
+                                                        order: nil,
+                                                        browserInfo: expectedBrowserInfo)
+
+        // When
+        sut.submit(data: paymentComponentData, component: sut)
+
+        // Then
+        paymentComponentDelegate.onDidSubmit = { data, _ in
+            XCTAssertNotNil(data.browserInfo)
+            XCTAssertEqual(expectedBrowserInfo.userAgent, data.browserInfo?.userAgent)
+        }
+    }
+}

--- a/Tests/AdyenTests/Adyen Tests/Components/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -46,7 +46,7 @@ class PaymentComponentSubjectTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testSubmitWithAnalyticsProviderCheckoutAttemptIdNotNilShouldSetCheckoutAttemptIdInPaymentComponentData() throws {
+    func testSubmitWithAnalyticsEnabledShouldSetCheckoutAttemptIdInPaymentComponentData() throws {
         // Given
         let expectedCheckoutAttemptId = "d06da733-ec41-4739-a532-5e8deab1262e16547639430681e1b021221a98c4bf13f7366b30fec4b376cc8450067ff98998682dd24fc9bda"
         analyticsProviderMock.underlyingCheckoutAttemptId = expectedCheckoutAttemptId
@@ -63,7 +63,7 @@ class PaymentComponentSubjectTests: XCTestCase {
         }
     }
 
-    func testSubmitWithAnalyticsProviderCheckoutAttemptIdNilShouldNotSetCheckoutAttemptIdInPaymentComponentData() throws {
+    func testSubmitWithAnalyticsDisabledShouldNotSetCheckoutAttemptIdInPaymentComponentData() throws {
         // Given
         analyticsProviderMock.underlyingCheckoutAttemptId = nil
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
This PR contains work to:
- Include the `checkoutAttemptId` as part of the `PaymentComponentData` provided in the `didSubmit` method.
- Set the `checkoutAttemptId` as a parameter in the `/payments` call within session.
- Update the demo project to send the `checkoutAttemptId` in non session scenarios.


## Tested scenarios
- Unit test `checkoutAttemptId` is being within the session `/payments` request.
- Unit test `PaymentComponent` submit implementation with test class `PaymentComponentSubject`.


**Fixed issue**:  [COIOS-533](https://youtrack.is.adyen.com/issue/COIOS-533)
