### PR TITLE
COIOS-603: ACH component improvements

### DIFF
--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -233,7 +233,9 @@ public final class ACHDirectDebitComponent: PaymentComponent,
         let item = FormButtonItem(style: configuration.style.mainButtonItem)
         item.identifier = ViewIdentifierBuilder.build(scopeInstance: self,
                                                       postfix: ViewIdentifier.payButtonItem)
-        item.title = localizedString(.confirmPurchase, configuration.localizationParameters)
+        item.title = localizedSubmitButtonTitle(with: payment?.amount,
+                                                style: .immediate,
+                                                configuration.localizationParameters)
         item.buttonSelectionHandler = { [weak self] in
             self?.didSelectSubmitButton()
         }

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -293,10 +293,23 @@ extension ACHDirectDebitComponent: ViewControllerDelegate {
     }
 }
 
+/// Describes any configuration for the ACH Direct Debit component.
+public protocol AnyACHDirectDebitComponentConfiguration {
+    
+    /// Indicates if the field for storing the card payment method should be displayed in the form.
+    var showsStorePaymentMethodField: Bool { get }
+    
+    /// Determines whether the billing address should be displayed or not.
+    var showsBillingAddress: Bool { get }
+    
+    /// List of ISO country codes that is supported for the billing address.
+    var billingAddressCountryCodes: [String] { get }
+}
+
 extension ACHDirectDebitComponent {
     
     /// Configuration for the ACH Direct Debit Component
-    public struct Configuration: AnyPersonalInformationConfiguration {
+    public struct Configuration: AnyACHDirectDebitComponentConfiguration, AnyPersonalInformationConfiguration {
 
         /// Describes the component's UI style.
         public var style: FormComponentStyle

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -294,7 +294,7 @@ extension ACHDirectDebitComponent: ViewControllerDelegate {
 }
 
 /// Describes any configuration for the ACH Direct Debit component.
-public protocol AnyACHDirectDebitComponentConfiguration {
+public protocol AnyACHDirectDebitConfiguration {
     
     /// Indicates if the field for storing the card payment method should be displayed in the form.
     var showsStorePaymentMethodField: Bool { get }
@@ -309,7 +309,7 @@ public protocol AnyACHDirectDebitComponentConfiguration {
 extension ACHDirectDebitComponent {
     
     /// Configuration for the ACH Direct Debit Component
-    public struct Configuration: AnyACHDirectDebitComponentConfiguration, AnyPersonalInformationConfiguration {
+    public struct Configuration: AnyACHDirectDebitConfiguration, AnyPersonalInformationConfiguration {
 
         /// Describes the component's UI style.
         public var style: FormComponentStyle

--- a/AdyenDropIn/Models/DropInConfiguration.swift
+++ b/AdyenDropIn/Models/DropInConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -55,6 +55,9 @@ public extension DropInComponent {
         /// Boleto component configuration.
         public var boleto: Boleto = .init()
         
+        /// The ACH Direct Debit configuration.
+        public var ach: ACH = .init()
+        
         /// Initializes the drop in configuration.
         /// - Parameters:
         ///   - style: The UI styles of the components.
@@ -82,6 +85,12 @@ public extension DropInComponent {
     struct Boleto {
         /// Indicates whether to show sendCopyByEmail checkbox and email text field
         public var showEmailAddress: Bool = true
+    }
+    
+    /// The ACH configuration
+    struct ACH {
+        /// Indicates if the field for storing the card payment method should be displayed in the form. Defaults to true.
+        public var showsStorePaymentMethodField: Bool = true
     }
     
     /// Card Component configuration specific to Drop In Component.

--- a/AdyenDropIn/Models/DropInConfiguration.swift
+++ b/AdyenDropIn/Models/DropInConfiguration.swift
@@ -88,7 +88,7 @@ public extension DropInComponent {
     }
     
     /// ACH Component configuration specific to Drop In Component.
-    struct ACH: AnyACHDirectDebitComponentConfiguration {
+    struct ACH: AnyACHDirectDebitConfiguration {
         
         /// Indicates if the field for storing the card payment method should be displayed in the form.
         /// Defaults to `true`.

--- a/AdyenDropIn/Models/DropInConfiguration.swift
+++ b/AdyenDropIn/Models/DropInConfiguration.swift
@@ -87,10 +87,37 @@ public extension DropInComponent {
         public var showEmailAddress: Bool = true
     }
     
-    /// The ACH configuration
-    struct ACH {
-        /// Indicates if the field for storing the card payment method should be displayed in the form. Defaults to true.
-        public var showsStorePaymentMethodField: Bool = true
+    /// ACH Component configuration specific to Drop In Component.
+    struct ACH: AnyACHDirectDebitComponentConfiguration {
+        
+        /// Indicates if the field for storing the card payment method should be displayed in the form.
+        /// Defaults to `true`.
+        public var showsStorePaymentMethodField: Bool
+        
+        /// Determines whether the billing address should be displayed or not.
+        /// Defaults to `true`.
+        public var showsBillingAddress: Bool
+        
+        /// List of ISO country codes that is supported for the billing address.
+        /// Defaults to `["US", "PR"].
+        public var billingAddressCountryCodes: [String]
+        
+        /// Configuration of the ACH component.
+        ///
+        /// - Parameters:
+        ///   - showsStorePaymentMethodField: Indicates if the field for storing the card payment method should be displayed in the form.
+        ///   Defaults to `true`.
+        ///   - showsBillingAddress: Determines whether the billing address should be displayed or not.
+        ///   Defaults to `true`.
+        ///   - billingAddressCountryCodes: List of ISO country codes that is supported for the billing address.
+        ///   Defaults to `["US", "PR"].
+        public init(showsStorePaymentMethodField: Bool = true,
+                    showsBillingAddress: Bool = true,
+                    billingAddressCountryCodes: [String] = ["US", "PR"]) {
+            self.showsStorePaymentMethodField = showsStorePaymentMethodField
+            self.showsBillingAddress = showsBillingAddress
+            self.billingAddressCountryCodes = billingAddressCountryCodes
+        }
     }
     
     /// Card Component configuration specific to Drop In Component.

--- a/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
+++ b/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -233,7 +233,8 @@ extension ComponentManager: PaymentComponentBuilder {
     private func createACHDirectDebitComponent(_ paymentMethod: ACHDirectDebitPaymentMethod) -> ACHDirectDebitComponent {
         let config = ACHDirectDebitComponent.Configuration(style: configuration.style.formComponent,
                                                            shopperInformation: configuration.shopperInformation,
-                                                           localizationParameters: configuration.localizationParameters)
+                                                           localizationParameters: configuration.localizationParameters,
+                                                           showsStorePaymentMethodField: configuration.ach.showsStorePaymentMethodField)
         return ACHDirectDebitComponent(paymentMethod: paymentMethod,
                                        context: context,
                                        configuration: config)

--- a/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
+++ b/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
@@ -234,7 +234,9 @@ extension ComponentManager: PaymentComponentBuilder {
         let config = ACHDirectDebitComponent.Configuration(style: configuration.style.formComponent,
                                                            shopperInformation: configuration.shopperInformation,
                                                            localizationParameters: configuration.localizationParameters,
-                                                           showsStorePaymentMethodField: configuration.ach.showsStorePaymentMethodField)
+                                                           showsStorePaymentMethodField: configuration.ach.showsStorePaymentMethodField,
+                                                           showsBillingAddress: configuration.ach.showsBillingAddress,
+                                                           billingAddressCountryCodes: configuration.ach.billingAddressCountryCodes)
         return ACHDirectDebitComponent(paymentMethod: paymentMethod,
                                        context: context,
                                        configuration: config)

--- a/Tests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -64,7 +64,9 @@ class ACHDirectDebitComponentTests: XCTestCase {
         XCTAssertEqual(sut.billingAddressItem.headerItem.text, localizedString(.billingAddressSectionTitle, sut.configuration.localizationParameters))
         XCTAssertEqual(sut.billingAddressItem.supportedCountryCodes, ["US", "UK"])
 
-        XCTAssertEqual(sut.payButton.title, localizedString(.confirmPurchase, sut.configuration.localizationParameters))
+        XCTAssertEqual(sut.payButton.title, localizedSubmitButtonTitle(with: sut.payment?.amount,
+                                                                       style: .immediate,
+                                                                       sut.configuration.localizationParameters))
     }
     
     func testUIConfiguration() {

--- a/Tests/DropIn Tests/ComponentManagerTests.swift
+++ b/Tests/DropIn Tests/ComponentManagerTests.swift
@@ -333,6 +333,23 @@ class ComponentManagerTests: XCTestCase {
         let boletoComponent = try XCTUnwrap(paymentComponent as? BoletoComponent)
         XCTAssertFalse(boletoComponent.configuration.showEmailAddress)
     }
+    
+    func testACHConfiguration() throws {
+        // Given
+        configuration.ach.showsStorePaymentMethodField = false
+        let sut = ComponentManager(paymentMethods: paymentMethods,
+                                   context: context,
+                                   configuration: configuration,
+                                   order: nil,
+                                   presentationDelegate: presentationDelegate)
+
+        // When
+        let paymentComponent = try XCTUnwrap(sut.regularComponents.first { $0.paymentMethod.type == .achDirectDebit })
+
+        // Then
+        let achComponent = try XCTUnwrap(paymentComponent as? ACHDirectDebitComponent)
+        XCTAssertFalse(achComponent.configuration.showsStorePaymentMethodField)
+    }
 
     // MARK: - Private
 

--- a/Tests/DropIn Tests/ComponentManagerTests.swift
+++ b/Tests/DropIn Tests/ComponentManagerTests.swift
@@ -337,6 +337,9 @@ class ComponentManagerTests: XCTestCase {
     func testACHConfiguration() throws {
         // Given
         configuration.ach.showsStorePaymentMethodField = false
+        configuration.ach.showsBillingAddress = false
+        configuration.ach.billingAddressCountryCodes = ["US", "UK"]
+        
         let sut = ComponentManager(paymentMethods: paymentMethods,
                                    context: context,
                                    configuration: configuration,
@@ -349,6 +352,8 @@ class ComponentManagerTests: XCTestCase {
         // Then
         let achComponent = try XCTUnwrap(paymentComponent as? ACHDirectDebitComponent)
         XCTAssertFalse(achComponent.configuration.showsStorePaymentMethodField)
+        XCTAssertFalse(achComponent.configuration.showsBillingAddress)
+        XCTAssertEqual(achComponent.configuration.billingAddressCountryCodes, ["US", "UK"])
     }
 
     // MARK: - Private


### PR DESCRIPTION
## Changes

### New
<new>

- For Drop-in, you can now configure the ACH Direct Debit payment method. When creating a Drop-in configuration, set the following in `ach` properties:
  - `showsStorePaymentMethodField`
  - `showsBillingAddress` 
  - `billingAddressCountryCodes`

</new>