### PR TITLE
Add ability to filter ApplePay by funding source

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -66,6 +66,9 @@ extension ApplePayComponent {
         /// An optional coupon code that is valid and has been applied to the payment request already.
         public var couponCode: String?
 
+        /// Payment source that the merchant supports. If `nil`, the transaction allows both credit and debit cards.
+        public var merchantCapabilitie: CardFundingSource?
+
         /// Initializes the configuration.
         ///
         /// - Parameter payment: Instance of ApplePay Payment object.
@@ -82,7 +85,7 @@ extension ApplePayComponent {
             paymentRequest.merchantIdentifier = merchantIdentifier
             paymentRequest.currencyCode = applePayPayment.currencyCode
             paymentRequest.supportedNetworks = supportedNetworks
-            paymentRequest.merchantCapabilities = .capability3DS
+            paymentRequest.merchantCapabilities = merchantCapabilities
             paymentRequest.paymentSummaryItems = applePayPayment.summaryItems
             paymentRequest.requiredBillingContactFields = requiredBillingContactFields
             paymentRequest.requiredShippingContactFields = requiredShippingContactFields
@@ -99,6 +102,14 @@ extension ApplePayComponent {
             }
 
             return paymentRequest
+        }
+
+        private var merchantCapabilities: PKMerchantCapability {
+            guard let funding = merchantCapabilitie else {
+                return .capability3DS
+            }
+
+            return [.capability3DS, funding == .credit ? .capabilityCredit : .capabilityDebit]
         }
 
         @_spi(AdyenInternal)

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -110,7 +110,7 @@ extension ApplePayComponent {
                 return [.capability3DS, .capabilityDebit]
             case .credit:
                 return [.capability3DS, .capabilityCredit]
-            default:
+            case .none:
                 return .capability3DS
             }
         }

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -67,7 +67,7 @@ extension ApplePayComponent {
         public var couponCode: String?
 
         /// Payment source that the merchant supports. If `nil`, the transaction allows both credit and debit cards.
-        public var merchantCapabilitie: CardFundingSource?
+        public var merchantCapability: CardFundingSource?
 
         /// Initializes the configuration.
         ///
@@ -105,7 +105,7 @@ extension ApplePayComponent {
         }
 
         private var merchantCapabilities: PKMerchantCapability {
-            guard let funding = merchantCapabilitie else {
+            guard let funding = merchantCapability else {
                 return .capability3DS
             }
 

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -66,7 +66,7 @@ extension ApplePayComponent {
         /// An optional coupon code that is valid and has been applied to the payment request already.
         public var couponCode: String?
 
-        /// Payment source that the merchant supports. If `nil`, the transaction allows both credit and debit cards.
+        /// A funding source supported by the merchant. If `nil`, the transaction allows both credit and debit cards.
         public var merchantCapability: CardFundingSource?
 
         /// Initializes the configuration.

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -105,11 +105,14 @@ extension ApplePayComponent {
         }
 
         private var merchantCapabilities: PKMerchantCapability {
-            guard let funding = merchantCapability else {
+            switch merchantCapability {
+            case .debit:
+                return [.capability3DS, .capabilityDebit]
+            case .credit:
+                return [.capability3DS, .capabilityCredit]
+            default:
                 return .capability3DS
             }
-
-            return [.capability3DS, funding == .credit ? .capabilityCredit : .capabilityDebit]
         }
 
         @_spi(AdyenInternal)

--- a/Demo/Common/IntegrationExampleComponents.swift
+++ b/Demo/Common/IntegrationExampleComponents.swift
@@ -151,7 +151,6 @@ extension IntegrationExample {
         config.requiredShippingContactFields = [.postalAddress]
         config.requiredBillingContactFields = [.postalAddress]
         config.shippingMethods = ConfigurationConstants.shippingMethods
-        config.merchantCapabilitie = .debit
         
         let component = try? ApplePayComponent(paymentMethod: paymentMethod,
                                                context: context,

--- a/Demo/Common/IntegrationExampleComponents.swift
+++ b/Demo/Common/IntegrationExampleComponents.swift
@@ -151,6 +151,7 @@ extension IntegrationExample {
         config.requiredShippingContactFields = [.postalAddress]
         config.requiredBillingContactFields = [.postalAddress]
         config.shippingMethods = ConfigurationConstants.shippingMethods
+        config.merchantCapabilitie = .debit
         
         let component = try? ApplePayComponent(paymentMethod: paymentMethod,
                                                context: context,


### PR DESCRIPTION
# Open PR

## Changes 

<new>

* For Apple Pay, you can now choose to only accept either debit cards or credit cards.

</new>