### PR TITLE
new: v4 Allow co-branded bcmc

### DIFF
--- a/Adyen/Core/Payment Methods/BCMCPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/BCMCPaymentMethod.swift
@@ -15,8 +15,9 @@ public struct BCMCPaymentMethod: AnyCardPaymentMethod {
     public var name: String { cardPaymentMethod.name }
     
     /// An array containing the supported brands, such as `"mc"`, `"visa"`, `"amex"`, `"bcmc"`.
-    /// In this case the brands is ["bcmc"].
-    public let brands: [String] = [PaymentMethodType.bcmc.rawValue]
+    ///
+    /// Used to configure the `allowedCardTypes` on the `BCMCComponent`'s configuration
+    public var brands: [String] { cardPaymentMethod.brands }
     
     /// :nodoc:
     public var fundingSource: CardFundingSource? { cardPaymentMethod.fundingSource }

--- a/AdyenCard/Components/BCMC/BCMCComponent.swift
+++ b/AdyenCard/Components/BCMC/BCMCComponent.swift
@@ -22,7 +22,8 @@ public final class BCMCComponent: CardComponent {
         let publicKeyProvider = PublicKeyProvider(apiContext: apiContext)
         let binInfoProvider = BinInfoProvider(apiClient: APIClient(apiContext: apiContext),
                                               publicKeyProvider: publicKeyProvider,
-                                              minBinLength: Constant.privateBinLength)
+                                              minBinLength: Constant.privateBinLength,
+                                              binLookupType: configuration.binLookupType)
         super.init(paymentMethod: paymentMethod,
                    apiContext: apiContext,
                    configuration: configuration,

--- a/AdyenCard/Components/BCMC/BCMCComponent.swift
+++ b/AdyenCard/Components/BCMC/BCMCComponent.swift
@@ -31,5 +31,21 @@ public final class BCMCComponent: CardComponent {
                    publicKeyProvider: publicKeyProvider,
                    binProvider: binInfoProvider)
     }
-
+    
+    override internal init(paymentMethod: AnyCardPaymentMethod,
+                           apiContext: APIContext,
+                           configuration: CardComponent.Configuration = CardComponent.Configuration(),
+                           shopperInformation: PrefilledShopperInformation? = nil,
+                           style: FormComponentStyle = .init(),
+                           publicKeyProvider: AnyPublicKeyProvider,
+                           binProvider: AnyBinInfoProvider) {
+           let configuration = configuration.bcmcConfiguration()
+           super.init(paymentMethod: paymentMethod,
+                      apiContext: apiContext,
+                      configuration: configuration,
+                      shopperInformation: shopperInformation,
+                      style: style,
+                      publicKeyProvider: publicKeyProvider,
+                      binProvider: binProvider)
+       }
 }

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -93,7 +93,8 @@ public class CardComponent: PublicKeyConsumer,
         let publicKeyProvider = PublicKeyProvider(apiContext: apiContext)
         let binInfoProvider = BinInfoProvider(apiClient: APIClient(apiContext: apiContext),
                                               publicKeyProvider: publicKeyProvider,
-                                              minBinLength: Constant.privateBinLength)
+                                              minBinLength: Constant.privateBinLength,
+                                              binLookupType: configuration.binLookupType)
         self.init(paymentMethod: paymentMethod,
                   apiContext: apiContext,
                   configuration: configuration,
@@ -130,9 +131,7 @@ public class CardComponent: PublicKeyConsumer,
         self.binInfoProvider = binProvider
 
         let paymentMethodCardTypes = paymentMethod.brands.compactMap(CardType.init)
-        let excludedCardTypes = configuration.excludedCardTypes
-        let allowedCardTypes = configuration.allowedCardTypes ?? paymentMethodCardTypes
-        self.supportedCardTypes = allowedCardTypes.minus(excludedCardTypes)
+        self.supportedCardTypes = configuration.allowedCardTypes ?? paymentMethodCardTypes
     }
     
     // MARK: - Presentable Component Protocol

--- a/AdyenCard/Components/Card/CardComponentConfiguration.swift
+++ b/AdyenCard/Components/Card/CardComponentConfiguration.swift
@@ -152,8 +152,7 @@ extension CardComponent {
             var configuration = Configuration(showsHolderNameField: showsHolderNameField,
                                               showsStorePaymentMethodField: showsStorePaymentMethodField,
                                               billingAddressMode: .none,
-                                              storedCardConfiguration: stored,
-                                              allowedCardTypes: [.bcmc, .visa, .maestro])
+                                              storedCardConfiguration: stored)
             configuration.showsSupportedCardLogos = false
             configuration.binLookupType = .bcmc
             return configuration

