### PR TITLE
COIOS-593: ThreeDS Opaque error handling  - Adding support to V4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
         - destination: 'name=iPhone 8,OS=13.7'
           scheme: AdyenUIHost
     steps:
-    - uses: actions/checkout@v2
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: actions/checkout@v3
+    - uses: n1hility/cancel-previous-runs@v3
       with:
         token: ${{ secrets.MANUAL_ACTION_TOKEN }}
 

--- a/.github/workflows/format_project.yml
+++ b/.github/workflows/format_project.yml
@@ -5,10 +5,10 @@ jobs:
   Update:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: n1hility/cancel-previous-runs@v3
       with:
         token: ${{ secrets.MANUAL_ACTION_TOKEN }}
 

--- a/.github/workflows/format_project.yml
+++ b/.github/workflows/format_project.yml
@@ -10,7 +10,7 @@ jobs:
         fetch-depth: 0
     - uses: n1hility/cancel-previous-runs@v3
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/pr_scan.yml
+++ b/.github/workflows/pr_scan.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: macos-12
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: actions/checkout@v3
+    - uses: n1hility/cancel-previous-runs@v3
       with:
         token: ${{ secrets.MANUAL_ACTION_TOKEN }}
     - uses: actions/setup-java@v1

--- a/.github/workflows/pr_scan.yml
+++ b/.github/workflows/pr_scan.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: n1hility/cancel-previous-runs@v3
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-java@v1
       with:
         java-version: '11'

--- a/.github/workflows/publich_podspec.yml
+++ b/.github/workflows/publich_podspec.yml
@@ -5,7 +5,7 @@ jobs:
   publish:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/publish-demo-app.yml
+++ b/.github/workflows/publish-demo-app.yml
@@ -5,10 +5,10 @@ jobs:
   Publish:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: n1hility/cancel-previous-runs@v3
       with:
         token: ${{ secrets.MANUAL_ACTION_TOKEN }}
 

--- a/.github/workflows/publish-demo-app.yml
+++ b/.github/workflows/publish-demo-app.yml
@@ -10,7 +10,7 @@ jobs:
         fetch-depth: 0
     - uses: n1hility/cancel-previous-runs@v3
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -5,10 +5,10 @@ jobs:
   Generate:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: n1hility/cancel-previous-runs@v3
       with:
         token: ${{ secrets.MANUAL_ACTION_TOKEN }}
 

--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -10,7 +10,7 @@ jobs:
         fetch-depth: 0
     - uses: n1hility/cancel-previous-runs@v3
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: n1hility/cancel-previous-runs@v3
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
 
     - name: Spell check

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -14,8 +14,8 @@ jobs:
   setup:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: actions/checkout@v3
+    - uses: n1hility/cancel-previous-runs@v3
       with:
         token: ${{ secrets.MANUAL_ACTION_TOKEN }}
 

--- a/.github/workflows/test-SPM-integration.yml
+++ b/.github/workflows/test-SPM-integration.yml
@@ -14,8 +14,8 @@ jobs:
   SPM:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: actions/checkout@v3
+    - uses: n1hility/cancel-previous-runs@v3
       with:
         token: ${{ secrets.MANUAL_ACTION_TOKEN }}
 

--- a/.github/workflows/test-SPM-integration.yml
+++ b/.github/workflows/test-SPM-integration.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: n1hility/cancel-previous-runs@v3
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/test-carthage-integration.yml
+++ b/.github/workflows/test-carthage-integration.yml
@@ -14,8 +14,8 @@ jobs:
   carthage:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v2
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: actions/checkout@v3
+    - uses: n1hility/cancel-previous-runs@v3
       with:
         token: ${{ secrets.MANUAL_ACTION_TOKEN }}
 

--- a/.github/workflows/test-carthage-integration.yml
+++ b/.github/workflows/test-carthage-integration.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: n1hility/cancel-previous-runs@v3
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: n1hility/cancel-previous-runs@v3
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -14,8 +14,8 @@ jobs:
   pods:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v2
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: actions/checkout@v3
+    - uses: n1hility/cancel-previous-runs@v3
       with:
         token: ${{ secrets.MANUAL_ACTION_TOKEN }}
 

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -10,12 +10,12 @@ jobs:
   Update:
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: n1hility/cancel-previous-runs@v2
+    - uses: n1hility/cancel-previous-runs@v3
       with:
-        token: ${{ secrets.MANUAL_ACTION_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -56,7 +56,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Actions' do |plugin|
     plugin.dependency 'Adyen/Core'
-    plugin.dependency 'Adyen3DS2', '2.3.1'
+    plugin.dependency 'Adyen3DS2', '2.3.2'
     plugin.source_files = 'AdyenActions/**/*.swift'
     plugin.exclude_files = 'AdyenActions/**/BundleSPMExtension.swift'
     plugin.resource_bundles = {

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -6736,7 +6736,7 @@
 			repositoryURL = "https://github.com/Adyen/adyen-3ds2-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 2.3.1;
+				version = 2.3.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2022 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -7,16 +7,23 @@
 import Adyen
 import Foundation
 
+internal enum ThreeDS2ActionHandlerError: Error {
+    case cancellation(AdditionalDetails)
+    case underlyingError(Error)
+    case unknown(UnknownError)
+    case missingTransaction
+}
+
 /// :nodoc:
 internal protocol AnyThreeDS2ActionHandler {
 
     /// :nodoc:
     func handle(_ fingerprintAction: ThreeDS2FingerprintAction,
-                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void)
+                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void)
 
     /// :nodoc:
     func handle(_ challengeAction: ThreeDS2ChallengeAction,
-                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void)
+                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void)
 }
 
 /// :nodoc:

--- a/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -12,6 +12,19 @@ internal enum ThreeDS2ActionHandlerError: Error {
     case underlyingError(Error)
     case unknown(UnknownError)
     case missingTransaction
+    
+    init(error: ThreeDS2CoreActionHandlerError) {
+        switch error {
+        case let .cancellationAction(threeDSResult):
+            self = .cancellation(ThreeDS2Details.challengeResult(threeDSResult))
+        case .missingTransaction:
+            self = .missingTransaction
+        case let .unknown(unknownError):
+            self = .unknown(unknownError)
+        case let .underlyingError(underlyingError):
+            self = .underlyingError(underlyingError)
+        }
+    }
 }
 
 /// :nodoc:

--- a/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -7,36 +7,16 @@
 import Adyen
 import Foundation
 
-internal enum ThreeDS2ActionHandlerError: Error {
-    case cancellation(AdditionalDetails)
-    case underlyingError(Error)
-    case unknown(UnknownError)
-    case missingTransaction
-    
-    init(error: ThreeDS2CoreActionHandlerError) {
-        switch error {
-        case let .cancellationAction(threeDSResult):
-            self = .cancellation(ThreeDS2Details.challengeResult(threeDSResult))
-        case .missingTransaction:
-            self = .missingTransaction
-        case let .unknown(unknownError):
-            self = .unknown(unknownError)
-        case let .underlyingError(underlyingError):
-            self = .underlyingError(underlyingError)
-        }
-    }
-}
-
 /// :nodoc:
 internal protocol AnyThreeDS2ActionHandler {
 
     /// :nodoc:
     func handle(_ fingerprintAction: ThreeDS2FingerprintAction,
-                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void)
+                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void)
 
     /// :nodoc:
     func handle(_ challengeAction: ThreeDS2ChallengeAction,
-                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void)
+                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void)
 }
 
 /// :nodoc:

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2022 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
@@ -65,15 +65,14 @@ internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, Component
             flavor: _isDropIn ? .dropin : .components,
             environment: apiContext.environment
         )
