### PR TITLE
v4: Keep "loaded state" when payment list skipped

### DIFF
--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -87,7 +87,6 @@ public final class DropInComponent: NSObject, PresentableComponent, LoadingCompo
     ///
     /// - Parameter action: The action to handle.
     public func handle(_ action: Action) {
-        rootComponent.stopLoadingIfNeeded()
         actionComponent.handle(action)
     }
 


### PR DESCRIPTION
# Open PR

## Changes

### Fix

<fixed>

* In `DropInComponent.Configuration`, when `allowsSkippingPaymentList` is set to **true**, Drop-in now stays in the `loading` state until the shopper cancels or completes the payment.

</fixed>