### PR TITLE
fix: Allow sessions without country code

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 		E72D9BAA26A6E66800FBDA48 /* Dimentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72D9BA926A6E66800FBDA48 /* Dimentions.swift */; };
 		E72DA33F23E19DE300707638 /* PreselectedPaymentMethodComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72DA33C23E19DE300707638 /* PreselectedPaymentMethodComponent.swift */; };
 		E72DA34123E1BE5300707638 /* DropInNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72DA34023E1BE5300707638 /* DropInNavigationController.swift */; };
+		E730E2822A444076000E48CA /* AdyenSessionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E730E2812A444076000E48CA /* AdyenSessionError.swift */; };
 		E7388D8523DB1F9A008E62B8 /* DimmingPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7388D8423DB1F9A008E62B8 /* DimmingPresentationController.swift */; };
 		E73C54E425EBD2DC00B57758 /* BrowserComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C54E325EBD2DC00B57758 /* BrowserComponent.swift */; };
 		E73C560625EE8C8D00B57758 /* APIClientHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C560525EE8C8D00B57758 /* APIClientHelper.swift */; };
@@ -1465,6 +1466,7 @@
 		E72D9BA926A6E66800FBDA48 /* Dimentions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dimentions.swift; sourceTree = "<group>"; };
 		E72DA33C23E19DE300707638 /* PreselectedPaymentMethodComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreselectedPaymentMethodComponent.swift; sourceTree = "<group>"; };
 		E72DA34023E1BE5300707638 /* DropInNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DropInNavigationController.swift; sourceTree = "<group>"; };
+		E730E2812A444076000E48CA /* AdyenSessionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenSessionError.swift; sourceTree = "<group>"; };
 		E736497E25277B6500AB76AE /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		E736498125277B9100AB76AE /* DataExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
 		E736498325277BAA00AB76AE /* IntegerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerExtension.swift; sourceTree = "<group>"; };
@@ -4142,6 +4144,7 @@
 				F9B8AF5D27DA4EA400DC0894 /* AdyenSession+DropInComponentDelegate.swift */,
 				F92980C327CF558E000CA5CA /* AdyenSession+ActionComponentDelegate.swift */,
 				F92980C527CF563C000CA5CA /* AdyenSession+PartialPaymentDelegate.swift */,
+				E730E2812A444076000E48CA /* AdyenSessionError.swift */,
 			);
 			path = AdyenSession;
 			sourceTree = "<group>";
@@ -6575,6 +6578,7 @@
 				F92980C227CF550C000CA5CA /* AdyenSession+PaymentComponentDelegate.swift in Sources */,
 				F967580E27D1253000A16FB6 /* SelfRetainingAPIClient.swift in Sources */,
 				F9B8AF5E27DA4EA400DC0894 /* AdyenSession+DropInComponentDelegate.swift in Sources */,
+				E730E2822A444076000E48CA /* AdyenSessionError.swift in Sources */,
 				F92980B227CE2B55000CA5CA /* AdyenSession.swift in Sources */,
 				F92980C427CF558E000CA5CA /* AdyenSession+ActionComponentDelegate.swift in Sources */,
 			);

--- a/AdyenSession/API/Session Setup/SessionSetupRequest.swift
+++ b/AdyenSession/API/Session Setup/SessionSetupRequest.swift
@@ -57,7 +57,7 @@ internal struct SessionSetupRequest: Request {
 
 internal struct SessionSetupResponse: SessionResponse {
     
-    internal let countryCode: String
+    internal let countryCode: String?
     
     internal let shopperLocale: String?
     

--- a/AdyenSession/AdyenSession.swift
+++ b/AdyenSession/AdyenSession.swift
@@ -57,7 +57,7 @@ public final class AdyenSession {
         public let identifier: String
         
         /// Country Code
-        public let countryCode: String
+        public let countryCode: String?
         
         /// Shopper Locale
         public let shopperLocale: String?

--- a/AdyenSession/AdyenSession.swift
+++ b/AdyenSession/AdyenSession.swift
@@ -108,10 +108,8 @@ public final class AdyenSession {
         if let context = configuration.context {
             return context
         }
-        var payment: Payment?
-        if let countryCode = configuration.countryCode {
-            payment = Payment(amount: sessionContext.amount, countryCode: countryCode)
-        }
+        
+        var payment = Payment(amount: sessionContext.amount, countryCode: sessionContext.countryCode)
         return AdyenContext(apiContext: configuration.apiContext,
                             payment: payment)
     }()

--- a/AdyenSession/AdyenSessionError.swift
+++ b/AdyenSession/AdyenSessionError.swift
@@ -1,0 +1,16 @@
+//
+// Copyright (c) 2023 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+public enum AdyenSessionError: LocalizedError {
+    case noCountryCode
+
+    public var errorDescription: String? {
+        "CountryCode value was not passed via /sessions. " +
+            "Make sure to provide 'countryCode' value to AdyenSession.Configuration."
+    }
+}

--- a/Tests/Session Tests/SessionTests.swift
+++ b/Tests/Session Tests/SessionTests.swift
@@ -63,6 +63,7 @@ class SessionTests: XCTestCase {
             case .failure:
                 XCTFail()
             case let .success(session):
+                XCTAssertEqual(session.adyenContext.payment?.countryCode, self.context.payment?.countryCode)
                 XCTAssertEqual(session.sessionContext.identifier, "session_id")
                 XCTAssertEqual(session.sessionContext.data, "session_data_1")
                 XCTAssertEqual(session.sessionContext.shopperLocale, "US")
@@ -129,8 +130,9 @@ class SessionTests: XCTestCase {
                 issuerListDictionary
             ]
         ]
+        let expectedCountryCode = "MX"
         let expectedPaymentMethods = try Coder.decode(dictionary) as PaymentMethods
-        apiClient.mockedResults = [.success(SessionSetupResponse(countryCode: "US",
+        apiClient.mockedResults = [.success(SessionSetupResponse(countryCode: nil,
                                                                  shopperLocale: "US",
                                                                  paymentMethods: expectedPaymentMethods,
                                                                  amount: .init(value: 220, currencyCode: "USD"),
@@ -139,7 +141,8 @@ class SessionTests: XCTestCase {
         let expectation = expectation(description: "Expect session object to be initialized")
         AdyenSession.initialize(with: .init(sessionIdentifier: "session_id",
                                             initialSessionData: "session_data_0",
-                                            context: AdyenContext(apiContext: Dummy.apiContext, payment: nil)),
+                                            apiContext: Dummy.apiContext,
+                                            countryCode: expectedCountryCode),
                                 delegate: SessionDelegateMock(),
                                 presentationDelegate: PresentationDelegateMock(),
                                 baseAPIClient: apiClient) { result in
@@ -147,7 +150,8 @@ class SessionTests: XCTestCase {
             case .failure:
                 XCTFail()
             case let .success(session):
-                XCTAssertEqual(session.sessionContext.countryCode, "US")
+                XCTAssertEqual(session.adyenContext.payment?.countryCode, expectedCountryCode)
+                XCTAssertEqual(session.sessionContext.countryCode, expectedCountryCode)
             }
             expectation.fulfill()
         }


### PR DESCRIPTION
# Open PR

## Changes

<fixed>

* Now Sessions could be used without optional `countryCode` parameter

</fixed>