-        coreActionHandler.handle(fingerprintAction, event: event) { [weak self] result in
-            guard let self = self else { return }
+        coreActionHandler.handle(fingerprintAction, event: event) { result in
             switch result {
             case let .success(encodedFingerprint):
                 let additionalDetails = ThreeDS2Details.fingerprint(encodedFingerprint)
                 let result = ThreeDSActionHandlerResult.details(additionalDetails)
                 completionHandler(.success(result))
             case let .failure(error):
-                completionHandler(.failure(self.onReceiveError(error: error)))
+                completionHandler(.failure(ThreeDS2ActionHandlerError(error: error)))
             }
         }
     }
@@ -98,7 +97,7 @@ internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, Component
             case let .success(result):
                 self.handle(result, completionHandler: completionHandler)
             case let .failure(error):
-                completionHandler(.failure(self.onReceiveError(error: error)))
+                completionHandler(.failure(ThreeDS2ActionHandlerError(error: error)))
             }
         }
     }
@@ -109,19 +108,6 @@ internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, Component
         completionHandler(.success(.details(additionalDetails)))
     }
     
-    private func onReceiveError(error: ThreeDS2CoreActionHandlerError) -> ThreeDS2ActionHandlerError {
-        switch error {
-        case let .cancellationAction(threeDSResult):
-            return .cancellation(ThreeDS2Details.challengeResult(threeDSResult))
-        case .missingTransaction:
-            return .missingTransaction
-        case let .unknown(unknownError):
-            return .unknown(unknownError)
-        case let .underlyingError(underlyingError):
-            return .underlyingError(underlyingError)
-        }
-    }
-
     // MARK: - Private
 
     private let fingerprintEventName = "3ds2fingerprint"

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
@@ -59,7 +59,7 @@ internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, Component
     /// - Parameter completionHandler: The completion closure.
     /// :nodoc:
     internal func handle(_ fingerprintAction: ThreeDS2FingerprintAction,
-                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void) {
+                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
         let event = Analytics.Event(
             component: fingerprintEventName,
             flavor: _isDropIn ? .dropin : .components,
@@ -72,7 +72,7 @@ internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, Component
                 let result = ThreeDSActionHandlerResult.details(additionalDetails)
                 completionHandler(.success(result))
             case let .failure(error):
-                completionHandler(.failure(ThreeDS2ActionHandlerError(error: error)))
+                completionHandler(.failure(error))
             }
         }
     }
@@ -85,7 +85,7 @@ internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, Component
     /// - Parameter completionHandler: The completion closure.
     /// :nodoc:
     internal func handle(_ challengeAction: ThreeDS2ChallengeAction,
-                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void) {
+                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
         let event = Analytics.Event(
             component: challengeEventName,
             flavor: _isDropIn ? .dropin : .components,
@@ -97,13 +97,13 @@ internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, Component
             case let .success(result):
                 self.handle(result, completionHandler: completionHandler)
             case let .failure(error):
-                completionHandler(.failure(ThreeDS2ActionHandlerError(error: error)))
+                completionHandler(.failure(error))
             }
         }
     }
 
     private func handle(_ threeDSResult: ThreeDSResult,
-                        completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void) {
+                        completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
         let additionalDetails = ThreeDS2Details.challengeResult(threeDSResult)
         completionHandler(.success(.details(additionalDetails)))
     }

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
@@ -60,7 +60,7 @@ internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, Com
     /// - Parameter completionHandler: The completion closure.
     /// :nodoc:
     internal func handle(_ fingerprintAction: ThreeDS2FingerprintAction,
-                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void) {
+                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
         let event = Analytics.Event(component: "\(threeDS2EventName).fingerprint",
                                     flavor: _isDropIn ? .dropin : .components,
                                     environment: apiContext.environment)
@@ -74,11 +74,11 @@ internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, Com
                     case let .success(threeDS2Result):
                         completionHandler(.success(threeDS2Result))
                     case let .failure(error):
-                        completionHandler(.failure(.underlyingError(error)))
+                        completionHandler(.failure(error))
                     }
                 }
             case let .failure(error):
-                completionHandler(.failure(ThreeDS2ActionHandlerError(error: error)))
+                completionHandler(.failure(error))
             }
         }
     }
@@ -91,7 +91,7 @@ internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, Com
     /// - Parameter completionHandler: The completion closure.
     /// :nodoc:
     internal func handle(_ challengeAction: ThreeDS2ChallengeAction,
-                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void) {
+                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
         let event = Analytics.Event(component: "\(threeDS2EventName).challenge",
                                     flavor: _isDropIn ? .dropin : .components,
                                     environment: apiContext.environment)
@@ -101,13 +101,13 @@ internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, Com
             case let .success(result):
                 self.handle(result, completionHandler: completionHandler)
             case let .failure(error):
-                completionHandler(.failure(ThreeDS2ActionHandlerError(error: error)))
+                completionHandler(.failure(error))
             }
         }
     }
 
     private func handle(_ threeDSResult: ThreeDSResult,
-                        completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void) {
+                        completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
         let additionalDetails = ThreeDS2Details.completed(threeDSResult)
         completionHandler(.success(.details(additionalDetails)))
     }

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
@@ -120,18 +120,3 @@ internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, Com
     private let threeDS2EventName = "3ds2"
 
 }
