### PR TITLE
change: make countryCode optional for external session call

### DIFF
--- a/AdyenSession/API/Session Setup/SessionSetupRequest.swift
+++ b/AdyenSession/API/Session Setup/SessionSetupRequest.swift
@@ -60,7 +60,7 @@ internal struct SessionSetupRequest: Request {
 
 internal struct SessionSetupResponse: SessionResponse {
     
-    internal let countryCode: String
+    internal let countryCode: String?
     
     internal let shopperLocale: String?
     

--- a/AdyenSession/AdyenSession.swift
+++ b/AdyenSession/AdyenSession.swift
@@ -57,7 +57,7 @@ public final class AdyenSession {
         public let identifier: String
         
         /// Country Code
-        public let countryCode: String
+        public let countryCode: String?
         
         /// Shopper Locale
         public let shopperLocale: String?


### PR DESCRIPTION
<changed>

## Changed

- The `countryCode` property of `AdyenSession.Context` is now optional to allow not including it in the `/sessions` request. Because this property isn't meant to be read, this breaking change shouldn't cause any build errors.

</changed>