### PR TITLE
chore: Moving sdk version to a custom plist field

### DIFF
--- a/Adyen/Analytics/Models/TelemetryData.swift
+++ b/Adyen/Analytics/Models/TelemetryData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -12,7 +12,7 @@ internal struct TelemetryData: Encodable {
     // MARK: - Properties
 
     internal let version: String? = {
-        Bundle(for: AnalyticsProvider.self).infoDictionary?["CFBundleShortVersionString"] as? String
+        Bundle(for: AnalyticsProvider.self).infoDictionary?["AdyenSDKVersion"] as? String
     }()
 
     internal let channel: String = "iOS"

--- a/Adyen/Info.plist
+++ b/Adyen/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AdyenSDKVersion</key>
+	<string>5.2.0</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
## Changes

* using a custom `AdyenSDKVersion` Info.plist field to provide the SDK version for telemetry

## Discussion
This is a first step of reporting the correct value and should/will be automated at a later stage