### PR TITLE
chore: Update country picker on address change

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		5AF730EA2667C3F10091C573 /* APIContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF730E92667C3F10091C573 /* APIContextTests.swift */; };
 		5AF8CD4D26691D3A00102339 /* Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF8CD4C26691D3A00102339 /* Dummy.swift */; };
 		8196F8BC2A2F7255007046B7 /* AdyenSdkVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8196F8BB2A2F7255007046B7 /* AdyenSdkVersion.swift */; };
+		81EA6C122A44836E0071A141 /* FormAddressItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81EA6C112A44836E0071A141 /* FormAddressItemTests.swift */; };
 		A009837D279859DC007E68C4 /* ACHDirectDebitComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A009837C279859DC007E68C4 /* ACHDirectDebitComponentTests.swift */; };
 		A009837F27986B50007E68C4 /* BankDetailsEncryptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A009837E27986B50007E68C4 /* BankDetailsEncryptorTests.swift */; };
 		A0113D9B2763887800AD395C /* ActionNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0113D9A2763887800AD395C /* ActionNavigationBar.swift */; };
@@ -1234,6 +1235,7 @@
 		5AF8CD4C26691D3A00102339 /* Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dummy.swift; sourceTree = "<group>"; };
 		8196F8BB2A2F7255007046B7 /* AdyenSdkVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenSdkVersion.swift; sourceTree = "<group>"; };
 		81C4006F2A4347FD007EC51C /* FormErrorItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormErrorItemTests.swift; sourceTree = "<group>"; };
+		81EA6C112A44836E0071A141 /* FormAddressItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormAddressItemTests.swift; sourceTree = "<group>"; };
 		A009837C279859DC007E68C4 /* ACHDirectDebitComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACHDirectDebitComponentTests.swift; sourceTree = "<group>"; };
 		A009837E27986B50007E68C4 /* BankDetailsEncryptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankDetailsEncryptorTests.swift; sourceTree = "<group>"; };
 		A0113D9A2763887800AD395C /* ActionNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionNavigationBar.swift; sourceTree = "<group>"; };
@@ -2365,6 +2367,7 @@
 			isa = PBXGroup;
 			children = (
 				F99D4602262D647400880D72 /* AddressViewModelTests.swift */,
+				81EA6C112A44836E0071A141 /* FormAddressItemTests.swift */,
 			);
 			path = Address;
 			sourceTree = "<group>";
@@ -6218,6 +6221,7 @@
 				F9AC61C2243751A70062A00D /* ActionComponentDelegateMock.swift in Sources */,
 				C9C0005F280474DF00CE2EEC /* AnalyticsProviderTests.swift in Sources */,
 				F9F1A98726CCFD1F0005CB1D /* JWAA256CBCHS512AlgorithmTests.swift in Sources */,
+				81EA6C122A44836E0071A141 /* FormAddressItemTests.swift in Sources */,
 				00EACBD1288558A00082B360 /* APIClientMock.swift in Sources */,
 				C9BB460627622E9600E6730B /* BACSConfirmationPresenterProtocolMock.swift in Sources */,
 				E759E24C25CB3BB700B1F8DC /* DropInTests.swift in Sources */,

--- a/Adyen/UI/Form/Items/Address/FormFullAddressItem.swift
+++ b/Adyen/UI/Form/Items/Address/FormFullAddressItem.swift
@@ -18,6 +18,12 @@ public final class FormAddressItem: FormValueItem<PostalAddress, AddressStyle>, 
         }
     }
     
+    public override var value: PostalAddress {
+        didSet {
+            updateCountrySelectItem()
+        }
+    }
+    
     private var items: [FormItem] = []
     
     private let localizationParameters: LocalizationParameters?
@@ -104,6 +110,18 @@ public final class FormAddressItem: FormValueItem<PostalAddress, AddressStyle>, 
     }
     
     // MARK: - Private
+    
+    private func updateCountrySelectItem() {
+        guard let country = value.country, country != countrySelectItem.value.identifier else {
+            return
+        }
+        
+        guard let matchingElement = countrySelectItem.selectableValues.first(where: { $0.identifier == value.country }) else {
+            return // TODO: Log an error for the merchant
+        }
+        
+        countrySelectItem.value = matchingElement
+    }
     
     private func reloadFields() {
         let subRegions = RegionRepository.subRegions(for: context.countryCode)

--- a/Adyen/UI/Form/Items/Address/FormFullAddressItem.swift
+++ b/Adyen/UI/Form/Items/Address/FormFullAddressItem.swift
@@ -117,7 +117,10 @@ public final class FormAddressItem: FormValueItem<PostalAddress, AddressStyle>, 
         }
         
         guard let matchingElement = countrySelectItem.selectableValues.first(where: { $0.identifier == value.country }) else {
-            return // TODO: Log an error for the merchant
+            AdyenAssertion.assertionFailure(
+                message: "The provided country '\(country)' is not supported per configuration."
+            )
+            return
         }
         
         countrySelectItem.value = matchingElement

--- a/Adyen/UI/Form/Items/Address/FormFullAddressItem.swift
+++ b/Adyen/UI/Form/Items/Address/FormFullAddressItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -18,9 +18,9 @@ public final class FormAddressItem: FormValueItem<PostalAddress, AddressStyle>, 
         }
     }
     
