### PR TITLE
Remove applePayCardNetwork from JSON

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayDetails.swift
+++ b/AdyenComponents/Apple Pay/ApplePayDetails.swift
@@ -58,7 +58,6 @@ public struct ApplePayDetails: PaymentMethodDetails {
     // MARK: - Coding
     
     private enum CodingKeys: String, CodingKey {
-        case network = "applePayCardNetwork"
         case token = "applePayToken"
         case type
     }

--- a/Demo/Common/Networking/PaymentsRequest.swift
+++ b/Demo/Common/Networking/PaymentsRequest.swift
@@ -63,6 +63,7 @@ internal struct PaymentsRequest: APIRequest {
         try container.encodeIfPresent(data.installments, forKey: .installments)
         try container.encode(ConfigurationConstants.lineItems, forKey: .lineItems)
         try container.encode(ConfigurationConstants.recurringProcessingModel, forKey: .recurringProcessingModel)
+        try container.encodeIfPresent(data.checkoutAttemptId, forKey: .checkoutAttemptId)
     }
     
     private enum CodingKeys: String, CodingKey {

--- a/Tests/Components Tests/Apple Pay/ApplePayDetailsTest.swift
+++ b/Tests/Components Tests/Apple Pay/ApplePayDetailsTest.swift
@@ -26,11 +26,9 @@ class ApplePayDetailsTest: XCTestCase {
         
         let expectedJson = [
             "applePayToken": "test_token",
-            "applePayCardNetwork": "test_network",
             "type": "applepay"
         ]
         XCTAssertEqual(expectedJson["applePayToken"], resultJson?["applePayToken"] as? String)
-        XCTAssertEqual(expectedJson["applePayCardNetwork"], resultJson?["applePayCardNetwork"] as? String)
         XCTAssertEqual(expectedJson["type"], resultJson?["type"] as? String)
     }
     


### PR DESCRIPTION
# Open PR

## Changes

<fixed>

* Field `applePayCardNetwork` will no longer appear on JSON payment details on Apple Pay.

</fixed>