### PR TITLE
v4: Add `didFinalize` callback for Apple Pay 

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		E7D5311A2446F525000046B4 /* FormSeparatorItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D531182446F525000046B4 /* FormSeparatorItem.swift */; };
 		E7D5311C2447065B000046B4 /* PreselectedPaymentComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D5311B2447065B000046B4 /* PreselectedPaymentComponentTests.swift */; };
 		E7E0E2382762005B001DF0C9 /* NSConstraintHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E0E2372762005B001DF0C9 /* NSConstraintHelper.swift */; };
+		E7E3BC9228B3B0FE00977CFA /* DropInInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E3BC9128B3B0FE00977CFA /* DropInInternalTests.swift */; };
 		E7E8343C24F3C81700EC3844 /* PublicKeyProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E8343B24F3C81700EC3844 /* PublicKeyProviderMock.swift */; };
 		E7ED5F5F25F25F8100EE5BCA /* Adyen3DS2 in Frameworks */ = {isa = PBXBuildFile; productRef = F9C5F08325C96919005A6E54 /* Adyen3DS2 */; };
 		E9021DAA225789B1009CF7F4 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9021DA9225789B1009CF7F4 /* Localization.swift */; };
@@ -1263,6 +1264,7 @@
 		E7D531182446F525000046B4 /* FormSeparatorItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormSeparatorItem.swift; sourceTree = "<group>"; };
 		E7D5311B2447065B000046B4 /* PreselectedPaymentComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreselectedPaymentComponentTests.swift; sourceTree = "<group>"; };
 		E7E0E2372762005B001DF0C9 /* NSConstraintHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSConstraintHelper.swift; sourceTree = "<group>"; };
+		E7E3BC9128B3B0FE00977CFA /* DropInInternalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropInInternalTests.swift; sourceTree = "<group>"; };
 		E7E8343B24F3C81700EC3844 /* PublicKeyProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKeyProviderMock.swift; sourceTree = "<group>"; };
 		E90139CA22846AD5004C74DA /* ModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalViewController.swift; sourceTree = "<group>"; };
 		E9021DA9225789B1009CF7F4 /* Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localization.swift; sourceTree = "<group>"; };
@@ -2696,6 +2698,7 @@
 				F92385B62757AE8B0082F7B7 /* XCTestCaseExtensions.swift */,
 				E7D189AF25D31936006AD3B7 /* DropInActionTests.swift */,
 				E74CE3DE26727EB1008231D2 /* DropInDelegateMock.swift */,
+				E7E3BC9128B3B0FE00977CFA /* DropInInternalTests.swift */,
 			);
 			path = DropIn;
 			sourceTree = "<group>";
@@ -5031,6 +5034,7 @@
 				E9E3DAB2221D79C800697074 /* CardNumberFormatterTests.swift in Sources */,
 				F9EDB796239663F800CFB3C9 /* PaymentComponentMock.swift in Sources */,
 				E7D189B025D31936006AD3B7 /* DropInActionTests.swift in Sources */,
+				E7E3BC9228B3B0FE00977CFA /* DropInInternalTests.swift in Sources */,
 				C95903DE275A48D000E7D3BC /* BACSDirectDebitComponentTests.swift in Sources */,
 				F9A781B02403ED4000E12487 /* NumericStringValidatorTests.swift in Sources */,
 				F960FB092371823A00AEF74B /* ApplePayComponentTests.swift in Sources */,

