### PR TITLE
fix: returning 8 digit pan when bin length is >= 16

### DIFF
--- a/AdyenCard/Form/FormCardNumberItem.swift
+++ b/AdyenCard/Form/FormCardNumberItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -90,7 +90,7 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
     
     private func updateBINIfNeeded() {
         switch (value, isValid()) {
-        case (_, true) where value.count > Constants.minimumPANLength:
+        case (_, true) where value.count >= Constants.minimumPANLength:
             binValue = String(value.prefix(Constants.largeBinLength))
         default:
             binValue = String(value.prefix(Constants.smallBinLength))

--- a/Tests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/Card Tests/BCMCComponentTests.swift
@@ -239,8 +239,8 @@ class BCMCComponentTests: XCTestCase {
         expectationBin.expectedFulfillmentCount = 1
         expectationBin.assertForOverFulfill = true
         let delegateMock = CardComponentDelegateMock(onBINDidChange: { value in
-                                                         XCTAssertTrue("670344".hasPrefix(value))
-                                                         XCTAssertTrue(value.count <= 6)
+                                                         XCTAssertTrue("67034444".hasPrefix(value))
+                                                         XCTAssertTrue(value.count <= 8)
                                                          expectationBin.fulfill()
                                                      },
                                                      onCardBrandChange: { _ in },
@@ -306,15 +306,15 @@ class BCMCComponentTests: XCTestCase {
         expectationBin.expectedFulfillmentCount = 2
         expectationBin.assertForOverFulfill = true
         let delegateMock = CardComponentDelegateMock(onBINDidChange: { value in
-                                                         XCTAssertTrue("670344".hasPrefix(value))
-                                                         XCTAssertTrue(value.count <= 6)
-                                                         if value == "670344" {
+                                                         XCTAssertTrue("67034444".hasPrefix(value))
+                                                         XCTAssertTrue(value.count <= 8)
+                                                         if value == "67034444" {
                                                              expectationBin.fulfill()
                                                          }
                                                      },
                                                      onCardBrandChange: { _ in },
                                                      onSubmitLastFour: { _, finalBin in
-                                                         XCTAssertEqual(finalBin, "670344")
+                                                         XCTAssertEqual(finalBin, "67034444")
                                                          expectationBin.fulfill()
                                                      })
         sut.cardComponentDelegate = delegateMock

--- a/Tests/Card Tests/CardComponentTests.swift
+++ b/Tests/Card Tests/CardComponentTests.swift
@@ -305,7 +305,7 @@ class CardComponentTests: XCTestCase {
         let expectationCardType = XCTestExpectation(description: "CardType Expectation")
         let expectationLastFour = XCTestExpectation(description: "LastFour Expectation")
         let delegateMock = CardComponentDelegateMock(onBINDidChange: { value in
-            XCTAssertEqual(value, "670344")
+            XCTAssertEqual(value, "67034444")
             expectationBin.fulfill()
         }, onCardBrandChange: { value in
             XCTAssertEqual(value, [CardBrand(type: .americanExpress)])


### PR DESCRIPTION
### Fixed
<fixed>

-   For cards, `CardComponentDelegate.didChangeBIN(:component:)` now provides the 8-digit BIN when the card number is 16 or more digits. Previously, it only provided the 8-digit BIN when the card number was 17 or more digits.

</fixed>