### PR TITLE
fix: gift card max max length - v4

### DIFF
--- a/AdyenCard/Formatters/CardNumberFormatter.swift
+++ b/AdyenCard/Formatters/CardNumberFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -33,7 +33,7 @@ public final class CardNumberFormatter: NumericFormatter {
         case .diners where length < 15:
             return [4, 6, 4]
         default:
-            return [4, 4, 4, 4, 4]
+            return Array(repeating: 4, count: (length / 4) + 1)
         }
     }
 }

--- a/Tests/AdyenTests/Adyen Tests/Components/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Components/Gift Card/GiftCardComponentTests.swift
@@ -95,6 +95,23 @@ class GiftCardComponentTests: XCTestCase {
 
         waitForExpectations(timeout: 10, handler: nil)
     }
+    
+    func testCheckBalanceCardNumberFormatting() throws {
+
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+
+        wait(for: .milliseconds(300))
+
+        XCTAssertTrue(errorView!.isHidden)
+
+        populate(cardNumber: "123456781234567812345678", pin: "73737")
+
+        XCTAssertEqual(numberItemView?.textField.text, "1234 5678 1234 5678 1234 5678")
+        
+        populate(cardNumber: "123456781234567812345", pin: "73737")
+        
+        XCTAssertEqual(numberItemView?.textField.text, "1234 5678 1234 5678 1234 5")
+    }
 
     func testBalanceAndTransactionLimitCurrencyMismatch() throws {
 


### PR DESCRIPTION
# Open PR

## Changes

<fixed>

* For gift cards, the shopper can now enter more than 20 digits in the **Card number** field.

</fixed>