### PR TITLE
v4 feature: changed the BillingAddressConfiguration to make it easy to make the address fields optional for all brands

### DIFF
--- a/AdyenCard/Components/Card/CardComponentConfiguration.swift
+++ b/AdyenCard/Components/Card/CardComponentConfiguration.swift
@@ -75,8 +75,33 @@ extension CardComponent {
         /// When nil, all countries are provided.
         public var billingAddressCountryCodes: [String]?
         
-        /// Card brands for which the billing address fields should be optional.
-        public var billingAddressOptionalForBrands: Set<CardType> = []
+        /// Indicates the requirement level of the address fields.
+        public var billingAddressRequirementPolicy: RequirementPolicy = .required
+        
+        /// Indicates the requirement level of a field.
+        public enum RequirementPolicy {
+            
+            /// Field is required.
+            case required
+            
+            /// Field is optional.
+            case optional
+            
+            /// Field is optional only for provided card types.
+            case optionalForCardTypes(Set<CardType>)
+        }
+        
+        /// :nodoc:
+        internal func isBillingAddressOptional(for cardTypes: [CardType]) -> Bool {
+            switch billingAddressRequirementPolicy {
+            case .required:
+                return false
+            case .optional:
+                return true
+            case let .optionalForCardTypes(optionalCardTypes):
+                return optionalCardTypes.isDisjoint(with: cardTypes) == false
+            }
+        }
 
         /// Configuration of Card component.
         /// - Parameters:
@@ -106,7 +131,7 @@ extension CardComponent {
                     allowedCardTypes: [CardType]? = nil,
                     installmentConfiguration: InstallmentConfiguration? = nil,
                     billingAddressCountryCodes: [String]? = nil,
-                    billingAddressOptionalForBrands: Set<CardType> = []) {
+                    billingAddressRequirementPolicy: RequirementPolicy = .required) {
             self.showsHolderNameField = showsHolderNameField
             self.showsSecurityCodeField = showsSecurityCodeField
             self.showsStorePaymentMethodField = showsStorePaymentMethodField
@@ -117,7 +142,7 @@ extension CardComponent {
             self.socialSecurityNumberMode = socialSecurityNumberMode
             self.installmentConfiguration = installmentConfiguration
             self.billingAddressCountryCodes = billingAddressCountryCodes
-            self.billingAddressOptionalForBrands = billingAddressOptionalForBrands
+            self.billingAddressRequirementPolicy = billingAddressRequirementPolicy
         }
 
         internal func bcmcConfiguration() -> Configuration {

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -192,8 +192,7 @@ internal class CardViewController: FormViewController {
     }
 
     private func updateBillingAddressOptionalStatus(brands: [CardBrand]) {
-        let optionalBrands = configuration.billingAddressOptionalForBrands
-        let isOptional = optionalBrands.isDisjoint(with: brands.map(\.type)) == false
+        let isOptional = configuration.isBillingAddressOptional(for: brands.map(\.type))
         switch configuration.billingAddressMode {
         case .full:
             items.billingAddressItem.updateOptionalStatus(isOptional: isOptional)

--- a/Tests/AdyenTests/Card Tests/CardComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/CardComponentTests.swift
@@ -1973,7 +1973,7 @@ class CardComponentTests: XCTestCase {
         var config = CardComponent.Configuration()
         config.billingAddressMode = .full
         config.billingAddressCountryCodes = ["US"]
-        config.billingAddressOptionalForBrands = [.visa]
+        config.billingAddressRequirementPolicy = .optionalForCardTypes([.visa])
         
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
@@ -2037,7 +2037,7 @@ class CardComponentTests: XCTestCase {
         var config = CardComponent.Configuration()
         config.billingAddressMode = .full
         config.billingAddressCountryCodes = ["US"]
-        config.billingAddressOptionalForBrands = [.visa]
+        config.billingAddressRequirementPolicy = .optionalForCardTypes([.visa])
         
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
@@ -2095,7 +2095,7 @@ class CardComponentTests: XCTestCase {
         var config = CardComponent.Configuration()
         config.billingAddressMode = .postalCode
         config.billingAddressCountryCodes = ["US"]
-        config.billingAddressOptionalForBrands = [.visa]
+        config.billingAddressRequirementPolicy = .optionalForCardTypes([.visa])
         
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
@@ -2155,7 +2155,7 @@ class CardComponentTests: XCTestCase {
         var config = CardComponent.Configuration()
         config.billingAddressMode = .postalCode
         config.billingAddressCountryCodes = ["US"]
-        config.billingAddressOptionalForBrands = [.visa]
+        config.billingAddressRequirementPolicy = .optionalForCardTypes([.visa])
         
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {


### PR DESCRIPTION
v4 feature: changed the BillingAddressConfiguration to make it easy to make the address fields optional for all brands