### PR TITLE
Allow gift card component to visualize more than 20 digits

### DIFF
--- a/AdyenCard/Formatters/CardNumberFormatter.swift
+++ b/AdyenCard/Formatters/CardNumberFormatter.swift
@@ -32,7 +32,7 @@ public final class CardNumberFormatter: NumericFormatter {
         case .diners where length < 15:
             return [4, 6, 4]
         default:
-            return [4, 4, 4, 4, 4]
+            return Array(repeating: 4, count: (length / 4) + 1)
         }
     }
 }

--- a/Tests/Components Tests/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/Components Tests/Gift Card/GiftCardComponentTests.swift
@@ -115,6 +115,21 @@ class GiftCardComponentTests: XCTestCase {
         waitForExpectations(timeout: 10, handler: nil)
     }
 
+    func testCheckBalanceCardNumberFormatting() throws {
+
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+
+        wait(for: .milliseconds(300))
+
+        XCTAssertTrue(errorView!.isHidden)
+
+        populate(cardNumber: "1234 5678 1234 5678 1234 5678", pin: "73737")
+
+        XCTAssertEqual(numberItemView?.textField.text, "1234 5678 1234 5678 1234 5678")
+
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+
     func testBalanceAndTransactionLimitCurrencyMismatch() throws {
 
         let publicKeyProviderExpectation = expectation(description: "Expect publicKeyProvider to be called.")

--- a/Tests/Components Tests/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/Components Tests/Gift Card/GiftCardComponentTests.swift
@@ -123,11 +123,13 @@ class GiftCardComponentTests: XCTestCase {
 
         XCTAssertTrue(errorView!.isHidden)
 
-        populate(cardNumber: "1234 5678 1234 5678 1234 5678", pin: "73737")
+        populate(cardNumber: "123456781234567812345678", pin: "73737")
 
         XCTAssertEqual(numberItemView?.textField.text, "1234 5678 1234 5678 1234 5678")
 
-        waitForExpectations(timeout: 10, handler: nil)
+        populate(cardNumber: "123456781234567812345", pin: "73737")
+
+        XCTAssertEqual(numberItemView?.textField.text, "1234 5678 1234 5678 1234 5")
     }
 
     func testBalanceAndTransactionLimitCurrencyMismatch() throws {


### PR DESCRIPTION
# Open PR

## Changes

<fixed>

* For gift cards, the shopper can now enter more than 20 digits in the **Card number** field.

</fixed>