### PR TITLE
chore: update ISK currency fraction digits

### DIFF
--- a/Adyen/Formatters/AmountFormatter.swift
+++ b/Adyen/Formatters/AmountFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -87,7 +87,7 @@ public final class AmountFormatter {
         // The below overrides are obtained from https://en.wikipedia.org/wiki/ISO_4217
         
         switch currencyCode {
-        case "ISK", "CLP", "COP":
+        case "CLP", "COP":
             // iOS returns 0, which is in accordance with ISO-4217, but conflicts with the Adyen backend.
             return 2
         case "MRO":

--- a/Tests/Adyen Tests/Utilities/AmountFormatterTests.swift
+++ b/Tests/Adyen Tests/Utilities/AmountFormatterTests.swift
@@ -33,6 +33,9 @@ class AmountFormatterTests: XCTestCase {
 
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: 218521.213969269, currencyCode: "CLF"), 2185212139)
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: -218521.213969269, currencyCode: "CLF"), -2185212139)
+        
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: 218521.213969269, currencyCode: "ISK"), 218521)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: -218521.213969269, currencyCode: "ISK"), -218521)
     }
     
     func testConversionFromDecimalToMinorAmounts() {
@@ -59,6 +62,9 @@ class AmountFormatterTests: XCTestCase {
 
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(218521.213969269), currencyCode: "CLF"), 2185212139)
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-218521.213969269), currencyCode: "CLF"), -2185212139)
+        
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(218521.213969269), currencyCode: "ISK"), 218521)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-218521.213969269), currencyCode: "ISK"), -218521)
     }
     
     func testDifferentLocales() {
@@ -69,6 +75,9 @@ class AmountFormatterTests: XCTestCase {
             
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "ko_KR"), "CVE 123,456.00")
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "fr_FR"), "123 456,00 CVE")
+            
+            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "123.456 ISK")
+            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK"), "ISK 123,456")
         } else {
             // pre iOS 13 formatting seems to add a character that looks exactly like a space but is not a space.
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "USD", localeIdentifier: "fr_FR"), "1 234,56 $US")


### PR DESCRIPTION
<changed>
* The Icelandic Krona currency (ISK) fraction digit count now aligns with ISO-4217.
</changed>