### PR TITLE
Make Payment Codable

### DIFF
--- a/Adyen/Model/Payment.swift
+++ b/Adyen/Model/Payment.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Describes the current payment.
-public struct Payment {
+public struct Payment: Codable {
     
     /// The amount for this payment.
     public let amount: Amount

--- a/Adyen/Model/Payment.swift
+++ b/Adyen/Model/Payment.swift
@@ -31,4 +31,8 @@ public struct Payment: Codable {
         self.countryCode = unsafeCountryCode
     }
 
+    private enum CodingKeys: String, CodingKey {
+        case amount
+        case countryCode
+    }
 }

--- a/Adyen/Model/Payment.swift
+++ b/Adyen/Model/Payment.swift
@@ -31,8 +31,4 @@ public struct Payment: Codable {
         self.countryCode = unsafeCountryCode
     }
 
-    private enum CodingKeys: String, CodingKey {
-        case amount
-        case countryCode
-    }
 }


### PR DESCRIPTION
## Summary
We noticed that the objects inside Payment are Codable but the Payment object is not.

This change is simple, it doesn't break anything and it's useful and ensure that can we handle Payment or PaymentMethods with the same way.

## Tested scenarios
Store payment methods, perform payments with drop-in

**Fixed issue**:  
