### PR TITLE
feature: new session delegate with session result

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		A0BC64E628F062E400CED2A1 /* AdyenSessionAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BC64E528F062E400CED2A1 /* AdyenSessionAware.swift */; };
 		A0C9B59B288AE34600D6BDAB /* InstallmentOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F41E5526CBCA6E0089AD6C /* InstallmentOptions.swift */; };
 		A0D48FB827109B0200C0B82C /* ArrayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D48FB727109B0200C0B82C /* ArrayHelpers.swift */; };
+		A0DDA6A72A6162F500EBD6AF /* AdyenSessionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0DDA6A62A6162F500EBD6AF /* AdyenSessionResult.swift */; };
 		A0DE8F6D26CEA04500F2F1E8 /* Installments.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0DE8F6C26CEA04500F2F1E8 /* Installments.swift */; };
 		A0F41EAC26CD4AA50089AD6C /* FormCardInstallmentsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F41EAB26CD4AA50089AD6C /* FormCardInstallmentsItem.swift */; };
 		A0F4559B295F0F58001742C7 /* MealVoucherPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F4559A295F0F58001742C7 /* MealVoucherPaymentMethod.swift */; };
@@ -1331,6 +1332,7 @@
 		A0B180302A2DE445003C608E /* MealVoucherDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealVoucherDetails.swift; sourceTree = "<group>"; };
 		A0BC64E528F062E400CED2A1 /* AdyenSessionAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenSessionAware.swift; sourceTree = "<group>"; };
 		A0D48FB727109B0200C0B82C /* ArrayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayHelpers.swift; sourceTree = "<group>"; };
+		A0DDA6A62A6162F500EBD6AF /* AdyenSessionResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenSessionResult.swift; sourceTree = "<group>"; };
 		A0DE8F6C26CEA04500F2F1E8 /* Installments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Installments.swift; sourceTree = "<group>"; };
 		A0F41E5526CBCA6E0089AD6C /* InstallmentOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallmentOptions.swift; sourceTree = "<group>"; };
 		A0F41EAB26CD4AA50089AD6C /* FormCardInstallmentsItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardInstallmentsItem.swift; sourceTree = "<group>"; };
@@ -4293,6 +4295,7 @@
 				F9B8AF5D27DA4EA400DC0894 /* AdyenSession+DropInComponentDelegate.swift */,
 				F92980C327CF558E000CA5CA /* AdyenSession+ActionComponentDelegate.swift */,
 				F92980C527CF563C000CA5CA /* AdyenSession+PartialPaymentDelegate.swift */,
+				A0DDA6A62A6162F500EBD6AF /* AdyenSessionResult.swift */,
 			);
 			path = AdyenSession;
 			sourceTree = "<group>";
@@ -6747,6 +6750,7 @@
 				F967580E27D1253000A16FB6 /* SelfRetainingAPIClient.swift in Sources */,
 				F9B8AF5E27DA4EA400DC0894 /* AdyenSession+DropInComponentDelegate.swift in Sources */,
 				F92980B227CE2B55000CA5CA /* AdyenSession.swift in Sources */,