--- a/Adyen/Core/Components/Base/Component.swift
+++ b/Adyen/Core/Components/Base/Component.swift
@@ -14,7 +14,7 @@ extension Component {
 
     /// Finalizes the payment if there is any, after being processed by payment provider.
     /// - Parameter success: The status of the payment.
-    @available(*, deprecated, message: "This property will no longer be available.")
+    @available(*, deprecated, message: "Use finalizeIfNeeded(with:, completion:) instead.")
     public func finalizeIfNeeded(with success: Bool) {
         stopLoadingIfNeeded()
         (self as? FinalizableComponent)?.didFinalize(with: success, completion: nil)
@@ -46,7 +46,7 @@ public protocol FinalizableComponent: Component {
 
     /// Finalizes payment after being processed by payment provider.
     /// - Parameter success: The status of the payment.
-    @available(*, deprecated, message: "This property will no longer be available. Use finalizeIfNeeded(with:, completion:) instead.")
+    @available(*, deprecated, message: "Use finalizeIfNeeded(with:, completion:) instead.")
     func didFinalize(with success: Bool)
 
     /// Finalizes payment after being processed by payment provider.

--- a/Adyen/Core/Components/Base/Component.swift
+++ b/Adyen/Core/Components/Base/Component.swift
@@ -14,9 +14,14 @@ extension Component {
 
     /// Finalizes the payment if there is any, after being processed by payment provider.
     /// - Parameter success: The status of the payment.
-    /// :nodoc:
+    @available(*, deprecated, message: "This property will no longer be available.")
     public func finalizeIfNeeded(with success: Bool) {
-        (self as? FinalizableComponent)?.didFinalize(with: success)
+        (self as? FinalizableComponent)?.didFinalize(with: success, completion: {})
+        stopLoadingIfNeeded()
+    }
+
+    public func finalizeIfNeeded(with success: Bool, completion: (() -> Void)?) {
+        (self as? FinalizableComponent)?.didFinalize(with: success, completion: completion)
         stopLoadingIfNeeded()
     }
 
@@ -37,7 +42,14 @@ public protocol FinalizableComponent: Component {
 
     /// Finalizes payment after being processed by payment provider.
     /// - Parameter success: The status of the payment.
+    @available(*, deprecated, message: "This property will no longer be available.")
     func didFinalize(with success: Bool)
+
+    /// Finalizes payment after being processed by payment provider.
+    /// - Parameter success: The status of the payment.
+    /// - Parameter completion: The block to execute after the component finalizes its activity.
+    /// Use of this block is recommended for ApplePayComponent. You may specify nil for this parameter.
+    func didFinalize(with success: Bool, completion: (() -> Void)?)
 }
 
 public extension Component {

--- a/Adyen/Core/Components/Base/Component.swift
+++ b/Adyen/Core/Components/Base/Component.swift
@@ -16,7 +16,6 @@ extension Component {
     /// - Parameter success: The status of the payment.
     @available(*, deprecated, message: "Use finalizeIfNeeded(with:, completion:) instead.")
     public func finalizeIfNeeded(with success: Bool) {
-        stopLoadingIfNeeded()
         (self as? FinalizableComponent)?.didFinalize(with: success, completion: nil)
     }
 

--- a/Adyen/Core/Components/Base/Component.swift
+++ b/Adyen/Core/Components/Base/Component.swift
@@ -16,13 +16,17 @@ extension Component {
     /// - Parameter success: The status of the payment.
     @available(*, deprecated, message: "This property will no longer be available.")
     public func finalizeIfNeeded(with success: Bool) {
-        (self as? FinalizableComponent)?.didFinalize(with: success, completion: {})
         stopLoadingIfNeeded()
+        (self as? FinalizableComponent)?.didFinalize(with: success, completion: nil)
     }
 
     public func finalizeIfNeeded(with success: Bool, completion: (() -> Void)?) {
-        (self as? FinalizableComponent)?.didFinalize(with: success, completion: completion)
         stopLoadingIfNeeded()
+        if let finalizable = self as? FinalizableComponent {
+            finalizable.didFinalize(with: success, completion: completion)
+        } else {
+            completion?()
+        }
     }
 
     /// Called when the user cancels the component.
@@ -42,7 +46,7 @@ public protocol FinalizableComponent: Component {
 
     /// Finalizes payment after being processed by payment provider.
     /// - Parameter success: The status of the payment.
-    @available(*, deprecated, message: "This property will no longer be available.")
+    @available(*, deprecated, message: "This property will no longer be available. Use finalizeIfNeeded(with:, completion:) instead.")
     func didFinalize(with success: Bool)
 
     /// Finalizes payment after being processed by payment provider.

--- a/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
+++ b/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
@@ -52,7 +52,6 @@ public final class PresentableComponentWrapper: PresentableComponent,
 
     /// :nodoc:
     public func didFinalize(with success: Bool) {
-        stopLoading()
         component.finalizeIfNeeded(with: success, completion: nil)
     }
 

--- a/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
+++ b/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
@@ -46,21 +46,20 @@ public final class PresentableComponentWrapper: PresentableComponent,
     
     /// :nodoc:
     public func didCancel() {
-        component.cancelIfNeeded()
         stopLoading()
+        component.cancelIfNeeded()
     }
 
     /// :nodoc:
     public func didFinalize(with success: Bool) {
-        component.finalizeIfNeeded(with: success, completion: {})
         stopLoading()
+        component.finalizeIfNeeded(with: success, completion: nil)
     }
 
     /// :nodoc:
     public func didFinalize(with success: Bool, completion: (() -> Void)?) {
-        component.finalizeIfNeeded(with: success, completion: { [weak self] in
-            self?.stopLoading()
-        })
+        stopLoading()
+        component.finalizeIfNeeded(with: success, completion: completion)
     }
 
     /// :nodoc:

--- a/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
+++ b/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
@@ -52,8 +52,15 @@ public final class PresentableComponentWrapper: PresentableComponent,
 
     /// :nodoc:
     public func didFinalize(with success: Bool) {
-        component.finalizeIfNeeded(with: success)
+        component.finalizeIfNeeded(with: success, completion: {})
         stopLoading()
+    }
+
+    /// :nodoc:
+    public func didFinalize(with success: Bool, completion: (() -> Void)?) {
+        component.finalizeIfNeeded(with: success, completion: { [weak self] in
+            self?.stopLoading()
+        })
     }
 
     /// :nodoc:

--- a/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
+++ b/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
@@ -46,8 +46,8 @@ public final class PresentableComponentWrapper: PresentableComponent,
     
     /// :nodoc:
     public func didCancel() {
-        stopLoading()
         component.cancelIfNeeded()
+        stopLoading()
     }
 
     /// :nodoc:

--- a/AdyenActions/Actions/DokuVoucherAction.swift
+++ b/AdyenActions/Actions/DokuVoucherAction.swift
@@ -16,12 +16,6 @@ public final class DokuVoucherAction: GenericVoucherAction, InstructionAwareVouc
     /// The shopper email.
     public let shopperEmail: String
     
-    /// The instruction url.
-    @available(*, deprecated, message: "Please use `instructionsURL` instead.")
-    public var instructionsUrl: String {
-        instructionsURL.absoluteString
-    }
-    
     /// The instruction `URL` object.
     public let instructionsURL: URL
 

--- a/AdyenActions/Actions/EContextStoresVoucherAction.swift
+++ b/AdyenActions/Actions/EContextStoresVoucherAction.swift
@@ -13,12 +13,6 @@ public class EContextStoresVoucherAction: GenericVoucherAction,
     /// Masked shopper telephone number.
     public let maskedTelephoneNumber: String
     
-    /// The instruction url.
-    @available(*, deprecated, message: "Please use `instructionsURL` instead.")
-    public var instructionsUrl: String {
-        instructionsURL.absoluteString
-    }
-    
     /// The instruction `URL` object.
     public let instructionsURL: URL
 

--- a/AdyenActions/Actions/OXXOVoucherAction.swift
+++ b/AdyenActions/Actions/OXXOVoucherAction.swift
@@ -21,12 +21,6 @@ public class OXXOVoucherAction: GenericVoucherAction,
     /// Download URL.
     public let downloadUrl: URL
     
-    /// The instruction url.
-    @available(*, deprecated, message: "Please use `instructionsURL` instead.")
-    public var instructionsUrl: String {
-        instructionsURL.absoluteString
-    }
-    
     /// The instruction `URL` object.
     public let instructionsURL: URL
 

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -116,7 +116,7 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
 
     /// Finalizes ApplePay payment after being processed by payment provider.
     /// - Parameter success: The status of the payment.
-    @available(*, deprecated, message: "This property will no longer be available.")
+    @available(*, deprecated, message: "This property will no longer be available. Use didFinalize(with:, completion:) instead.")
     public func didFinalize(with success: Bool) {
         finalizeCompletion = {}
         paymentAuthorizationCompletion?(success ? .success : .failure)

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -11,6 +11,10 @@ import PassKit
 /// A component that handles Apple Pay payments.
 public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent, Localizable, FinalizableComponent {
 
+    internal var isFinalised: Bool {
+        finalizeCompletion != nil
+    }
+
     /// :nodoc:
     internal var finalizeCompletion: (() -> Void)?
     

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -116,7 +116,7 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
 
     /// Finalizes ApplePay payment after being processed by payment provider.
     /// - Parameter success: The status of the payment.
-    @available(*, deprecated, message: "This property will no longer be available. Use didFinalize(with:, completion:) instead.")
+    @available(*, deprecated, message: "Use didFinalize(with:, completion:) instead.")
     public func didFinalize(with success: Bool) {
         finalizeCompletion = {}
         paymentAuthorizationCompletion?(success ? .success : .failure)

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -14,12 +14,12 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     /// :nodoc:
     public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
         paymentAuthorizationViewController = nil
-        guard isFinalised else {
+        guard case let .finalized(completion) = state else {
             self.delegate?.didFail(with: ComponentError.cancelled, from: self)
             return
         }
 
-        finalizeCompletion?()
+        completion?()
     }
     
     /// :nodoc:
@@ -32,7 +32,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
             return
         }
 
-        paymentAuthorizationCompletion = completion
+        state = .paid(completion)
         let token = payment.token.paymentData.base64EncodedString()
         let network = payment.token.paymentMethod.network?.rawValue ?? ""
         let billingContact = payment.billingContact

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -14,12 +14,12 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     /// :nodoc:
     public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
         paymentAuthorizationViewController = nil
-        guard let completion = finalizeCompletion else {
+        guard isFinalised else {
             self.delegate?.didFail(with: ComponentError.cancelled, from: self)
             return
         }
 
-        completion()
+        finalizeCompletion?()
     }
     
     /// :nodoc:

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -13,10 +13,13 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     
     /// :nodoc:
     public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
-        dismiss { [weak self] in
-            guard let self = self, self.success == false else { return }
+        paymentAuthorizationViewController = nil
+        guard let completion = finalizeCompletion else {
             self.delegate?.didFail(with: ComponentError.cancelled, from: self)
+            return
         }
+
+        completion()
     }
     
     /// :nodoc:

--- a/AdyenDropIn/Components/PreApplePayComponent.swift
+++ b/AdyenDropIn/Components/PreApplePayComponent.swift
@@ -69,7 +69,11 @@ internal final class PreApplePayComponent: Localizable, PresentableComponent, Fi
     
     /// :nodoc
     internal func didFinalize(with success: Bool) {
-        applePayComponent.didFinalize(with: success)
+        assertionFailure("Do not call this method. Use didFinalize(with success:completion:) ")
+    }
+
+    internal func didFinalize(with success: Bool, completion: (() -> Void)?) {
+        applePayComponent.didFinalize(with: success, completion: completion)
     }
     
     /// :nodoc:

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -122,13 +122,17 @@ extension DropInComponent: FinalizableComponent {
 
     public func didFinalize(with success: Bool, completion: (() -> Void)?) {
         stopLoading()
-        selectedPaymentComponent?.finalizeIfNeeded(with: success, completion: completion)
+        if let component = selectedPaymentComponent {
+            component.finalizeIfNeeded(with: success, completion: completion)
+        } else {
+            completion?()
+        }
     }
 
     /// Stops loading and finalize DropIn's selected payment if necessary.
     /// This method must be called after certain payment methods (e.x. ApplePay)
     /// - Parameter success: Status of the payment.
-    @available(*, deprecated, message: "This property will no longer be available.")
+    @available(*, deprecated, message: "This property will no longer be available. Use finalizeIfNeeded(with:, completion:) instead.")
     public func didFinalize(with success: Bool) {
         stopLoading()
         selectedPaymentComponent?.finalizeIfNeeded(with: success)

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -132,7 +132,7 @@ extension DropInComponent: FinalizableComponent {
     /// Stops loading and finalize DropIn's selected payment if necessary.
     /// This method must be called after certain payment methods (e.x. ApplePay)
     /// - Parameter success: Status of the payment.
-    @available(*, deprecated, message: "This property will no longer be available. Use finalizeIfNeeded(with:, completion:) instead.")
+    @available(*, deprecated, message: "Use didFinalize(with:, completion:) instead.")
     public func didFinalize(with success: Bool) {
         stopLoading()
         selectedPaymentComponent?.finalizeIfNeeded(with: success)

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -120,9 +120,15 @@ extension DropInComponent: PresentationDelegate {
 
 extension DropInComponent: FinalizableComponent {
 
+    public func didFinalize(with success: Bool, completion: (() -> Void)?) {
+        stopLoading()
+        selectedPaymentComponent?.finalizeIfNeeded(with: success, completion: completion)
+    }
+
     /// Stops loading and finalize DropIn's selected payment if necessary.
     /// This method must be called after certain payment methods (e.x. ApplePay)
     /// - Parameter success: Status of the payment.
+    @available(*, deprecated, message: "This property will no longer be available.")
     public func didFinalize(with success: Bool) {
         stopLoading()
         selectedPaymentComponent?.finalizeIfNeeded(with: success)

--- a/Demo/Common/IntegrationExample.swift
+++ b/Demo/Common/IntegrationExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2022 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -79,25 +79,25 @@ internal final class IntegrationExample: APIClientAware {
 
     internal func finish(with resultCode: PaymentsResponse.ResultCode) {
         let success = resultCode == .authorised || resultCode == .received || resultCode == .pending
-        currentComponent?.finalizeIfNeeded(with: success)
-
-        presenter?.dismiss { [weak self] in
-            // Payment is processed. Add your code here.
-            self?.presentAlert(withTitle: resultCode.rawValue)
+        currentComponent?.finalizeIfNeeded(with: success) { [weak self] in
+            self?.presenter?.dismiss { [weak self] in
+                // Payment is processed. Add your code here.
+                self?.presentAlert(withTitle: resultCode.rawValue)
+            }
         }
     }
 
     internal func finish(with error: Error) {
-        currentComponent?.finalizeIfNeeded(with: false)
-
-        presenter?.dismiss { [weak self] in
-            // Payment is unsuccessful. Add your code here.
-            if let componentError = (error as? ComponentError), componentError == ComponentError.cancelled {
-                self?.presentAlert(withTitle: "Cancelled")
-            } else {
-                self?.presentAlert(with: error)
+        currentComponent?.finalizeIfNeeded(with: false, completion: { [weak self] in
+            self?.presenter?.dismiss { [weak self] in
+                // Payment is unsuccessful. Add your code here.
+                if let componentError = (error as? ComponentError), componentError == ComponentError.cancelled {
+                    self?.presentAlert(withTitle: "Cancelled")
+                } else {
+                    self?.presentAlert(with: error)
+                }
             }
-        }
+        })
     }
 
     internal func presentAlert(with error: Error, retryHandler: (() -> Void)? = nil) {

--- a/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTests.swift
@@ -212,10 +212,10 @@ class ApplePayComponentTest: XCTestCase {
 
     func testFinaliseOnSuccesfullPayment() {
         let onPaymentProccessedExpectation = expectation(description: "Wait for component to finalise")
-        sut.paymentAuthorizationCompletion = { status in
+        sut.state = .paid({ status in
             XCTAssertTrue(status == .success)
             onPaymentProccessedExpectation.fulfill()
-        }
+        })
 
         let onFinaliseExpectation = expectation(description: "Wait for component to finalise")
         sut.finalizeIfNeeded(with: true, completion: {

--- a/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/ApplePayComponentTests.swift
@@ -41,30 +41,6 @@ class ApplePayComponentTest: XCTestCase {
         UIApplication.shared.keyWindow!.rootViewController = emptyVC
     }
 
-    func testApplePayViewControllerIsDismissedFromInside() {
-        guard Available.iOS12 else { return }
-        let dummyExpectation = expectation(description: "Wait stop dismissing")
-
-        mockDelegate.onDidFail = { error, component in
-            XCTFail("should not call didFail")
-        }
-
-        let viewController = sut.viewController
-        UIApplication.shared.keyWindow!.rootViewController = emptyVC
-        UIApplication.shared.keyWindow!.rootViewController!.present(self.sut.viewController, animated: false)
-        
-        wait(for: .seconds(1))
-        
-        self.sut.dismiss {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                dummyExpectation.fulfill()
-            }
-        }
-
-        waitForExpectations(timeout: 10)
-        XCTAssertTrue(viewController !== self.sut.viewController)
-    }
-
     func testApplePayViewControllerShouldCallDelegateDidFail() {
         guard Available.iOS12 else { return }
         let viewController = sut!.viewController

--- a/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/PreApplePayComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Apple Pay/PreApplePayComponentTests.swift
@@ -63,7 +63,6 @@ class PreApplePayComponentTests: XCTestCase {
     
     func testApplePayPresented() {
         guard Available.iOS12 else { return }
-        let dummyExpectation = expectation(description: "Dummy Expectation")
         
         UIApplication.shared.keyWindow?.rootViewController = sut.viewController
         
@@ -78,28 +77,29 @@ class PreApplePayComponentTests: XCTestCase {
         XCTAssertNotNil(applePayButton)
         
         applePayButton?.sendActions(for: .touchUpInside)
+
+        wait(for: .seconds(1))
         
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            XCTAssertTrue(UIApplication.shared.keyWindow?.rootViewController?.presentedViewController is PKPaymentAuthorizationViewController)
-            UIApplication.shared.keyWindow?.rootViewController?.presentedViewController?.dismiss(animated: false, completion: nil)
-            dummyExpectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 10, handler: nil)
+        XCTAssertTrue(UIApplication.shared.keyWindow?.rootViewController?.presentedViewController is PKPaymentAuthorizationViewController)
+        UIApplication.shared.keyWindow?.rootViewController?.presentedViewController?.dismiss(animated: false, completion: nil)
     }
     
     func testHintLabelAmount() {
         UIApplication.shared.keyWindow?.rootViewController = UIViewController()
         UIApplication.shared.keyWindow?.rootViewController?.present(component: sut)
-        
-        let dummyExpectation = expectation(description: "Dummy Expectation")
 
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            let hintLabel = self.sut.viewController.view.findView(by: "hintLabel") as? UILabel
-            
-            XCTAssertNotNil(hintLabel)
-            XCTAssertEqual(hintLabel?.text, self.amount.formatted)
-            
+        wait(for: .seconds(1))
+
+        let hintLabel = sut.viewController.view.findView(by: "hintLabel") as? UILabel
+        
+        XCTAssertNotNil(hintLabel)
+        XCTAssertEqual(hintLabel?.text, amount.formatted)
+    }
+
+    func testFinalise() {
+
+        let dummyExpectation = expectation(description: "Dummy Expectation")
+        sut.finalizeIfNeeded(with: true) {
             dummyExpectation.fulfill()
         }
         

--- a/Tests/AdyenTests/Adyen Tests/DropIn/DropInInternalTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/DropIn/DropInInternalTests.swift
@@ -6,4 +6,39 @@
 //  Copyright © 2022 Adyen. All rights reserved.
 //
 
-import Foundation
+@testable import Adyen
+import AdyenDropIn
+import XCTest
+
+class DropInInternalTests: XCTestCase {
+
+func testFinaliseIfNeededSelectedComponent() {
+    let config = DropInComponent.Configuration(apiContext: Dummy.context, allowsSkippingPaymentList: true)
+    config.payment = Payment(amount: Amount(value: 100, currencyCode: "CNY"), countryCode: "CN")
+
+    let paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsWithSingleInstant.data(using: .utf8)!)
+    let sut = DropInComponent(paymentMethods: paymentMethods, configuration: config)
+
+    let root = UIViewController()
+    UIApplication.shared.keyWindow?.rootViewController = root
+    root.present(sut.viewController, animated: true, completion: nil)
+
+    let waitExpectation = expectation(description: "Expect Drop-In to finalize")
+
+    wait(for: .seconds(1))
+
+    let topVC = sut.viewController.findChild(of: ListViewController.self)
+    topVC?.tableView(topVC!.tableView, didSelectRowAt: .init(item: 0, section: 0))
+        let cell = topVC?.tableView.cellForRow(at: .init(item: 0, section: 0)) as! ListCell
+        XCTAssertTrue(cell.showsActivityIndicator)
+
+    wait(for: .seconds(1))
+
+    sut.finalizeIfNeeded(with: true) {
+        XCTAssertFalse(cell.showsActivityIndicator)
+        waitExpectation.fulfill()
+    }
+
+    waitForExpectations(timeout: 5, handler: nil)
+}
+}

--- a/Tests/AdyenTests/Adyen Tests/DropIn/DropInInternalTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/DropIn/DropInInternalTests.swift
@@ -1,0 +1,9 @@
+//
+//  DropInInternalTests.swift
+//  AdyenUIKitTests
+//
+//  Created by Vladimir Abramichev on 22/08/2022.
+//  Copyright © 2022 Adyen. All rights reserved.
+//
+
+import Foundation

--- a/Tests/AdyenTests/Adyen Tests/DropIn/DropInTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/DropIn/DropInTests.swift
@@ -261,11 +261,32 @@ class DropInTests: XCTestCase {
         XCTAssertEqual(topVC!.sections.count, 1)
         XCTAssertEqual(topVC!.sections[0].items.count, 1)
     }
+
+    func testFinaliseIfNeededEmptyList() {
+        let config = DropInComponent.Configuration(apiContext: Dummy.context, allowsSkippingPaymentList: true)
+        config.payment = Payment(amount: Amount(value: 100, currencyCode: "CNY"), countryCode: "CN")
+
+        let paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsWithSingleInstant.data(using: .utf8)!)
+        sut = DropInComponent(paymentMethods: paymentMethods, configuration: config)
+
+        let root = UIViewController()
+        UIApplication.shared.keyWindow?.rootViewController = root
+        root.present(sut.viewController, animated: true, completion: nil)
+
+        let waitExpectation = expectation(description: "Expect Drop-In to finalize")
+
+        wait(for: .seconds(1))
+        sut.finalizeIfNeeded(with: true) {
+            waitExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5, handler: nil)
+    }
 }
 
 extension UIViewController {
 
-    fileprivate func findChild<T: UIViewController>(of type: T.Type) -> T? {
+    internal func findChild<T: UIViewController>(of type: T.Type) -> T? {
         if self is T { return self as? T }
         var result: T?
         for child in self.children {


### PR DESCRIPTION
# Open PR

## Changes

* deprecate `didFinalize(with success: Bool)`
* add `didFinalize(with success: Bool, completion: (() -> Void)?)` as default