-
-private extension ThreeDS2ActionHandlerError {
-    init(error: ThreeDS2CoreActionHandlerError) {
-        switch error {
-        case let .cancellationAction(threeDSResult):
-            self = .cancellation(ThreeDS2Details.challengeResult(threeDSResult))
-        case .missingTransaction:
-            self = .missingTransaction
-        case let .unknown(unknownError):
-            self = .unknown(unknownError)
-        case let .underlyingError(underlyingError):
-            self = .underlyingError(underlyingError)
-        }
-    }
-}

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
@@ -69,14 +69,8 @@ internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, Com
             switch result {
             case let .success(encodedFingerprint):
                 self.fingerprintSubmitter.submit(fingerprint: encodedFingerprint,
-                                                 paymentData: fingerprintAction.paymentData) { result in
-                    switch result {
-                    case let .success(threeDS2Result):
-                        completionHandler(.success(threeDS2Result))
-                    case let .failure(error):
-                        completionHandler(.failure(error))
-                    }
-                }
+                                                 paymentData: fingerprintAction.paymentData,
+                                                 completionHandler: completionHandler)
             case let .failure(error):
                 completionHandler(.failure(error))
             }

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CoreActionHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2022 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -18,6 +18,10 @@ extension NSError {
 /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
 /// :nodoc:
 internal class ThreeDS2CoreActionHandler: Component {
+    
+    private enum Constant {
+        static let transStatusWhenError = "U"
+    }
     
     /// :nodoc:
     internal let apiContext: APIContext
@@ -187,7 +191,7 @@ internal class ThreeDS2CoreActionHandler: Component {
         do {
             let threeDSResult = try ThreeDSResult(authorizationToken: authorizationToken,
                                                   threeDS2SDKError: threeDS2SDKError,
-                                                  transStatus: "U")
+                                                  transStatus: Constant.transStatusWhenError)
             transaction = nil
             completionHandler(.success(threeDSResult))
         } catch {

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CoreActionHandler.swift
@@ -8,13 +8,6 @@ import Adyen
 import Adyen3DS2
 import Foundation
 
-// TODO: Remove this once 3ds2 sdk is released.
-extension NSError {
-    func base64Representation() -> String {
-        "base64Representation"
-    }
-}
-
 /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
 /// :nodoc:
 internal class ThreeDS2CoreActionHandler: Component {

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CoreActionHandler.swift
@@ -185,7 +185,9 @@ internal class ThreeDS2CoreActionHandler: Component {
                            authorizationToken: String?,
                            completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void) {
         do {
-            let threeDSResult = try ThreeDSResult(authorizationToken: authorizationToken, threeDS2SDKError: threeDS2SDKError)
+            let threeDSResult = try ThreeDSResult(authorizationToken: authorizationToken,
+                                                  threeDS2SDKError: threeDS2SDKError,
+                                                  transStatus: "U")
             transaction = nil
             completionHandler(.success(threeDSResult))
         } catch {

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CoreActionHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -7,6 +7,20 @@
 import Adyen
 import Adyen3DS2
 import Foundation
+
+// TODO: Remove this once 3ds2 sdk is released.
+extension NSError {
+    func base64Representation() -> String {
+        "base64Representation"
+    }
+}
+
+internal enum ThreeDS2CoreActionHandlerError: Error {
+    case cancellationAction(ThreeDSResult)
+    case underlyingError(Error)
+    case unknown(UnknownError)
+    case missingTransaction
+}
 
 /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
 /// :nodoc:
@@ -55,7 +69,7 @@ internal class ThreeDS2CoreActionHandler: Component {
     /// :nodoc:
     internal func handle(_ fingerprintAction: ThreeDS2FingerprintAction,
                          event: Analytics.Event,
-                         completionHandler: @escaping (Result<String, Error>) -> Void) {
+                         completionHandler: @escaping (Result<String, ThreeDS2CoreActionHandlerError>) -> Void) {
         Analytics.sendEvent(event)
 
         createFingerprint(fingerprintAction) { [weak self] result in
@@ -69,7 +83,7 @@ internal class ThreeDS2CoreActionHandler: Component {
     }
 
     private func createFingerprint(_ action: ThreeDS2FingerprintAction,
-                                   completionHandler: @escaping (Result<String, Error>) -> Void) {
+                                   completionHandler: @escaping (Result<String, ThreeDS2CoreActionHandlerError>) -> Void) {
         do {
             let token = try Coder.decodeBase64(action.fingerprintToken) as ThreeDS2Component.FingerprintToken
 
@@ -84,11 +98,28 @@ internal class ThreeDS2CoreActionHandler: Component {
                 }
             }
         } catch {
-            didFail(with: error, completionHandler: completionHandler)
+            didFail(with: .underlyingError(error), completionHandler: completionHandler)
         }
     }
 
-    private func getFingerprint<R>(messageVersion: String, completionHandler: @escaping (Result<R, Error>) -> Void) -> String? {
+    private func getFingerprint(messageVersion: String, completionHandler: @escaping (Result<String, ThreeDS2CoreActionHandlerError>) -> Void) -> String? {
+        do {
+            switch transaction(messageVersion: messageVersion) {
+            case let .success(newTransaction):
+                let encodedFingerprint = try Coder.encodeBase64(ThreeDS2Component.Fingerprint(
+                    authenticationRequestParameters: newTransaction.authenticationParameters
+                ))
+                self.transaction = newTransaction
+                completionHandler(.success(encodedFingerprint))
+
+            case let .failure(error):
+                let encodedError = try Coder.encodeBase64(ThreeDS2Component.Fingerprint(threeDS2SDKError: error.base64Representation()))
+                completionHandler(.success(encodedError))
+            }
+        } catch {
+            didFail(with: .underlyingError(error), completionHandler: completionHandler)
+        }
+
         do {
             let newTransaction = try service.transaction(withMessageVersion: messageVersion)
             self.transaction = newTransaction
@@ -100,9 +131,18 @@ internal class ThreeDS2CoreActionHandler: Component {
 
             return encodedFingerprint
         } catch {
-            didFail(with: error, completionHandler: completionHandler)
+            didFail(with: .underlyingError(error), completionHandler: completionHandler)
         }
         return nil
+    }
+    
+    private func transaction(messageVersion: String) -> Result<AnyADYTransaction, NSError> {
+        do {
+            let newTransaction = try service.transaction(withMessageVersion: messageVersion)
+            return .success(newTransaction)
+        } catch let error as NSError {
+            return .failure(error)
+        }
     }
 
     // MARK: - Challenge
@@ -115,9 +155,9 @@ internal class ThreeDS2CoreActionHandler: Component {
     /// :nodoc:
     internal func handle(_ challengeAction: ThreeDS2ChallengeAction,
                          event: Analytics.Event,
-                         completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void) {
+                         completionHandler: @escaping (Result<ThreeDSResult, ThreeDS2CoreActionHandlerError>) -> Void) {
         guard let transaction = transaction else {
-            return didFail(with: ThreeDS2Component.Error.missingTransaction, completionHandler: completionHandler)
+            return didFail(with: .missingTransaction, completionHandler: completionHandler)
         }
 
         Analytics.sendEvent(event)
@@ -126,15 +166,14 @@ internal class ThreeDS2CoreActionHandler: Component {
         do {
             token = try Coder.decodeBase64(challengeAction.challengeToken) as ThreeDS2Component.ChallengeToken
         } catch {
-            return didFail(with: error, completionHandler: completionHandler)
+            return didFail(with: .underlyingError(error), completionHandler: completionHandler)
         }
 
         let challengeParameters = ADYChallengeParameters(from: token,
                                                          threeDSRequestorAppURL: token.threeDSRequestorAppURL)
         transaction.performChallenge(with: challengeParameters) { [weak self] challengeResult, error in
             guard let result = challengeResult else {
-                let error = error ?? UnknownError(errorDescription: "Both error and result are nil, this should never happen.")
-                self?.didFail(with: error, completionHandler: completionHandler)
+                self?.didReceiveErrorOnChallenge(error: error, challengeAction: challengeAction, completionHandler: completionHandler)
                 return
             }
 
@@ -144,24 +183,67 @@ internal class ThreeDS2CoreActionHandler: Component {
         }
 
     }
+    
+    /// Invoked to handle the error flow of a challenge handling by the 3ds2sdk.
+    /// For challenge cancelled we return the control back to the merchant immediately as an error.
+    private func didReceiveErrorOnChallenge(error: Error?,
+                                            challengeAction: ThreeDS2ChallengeAction,
+                                            completionHandler: @escaping (Result<ThreeDSResult, ThreeDS2CoreActionHandlerError>) -> Void) {
+        guard let error = error as? NSError else {
+            didFail(with: .unknown(UnknownError(errorDescription: "Both error and result are nil, this should never happen.")),
+                    completionHandler: completionHandler)
+            return
+        }
+        switch (error.domain, error.code) {
+        case (ADYRuntimeErrorDomain, Int(ADYRuntimeErrorCode.challengeCancelled.rawValue)):
+            do {
+                let cancellationResult = try ThreeDSResult(authorizationToken: challengeAction.authorisationToken,
+                                                           threeDS2SDKError: error.base64Representation())
+                let cancellationError = ThreeDS2CoreActionHandlerError.cancellationAction(cancellationResult)
+                didFail(with: cancellationError,
+                        completionHandler: completionHandler)
+            } catch {
+                didFail(with: .unknown(UnknownError(errorDescription: "Unable to create ThreeDSResult on error.")),
+                        completionHandler: completionHandler)
+            }
+        default:
+            didFinish(threeDS2SDKError: error.base64Representation(),
+                      authorizationToken: challengeAction.authorisationToken,
+                      completionHandler: completionHandler)
+        }
+    }
+
+    private func didFinish(threeDS2SDKError: String,
+                           authorizationToken: String?,
+                           completionHandler: @escaping (Result<ThreeDSResult, ThreeDS2CoreActionHandlerError>) -> Void) {
+        do {
+            let threeDSResult = try ThreeDSResult(authorizationToken: authorizationToken, threeDS2SDKError: threeDS2SDKError)
+            transaction = nil
+            completionHandler(.success(threeDSResult))
+        } catch {
+            completionHandler(.failure(.underlyingError(error)))
+        }
+    }
 
     private func didFinish(with challengeResult: AnyChallengeResult,
                            authorizationToken: String?,
-                           completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void) {
+                           completionHandler: @escaping (Result<ThreeDSResult, ThreeDS2CoreActionHandlerError>) -> Void) {
 
         do {
             let threeDSResult = try ThreeDSResult(from: challengeResult,
-                                                  authorizationToken: authorizationToken)
+                                                  delegatedAuthenticationSDKOutput: nil,
+                                                  authorizationToken: authorizationToken,
+                                                  threeDS2SDKError: nil)
 
             transaction = nil
             completionHandler(.success(threeDSResult))
         } catch {
-            completionHandler(.failure(error))
+            completionHandler(.failure(.underlyingError(error)))
         }
     }
 
-    private func didFail<R>(with error: Error,
-                            completionHandler: @escaping (Result<R, Error>) -> Void) {
+    private func didFail<R>(with error: ThreeDS2CoreActionHandlerError,
+                            completionHandler: @escaping (Result<R, ThreeDS2CoreActionHandlerError>) -> Void) {
         transaction = nil
 
         completionHandler(.failure(error))

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CoreActionHandler.swift
@@ -231,7 +231,6 @@ internal class ThreeDS2CoreActionHandler: Component {
 
         do {
             let threeDSResult = try ThreeDSResult(from: challengeResult,
-                                                  delegatedAuthenticationSDKOutput: nil,
                                                   authorizationToken: authorizationToken,
                                                   threeDS2SDKError: nil)
 

--- a/AdyenActions/Components/3DS2/Fingerprint Submitter/ThreeDS2FingerprintSubmitter.swift
+++ b/AdyenActions/Components/3DS2/Fingerprint Submitter/ThreeDS2FingerprintSubmitter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2022 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Fingerprint Submitter/ThreeDS2FingerprintSubmitter.swift
+++ b/AdyenActions/Components/3DS2/Fingerprint Submitter/ThreeDS2FingerprintSubmitter.swift
@@ -34,7 +34,7 @@ internal final class ThreeDS2FingerprintSubmitter: AnyThreeDS2FingerprintSubmitt
     /// :nodoc:
     internal func submit(fingerprint: String,
                          paymentData: String?,
-                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
+                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Swift.Error>) -> Void) {
 
         let request = Submit3DS2FingerprintRequest(clientKey: apiContext.clientKey,
                                                    fingerprint: fingerprint,

--- a/AdyenActions/Components/3DS2/Fingerprint Submitter/ThreeDS2FingerprintSubmitter.swift
+++ b/AdyenActions/Components/3DS2/Fingerprint Submitter/ThreeDS2FingerprintSubmitter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -8,12 +8,16 @@ import Adyen
 import AdyenNetworking
 import Foundation
 
+internal enum ThreeDS2FingerprintSubmitterError: Error {
+    case underlyingError(Error)
+}
+
 /// :nodoc:
 internal protocol AnyThreeDS2FingerprintSubmitter {
     /// :nodoc:
     func submit(fingerprint: String,
                 paymentData: String?,
-                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void)
+                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2FingerprintSubmitterError>) -> Void)
 }
 
 /// :nodoc:
@@ -34,7 +38,7 @@ internal final class ThreeDS2FingerprintSubmitter: AnyThreeDS2FingerprintSubmitt
     /// :nodoc:
     internal func submit(fingerprint: String,
                          paymentData: String?,
-                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Swift.Error>) -> Void) {
+                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2FingerprintSubmitterError>) -> Void) {
 
         let request = Submit3DS2FingerprintRequest(clientKey: apiContext.clientKey,
                                                    fingerprint: fingerprint,
@@ -47,12 +51,12 @@ internal final class ThreeDS2FingerprintSubmitter: AnyThreeDS2FingerprintSubmitt
 
     /// :nodoc:
     private func handle(_ result: Result<Submit3DS2FingerprintResponse, Swift.Error>,
-                        completionHandler: (Result<ThreeDSActionHandlerResult, Swift.Error>) -> Void) {
+                        completionHandler: (Result<ThreeDSActionHandlerResult, ThreeDS2FingerprintSubmitterError>) -> Void) {
         switch result {
         case let .success(response):
             completionHandler(.success(response.result))
         case let .failure(error):
-            completionHandler(.failure(error))
+            completionHandler(.failure(.underlyingError(error)))
         }
     }
 }

--- a/AdyenActions/Components/3DS2/Fingerprint Submitter/ThreeDS2FingerprintSubmitter.swift
+++ b/AdyenActions/Components/3DS2/Fingerprint Submitter/ThreeDS2FingerprintSubmitter.swift
@@ -8,16 +8,12 @@ import Adyen
 import AdyenNetworking
 import Foundation
 
-internal enum ThreeDS2FingerprintSubmitterError: Error {
-    case underlyingError(Error)
-}
-
 /// :nodoc:
 internal protocol AnyThreeDS2FingerprintSubmitter {
     /// :nodoc:
     func submit(fingerprint: String,
                 paymentData: String?,
-                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2FingerprintSubmitterError>) -> Void)
+                completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void)
 }
 
 /// :nodoc:
@@ -38,7 +34,7 @@ internal final class ThreeDS2FingerprintSubmitter: AnyThreeDS2FingerprintSubmitt
     /// :nodoc:
     internal func submit(fingerprint: String,
                          paymentData: String?,
-                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2FingerprintSubmitterError>) -> Void) {
+                         completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
 
         let request = Submit3DS2FingerprintRequest(clientKey: apiContext.clientKey,
                                                    fingerprint: fingerprint,
@@ -51,12 +47,12 @@ internal final class ThreeDS2FingerprintSubmitter: AnyThreeDS2FingerprintSubmitt
 
     /// :nodoc:
     private func handle(_ result: Result<Submit3DS2FingerprintResponse, Swift.Error>,
-                        completionHandler: (Result<ThreeDSActionHandlerResult, ThreeDS2FingerprintSubmitterError>) -> Void) {
+                        completionHandler: (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
         switch result {
         case let .success(response):
             completionHandler(.success(response.result))
         case let .failure(error):
-            completionHandler(.failure(.underlyingError(error)))
+            completionHandler(.failure(error))
         }
     }
 }

--- a/AdyenActions/Components/3DS2/ThreeDS2Component.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2Component.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2022 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/ThreeDS2Component.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2Component.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -99,8 +99,21 @@ public final class ThreeDS2Component: ActionComponent {
     
     // MARK: - Private
 
-    private func didReceive(_ result: Result<ThreeDSActionHandlerResult, Swift.Error>, paymentData: String?) {
-        switch result {
+    private func didReceive(_ result: Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>, paymentData: String?) {
+        let mappedResult: Result<ThreeDSActionHandlerResult, Swift.Error> = result.mapError {
+            switch $0 {
+            case let .cancellation(threeDS2Result):
+                return ThreeDS2Component.Error.challengeCancelled(ActionComponentData(details: threeDS2Result, paymentData: nil))
+            case .missingTransaction:
+                return ThreeDS2Component.Error.missingTransaction
+            case let .unknown(unknownError):
+                return unknownError
+            case let .underlyingError(underlyingError):
+                return underlyingError
+            }
+        }
+
+        switch mappedResult {
         case let .success(result):
             didReceive(result, paymentData: paymentData)
         case let .failure(error):
@@ -197,6 +210,7 @@ extension ThreeDS2Component {
         /// Indicates that the Checkout API returned an unexpected `Action` during processing the 3DS2 flow.
         case unexpectedAction
 
+        case challengeCancelled(ActionComponentData)
     }
 
 }

--- a/AdyenActions/Components/3DS2/ThreeDS2Component.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2Component.swift
@@ -99,21 +99,8 @@ public final class ThreeDS2Component: ActionComponent {
     
     // MARK: - Private
 
-    private func didReceive(_ result: Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>, paymentData: String?) {
-        let mappedResult: Result<ThreeDSActionHandlerResult, Swift.Error> = result.mapError {
-            switch $0 {
-            case let .cancellation(threeDS2Result):
-                return ThreeDS2Component.Error.challengeCancelled(ActionComponentData(details: threeDS2Result, paymentData: nil))
-            case .missingTransaction:
-                return ThreeDS2Component.Error.missingTransaction
-            case let .unknown(unknownError):
-                return unknownError
-            case let .underlyingError(underlyingError):
-                return underlyingError
-            }
-        }
-
-        switch mappedResult {
+    private func didReceive(_ result: Result<ThreeDSActionHandlerResult, Swift.Error>, paymentData: String?) {
+        switch result {
         case let .success(result):
             didReceive(result, paymentData: paymentData)
         case let .failure(error):
@@ -209,8 +196,6 @@ extension ThreeDS2Component {
 
         /// Indicates that the Checkout API returned an unexpected `Action` during processing the 3DS2 flow.
         case unexpectedAction
-
-        case challengeCancelled(ActionComponentData)
     }
 
 }

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprint.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprint.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2022 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprint.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprint.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -11,12 +11,13 @@ internal extension ThreeDS2Component {
     
     struct Fingerprint: Encodable { // swiftlint:disable:this explicit_acl
         
-        private let deviceInformation: String
-        private let sdkEphemeralPublicKey: EphemeralPublicKey
-        private let sdkReferenceNumber: String
-        private let sdkApplicationIdentifier: String
-        private let sdkTransactionIdentifier: String
-        
+        private let deviceInformation: String?
+        private let sdkEphemeralPublicKey: EphemeralPublicKey?
+        private let sdkReferenceNumber: String?
+        private let sdkApplicationIdentifier: String?
+        private let sdkTransactionIdentifier: String?
+        internal let threeDS2SDKError: String?
+
         internal init(authenticationRequestParameters: AnyAuthenticationRequestParameters) throws {
             let sdkEphemeralPublicKeyData = Data(authenticationRequestParameters.sdkEphemeralPublicKey.utf8)
             let sdkEphemeralPublicKey = try JSONDecoder().decode(EphemeralPublicKey.self, from: sdkEphemeralPublicKeyData)
@@ -26,14 +27,26 @@ internal extension ThreeDS2Component {
             self.sdkReferenceNumber = authenticationRequestParameters.sdkReferenceNumber
             self.sdkApplicationIdentifier = authenticationRequestParameters.sdkApplicationIdentifier
             self.sdkTransactionIdentifier = authenticationRequestParameters.sdkTransactionIdentifier
+            self.threeDS2SDKError = nil
         }
         
+        internal init(threeDS2SDKError: String) {
+            self.threeDS2SDKError = threeDS2SDKError
+            
+            self.deviceInformation = nil
+            self.sdkEphemeralPublicKey = nil
+            self.sdkReferenceNumber = nil
+            self.sdkApplicationIdentifier = nil
+            self.sdkTransactionIdentifier = nil
+        }
+
         private enum CodingKeys: String, CodingKey {
             case deviceInformation = "sdkEncData"
             case sdkEphemeralPublicKey = "sdkEphemPubKey"
             case sdkReferenceNumber
             case sdkApplicationIdentifier = "sdkAppID"
             case sdkTransactionIdentifier = "sdkTransID"
+            case threeDS2SDKError
         }
         
     }

--- a/AdyenActions/Components/3DS2/ThreeDSResult.swift
+++ b/AdyenActions/Components/3DS2/ThreeDSResult.swift
@@ -20,7 +20,8 @@ public struct ThreeDSResult: Decodable {
     }
     
     internal init(authorizationToken: String?,
-                  threeDS2SDKError: String?) throws {
+                  threeDS2SDKError: String?,
+                  transStatus: String) throws {
         let payload = Payload(authorisationToken: authorizationToken,
                               threeDS2SDKError: threeDS2SDKError,
                               transStatus: nil)

--- a/AdyenActions/Components/3DS2/ThreeDSResult.swift
+++ b/AdyenActions/Components/3DS2/ThreeDSResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2022 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/ThreeDSResult.swift
+++ b/AdyenActions/Components/3DS2/ThreeDSResult.swift
@@ -24,7 +24,7 @@ public struct ThreeDSResult: Decodable {
                   transStatus: String) throws {
         let payload = Payload(authorisationToken: authorizationToken,
                               threeDS2SDKError: threeDS2SDKError,
-                              transStatus: nil)
+                              transStatus: transStatus)
         let payloadData = try JSONEncoder().encode(payload)
         self.payload = payloadData.base64EncodedString()
     }

--- a/AdyenActions/Components/3DS2/ThreeDSResult.swift
+++ b/AdyenActions/Components/3DS2/ThreeDSResult.swift
@@ -15,7 +15,6 @@ public struct ThreeDSResult: Decodable {
 
     private struct Payload: Codable {
         internal let authorisationToken: String?
-        internal let delegatedAuthenticationSDKOutput: String?
         internal let threeDS2SDKError: String?
         internal let transStatus: String?
     }
@@ -23,7 +22,6 @@ public struct ThreeDSResult: Decodable {
     internal init(authorizationToken: String?,
                   threeDS2SDKError: String?) throws {
         let payload = Payload(authorisationToken: authorizationToken,
-                              delegatedAuthenticationSDKOutput: nil,
                               threeDS2SDKError: threeDS2SDKError,
                               transStatus: nil)
         let payloadData = try JSONEncoder().encode(payload)
@@ -31,11 +29,9 @@ public struct ThreeDSResult: Decodable {
     }
 
     internal init(from challengeResult: AnyChallengeResult,
-                  delegatedAuthenticationSDKOutput: String?,
                   authorizationToken: String?,
                   threeDS2SDKError: String?) throws {
         let payload = Payload(authorisationToken: authorizationToken,
-                              delegatedAuthenticationSDKOutput: delegatedAuthenticationSDKOutput,
                               threeDS2SDKError: threeDS2SDKError,
                               transStatus: challengeResult.transactionStatus)
         

--- a/AdyenActions/Components/3DS2/ThreeDSResult.swift
+++ b/AdyenActions/Components/3DS2/ThreeDSResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -13,15 +13,33 @@ public struct ThreeDSResult: Decodable {
     /// The payload to submit to verify the authentication.
     public let payload: String
 
-    internal init(from challengeResult: AnyChallengeResult, authorizationToken: String?) throws {
-        var payloadJson = ["transStatus": challengeResult.transactionStatus]
+    private struct Payload: Codable {
+        internal let authorisationToken: String?
+        internal let delegatedAuthenticationSDKOutput: String?
+        internal let threeDS2SDKError: String?
+        internal let transStatus: String?
+    }
+    
+    internal init(authorizationToken: String?,
+                  threeDS2SDKError: String?) throws {
+        let payload = Payload(authorisationToken: authorizationToken,
+                              delegatedAuthenticationSDKOutput: nil,
+                              threeDS2SDKError: threeDS2SDKError,
+                              transStatus: nil)
+        let payloadData = try JSONEncoder().encode(payload)
+        self.payload = payloadData.base64EncodedString()
+    }
 
-        if let authorizationToken = authorizationToken {
-            payloadJson["authorisationToken"] = authorizationToken
-        }
-
-        let payloadData = try JSONSerialization.data(withJSONObject: payloadJson,
-                                                     options: [])
+    internal init(from challengeResult: AnyChallengeResult,
+                  delegatedAuthenticationSDKOutput: String?,
+                  authorizationToken: String?,
+                  threeDS2SDKError: String?) throws {
+        let payload = Payload(authorisationToken: authorizationToken,
+                              delegatedAuthenticationSDKOutput: delegatedAuthenticationSDKOutput,
+                              threeDS2SDKError: threeDS2SDKError,
+                              transStatus: challengeResult.transactionStatus)
+        
+        let payloadData = try JSONEncoder().encode(payload)
 
         self.payload = payloadData.base64EncodedString()
     }

--- a/AdyenCard/Components/Card/ThreeDS2SdkVersion.swift
+++ b/AdyenCard/Components/Card/ThreeDS2SdkVersion.swift
@@ -7,4 +7,4 @@
 import Foundation
 
 /// The 3DS2 SDK version.
-public let threeDS2SdkVersion: String = "2.3.1"
+public let threeDS2SdkVersion: String = "2.3.2"

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "adyen/adyen-3ds2-ios" == 2.3.1
+github "adyen/adyen-3ds2-ios" == 2.3.2
 github "adyen/adyen-networking-ios" == 2.0.0
 github "adyen/adyen-wechatpay-ios" == 2.1.0

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -23,7 +23,7 @@ internal enum ConfigurationConstants {
 
     static let reference = "Test Order Reference - iOS UIHost"
 
-    static let returnUrl = "ui-host://"
+    static let returnUrl = "ui-host://payments"
     
     static let shopperReference = "iOS Checkout Shopper"
 

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(
             name: "Adyen3DS2",
             url: "https://github.com/Adyen/adyen-3ds2-ios",
-            .exact(Version(2, 3, 1))
+            .exact(Version(2, 3, 2))
         ),
         .package(
             name: "AdyenNetworking",

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/AnyThreeDS2ActionHandlerMock.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/AnyThreeDS2ActionHandlerMock.swift
@@ -12,16 +12,16 @@ import Foundation
 
 final class AnyThreeDS2ActionHandlerMock: AnyThreeDS2ActionHandler {
 
-    var mockedFingerprintResult: Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>?
+    var mockedFingerprintResult: Result<ThreeDSActionHandlerResult, Error>?
 
-    func handle(_ action: ThreeDS2FingerprintAction, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void) {
+    func handle(_ action: ThreeDS2FingerprintAction, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
         guard let result = mockedFingerprintResult else { assertionFailure(); return }
         completionHandler(result)
     }
 
-    var mockedChallengeResult: Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>?
+    var mockedChallengeResult: Result<ThreeDSActionHandlerResult, Error>?
 
-    func handle(_ action: ThreeDS2ChallengeAction, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void) {
+    func handle(_ action: ThreeDS2ChallengeAction, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
         guard let result = mockedChallengeResult else { assertionFailure(); return }
         completionHandler(result)
     }

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/AnyThreeDS2ActionHandlerMock.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/AnyThreeDS2ActionHandlerMock.swift
@@ -12,16 +12,16 @@ import Foundation
 
 final class AnyThreeDS2ActionHandlerMock: AnyThreeDS2ActionHandler {
 
-    var mockedFingerprintResult: Result<ThreeDSActionHandlerResult, Error>?
+    var mockedFingerprintResult: Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>?
 
-    func handle(_ action: ThreeDS2FingerprintAction, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
+    func handle(_ action: ThreeDS2FingerprintAction, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void) {
         guard let result = mockedFingerprintResult else { assertionFailure(); return }
         completionHandler(result)
     }
 
-    var mockedChallengeResult: Result<ThreeDSActionHandlerResult, Error>?
+    var mockedChallengeResult: Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>?
 
-    func handle(_ action: ThreeDS2ChallengeAction, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
+    func handle(_ action: ThreeDS2ChallengeAction, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2ActionHandlerError>) -> Void) {
         guard let result = mockedChallengeResult else { assertionFailure(); return }
         completionHandler(result)
     }

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/AnyThreeDS2FingerprintSubmitterMock.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/AnyThreeDS2FingerprintSubmitterMock.swift
@@ -11,9 +11,9 @@ import Foundation
 
 final class AnyThreeDS2FingerprintSubmitterMock: AnyThreeDS2FingerprintSubmitter {
 
-    var mockedResult: Result<ThreeDSActionHandlerResult, Error>?
+    var mockedResult: Result<ThreeDSActionHandlerResult, ThreeDS2FingerprintSubmitterError>?
 
-    func submit(fingerprint: String, paymentData: String?, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
+    func submit(fingerprint: String, paymentData: String?, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2FingerprintSubmitterError>) -> Void) {
         guard let result = mockedResult else { assertionFailure(); return }
         completionHandler(result)
     }

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/AnyThreeDS2FingerprintSubmitterMock.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/AnyThreeDS2FingerprintSubmitterMock.swift
@@ -11,9 +11,9 @@ import Foundation
 
 final class AnyThreeDS2FingerprintSubmitterMock: AnyThreeDS2FingerprintSubmitter {
 
-    var mockedResult: Result<ThreeDSActionHandlerResult, ThreeDS2FingerprintSubmitterError>?
+    var mockedResult: Result<ThreeDSActionHandlerResult, Error>?
 
-    func submit(fingerprint: String, paymentData: String?, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, ThreeDS2FingerprintSubmitterError>) -> Void) {
+    func submit(fingerprint: String, paymentData: String?, completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void) {
         guard let result = mockedResult else { assertionFailure(); return }
         completionHandler(result)
     }

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
@@ -207,7 +207,6 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
             case .success:
                 XCTFail()
             case let .failure(error):
-                let error = error as! ThreeDS2Component.Error
                 switch error {
                 case .missingTransaction: ()
                 default:

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
@@ -111,12 +111,9 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
             case .success:
                 XCTFail()
             case let .failure(error):
-                switch error {
-                case .underlyingError(let decodingError as DecodingError):
-                    switch decodingError {
-                    case .dataCorrupted: break
-                    default: XCTFail()
-                    }
+                let decodingError = error as? DecodingError
+                switch decodingError {
+                case .dataCorrupted?: ()
                 default:
                     XCTFail()
                 }
@@ -224,8 +221,9 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
             case .success:
                 XCTFail()
             case let .failure(error):
-                switch error {
-                case .missingTransaction: ()
+                let componentError = error as? ThreeDS2Component.Error
+                switch componentError {
+                case .missingTransaction?: ()
                 default:
                     XCTFail()
                 }
@@ -258,15 +256,9 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
             case .success:
                 XCTFail()
             case let .failure(error):
-                switch error {
-                case .underlyingError(let decodingError as DecodingError):
-                    switch decodingError {
-                    case .dataCorrupted: ()
-                    default:
-                        XCTFail()
-                    }
-
-                    break
+                let decodingError = error as? DecodingError
+                switch decodingError {
+                case .dataCorrupted?: ()
                 default:
                     XCTFail()
                 }

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
@@ -152,11 +152,13 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
                     switch additionalDetails {
                     case .completed(let threeDSResult):
                         struct Payload: Codable {
-                            let threeDS2SDKError: String?
+                            let threeDS2SDKError: String
+                            let transStatus: String?
                         }
                         // Check if there is a threeDS2SDKError in the payload.
                         let payload: Payload? = try? Coder.decodeBase64(threeDSResult.payload)
                         XCTAssertNotNil(payload?.threeDS2SDKError)
+                        XCTAssertEqual(payload?.transStatus, "U")
                     default:
                         XCTFail()
                     }

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
@@ -325,7 +325,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
     func testFingerprintFlowSubmitterFailure() throws {
         let submitter = AnyThreeDS2FingerprintSubmitterMock()
 
-        submitter.mockedResult = .failure(Dummy.error)
+        submitter.mockedResult = .failure(.underlyingError(Dummy.error))
 
         let service = AnyADYServiceMock()
         service.authenticationRequestParameters = authenticationRequestParameters
@@ -337,7 +337,12 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
             case .success:
                 XCTFail()
             case let .failure(error):
-                XCTAssertEqual(error as? Dummy, Dummy.error)
+                switch error {
+                case .underlyingError:
+                    break
+                default:
+                    XCTFail()
+                }
             }
             resultExpectation.fulfill()
         }

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
@@ -73,15 +73,9 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
             case .success:
                 XCTFail()
             case let .failure(error):
-                switch error {
-                case .underlyingError(let decodingError as DecodingError):
-                    switch decodingError {
-                    case .dataCorrupted: ()
-                    default:
-                        XCTFail()
-                    }
-
-                    break
+                let decodingError = error as? DecodingError
+                switch decodingError {
+                case .dataCorrupted?: ()
                 default:
                     XCTFail()
                 }
@@ -200,15 +194,9 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
             case .success:
                 XCTFail()
             case let .failure(error):
-                switch error {
-                case .underlyingError(let decodingError as DecodingError):
-                    switch decodingError {
-                    case .dataCorrupted: ()
-                    default:
-                        XCTFail()
-                    }
-
-                    break
+                let decodingError = error as? DecodingError
+                switch decodingError {
+                case .dataCorrupted?: ()
                 default:
                     XCTFail()
                 }
@@ -232,8 +220,9 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
             case .success:
                 XCTFail()
             case let .failure(error):
-                switch error {
-                case .missingTransaction: break
+                let componentError = error as? ThreeDS2Component.Error
+                switch componentError {
+                case .missingTransaction?: ()
                 default:
                     XCTFail()
                 }
@@ -265,15 +254,9 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
             case .success:
                 XCTFail()
             case let .failure(error):
-                switch error {
-                case .underlyingError(let decodingError as DecodingError):
-                    switch decodingError {
-                    case .dataCorrupted: ()
-                    default:
-                        XCTFail()
-                    }
-
-                    break
+                let decodingError = error as? DecodingError
+                switch decodingError {
+                case .dataCorrupted?: ()
                 default:
                     XCTFail()
                 }
@@ -369,13 +352,9 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
             case .success:
                 XCTFail()
             case let .failure(error):
-                switch error {
-                case .underlyingError:
-                    break
-                default:
-                    XCTFail()
-                }
+                XCTAssertEqual(error as? Dummy, Dummy.error)
             }
+
             resultExpectation.fulfill()
         }
 

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
@@ -167,8 +167,12 @@ class ThreeDS2ComponentTests: XCTestCase {
         delegate.onDidFail = { error, component in
             XCTAssertTrue(component === sut)
 
-            let error = error as! ThreeDS2Component.Error
-            XCTAssertEqual(error, .unexpectedAction)
+            switch error as? ThreeDS2Component.Error {
+            case .unexpectedAction:
+                break
+            default:
+                XCTFail()
+            }
             delegateExpectation.fulfill()
         }
         sut.delegate = delegate
@@ -186,7 +190,7 @@ class ThreeDS2ComponentTests: XCTestCase {
 
         let threeDS2ActionHandler = AnyThreeDS2ActionHandlerMock()
         threeDS2ActionHandler.mockedFingerprintResult = .success(.action(.threeDS2(.challenge(mockedAction))))
-        threeDS2ActionHandler.mockedChallengeResult = .failure(Dummy.error)
+        threeDS2ActionHandler.mockedChallengeResult = .failure(.underlyingError(Dummy.error))
 
         let redirectComponent = AnyRedirectComponentMock()
         redirectComponent.onHandle = { action in
@@ -217,7 +221,7 @@ class ThreeDS2ComponentTests: XCTestCase {
     func testFullFlowFingerprintFailure() throws {
 
         let threeDS2ActionHandler = AnyThreeDS2ActionHandlerMock()
-        threeDS2ActionHandler.mockedFingerprintResult = .failure(Dummy.error)
+        threeDS2ActionHandler.mockedFingerprintResult = .failure(.underlyingError(Dummy.error))
 
         let redirectComponent = AnyRedirectComponentMock()
         redirectComponent.onHandle = { action in

--- a/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
@@ -190,7 +190,7 @@ class ThreeDS2ComponentTests: XCTestCase {
 
         let threeDS2ActionHandler = AnyThreeDS2ActionHandlerMock()
         threeDS2ActionHandler.mockedFingerprintResult = .success(.action(.threeDS2(.challenge(mockedAction))))
-        threeDS2ActionHandler.mockedChallengeResult = .failure(.underlyingError(Dummy.error))
+        threeDS2ActionHandler.mockedChallengeResult = .failure(Dummy.error)
 
         let redirectComponent = AnyRedirectComponentMock()
         redirectComponent.onHandle = { action in
@@ -221,7 +221,7 @@ class ThreeDS2ComponentTests: XCTestCase {
     func testFullFlowFingerprintFailure() throws {
 
         let threeDS2ActionHandler = AnyThreeDS2ActionHandlerMock()
-        threeDS2ActionHandler.mockedFingerprintResult = .failure(.underlyingError(Dummy.error))
+        threeDS2ActionHandler.mockedFingerprintResult = .failure(Dummy.error)
 
         let redirectComponent = AnyRedirectComponentMock()
         redirectComponent.onHandle = { action in


### PR DESCRIPTION
## Summary
The corresponding change for V5 of checkout is [here](https://github.com/Adyen/adyen-ios/pull/1198)

Errors from the 3ds sdk reported to the adyen backend '
Why:
Adyen doesn't have visibility of the errors that merchant face during a 3ds challenge, to help the merchant understand errors from the sdk.

What:
We provide some error information back to the merchant as a base64 string. This is passed back to the backend, so that adyen has visibility of the error that occurs and handle it accordingly.

- [x] Fix tests
- [x] Execute tests with the backend


