### PR TITLE
chore: adyen sdk version validation V4

### DIFF
--- a/.github/workflows/pr_scan.yml
+++ b/.github/workflows/pr_scan.yml
@@ -33,6 +33,10 @@ jobs:
     - name: Validate 3DS2 SDK version
       run: |
         Scripts/validate-3ds2-SDK-version.sh
+        
+    - name: Validate Adyen SDK version
+      run: |
+        Scripts/validate-Adyen-SDK-version.sh
 
     - name: Build and test
       run: |

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		5AD755DB268E11DA0040B919 /* VoucherComponentExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD755DA268E11DA0040B919 /* VoucherComponentExtensions.swift */; };
 		5AF730EA2667C3F10091C573 /* APIContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF730E92667C3F10091C573 /* APIContextTests.swift */; };
 		5AF8CD4D26691D3A00102339 /* Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF8CD4C26691D3A00102339 /* Dummy.swift */; };
+		8140A3782A332DCA00896403 /* AdyenSdkVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8140A3772A332DCA00896403 /* AdyenSdkVersion.swift */; };
 		A009837D279859DC007E68C4 /* ACHDirectDebitComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A009837C279859DC007E68C4 /* ACHDirectDebitComponentTests.swift */; };
 		A009837F27986B50007E68C4 /* BankDetailsEncryptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A009837E27986B50007E68C4 /* BankDetailsEncryptorTests.swift */; };
 		A0113D9B2763887800AD395C /* ActionNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0113D9A2763887800AD395C /* ActionNavigationBar.swift */; };
@@ -1006,6 +1007,7 @@
 		5AD755DA268E11DA0040B919 /* VoucherComponentExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoucherComponentExtensions.swift; sourceTree = "<group>"; };
 		5AF730E92667C3F10091C573 /* APIContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIContextTests.swift; sourceTree = "<group>"; };
 		5AF8CD4C26691D3A00102339 /* Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dummy.swift; sourceTree = "<group>"; };
+		8140A3772A332DCA00896403 /* AdyenSdkVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenSdkVersion.swift; sourceTree = "<group>"; };
 		A009837C279859DC007E68C4 /* ACHDirectDebitComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACHDirectDebitComponentTests.swift; sourceTree = "<group>"; };
 		A009837E27986B50007E68C4 /* BankDetailsEncryptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankDetailsEncryptorTests.swift; sourceTree = "<group>"; };
 		A0113D9A2763887800AD395C /* ActionNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionNavigationBar.swift; sourceTree = "<group>"; };
@@ -2517,6 +2519,7 @@
 				5AD40EFA26303D490090E01C /* UILabelHelpers.swift */,
 				A0D48FB727109B0200C0B82C /* ArrayHelpers.swift */,
 				E7E0E2372762005B001DF0C9 /* NSConstraintHelper.swift */,
+				8140A3772A332DCA00896403 /* AdyenSdkVersion.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -5005,6 +5008,7 @@
 				E9093401228C54CD00C9F04B /* LogoURLProvider.swift in Sources */,
 				F99E7278261F6C6F00EA5B78 /* KeyboardObserver.swift in Sources */,
 				E21895E622A7CC56001B6EE0 /* FormSplitItemView.swift in Sources */,
+				8140A3782A332DCA00896403 /* AdyenSdkVersion.swift in Sources */,
 				E9021DF8225E2240009CF7F4 /* ListSection.swift in Sources */,
 				E787C9AC24696A8900B401E0 /* CornerRadiusStyle.swift in Sources */,
 				F9D5752A237C6084009C18B5 /* StoredBCMCPaymentMethod.swift in Sources */,

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -5730,6 +5730,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				MARKETING_VERSION = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 6;
 			};
@@ -5739,6 +5740,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				MARKETING_VERSION = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = 6;
 			};
@@ -5799,7 +5801,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -5859,7 +5861,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -5890,7 +5892,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.Adyen;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -5922,7 +5924,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.Adyen;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -5946,6 +5948,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AdyenUIHost.app/AdyenUIHost";
@@ -5965,6 +5968,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AdyenUIHost.app/AdyenUIHost";
@@ -5988,7 +5992,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenCard;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -6015,7 +6019,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenCard;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -6042,7 +6046,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-expression-type-checking=100";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.CheckoutDemoUIKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -6068,7 +6072,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-expression-type-checking=100";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.CheckoutDemoUIKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -6096,7 +6100,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenDropIn;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -6125,7 +6129,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenDropIn;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -6154,7 +6158,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenComponents;
@@ -6186,7 +6190,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenComponents;
@@ -6218,7 +6222,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenActions;
@@ -6250,7 +6254,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenActions;
@@ -6282,7 +6286,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenEncryption;
@@ -6314,7 +6318,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenEncryption;
@@ -6346,7 +6350,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenSwiftUI;
@@ -6377,7 +6381,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenSwiftUI;
@@ -6407,7 +6411,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.CheckoutDemoSwiftUI;
@@ -6436,7 +6440,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.CheckoutDemoSwiftUI;
@@ -6459,6 +6463,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenSwiftUITests;
@@ -6482,6 +6487,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adyen.AdyenSwiftUITests;
@@ -6515,7 +6521,7 @@
 					"@loader_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = (
@@ -6558,7 +6564,7 @@
 					"@loader_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = 4.7.3;
