### PR TITLE
bump 3DS2 SDK version to 2.3.0

### DIFF
--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -56,7 +56,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Actions' do |plugin|
     plugin.dependency 'Adyen/Core'
-    plugin.dependency 'Adyen3DS2', '2.2.6'
+    plugin.dependency 'Adyen3DS2', '2.3.0'
     plugin.source_files = 'AdyenActions/**/*.swift'
     plugin.exclude_files = 'AdyenActions/**/BundleSPMExtension.swift'
     plugin.resource_bundles = {

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -6726,7 +6726,7 @@
 			repositoryURL = "https://github.com/Adyen/adyen-3ds2-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 2.2.5;
+				version = 2.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/AnyChallengeResult.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/AnyChallengeResult.swift
@@ -11,7 +11,7 @@ internal protocol AnyChallengeResult {
 
     var sdkTransactionIdentifier: String { get }
 
-    var transactionStatus: String? { get }
+    var transactionStatus: String { get }
 }
 
 extension ADYChallengeResult: AnyChallengeResult {}

--- a/AdyenCard/Components/Card/ThreeDS2SdkVersion.swift
+++ b/AdyenCard/Components/Card/ThreeDS2SdkVersion.swift
@@ -7,4 +7,4 @@
 import Foundation
 
 /// The 3DS2 SDK version.
-public let threeDS2SdkVersion: String = "2.2.6"
+public let threeDS2SdkVersion: String = "2.3.0"

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "adyen/adyen-3ds2-ios" == 2.2.6
+github "adyen/adyen-3ds2-ios" == 2.3.0
 github "adyen/adyen-networking-ios" == 1.0.0
 github "adyen/adyen-wechatpay-ios" == 2.1.0

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(
             name: "Adyen3DS2",
             url: "https://github.com/Adyen/adyen-3ds2-ios",
-            .exact(Version(2, 2, 6))
+            .exact(Version(2, 3, 0))
         ),
         .package(
             name: "AdyenNetworking",

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/AnyADYServiceMock.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/AnyADYServiceMock.swift
@@ -50,7 +50,7 @@ internal struct AnyChallengeResultMock: AnyChallengeResult {
 
     var sdkTransactionIdentifier: String
 
-    var transactionStatus: String?
+    var transactionStatus: String
 }
 
 final class AnyADYTransactionMock: AnyADYTransaction {


### PR DESCRIPTION
This is a cherry-pick from https://github.com/Adyen/adyen-ios/commit/34fe5e7da5b2aa8389d2f3b936c4f99d1c43679a
towards `v4`.

We at http://github.com/bokadirekt would like to continue using `v4` for some more time but we have noticed some expired certificates with 2.2.6 version of Adyen3DS2 
<img width="560" alt="screenshot_2023-03-17_at_14 43 26" src="https://user-images.githubusercontent.com/385456/226315057-266f2cf1-3c43-4193-b27a-2d9dbebbe92d.png">