--- a/AdyenCard/Components/Card/CardComponentConfiguration.swift
+++ b/AdyenCard/Components/Card/CardComponentConfiguration.swift
@@ -64,10 +64,7 @@ extension CardComponent {
         /// By default list of supported cards is extracted from component's `AnyCardPaymentMethod`.
         /// Use this property to enforce a custom collection of card types.
         public var allowedCardTypes: [CardType]?
-
-        /// Indicates the card brands excluded from the supported brands.
-        internal var excludedCardTypes: Set<CardType> = [.bcmc]
-
+        
         /// Installments options to present to the user.
         public var installmentConfiguration: InstallmentConfiguration?
         
@@ -77,6 +74,12 @@ extension CardComponent {
         
         /// Indicates the requirement level of the address fields.
         public var billingAddressRequirementPolicy: RequirementPolicy = .required
+        
+        /// Indicates whether or not to show the supported card logos under the card number item
+        internal var showsSupportedCardLogos: Bool = true
+        
+        /// The type used for the bin lookup
+        internal var binLookupType: BinLookupRequestType = .card
         
         /// Indicates the requirement level of a field.
         public enum RequirementPolicy {
@@ -146,15 +149,13 @@ extension CardComponent {
         }
 
         internal func bcmcConfiguration() -> Configuration {
-            var storedCardConfiguration = stored
-            storedCardConfiguration.showsSecurityCodeField = false
             var configuration = Configuration(showsHolderNameField: showsHolderNameField,
                                               showsStorePaymentMethodField: showsStorePaymentMethodField,
-                                              showsSecurityCodeField: false,
                                               billingAddressMode: .none,
-                                              storedCardConfiguration: storedCardConfiguration,
-                                              allowedCardTypes: [.bcmc])
-            configuration.excludedCardTypes = []
+                                              storedCardConfiguration: stored,
+                                              allowedCardTypes: [.bcmc, .maestro, .visa])
+            configuration.showsSupportedCardLogos = false
+            configuration.binLookupType = .bcmc
             return configuration
         }
 

--- a/AdyenCard/Components/Card/CardComponentConfiguration.swift
+++ b/AdyenCard/Components/Card/CardComponentConfiguration.swift
@@ -153,7 +153,7 @@ extension CardComponent {
                                               showsStorePaymentMethodField: showsStorePaymentMethodField,
                                               billingAddressMode: .none,
                                               storedCardConfiguration: stored,
-                                              allowedCardTypes: [.bcmc, .maestro, .visa])
+                                              allowedCardTypes: [.bcmc, .visa, .maestro])
             configuration.showsSupportedCardLogos = false
             configuration.binLookupType = .bcmc
             return configuration

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -200,7 +200,7 @@ internal class CardViewController: FormViewController {
     
     /// Updates relevant other fields after number field changes
     private func updateFields(from brand: CardBrand?) {
-        items.securityCodeItem.isOptional = brand?.isCVCOptional ?? false
+        items.securityCodeItem.displayMode = brand?.securityCodeItemDisplayMode ?? .required
         items.expiryDateItem.isOptional = brand?.isExpiryDateOptional ?? false
         
         let kcpItemsHidden = shouldHideKcpItems(with: issuingCountryCode)
@@ -319,5 +319,16 @@ internal protocol CardViewControllerDelegate: AnyObject {
 extension FormValueItem where ValueType == String {
     internal var nonEmptyValue: String? {
         self.value.isEmpty ? nil : self.value
+    }
+}
+
+extension CardBrand {
+
+    internal var securityCodeItemDisplayMode: FormCardSecurityCodeItem.DisplayMode {
+        switch self.cvcPolicy {
+        case .hidden: return .hidden
+        case .optional: return .optional
+        case .required: return .required
+        }
     }
 }

--- a/AdyenCard/Components/Card/CardViewControllerItemsProvider.swift
+++ b/AdyenCard/Components/Card/CardViewControllerItemsProvider.swift
@@ -80,6 +80,7 @@ extension CardViewController {
 
         internal lazy var numberContainerItem: FormCardNumberContainerItem = {
             let item = FormCardNumberContainerItem(cardTypeLogos: cardLogos,
+                                                   showsSupportedCardLogos: configuration.showsSupportedCardLogos,
                                                    style: formStyle.textField,
                                                    localizationParameters: localizationParameters)
             item.identifier = ViewIdentifierBuilder.build(scopeInstance: scope, postfix: "numberContainerItem")

--- a/AdyenCard/Form/FormCardNumberContainerItem.swift
+++ b/AdyenCard/Form/FormCardNumberContainerItem.swift
@@ -68,8 +68,9 @@ internal final class FormCardNumberContainerItem: FormItem, Observer {
     internal func update(brands: [CardBrand]) {
         numberItem.update(brands: brands)
         
-        let shouldHideCardLogos = !showsSupportedCardLogos || brands.contains(where: \.isSupported)
-        supportedCardLogosItem.isHidden.wrappedValue = shouldHideCardLogos
+        if showsSupportedCardLogos {
+            supportedCardLogosItem.isHidden.wrappedValue = brands.contains(where: \.isSupported)
+        }
     }
 }
 

--- a/AdyenCard/Form/FormCardNumberContainerItem.swift
+++ b/AdyenCard/Form/FormCardNumberContainerItem.swift
@@ -17,9 +17,17 @@ internal final class FormCardNumberContainerItem: FormItem, Observer {
     
     internal let style: FormTextItemStyle
     
+    internal let showsSupportedCardLogos: Bool
+    
     private let localizationParameters: LocalizationParameters?
    
-    internal lazy var subitems: [FormItem] = [numberItem, supportedCardLogosItem]
+    internal lazy var subitems: [FormItem] = {
+            var subItems: [FormItem] = [numberItem]
+            if showsSupportedCardLogos {
+                subItems.append(supportedCardLogosItem)
+            }
+            return subItems
+        }()
     
     internal lazy var numberItem: FormCardNumberItem = {
         let item = FormCardNumberItem(cardTypeLogos: cardTypeLogos,
@@ -36,17 +44,20 @@ internal final class FormCardNumberContainerItem: FormItem, Observer {
     }()
     
     internal init(cardTypeLogos: [FormCardLogosItem.CardTypeLogo],
+                  showsSupportedCardLogos: Bool = true,
                   style: FormTextItemStyle,
                   localizationParameters: LocalizationParameters?) {
         self.cardTypeLogos = cardTypeLogos
+        self.showsSupportedCardLogos = showsSupportedCardLogos
         self.localizationParameters = localizationParameters
         self.style = style
         
-        observe(numberItem.$isActive) { [weak self] isActive in
-            guard let self = self else { return }
-            // logo item only visible when number item is active or when it's invalid
-            let hidden = !isActive && self.numberItem.isValid()
-            self.supportedCardLogosItem.isHidden.wrappedValue = hidden
+        if showsSupportedCardLogos {
+            observe(numberItem.$isActive) { [weak self] _ in
+                guard let self = self else { return }
+                // logo item should be visible when field is invalid after active state changes
+                self.supportedCardLogosItem.isHidden.wrappedValue = self.numberItem.isValid()
+            }
         }
     }
     
@@ -55,10 +66,16 @@ internal final class FormCardNumberContainerItem: FormItem, Observer {
     }
     
     internal func update(brands: [CardBrand]) {
+        numberItem.update(brands: brands)
+        
+        guard showsSupportedCardLogos else {
+            supportedCardLogosItem.isHidden.wrappedValue = false
+            return
+        }
+        
         // reduce alpha of supported card icons if brand is detected
         let supportedBrands = brands.filter(\.isSupported)
         supportedCardLogosItem.alpha = supportedBrands.isEmpty ? 1 : 0.3
-        numberItem.update(brands: brands)
     }
 }
 

--- a/AdyenCard/Form/FormCardNumberContainerItem.swift
+++ b/AdyenCard/Form/FormCardNumberContainerItem.swift
@@ -68,14 +68,13 @@ internal final class FormCardNumberContainerItem: FormItem, Observer {
     internal func update(brands: [CardBrand]) {
         numberItem.update(brands: brands)
         
-        guard showsSupportedCardLogos else {
+        if showsSupportedCardLogos {
+            // reduce alpha of supported card icons if brand is detected
+            let supportedBrands = brands.filter(\.isSupported)
+            supportedCardLogosItem.alpha = supportedBrands.isEmpty ? 1 : 0.3
+        } else {
             supportedCardLogosItem.isHidden.wrappedValue = false
-            return
         }
-        
-        // reduce alpha of supported card icons if brand is detected
-        let supportedBrands = brands.filter(\.isSupported)
-        supportedCardLogosItem.alpha = supportedBrands.isEmpty ? 1 : 0.3
     }
 }
 

--- a/AdyenCard/Form/FormCardNumberContainerItem.swift
+++ b/AdyenCard/Form/FormCardNumberContainerItem.swift
@@ -68,13 +68,8 @@ internal final class FormCardNumberContainerItem: FormItem, Observer {
     internal func update(brands: [CardBrand]) {
         numberItem.update(brands: brands)
         
-        if showsSupportedCardLogos {
-            // reduce alpha of supported card icons if brand is detected
-            let supportedBrands = brands.filter(\.isSupported)
-            supportedCardLogosItem.alpha = supportedBrands.isEmpty ? 1 : 0.3
-        } else {
-            supportedCardLogosItem.isHidden.wrappedValue = false
-        }
+        let shouldHideCardLogos = !showsSupportedCardLogos || brands.contains(where: \.isSupported)
+        supportedCardLogosItem.isHidden.wrappedValue = shouldHideCardLogos
     }
 }
 

--- a/AdyenCard/Form/FormCardSecurityCodeItem.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItem.swift
@@ -20,13 +20,6 @@ internal final class FormCardSecurityCodeItem: FormTextItem {
             case .hidden: return false
             }
         }
-
-        internal var isOptional: Bool {
-            switch self {
-            case .optional: return true
-            case .hidden, .required: return false
-            }
-        }
     }
     
     /// :nodoc:

--- a/AdyenCard/Form/FormCardSecurityCodeItem.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItem.swift
@@ -9,6 +9,26 @@ import Adyen
 /// A form item into which a card's security code (CVC/CVV) is entered.
 internal final class FormCardSecurityCodeItem: FormTextItem {
 
+    internal enum DisplayMode {
+        case required
+        case optional
+        case hidden
+
+        internal var isVisible: Bool {
+            switch self {
+            case .required, .optional: return true
+            case .hidden: return false
+            }
+        }
+
+        internal var isOptional: Bool {
+            switch self {
+            case .optional: return true
+            case .hidden, .required: return false
+            }
+        }
+    }
+    
     /// :nodoc:
     internal var localizationParameters: LocalizationParameters?
     
@@ -16,7 +36,7 @@ internal final class FormCardSecurityCodeItem: FormTextItem {
     @Observable(nil) internal var selectedCard: CardType?
 
     /// :nodoc:
-    @Observable(false) internal var isOptional: Bool {
+    @Observable(.required) internal var displayMode: DisplayMode {
         didSet {
             updateFormState()
         }
@@ -37,14 +57,19 @@ internal final class FormCardSecurityCodeItem: FormTextItem {
     }
 
     internal func updateFormState() {
-        // when optional, if user enters anything it should be validated as regular entry.
-        if isOptional {
-            title = localizedString(.cardCvcItemTitleOptional, localizationParameters)
-            validator = NumericStringValidator(exactLength: 0) || securityCodeValidator
-        } else {
-            title = localizedString(.cardCvcItemTitle, localizationParameters)
-            validator = securityCodeValidator
-        }
+ 
+        switch displayMode {
+            case .required:
+                title = localizedString(.cardCvcItemTitle, localizationParameters)
+                validator = securityCodeValidator
+            case .hidden:
+                validator = nil
+                value = ""
+            case .optional:
+                // when optional, if user enters anything it should be validated as regular entry.
+                title = localizedString(.cardCvcItemTitleOptional, localizationParameters)
+                validator = NumericStringValidator(exactLength: 0) || securityCodeValidator
+            }
     }
     
     override internal func build(with builder: FormItemViewBuilder) -> AnyFormItemView {

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -24,7 +24,7 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
             }
         }
 
-        observe(item.$isOptional) { [weak self] _ in
+        observe(item.$displayMode) { [weak self] _ in
             self?.updateValidationStatus()
         }
         
@@ -40,7 +40,11 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
     override internal func updateValidationStatus(forced: Bool = false) {
         super.updateValidationStatus(forced: forced)
 
-        if item.isOptional {
+        alpha = item.displayMode.isVisible ? 1.0 : 0.0
+        isUserInteractionEnabled = item.displayMode.isVisible
+        isAccessibilityElement = item.displayMode.isVisible
+        
+        if item.displayMode.isOptional {
             accessory = .customView(cardHintView)
         }
     }

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -42,7 +42,6 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
 
         alpha = item.displayMode.isVisible ? 1.0 : 0.0
         isUserInteractionEnabled = item.displayMode.isVisible
-        isAccessibilityElement = item.displayMode.isVisible
         
         switch item.displayMode {
         case .optional:

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -44,8 +44,11 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
         isUserInteractionEnabled = item.displayMode.isVisible
         isAccessibilityElement = item.displayMode.isVisible
         
-        if item.displayMode.isOptional {
+        switch item.displayMode {
+        case .optional:
             accessory = .customView(cardHintView)
+        case .hidden, .required:
+            break
         }
     }
     

--- a/AdyenCard/Utilities/BinLookup/BinLookupRequest.swift
+++ b/AdyenCard/Utilities/BinLookup/BinLookupRequest.swift
@@ -8,6 +8,11 @@ import Adyen
 import AdyenNetworking
 import Foundation
 
+internal enum BinLookupRequestType: String, Codable {
+    case card = "card"
+    case bcmc = "bcmc"
+}
+
 internal struct BinLookupRequest: APIRequest {
     
     internal typealias ResponseType = BinLookupResponse
@@ -28,9 +33,12 @@ internal struct BinLookupRequest: APIRequest {
     
     internal let requestId = UUID().uuidString
     
+    internal let type: BinLookupRequestType
+    
     private enum CodingKeys: String, CodingKey {
         case encryptedBin
         case supportedBrands
         case requestId
+        case type
     }
 }

--- a/AdyenCard/Utilities/BinLookup/BinLookupService.swift
+++ b/AdyenCard/Utilities/BinLookup/BinLookupService.swift
@@ -18,7 +18,7 @@ internal protocol AnyBinLookupService {
     typealias CompletionHandler = (Result<BinLookupResponse, Error>) -> Void
     
     /// :nodoc:
-    func requestCardType(for bin: String, supportedCardTypes: [CardType], caller: @escaping CompletionHandler)
+    func requestCardType(for bin: String, supportedCardTypes: [CardType], completion: @escaping CompletionHandler)
 }
 
 internal final class BinLookupService: AnyBinLookupService {
@@ -37,22 +37,22 @@ internal final class BinLookupService: AnyBinLookupService {
         self.binLookupType = binLookupType
     }
     
-    internal func requestCardType(for bin: String, supportedCardTypes: [CardType], caller: @escaping CompletionHandler) {
+    internal func requestCardType(for bin: String, supportedCardTypes: [CardType], completion: @escaping CompletionHandler) {
         if let cached = cache[bin] {
-            return caller(.success(cached))
+            return completion(.success(cached))
         }
 
         let encryptedBin: String
         do {
             encryptedBin = try CardEncryptor.encrypt(bin: bin, with: publicKey)
         } catch {
-            return caller(.failure(error))
+            return completion(.failure(error))
         }
         
         let request = BinLookupRequest(encryptedBin: encryptedBin, supportedBrands: supportedCardTypes, type: binLookupType)
         apiClient.perform(request) { [weak self] result in
             _ = result.map { self?.cache[bin] = $0 }
-            caller(result)
+            completion(result)
         }
     }
 }

--- a/AdyenCard/Utilities/BinLookup/BinLookupService.swift
+++ b/AdyenCard/Utilities/BinLookup/BinLookupService.swift
@@ -29,9 +29,12 @@ internal final class BinLookupService: AnyBinLookupService {
 
     private var cache = [String: BinLookupResponse]()
     
-    internal init(publicKey: String, apiClient: APIClientProtocol) {
+    private let binLookupType: BinLookupRequestType
+    
+    internal init(publicKey: String, apiClient: APIClientProtocol, binLookupType: BinLookupRequestType) {
         self.publicKey = publicKey
         self.apiClient = apiClient
+        self.binLookupType = binLookupType
     }
     
     internal func requestCardType(for bin: String, supportedCardTypes: [CardType], caller: @escaping CompletionHandler) {
@@ -46,7 +49,7 @@ internal final class BinLookupService: AnyBinLookupService {
             return caller(.failure(error))
         }
         
-        let request = BinLookupRequest(encryptedBin: encryptedBin, supportedBrands: supportedCardTypes)
+        let request = BinLookupRequest(encryptedBin: encryptedBin, supportedBrands: supportedCardTypes, type: binLookupType)
         apiClient.perform(request) { [weak self] result in
             _ = result.map { self?.cache[bin] = $0 }
             caller(result)

--- a/AdyenCard/Utilities/CardType/BinInfoProvider.swift
+++ b/AdyenCard/Utilities/CardType/BinInfoProvider.swift
@@ -21,11 +21,13 @@ internal final class BinInfoProvider: AnyBinInfoProvider {
 
     private let apiClient: APIClientProtocol
 
-    private var binLookupService: BinLookupService?
+    private var binLookupService: AnyBinLookupService?
     
     private let publicKeyProvider: AnyPublicKeyProvider
 
     private let fallbackCardTypeProvider: AnyBinInfoProvider
+    
+    private let binLookupType: BinLookupRequestType
     
     /// Create a new instance of CardTypeProvider.
     /// - Parameters:
@@ -36,11 +38,13 @@ internal final class BinInfoProvider: AnyBinInfoProvider {
     internal init(apiClient: APIClientProtocol,
                   publicKeyProvider: AnyPublicKeyProvider,
                   fallbackCardTypeProvider: AnyBinInfoProvider = FallbackBinInfoProvider(),
-                  minBinLength: Int) {
+                  minBinLength: Int,
+                  binLookupType: BinLookupRequestType) {
         self.apiClient = apiClient
         self.publicKeyProvider = publicKeyProvider
         self.fallbackCardTypeProvider = fallbackCardTypeProvider
         self.minBinLength = minBinLength
+        self.binLookupType = binLookupType
     }
     
     /// Request card types based on entered BIN.
@@ -60,7 +64,7 @@ internal final class BinInfoProvider: AnyBinInfoProvider {
             return fallback()
         }
 
-        let useService: (BinLookupService) -> Void = { service in
+        let useService: (AnyBinLookupService) -> Void = { service in
             service.requestCardType(for: bin, supportedCardTypes: supportedTypes) { result in
                 switch result {
                 case let .success(response):
@@ -78,7 +82,7 @@ internal final class BinInfoProvider: AnyBinInfoProvider {
                 guard let self = self else { return }
                 switch result {
                 case let .success(publicKey):
-                    let service = BinLookupService(publicKey: publicKey, apiClient: self.apiClient)
+                    let service = BinLookupService(publicKey: publicKey, apiClient: self.apiClient, binLookupType: self.binLookupType)
                     self.binLookupService = service
                     useService(service)
                 case .failure:

--- a/Tests/AdyenTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/BCMCComponentTests.swift
@@ -7,6 +7,7 @@
 @testable import Adyen
 @testable import AdyenCard
 @testable import AdyenDropIn
+@testable import AdyenEncryption
 import XCTest
 
 class BCMCComponentTests: XCTestCase {
@@ -38,20 +39,49 @@ class BCMCComponentTests: XCTestCase {
                                 apiContext: Dummy.context)
         UIApplication.shared.keyWindow?.rootViewController = sut.viewController
         
-        XCTAssertEqual(sut.configuration.allowedCardTypes, [.bcmc])
-        XCTAssertEqual(sut.configuration.excludedCardTypes, [])
+        XCTAssertEqual(sut.configuration.allowedCardTypes, [.bcmc, .visa, .maestro])
         let expectation = XCTestExpectation(description: "Dummy Expectation")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem"))
-            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem.cardTypeLogos"))
-            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.supportedCardLogosItem"))
+            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem"))
+            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem.cardTypeLogos"))
+            XCTAssertNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.supportedCardLogosItem"))
             XCTAssertNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.holderNameItem"))
             XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem"))
-            XCTAssertNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.securityCodeItem"))
+            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.securityCodeItem"))
             XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.storeDetailsItem"))
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 5)
+    }
+    
+    func testCardLogos() throws {
+        let cardPaymentMethod = CardPaymentMethod(type: "bcmc", name: "Test name", fundingSource: .debit, brands: ["any_test_brand_name"])
+        let paymentMethod = BCMCPaymentMethod(cardPaymentMethod: cardPaymentMethod)
+        let sut = BCMCComponent(paymentMethod: paymentMethod,
+                                configuration: CardComponent.Configuration(),
+                                apiContext: Dummy.context)
+
+        XCTAssertFalse(sut.cardViewController.items.numberContainerItem.showsSupportedCardLogos)
+
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        wait(for: .milliseconds(30))
+
+        let supportedCardLogosItemId = "AdyenCard.BCMCComponent.numberContainerItem.supportedCardLogosItem"
+
+        var supportedCardLogosItem: FormCardLogosItemView? = sut.viewController.view.findView(with: supportedCardLogosItemId)
+        XCTAssertNil(supportedCardLogosItem)
+
+        // Valid input
+        
+        fillCard(on: sut.viewController.view, with: Dummy.bancontactCard)
+
+        var binResponse = BinLookupResponse(brands: [CardBrand(type: .bcmc, isSupported: true)])
+        sut.cardViewController.update(binInfo: binResponse)
+
+        wait(for: .milliseconds(30))
+
+        supportedCardLogosItem = sut.viewController.view.findView(with: supportedCardLogosItemId)
+        XCTAssertNil(supportedCardLogosItem)
     }
     
     func testShowHolderNameField() {
@@ -64,15 +94,14 @@ class BCMCComponentTests: XCTestCase {
                                 apiContext: Dummy.context)
         UIApplication.shared.keyWindow?.rootViewController = sut.viewController
         
-        XCTAssertEqual(sut.configuration.allowedCardTypes, [.bcmc])
-        XCTAssertEqual(sut.configuration.excludedCardTypes, [])
+        XCTAssertEqual(sut.configuration.allowedCardTypes, [.bcmc, .visa, .maestro])
         let expectation = XCTestExpectation(description: "Dummy Expectation")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem"))
-            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem.cardTypeLogos"))
+            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem"))
+            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem.cardTypeLogos"))
             XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.holderNameItem"))
             XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem"))
-            XCTAssertNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.securityCodeItem"))
+            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.securityCodeItem"))
             XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.storeDetailsItem"))
             expectation.fulfill()
         }
@@ -89,15 +118,14 @@ class BCMCComponentTests: XCTestCase {
                                 apiContext: Dummy.context)
         UIApplication.shared.keyWindow?.rootViewController = sut.viewController
         
-        XCTAssertEqual(sut.configuration.allowedCardTypes, [.bcmc])
-        XCTAssertEqual(sut.configuration.excludedCardTypes, [])
+        XCTAssertEqual(sut.configuration.allowedCardTypes, [.bcmc, .visa, .maestro])
         let expectation = XCTestExpectation(description: "Dummy Expectation")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem"))
-            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem.cardTypeLogos"))
+            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem"))
+            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem.cardTypeLogos"))
             XCTAssertNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.holderNameItem"))
             XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem"))
-            XCTAssertNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.securityCodeItem"))
+            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.securityCodeItem"))
             XCTAssertNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.storeDetailsItem"))
             expectation.fulfill()
         }
@@ -113,16 +141,16 @@ class BCMCComponentTests: XCTestCase {
         
         let expectation = XCTestExpectation(description: "Dummy Expectation")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
+            let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
             XCTAssertNotNil(cardNumberItemView)
-            let textItemView: FormCardNumberItemView? = cardNumberItemView!.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
+            let textItemView: FormCardNumberItemView? = cardNumberItemView!.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
             XCTAssertNotNil(textItemView)
             self.populate(textItemView: textItemView!, with: Dummy.bancontactCard.number!)
             
             let cardNumberItem = cardNumberItemView!.item
-            XCTAssertEqual(cardNumberItem.cardTypeLogos.count, 1)
+            XCTAssertEqual(cardNumberItem.cardTypeLogos.count, 3)
             XCTAssertEqual(cardNumberItem.cardTypeLogos.first?.url, LogoURLProvider.logoURL(withName: "bcmc", environment: sut.apiContext.environment))
-            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem.cardTypeLogos"))
+            XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem.cardTypeLogos"))
             
             expectation.fulfill()
         }
@@ -137,7 +165,7 @@ class BCMCComponentTests: XCTestCase {
         UIApplication.shared.keyWindow?.rootViewController = sut.viewController
         
         let expectation = XCTestExpectation(description: "Dummy Expectation")
-        let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
+        let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
         XCTAssertNotNil(cardNumberItemView)
 
         let cardNumberItem = cardNumberItemView!.item
@@ -159,6 +187,7 @@ class BCMCComponentTests: XCTestCase {
         PublicKeyProvider.publicKeysCache[Dummy.context.clientKey] = Dummy.publicKey
         sut.delegate = delegate
         UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        self.wait(for: .milliseconds(300))
         
         let didSubmitExpectation = XCTestExpectation(description: "Expect delegate.didSubmit() to be called")
         delegate.onDidSubmit = { paymentData, component in
@@ -182,31 +211,82 @@ class BCMCComponentTests: XCTestCase {
         delegate.onDidFail = { error, _ in
             XCTFail("delegate.didFail() must not be called")
         }
-
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            // Enter Card Number
-            let cardNumberView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
-            XCTAssertNotNil(cardNumberView)
-            self.populate(textItemView: cardNumberView!, with: Dummy.bancontactCard.number!)
-            
-            // Enter Expiry Date
-            let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem>? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem")
-            XCTAssertNotNil(expiryDateItemView)
-            let date = Date(timeIntervalSinceNow: 60 * 60 * 24 * 30 * 2)
-            let calendar = Calendar(identifier: .gregorian)
-            let components = calendar.dateComponents([.month, .year], from: date)
-            let expiryDate = "\(String(format: "%02d/%02d", components.month!, components.year! % 100))"
-            self.populate(textItemView: expiryDateItemView!, with: expiryDate)
-            
-            // Tap submit button
-            let submitButton: UIControl? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.payButtonItem.button")
-            XCTAssertNotNil(submitButton)
-            submitButton!.sendActions(for: .touchUpInside)
-        }
-        wait(for: [didSubmitExpectation], timeout: 10)
+        
+        let binChangeCalled = expectation(description: "onBINDidChange was called")
+        
+        let delegateMock = CardComponentDelegateMock(onBINDidChange: { _ in },
+                                                     onCardBrandChange: { value in
+            binChangeCalled.fulfill()
+        },
+                                                     onSubmitLastFour: { _ in })
+        sut.cardComponentDelegate = delegateMock
+        
+        // Enter Card Number
+        let cardNumberView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
+        XCTAssertNotNil(cardNumberView)
+        self.populate(textItemView: cardNumberView!, with: Dummy.bancontactCard.number!)
+        
+        wait(for: [binChangeCalled], timeout: 5)
+        
+        // Enter Expiry Date
+        let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem>? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem")
+        XCTAssertNotNil(expiryDateItemView)
+        let date = Date(timeIntervalSinceNow: 60 * 60 * 24 * 30 * 2)
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents([.month, .year], from: date)
+        let expiryDate = "\(String(format: "%02d/%02d", components.month!, components.year! % 100))"
+        self.populate(textItemView: expiryDateItemView!, with: expiryDate)
+        
+        // Tap submit button
+        let submitButton: UIControl? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.payButtonItem.button")
+        XCTAssertNotNil(submitButton)
+        submitButton!.sendActions(for: .touchUpInside)
+        
+        wait(for: [didSubmitExpectation], timeout: 5)
     }
     
-    func testDelegateCallledCorrectCard() {
+    func testBinLookupRequiredCVC() throws {
+
+        let expectationBinLookup = XCTestExpectation(description: "Bin Lookup Expectation")
+        let cardTypeProviderMock = BinInfoProviderMock()
+        cardTypeProviderMock.onFetch = {
+            $0(BinLookupResponse(brands: [CardBrand(type: .bcmc, cvcPolicy: .required, panLength: 19)]))
+            expectationBinLookup.fulfill()
+        }
+
+        let method = CardPaymentMethod(type: "bcmc", name: "Test name", fundingSource: .debit, brands: ["any_test_brand_name"])
+        let paymentMethod = BCMCPaymentMethod(cardPaymentMethod: method)
+        let sut = BCMCComponent(paymentMethod: paymentMethod,
+                                apiContext: Dummy.context,
+                                configuration: .init(),
+                                publicKeyProvider: PublicKeyProviderMock(),
+                                binProvider: cardTypeProviderMock)
+
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+
+        let expectationBin = XCTestExpectation(description: "Bin Expectation")
+        let delegateMock = CardComponentDelegateMock(
+            onBINDidChange: { _ in },
+             onCardBrandChange: { _ in },
+             onSubmitLastFour: { _ in
+                 expectationBin.fulfill()
+             })
+
+        sut.cardComponentDelegate = delegateMock
+
+        wait(for: .milliseconds(30))
+
+        fillCard(on: sut.viewController.view, with: Dummy.bancontactCard)
+        wait(for: [expectationBinLookup], timeout: 1)
+        tapSubmitButton(on: sut.viewController.view) // Should not trigger `didSubmit` as the security code is required
+        
+        let securityCodeItemView: FormCardSecurityCodeItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.securityCodeItem"))
+        populate(textItemView: securityCodeItemView, with: "123")
+        tapSubmitButton(on: sut.viewController.view) // Should trigger `didSubmit` as the security code is provided
+        wait(for: [expectationBin], timeout: 1)
+    }
+    
+    func testDelegateCalledCorrectCard() {
         let method = CardPaymentMethod(type: "bcmc", name: "Test name", fundingSource: .debit, brands: ["any_test_brand_name"])
         let paymentMethod = BCMCPaymentMethod(cardPaymentMethod: method)
         let sut = BCMCComponent(paymentMethod: paymentMethod,
@@ -215,7 +295,7 @@ class BCMCComponentTests: XCTestCase {
         UIApplication.shared.keyWindow?.rootViewController = sut.viewController
         
         let expectationCardType = XCTestExpectation(description: "CardType Expectation")
-        let mockedBrands = [CardBrand(type: .bcmc, cvcPolicy: .optional)]
+        let mockedBrands = [CardBrand(type: .bcmc, cvcPolicy: .optional), CardBrand(type: .maestro, cvcPolicy: .optional)]
         let delegateMock = CardComponentDelegateMock(onBINDidChange: { _ in },
                                                      onCardBrandChange: { value in
                                                          XCTAssertEqual(value, mockedBrands)
@@ -225,7 +305,7 @@ class BCMCComponentTests: XCTestCase {
         sut.cardComponentDelegate = delegateMock
         
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
+            let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
             self.populate(textItemView: cardNumberItemView!, with: "67034")
         }
         
@@ -250,7 +330,7 @@ class BCMCComponentTests: XCTestCase {
         sut.cardComponentDelegate = delegateMock
 
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
+            let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
             self.populate(textItemView: cardNumberItemView!, with: Dummy.bancontactCard.number!)
         }
 
@@ -275,7 +355,7 @@ class BCMCComponentTests: XCTestCase {
         sut.cardComponentDelegate = delegateMock
         
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
+            let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
             self.populate(textItemView: cardNumberItemView!, with: "32145")
         }
         
@@ -300,7 +380,7 @@ class BCMCComponentTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Dummy Expectation")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
             // Enter invalid Card Number
-            let cardNumberView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
+            let cardNumberView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
             XCTAssertNotNil(cardNumberView)
             self.populate(textItemView: cardNumberView!, with: "123")
             
@@ -317,7 +397,7 @@ class BCMCComponentTests: XCTestCase {
             
             // wait until the alert popup is shown
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-                let alertLabel: UILabel? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem.alertLabel")
+                let alertLabel: UILabel? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem.alertLabel")
                 XCTAssertNotNil(alertLabel)
                 XCTAssertEqual(alertLabel?.text, cardNumberView?.item.validationFailureMessage)
                 expectation.fulfill()
@@ -339,4 +419,20 @@ class BCMCComponentTests: XCTestCase {
         XCTAssertEqual(sut.viewController.title, cardPaymentMethod.name)
     }
     
+    func fillCard(on view: UIView, with card: Card) {
+        let cardNumberItemView: FormCardNumberItemView? = view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
+        let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem>? = view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem")
+        let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem>? = view.findView(with: "AdyenCard.BCMCComponent.securityCodeItem")
+
+        populate(textItemView: cardNumberItemView!, with: card.number ?? "")
+        populate(textItemView: expiryDateItemView!, with: "\(card.expiryMonth ?? "") \(card.expiryYear ?? "")")
+        if let securityCode = card.securityCode {
+            populate(textItemView: securityCodeItemView!, with: securityCode)
+        }
+    }
+    
+    func tapSubmitButton(on view: UIView) {
+        let payButtonItemViewButton: UIControl? = view.findView(with: "AdyenCard.BCMCComponent.payButtonItem.button")
+        payButtonItemViewButton?.sendActions(for: .touchUpInside)
+    }
 }

--- a/Tests/AdyenTests/Card Tests/CardComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/CardComponentTests.swift
@@ -1575,15 +1575,15 @@ class CardComponentTests: XCTestCase {
         
         var binResponse = BinLookupResponse(brands: [CardBrand(type: .americanExpress)])
         sut.cardViewController.update(binInfo: binResponse)
-        XCTAssertEqual(logoItem.alpha, 0.3)
+        XCTAssertTrue(logoItem.isHidden.wrappedValue)
         
         binResponse = BinLookupResponse(brands: [])
         sut.cardViewController.update(binInfo: binResponse)
-        XCTAssertEqual(logoItem.alpha, 1)
+        XCTAssertFalse(logoItem.isHidden.wrappedValue)
         
         binResponse = BinLookupResponse(brands: [CardBrand(type: .americanExpress, isSupported: false)])
         sut.cardViewController.update(binInfo: binResponse)
-        XCTAssertEqual(logoItem.alpha, 1)
+        XCTAssertFalse(logoItem.isHidden.wrappedValue)
     }
     
     func testClearShouldResetPostalCodeItemToEmptyValue() throws {

--- a/Tests/AdyenTests/Card Tests/CardComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/CardComponentTests.swift
@@ -1254,40 +1254,40 @@ class CardComponentTests: XCTestCase {
         XCTAssertTrue(cardNumberItem.isValid())
     }
     
-    func testUnSupportedBrands() {
+    func testCardLogos() throws {
+
         let method = CardPaymentMethod(type: "bcmc", name: "Test name", fundingSource: .credit, brands: ["visa", "amex", "mc", "elo"])
-        var config = CardComponent.Configuration()
-        config.excludedCardTypes = [.americanExpress]
         
         let sut = CardComponent(paymentMethod: method,
                                 apiContext: Dummy.context,
-                                configuration: config,
-                                style: .init())
+                                configuration: CardComponent.Configuration())
+
+        XCTAssertTrue(sut.cardViewController.items.numberContainerItem.showsSupportedCardLogos)
+
+        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        wait(for: .milliseconds(30))
+
+        let supportedCardLogosItemId = "AdyenCard.CardComponent.numberContainerItem.supportedCardLogosItem"
+
+        var supportedCardLogosItem: FormCardLogosItemView = try XCTUnwrap(sut.viewController.view.findView(with: supportedCardLogosItemId))
+        XCTAssertFalse(supportedCardLogosItem.isHidden)
+
+        // Valid input
         
         fillCard(on: sut.viewController.view, with: Dummy.visaCard)
-        let cardNumberItem = sut.cardViewController.items.numberContainerItem.numberItem
         var binResponse = BinLookupResponse(brands: [CardBrand(type: .visa, isSupported: true)])
         sut.cardViewController.update(binInfo: binResponse)
-        XCTAssertFalse(cardNumberItem.allowsValidationWhileEditing)
-        XCTAssertTrue(cardNumberItem.isValid())
-        XCTAssertTrue(binResponse.isCreatedLocally)
         
-        fillCard(on: sut.viewController.view, with: Dummy.amexCard)
-        binResponse = BinLookupResponse(brands: [CardBrand(type: .americanExpress, isSupported: false)])
-        sut.cardViewController.update(binInfo: binResponse)
-        XCTAssertTrue(cardNumberItem.allowsValidationWhileEditing)
-        XCTAssertFalse(cardNumberItem.isValid())
+        wait(for: .milliseconds(30))
         
-        binResponse = BinLookupResponse(brands: [], isCreatedLocally: false)
-        sut.cardViewController.update(binInfo: binResponse)
-        XCTAssertFalse(cardNumberItem.allowsValidationWhileEditing)
-        XCTAssertFalse(binResponse.isCreatedLocally)
+        supportedCardLogosItem = try XCTUnwrap(sut.viewController.view.findView(with: supportedCardLogosItemId))
+        XCTAssertTrue(supportedCardLogosItem.isHidden)
     }
     
-    func testCVCOptionality() {
+    func testCVCDisplayMode() {
         let brands = [CardBrand(type: .visa, cvcPolicy: .required),
-                      CardBrand(type: .masterCard, cvcPolicy: .hidden),
-                      CardBrand(type: .masterCard, cvcPolicy: .optional)]
+                      CardBrand(type: .americanExpress, cvcPolicy: .optional),
+                      CardBrand(type: .masterCard, cvcPolicy: .hidden)]
         
         let method = CardPaymentMethod(type: "visa",
                                        name: "Test name",
@@ -1300,20 +1300,31 @@ class CardComponentTests: XCTestCase {
         
         let cvcItem = sut.cardViewController.items.securityCodeItem
         cvcItem.value = ""
-        cvcItem.isOptional = brands[0].isCVCOptional
+        cvcItem.displayMode = brands[0].securityCodeItemDisplayMode
         XCTAssertFalse(cvcItem.isValid())
         cvcItem.value = "1"
         XCTAssertFalse(cvcItem.isValid())
         cvcItem.value = "123"
         XCTAssertTrue(cvcItem.isValid())
-        
-        cvcItem.isOptional = brands[1].isCVCOptional
+
+        cvcItem.displayMode = brands[1].securityCodeItemDisplayMode
         XCTAssertTrue(cvcItem.isValid())
         cvcItem.value = "1"
         XCTAssertFalse(cvcItem.isValid())
-        // no value or correct value (3-4 digits) is valid
+        cvcItem.value = "" // no value or correct value (3-4 digits) is valid
+        XCTAssertTrue(cvcItem.isValid())
+
+        cvcItem.displayMode = brands[2].securityCodeItemDisplayMode
+        XCTAssertTrue(cvcItem.isValid())
+        cvcItem.value = "1"
+        XCTAssertTrue(cvcItem.isValid())
         cvcItem.value = ""
         XCTAssertTrue(cvcItem.isValid())
+
+        cvcItem.displayMode = .required
+        cvcItem.value = "123"
+        cvcItem.displayMode = .hidden
+        XCTAssertEqual(cvcItem.value, "")
     }
     
     func testExpiryDateOptionality() {
@@ -2472,10 +2483,10 @@ extension UIView {
     }
 }
 
-extension XCTestCase {
+extension CardComponentTests {
     
     func fillCard(on view: UIView, with card: Card) {
-        let cardNumberItemView: FormTextItemView<FormCardNumberItem>? = view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
+        let cardNumberItemView: FormCardNumberItemView? = view.findView(with: "AdyenCard.CardComponent.numberContainerItem.numberItem")
         let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem>? = view.findView(with: "AdyenCard.CardComponent.expiryDateItem")
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem>? = view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
         

--- a/Tests/AdyenTests/Card Tests/CardComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/CardComponentTests.swift
@@ -2486,7 +2486,7 @@ extension UIView {
 extension CardComponentTests {
     
     func fillCard(on view: UIView, with card: Card) {
-        let cardNumberItemView: FormCardNumberItemView? = view.findView(with: "AdyenCard.CardComponent.numberContainerItem.numberItem")
+        let cardNumberItemView: FormCardNumberItemView? = view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
         let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem>? = view.findView(with: "AdyenCard.CardComponent.expiryDateItem")
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem>? = view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
         

--- a/Tests/AdyenTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
+++ b/Tests/AdyenTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
@@ -20,7 +20,8 @@ class FormCardNumberItemTests: XCTestCase {
         publicKeyProvider = PublicKeyProviderMock()
         cardBrandProvider = BinInfoProvider(apiClient: apiClient,
                                             publicKeyProvider: publicKeyProvider,
-                                            minBinLength: 11)
+                                            minBinLength: 11,
+                                            binLookupType: .card)
     }
 
     override func tearDown() {

--- a/Tests/AdyenTests/Card Tests/Utilities/CardBrandProviderTests.swift
+++ b/Tests/AdyenTests/Card Tests/Utilities/CardBrandProviderTests.swift
@@ -18,7 +18,8 @@ class CardBrandProviderTests: XCTestCase {
         apiClientMock = APIClientMock()
         sut = BinInfoProvider(apiClient: apiClientMock,
                               publicKeyProvider: publicKeyProvider,
-                              minBinLength: 11)
+                              minBinLength: 11,
+                              binLookupType: .card)
     }
 
     override func tearDown() {


### PR DESCRIPTION
## Summary

<new>

* Bancontact cards are now supported in the `CardComponent`
* Dual-branded Bancontact cards now allow brand selection in the `BCMCComponent`

</new>

- Adding type to BinLookupRequest for correct card brand sorting
- Using CardPaymentMethod's `brands` to configure the `BCMCComponent`