+				MARKETING_VERSION = "";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = (

--- a/Adyen/Helpers/AdyenSdkVersion.swift
+++ b/Adyen/Helpers/AdyenSdkVersion.swift
@@ -1,0 +1,10 @@
+//
+// Copyright (c) 2023 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+/// The Adyen SDK version.
+public let adyenSdkVersion: String = "4.10.3"

--- a/Adyen/Utilities/Analytics.swift
+++ b/Adyen/Utilities/Analytics.swift
@@ -67,7 +67,7 @@ public class Analytics {
     
     // MARK: - Private
     
-    private static let libraryVersion = Bundle(for: Analytics.self).infoDictionary?["CFBundleShortVersionString"] as? String
+    private static let libraryVersion = adyenSdkVersion
     private static let payloadVersion = "1"
     private static let platform = "ios"
     

--- a/Scripts/increment_version.sh
+++ b/Scripts/increment_version.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PODSPEC_PATH=Adyen.podspec
+ADYEN_SDK_VERSION_PATH='./Adyen/Helpers/AdyenSdkVersion.swift'
 CURRENT_VERSION=`agvtool vers -terse`
 
 echo "Current Version: ${CURRENT_VERSION}"
@@ -12,4 +13,5 @@ then
   agvtool new-marketing-version $NEW_VERSION
 
   sed -i '' -e "s/$CURRENT_VERSION/$NEW_VERSION/" $PODSPEC_PATH
+  sed -i '' '$d' $ADYEN_SDK_VERSION_PATH && echo 'public let adyenSdkVersion: String = "'$NEW_VERSION'"' >> $ADYEN_SDK_VERSION_PATH
 fi

--- a/Scripts/validate-3ds2-SDK-version.sh
+++ b/Scripts/validate-3ds2-SDK-version.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-cardDetails3DS2SDKVersion=$(sed -En 's/^.*public.*let.*threeDS2SdkVersion.*:.*String.*=.*"([0-9]+.[0-9].[0-9]+)".*$/\1/p' AdyenCard/Components/Card/ThreeDS2SdkVersion.swift)
-cocoapods3DS2SDKVersion=$(sed -En "s/^.*dependency.*\'Adyen3DS2'.*,.*'([0-9]+.[0-9].[0-9]+)'.*$/\1/p" Adyen.podspec)
-carthage3DS2SDKVersion=$(sed -En 's/^.*github.*"adyen\/adyen-3ds2-ios".*==.*([0-9]+.[0-9].[0-9]+).*$/\1/p' Cartfile)
+cardDetails3DS2SDKVersion=$(sed -En 's/^.*public.*let.*threeDS2SdkVersion.*:.*String.*=.*"([0-9]+.[0-9]+.[0-9]+)".*$/\1/p' AdyenCard/Components/Card/ThreeDS2SdkVersion.swift)
+cocoapods3DS2SDKVersion=$(sed -En "s/^.*dependency.*\'Adyen3DS2'.*,.*'([0-9]+.[0-9]+.[0-9]+)'.*$/\1/p" Adyen.podspec)
+carthage3DS2SDKVersion=$(sed -En 's/^.*github.*"adyen\/adyen-3ds2-ios".*==.*([0-9]+.[0-9]+.[0-9]+).*$/\1/p' Cartfile)
 swiftPackageManager3DS2SDKVersion=$(cat Package.swift | tr -d '[[:blank:]]\n\r' | sed -rn 's/.*name:"Adyen3DS2",url:"https:\/\/github\.com\/Adyen\/adyen\-3ds2\-ios",\.exact\(Version\(([0-9]+),([0-9]+),([0-9]+)\)\).*/\1.\2.\3/p')
 
-echo '\n'
+echo '\n3DS2 SDK Version Validation'
 echo '-----------------------------------------------------'
 echo "ThreeDS2SdkVersion.swift: $cardDetails3DS2SDKVersion"
 echo "Adyen.podspec:            $cocoapods3DS2SDKVersion"

--- a/Scripts/validate-Adyen-SDK-version.sh
+++ b/Scripts/validate-Adyen-SDK-version.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+adyenSdkVersion=$(agvtool what-marketing-version -terse1)
+adyenHelpersAdyenSDKVersion=$(sed -En 's/^.*public.*let.*adyenSdkVersion.*:.*String.*=.*"([0-9]+.[0-9]+.[0-9]+)".*$/\1/p' Adyen/Helpers/AdyenSdkVersion.swift)
+cocoapodsAdyenSDKVersion=$(sed -En "s/^.*s.version.*=.*'([0-9]+.[0-9]+.[0-9]+)'.*$/\1/p" Adyen.podspec)
+
+echo '\nAdyen SDK Version Validation'
+echo '-----------------------------------------------------'
+echo "CFBundleShortVersionString: $adyenSdkVersion"
+echo "AdyenSdkVersion.swift:      $adyenHelpersAdyenSDKVersion"
+echo "Adyen.podspec:              $cocoapodsAdyenSDKVersion"
+echo '------------------------------------------------------\n'
+
+declare -a array=( $adyenSdkVersion $adyenHelpersAdyenSDKVersion $cocoapodsAdyenSDKVersion )
+
+declare -a uniq=($(echo "${array[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+
+if [ ${#uniq[@]} -ne 1 ]; then
+  RED='\033[0;31m'
+  NC='\033[0m'
+  echo "[ERROR] : ${RED}Adyen SDK version in Info.plist (CFBundleShortVersionString), Adyen.podspec, and AdyenSdkVersion.swift files do not match, please fix the conflict and try to commit again.${NC}"
+  exit 1
+fi


### PR DESCRIPTION
## Changes

* adding a global adyenSdkVersion parameter to the Adyen bundle
* adding a script to verify the correct application of the sdk version everywhere
* allowing version numbers with a minor version >9 on the 3DS2 SDK