+				A0DDA6A72A6162F500EBD6AF /* AdyenSessionResult.swift in Sources */,
 				F92980C427CF558E000CA5CA /* AdyenSession+ActionComponentDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AdyenSession/API/Payments/PaymentsRequest.swift
+++ b/AdyenSession/API/Payments/PaymentsRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -75,7 +75,7 @@ internal struct PaymentsRequest: APIRequest {
     }
 }
 
-internal struct PaymentsResponse: SessionResponse, PaymentResultCodeAware {
+internal struct PaymentsResponse: SessionResponse, SessionPaymentResultAware {
     
     internal let resultCode: ResultCode
     
@@ -85,11 +85,14 @@ internal struct PaymentsResponse: SessionResponse, PaymentResultCodeAware {
     
     internal let sessionData: String
     
+    internal let sessionResult: String?
+    
     private enum CodingKeys: String, CodingKey {
         case action
         case order
         case sessionData
         case resultCode
+        case sessionResult
     }
 }
 

--- a/AdyenSession/API/Session Setup/SessionSetupRequest.swift
+++ b/AdyenSession/API/Session Setup/SessionSetupRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -12,8 +12,11 @@ internal protocol SessionResponse: Response {
     var sessionData: String { get }
 }
 
-internal protocol PaymentResultCodeAware {
+/// A protocol that contains payment result values for session calls.
+internal protocol SessionPaymentResultAware {
     var resultCode: PaymentsResponse.ResultCode { get }
+    
+    var sessionResult: String? { get }
 }
 
 internal struct SessionSetupRequest: Request {

--- a/AdyenSession/API/SessionAPIClient.swift
+++ b/AdyenSession/API/SessionAPIClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -29,8 +29,9 @@ internal final class SessionAPIClient: APIClientProtocol {
                 if let response = response as? SessionResponse {
                     self?.session?.sessionContext.data = response.sessionData
                 }
-                if let response = response as? PaymentResultCodeAware {
+                if let response = response as? SessionPaymentResultAware {
                     self?.session?.sessionContext.resultCode = response.resultCode
+                    self?.session?.sessionContext.sessionResult = response.sessionResult
                 }
             }
             completionHandler(result)

--- a/AdyenSession/AdyenSession+ActionComponentDelegate.swift
+++ b/AdyenSession/AdyenSession+ActionComponentDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -25,8 +25,12 @@ extension AdyenSession: ActionComponentDelegate {
             AdyenAssertion.assertionFailure(message: "Missing resultCode.")
             return
         }
+        // keeping deprecated one until v6
         delegate?.didComplete(with: SessionPaymentResultCode(paymentResultCode: resultCode),
                               component: currentComponent, session: self)
+        let result = AdyenSessionResult(resultCode: SessionPaymentResultCode(paymentResultCode: resultCode),
+                                        encodedResult: sessionContext.sessionResult)
+        delegate?.didComplete(with: result, component: currentComponent, session: self)
     }
 
     public func didProvide(_ data: ActionComponentData, from component: ActionComponent) {

--- a/AdyenSession/AdyenSession.swift
+++ b/AdyenSession/AdyenSession.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -70,6 +70,9 @@ public final class AdyenSession {
         
         /// Result code from the latest API call
         internal var resultCode: PaymentsResponse.ResultCode?
+        
+        /// Encoded result string from the latest API call
+        internal var sessionResult: String?
         
         /// Component related configuration object
         internal let configuration: SessionSetupResponse.Configuration

--- a/AdyenSession/AdyenSessionDelegate.swift
+++ b/AdyenSession/AdyenSessionDelegate.swift
@@ -78,7 +78,7 @@ public extension AdyenSessionDelegate {
     
     func didOpenExternalApplication(component: ActionComponent, session: AdyenSession) {}
     
-    // Providing default implementation on the deprecated one to prevent forced comformance.
+    // Providing default implementation on the deprecated one to prevent forced conformance.
     func didComplete(with resultCode: SessionPaymentResultCode, component: Component, session: AdyenSession) {}
 }
 

--- a/AdyenSession/AdyenSessionDelegate.swift
+++ b/AdyenSession/AdyenSessionDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -21,7 +21,17 @@ public protocol AdyenSessionDelegate: AnyObject {
     ///   - resultCode: The result code of the completed payment.
     ///   - component: The component object.
     ///   - session: The session object.
+    @available(*, deprecated, message: "Use the new `didComplete(with result:, component:, session:` method instead.")
     func didComplete(with resultCode: SessionPaymentResultCode, component: Component, session: AdyenSession)
+    
+    /// Invoked when the component finishes without any further steps needed by the application.
+    /// The application only needs to dismiss the component.
+    ///
+    /// - Parameters:
+    ///   - result: The result object of the completed payment.
+    ///   - component: The component object.
+    ///   - session: The session object.
+    func didComplete(with result: AdyenSessionResult, component: Component, session: AdyenSession)
     
     /// Invoked when a payment component fails.
     ///
@@ -67,6 +77,9 @@ public extension AdyenSessionDelegate {
     func handlerForAdditionalDetails(in component: ActionComponent, session: AdyenSession) -> AdyenSessionPaymentDetailsHandler? { nil }
     
     func didOpenExternalApplication(component: ActionComponent, session: AdyenSession) {}
+    
+    // Providing default implementation on the deprecated one to prevent forced comformance.
+    func didComplete(with resultCode: SessionPaymentResultCode, component: Component, session: AdyenSession) {}
 }
 
 /// Describes the interface to take over the step where data is provided for the payments call.
@@ -96,7 +109,7 @@ public protocol AdyenSessionPaymentDetailsHandler {
     func didProvide(_ actionComponentData: ActionComponentData, from component: ActionComponent, session: AdyenSession)
 }
 
-/// Represents the result of a payment via ``AdyenSession``.
+/// Represents the status of a payment via ``AdyenSession``.
 public enum SessionPaymentResultCode: String {
     /// Indicates the payment was successfully authorised.
     case authorised = "Authorised"

--- a/AdyenSession/AdyenSessionResult.swift
+++ b/AdyenSession/AdyenSessionResult.swift
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2023 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+/// Contains information regarding the status of a payment done via `AdyenSession`.
+public struct AdyenSessionResult {
+    
+    /// The result code of the completed payment.
+    public let resultCode: SessionPaymentResultCode
+    
+    /// An encoded string that can be used to get the payment outcome on your server.
+    /// - Description: Use this value with the new  `/sessions/id` endpoint
+    /// as a query string on your server to get a synchronous result for your payment.
+    public let encodedResult: String?
+}

--- a/Demo/Common/IntegrationExamples/Components/ApplePayComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Components/ApplePayComponentExample.swift
@@ -110,9 +110,9 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
 }
 
 extension ApplePayComponentExample: AdyenSessionDelegate {
-
-    func didComplete(with resultCode: SessionPaymentResultCode, component: Component, session: AdyenSession) {
-        dismissAndShowAlert(resultCode.isSuccess, resultCode.rawValue)
+    
+    func didComplete(with result: AdyenSessionResult, component: Component, session: AdyenSession) {
+        dismissAndShowAlert(result.resultCode.isSuccess, result.resultCode.rawValue)
     }
 
     func didFail(with error: Error, from component: Component, session: AdyenSession) {

--- a/Demo/Common/IntegrationExamples/Components/CardComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Components/CardComponentExample.swift
@@ -136,9 +136,9 @@ extension CardComponentExample: CardComponentDelegate {
 }
 
 extension CardComponentExample: AdyenSessionDelegate {
-
-    func didComplete(with resultCode: SessionPaymentResultCode, component: Component, session: AdyenSession) {
-        dismissAndShowAlert(resultCode.isSuccess, resultCode.rawValue)
+    
+    func didComplete(with result: AdyenSessionResult, component: Component, session: AdyenSession) {
+        dismissAndShowAlert(result.resultCode.isSuccess, result.resultCode.rawValue)
     }
 
     func didFail(with error: Error, from component: Component, session: AdyenSession) {

--- a/Demo/Common/IntegrationExamples/DropIn/DropInExample.swift
+++ b/Demo/Common/IntegrationExamples/DropIn/DropInExample.swift
@@ -118,8 +118,8 @@ internal final class DropInExample: InitialDataFlowProtocol {
 
 extension DropInExample: AdyenSessionDelegate {
 
-    func didComplete(with resultCode: SessionPaymentResultCode, component: Component, session: AdyenSession) {
-        dismissAndShowAlert(resultCode.isSuccess, resultCode.rawValue)
+    func didComplete(with result: AdyenSessionResult, component: Component, session: AdyenSession) {
+        dismissAndShowAlert(result.resultCode.isSuccess, result.resultCode.rawValue)
     }
 
     func didFail(with error: Error, from component: Component, session: AdyenSession) {

--- a/Tests/Session Tests/SessionDelegateMock.swift
+++ b/Tests/Session Tests/SessionDelegateMock.swift
@@ -15,12 +15,12 @@ import AdyenSession
 class SessionDelegateMock: AdyenSessionDelegate {
     
     var handlerMock: SessionAdvancedHandlerMock?
-    var onDidComplete: ((SessionPaymentResultCode, Component, AdyenSession) -> Void)?
+    var onDidComplete: ((AdyenSessionResult, Component, AdyenSession) -> Void)?
     var onDidFail: ((Error, Component, AdyenSession) -> Void)?
     var onDidOpenExternalApplication: (() -> Void)?
     
-    func didComplete(with resultCode: SessionPaymentResultCode, component: Component, session: AdyenSession) {
-        onDidComplete?(resultCode, component, session)
+    func didComplete(with result: AdyenSessionResult, component: Component, session: AdyenSession) {
+        onDidComplete?(result, component, session)
     }
     
     func didFail(with error: Error, from component: Component, session: AdyenSession) {

--- a/Tests/Session Tests/SessionTests.swift
+++ b/Tests/Session Tests/SessionTests.swift
@@ -95,7 +95,8 @@ class SessionTests: XCTestCase {
         apiClient.mockedResults = [.success(PaymentsResponse(resultCode: .authorised,
                                                              action: nil,
                                                              order: nil,
-                                                             sessionData: "session_data"))]
+                                                             sessionData: "session_data",
+                                                             sessionResult: "sessionResultString"))]
         let didSubmitExpectation = expectation(description: "Expect payments call to be made")
         apiClient.onExecute = {
             didSubmitExpectation.fulfill()
@@ -203,7 +204,8 @@ class SessionTests: XCTestCase {
                         expectedAction
                     ),
                     order: nil,
-                    sessionData: "session_data"
+                    sessionData: "session_data",
+                    sessionResult: "sessionResultString"
                 )
             ),
             .success(
@@ -211,7 +213,8 @@ class SessionTests: XCTestCase {
                     resultCode: .authorised,
                     action: nil,
                     order: nil,
-                    sessionData: "session_data"
+                    sessionData: "session_data",
+                    sessionResult: "sessionResultString"
                 )
             )
         ]
@@ -289,7 +292,8 @@ class SessionTests: XCTestCase {
                     resultCode: .authorised,
                     action: nil,
                     order: expectedOrder,
-                    sessionData: "session_data"
+                    sessionData: "session_data",
+                    sessionResult: "sessionResultString"
                 )
             ),
             .success(
@@ -404,7 +408,8 @@ class SessionTests: XCTestCase {
                     resultCode: .refused,
                     action: nil,
                     order: expectedOrder,
-                    sessionData: "session_data"
+                    sessionData: "session_data",
+                    sessionResult: "sessionResultString"
                 )
             ),
             .success(
@@ -713,13 +718,15 @@ class SessionTests: XCTestCase {
                 resultCode: .authorised,
                 action: nil,
                 order: nil,
-                sessionData: "session_data"
+                sessionData: "session_data",
+                sessionResult: "sessionResultString"
             )
         )]
         
         let didCompleteExpectation = expectation(description: "didComplete should be called")
         sessionDelegate.onDidComplete = { result, _, _ in
-            XCTAssertEqual(result, .authorised)
+            XCTAssertEqual(result.resultCode, .authorised)
+            XCTAssertEqual(result.encodedResult, "sessionResultString")
             didCompleteExpectation.fulfill()
         }
         let actionData = try ActionComponentData(
@@ -744,13 +751,15 @@ class SessionTests: XCTestCase {
                 resultCode: .pending,
                 action: nil,
                 order: nil,
-                sessionData: "session_data"
+                sessionData: "session_data",
+                sessionResult: nil
             )
         )]
         
         let didCompleteExpectation = expectation(description: "didComplete should be called")
         sessionDelegate.onDidComplete = { result, _, _ in
-            XCTAssertEqual(result, .pending)
+            XCTAssertEqual(result.resultCode, .pending)
+            XCTAssertNil(result.encodedResult)
             didCompleteExpectation.fulfill()
         }
         let actionData = try ActionComponentData(
@@ -775,13 +784,15 @@ class SessionTests: XCTestCase {
                 resultCode: .refused,
                 action: nil,
                 order: nil,
-                sessionData: "session_data"
+                sessionData: "session_data",
+                sessionResult: nil
             )
         )]
         
         let didCompleteExpectation = expectation(description: "didComplete should be called")
         sessionDelegate.onDidComplete = { result, _, _ in
-            XCTAssertEqual(result, .refused)
+            XCTAssertEqual(result.resultCode, .refused)
+            XCTAssertNil(result.encodedResult)
             didCompleteExpectation.fulfill()
         }
         let actionData = try ActionComponentData(
@@ -806,13 +817,15 @@ class SessionTests: XCTestCase {
                 resultCode: .cancelled,
                 action: nil,
                 order: nil,
-                sessionData: "session_data"
+                sessionData: "session_data",
+                sessionResult: "sessionResultString"
             )
         )]
         
         let didCompleteExpectation = expectation(description: "didComplete should be called")
         sessionDelegate.onDidComplete = { result, _, _ in
-            XCTAssertEqual(result, .cancelled)
+            XCTAssertEqual(result.resultCode, .cancelled)
+            XCTAssertEqual(result.encodedResult, "sessionResultString")
             didCompleteExpectation.fulfill()
         }
         let actionData = try ActionComponentData(
@@ -837,13 +850,15 @@ class SessionTests: XCTestCase {
                 resultCode: .received,
                 action: nil,
                 order: nil,
-                sessionData: "session_data"
+                sessionData: "session_data",
+                sessionResult: "sessionResultString"
             )
         )]
         
         let didCompleteExpectation = expectation(description: "didComplete should be called")
         sessionDelegate.onDidComplete = { result, _, _ in
-            XCTAssertEqual(result, .received)
+            XCTAssertEqual(result.resultCode, .received)
+            XCTAssertEqual(result.encodedResult, "sessionResultString")
             didCompleteExpectation.fulfill()
         }
         let actionData = try ActionComponentData(
@@ -868,13 +883,15 @@ class SessionTests: XCTestCase {
                 resultCode: .presentToShopper,
                 action: nil,
                 order: nil,
-                sessionData: "session_data"
+                sessionData: "session_data",
+                sessionResult: "sessionResultString"
             )
         )]
         
         let didCompleteExpectation = expectation(description: "didComplete should be called")
         sessionDelegate.onDidComplete = { result, _, _ in
-            XCTAssertEqual(result, .presentToShopper)
+            XCTAssertEqual(result.resultCode, .presentToShopper)
+            XCTAssertEqual(result.encodedResult, "sessionResultString")
             didCompleteExpectation.fulfill()
         }
         let paymentMethod = expectedPaymentMethods.regular.first as! GiftCardPaymentMethod
@@ -903,13 +920,15 @@ class SessionTests: XCTestCase {
                 resultCode: .error,
                 action: nil,
                 order: nil,
-                sessionData: "session_data"
+                sessionData: "session_data",
+                sessionResult: nil
             )
         )]
         
         let didCompleteExpectation = expectation(description: "didComplete should be called")
         sessionDelegate.onDidComplete = { result, _, _ in
-            XCTAssertEqual(result, .error)
+            XCTAssertEqual(result.resultCode, .error)
+            XCTAssertNil(result.encodedResult)
             didCompleteExpectation.fulfill()
         }
         let actionData = try ActionComponentData(
@@ -934,13 +953,15 @@ class SessionTests: XCTestCase {
                 resultCode: .redirectShopper,
                 action: nil,
                 order: nil,
-                sessionData: "session_data"
+                sessionData: "session_data",
+                sessionResult: "sessionResultString"
             )
         )]
         
         let didCompleteExpectation = expectation(description: "didComplete should be called")
         sessionDelegate.onDidComplete = { result, _, _ in
-            XCTAssertEqual(result, .error)
+            XCTAssertEqual(result.resultCode, .error)
+            XCTAssertEqual(result.encodedResult, "sessionResultString")
             didCompleteExpectation.fulfill()
         }
         let actionData = try ActionComponentData(


### PR DESCRIPTION
## Changes

<new>

## New
`func didComplete(with result: AdyenSessionResult, component: Component, session: AdyenSession)`
- The Session delegate has a new `didComplete` method with the `AdyenSessionResult` object.

</new>

<removed>

## Removed
`func didComplete(with resultCode: SessionPaymentResultCode, component: Component, session: AdyenSession)`
- Use the new `didComplete` method with the `AdyenSessionResult` object instead.

</removed>