### PR TITLE
fixed: ListSectionHeaderStyle is not applied to stored payment method and Issuers'list background color

### DIFF
--- a/Adyen/UI/View Controllers/SearchViewController.swift
+++ b/Adyen/UI/View Controllers/SearchViewController.swift
@@ -17,11 +17,14 @@ public class SearchViewController: UIViewController {
 
     internal let childViewController: UIViewController
     private let localizationParameters: LocalizationParameters?
+    private let style: ViewStyle
 
     public init(childViewController: UIViewController,
+                style: ViewStyle,
                 delegate: SearchViewControllerDelegate,
                 localizationParameters: LocalizationParameters? = nil) {
         self.childViewController = childViewController
+        self.style = style
         self.delegate = delegate
         self.localizationParameters = localizationParameters
         super.init(nibName: nil, bundle: nil)
@@ -92,6 +95,7 @@ public class SearchViewController: UIViewController {
 
     override public func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = style.backgroundColor
         view.addSubview(searchBar)
         view.addSubview(noResultsStackView)
         noResultsStackView.isHidden = true

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -50,7 +50,9 @@ public final class IssuerListComponent: PaymentComponent, PaymentAware, Presenta
     }
 
     private lazy var searchViewController: SearchViewController = {
-        SearchViewController(childViewController: listViewController, delegate: self)
+        SearchViewController(childViewController: listViewController,
+                             style: configuration.style,
+                             delegate: self)
     }()
 
     public func stopLoading() {

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -82,10 +82,7 @@ internal final class ComponentManager {
                                               components: storedComponents,
                                               footer: nil)
         } else {
-            storedSection = ComponentsSection(header: .init(title: localizedString(.paymentMethodsStoredMethods,
-                                                                                   configuration.localizationParameters),
-                                                            style: configuration.style.listComponent.sectionHeader),
-                                              components: storedComponents)
+            storedSection = ComponentsSection(components: storedComponents)
         }
         
         // Regular section

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -78,11 +78,14 @@ internal final class ComponentManager {
             storedSection = ComponentsSection(header: .init(title: localizedString(.paymentMethodsStoredMethods,
                                                                                    configuration.localizationParameters),
                                                             editingStyle: editingStyle,
-                                                            style: ListSectionHeaderStyle()),
+                                                            style: configuration.style.listComponent.sectionHeader),
                                               components: storedComponents,
                                               footer: nil)
         } else {
-            storedSection = ComponentsSection(components: storedComponents)
+            storedSection = ComponentsSection(header: .init(title: localizedString(.paymentMethodsStoredMethods,
+                                                                                   configuration.localizationParameters),
+                                                            style: configuration.style.listComponent.sectionHeader),
+                                              components: storedComponents)
         }
         
         // Regular section


### PR DESCRIPTION
# fixed:
<fixed>

* For stored payment methods, the section header now gets the style from ```ListSectionHeaderStyle```.
* When a list of issuers is shown during checkout, the background is no longer transparent.

</fixed>