### PR TITLE
Fix warning on GitHubAction

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,7 +17,7 @@ jobs:
         xcode-version: latest-stable
 
     - name: Set current marketing version
-      run: echo "::set-output name=MARKETING_VERSION::$(agvtool what-marketing-version -terse1)"
+      run: echo "MARKETING_VERSION=$(agvtool what-marketing-version -terse1)" >> $GITHUB_OUTPUT
       id: get-current-marketing-version
 
     - name: Deploy to current version 🚀
@@ -26,6 +26,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/html
         destination_dir: ./${{ steps.get-current-marketing-version.outputs.MARKETING_VERSION }}
+        
     - name: Deploy to root 🚀
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -23,7 +23,7 @@ jobs:
              echo -e "${RED}$FILE_NAME file doesn't exits in the root of the respository${NC}"
              exit 1
           fi 
-          echo "::set-output name=LABELS::$(cat $FILE_PATH),chore"
+          echo "LABELS=$(cat $FILE_PATH),chore" >> $GITHUB_OUTPUT
         id: get-allowed_labels
         env:
           PROJECT_ROOT: ${{ github.workspace }}


### PR DESCRIPTION
# Open PR

GitHub Actions: Deprecating save-state and set-output commands

This:
```
echo "::set-output name={name}::{value}"
```

Become this:
```
echo "{name}={value}" >> $GITHUB_OUTPUT
```


https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Changes

* fix deprecated `set-output`