### PR TITLE
Fixing SwiftUI interface for iPad

### DIFF
--- a/Demo/Common/Configuration/ConfigurationView.swift
+++ b/Demo/Common/Configuration/ConfigurationView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -52,7 +52,9 @@ internal struct ConfigurationView: View {
                     leading: Button("Default", action: viewModel.defaultTapped),
                     trailing: Button("Save", action: viewModel.doneTapped)
                 )
-        }.onAppear {
+        }
+        .navigationViewStyle(.stack)
+        .onAppear {
             countrySearchSting = ""
             currencySearchString = ""
         }

--- a/Demo/SwiftUI/ComponentsView.swift
+++ b/Demo/SwiftUI/ComponentsView.swift
@@ -13,8 +13,8 @@ internal struct ComponentsView: View {
     @ObservedObject internal var viewModel = PaymentsViewModel()
 
     internal var body: some View {
-        NavigationView {
-            ZStack {
+        ZStack {
+            NavigationView {
                 List {
                     Toggle(isOn: $viewModel.isUsingSession) {
                         Text("Using Session")
@@ -39,12 +39,13 @@ internal struct ComponentsView: View {
                 .listStyle(.insetGrouped)
                 .navigationBarTitle("Components")
                 .navigationBarItems(trailing: configurationButton)
-                
-                if viewModel.isLoading {
-                    loadingIndicator
-                }
+            }
+            
+            if viewModel.isLoading {
+                loadingIndicator
             }
         }
+        .ignoresSafeArea()
         .present(viewController: $viewModel.viewControllerToPresent)
         .onAppear {
             self.viewModel.viewDidAppear()


### PR DESCRIPTION
## Changes

### Chore
<fixed>

- Spinner is only covering the list but does not extend over the sides
- Configuration view shows in a multi-column layout

</fixed>


![Simulator Screenshot - iPad (10th generation) - 2023-05-10 at 13 50 20](https://github.com/Adyen/adyen-ios/assets/4838877/3cae95a6-88b1-4082-a24b-a00f30fd8941)