-    public override var value: PostalAddress {
+    override public var value: PostalAddress {
         didSet {
-            updateCountrySelectItem()
+            updateCountryPicker()
         }
     }
     
@@ -79,8 +79,8 @@ public final class FormAddressItem: FormValueItem<PostalAddress, AddressStyle>, 
         self.identifier = identifier
         reloadFields()
         
-        bind(countrySelectItem.publisher, at: \.identifier, to: self, at: \.value.country)
-        observe(countrySelectItem.publisher, eventHandler: { [weak self] event in
+        bind(countryPickerItem.publisher, at: \.identifier, to: self, at: \.value.country)
+        observe(countryPickerItem.publisher, eventHandler: { [weak self] event in
             self?.context.countryCode = event.element.identifier
         })
     }
@@ -92,7 +92,7 @@ public final class FormAddressItem: FormValueItem<PostalAddress, AddressStyle>, 
         return item
     }()
     
-    internal lazy var countrySelectItem: FormRegionPickerItem = {
+    internal lazy var countryPickerItem: FormRegionPickerItem = {
         let locale = Locale(identifier: localizationParameters?.locale ?? Locale.current.identifier)
         let countries = RegionRepository.regions(from: locale as NSLocale,
                                                  countryCodes: supportedCountryCodes).sorted { $0.name < $1.name }
@@ -111,19 +111,19 @@ public final class FormAddressItem: FormValueItem<PostalAddress, AddressStyle>, 
     
     // MARK: - Private
     
-    private func updateCountrySelectItem() {
-        guard let country = value.country, country != countrySelectItem.value.identifier else {
+    private func updateCountryPicker() {
+        guard let country = value.country, country != countryPickerItem.value.identifier else {
             return
         }
         
-        guard let matchingElement = countrySelectItem.selectableValues.first(where: { $0.identifier == value.country }) else {
+        guard let matchingElement = countryPickerItem.selectableValues.first(where: { $0.identifier == value.country }) else {
             AdyenAssertion.assertionFailure(
                 message: "The provided country '\(country)' is not supported per configuration."
             )
             return
         }
         
-        countrySelectItem.value = matchingElement
+        countryPickerItem.value = matchingElement
     }
     
     private func reloadFields() {
@@ -132,7 +132,7 @@ public final class FormAddressItem: FormValueItem<PostalAddress, AddressStyle>, 
         
         items = [FormSpacerItem(),
                  headerItem.addingDefaultMargins(),
-                 countrySelectItem]
+                 countryPickerItem]
         for field in addressViewModel.scheme {
             switch field {
             case let .item(fieldType):

--- a/Tests/Adyen Tests/UI/Form/FormItems/Address/FormAddressItemTests.swift
+++ b/Tests/Adyen Tests/UI/Form/FormItems/Address/FormAddressItemTests.swift
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2023 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+import XCTest
+
+class FormAddressItemTests: XCTestCase {
+
+    func testCountrySelectItemUpdate() throws {
+        
+        let formAddressItem = FormAddressItem(
+            initialCountry: "NL",
+            style: .init(),
+            supportedCountryCodes: ["NL", "US"],
+            addressViewModelBuilder: DefaultAddressViewModelBuilder()
+        )
+        
+        XCTAssertEqual(formAddressItem.countrySelectItem.value.identifier, "NL")
+        
+        formAddressItem.value = .init(country: "US")
+        XCTAssertEqual(formAddressItem.countrySelectItem.value.identifier, "US")
+    }
+}

--- a/Tests/Adyen Tests/UI/Form/FormItems/Address/FormAddressItemTests.swift
+++ b/Tests/Adyen Tests/UI/Form/FormItems/Address/FormAddressItemTests.swift
@@ -47,6 +47,6 @@ class FormAddressItemTests: XCTestCase {
         
         formAddressItem.value = .init(country: "XX")
         
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: 0)
     }
 }

--- a/Tests/Adyen Tests/UI/Form/FormItems/Address/FormAddressItemTests.swift
+++ b/Tests/Adyen Tests/UI/Form/FormItems/Address/FormAddressItemTests.swift
@@ -9,7 +9,12 @@ import XCTest
 
 class FormAddressItemTests: XCTestCase {
 
-    func testCountrySelectItemUpdate() throws {
+    override func tearDown() {
+        super.tearDown()
+        AdyenAssertion.listener = nil
+    }
+    
+    func testCountryPickerItemUpdate() throws {
         
         let formAddressItem = FormAddressItem(
             initialCountry: "NL",
@@ -18,9 +23,30 @@ class FormAddressItemTests: XCTestCase {
             addressViewModelBuilder: DefaultAddressViewModelBuilder()
         )
         
-        XCTAssertEqual(formAddressItem.countrySelectItem.value.identifier, "NL")
+        XCTAssertEqual(formAddressItem.countryPickerItem.value.identifier, "NL")
         
         formAddressItem.value = .init(country: "US")
-        XCTAssertEqual(formAddressItem.countrySelectItem.value.identifier, "US")
+        XCTAssertEqual(formAddressItem.countryPickerItem.value.identifier, "US")
+    }
+    
+    func testCountryPickerItemUpdateUnsupportedCountry() throws {
+        
+        let formAddressItem = FormAddressItem(
+            initialCountry: "NL",
+            style: .init(),
+            supportedCountryCodes: ["NL", "US"],
+            addressViewModelBuilder: DefaultAddressViewModelBuilder()
+        )
+        
+        let expectation = XCTestExpectation(description: "Setting unsupported country should fail")
+        
+        AdyenAssertion.listener = { assertion in
+            XCTAssertEqual(assertion, "The provided country 'XX' is not supported per configuration.")
+            expectation.fulfill()
+        }
+        
+        formAddressItem.value = .init(country: "XX")
+        
+        wait(for: [expectation])
     }
 }


### PR DESCRIPTION
## Changes

* update the `FormFullAddressItem.countrySelectItem` to reflect the changes when the `FormFullAddressItem.value` is changed externally