### PR TITLE
change: ISK and few other currency minor units updates

### DIFF
--- a/Adyen/Formatters/AmountFormatter.swift
+++ b/Adyen/Formatters/AmountFormatter.swift
@@ -20,8 +20,8 @@ public final class AmountFormatter {
     /// - Returns: The formatted text formatted as currency amount.
     public static func formatted(amount: Int, currencyCode: String, localeIdentifier: String? = nil) -> String? {
         let decimalAmount = AmountFormatter.decimalAmount(amount, currencyCode: currencyCode, localeIdentifier: localeIdentifier)
-        
-        return defaultFormatter(currencyCode: currencyCode, localeIdentifier: localeIdentifier).string(from: decimalAmount)
+        let formatter = defaultFormatter(currencyCode: currencyCode, localeIdentifier: localeIdentifier)
+        return formatter.string(from: decimalAmount)
     }
     
     /// Converts an amount in major currency unit to an amount in minor currency units.
@@ -31,7 +31,7 @@ public final class AmountFormatter {
     ///   - currencyCode: The code of the currency.
     ///   - localeIdentifier: The identifier of the locale. If nil, device's current locale is used.
     public static func minorUnitAmount(from majorUnitAmount: Double, currencyCode: String, localeIdentifier: String? = nil) -> Int {
-        let maximumFractionDigits = AmountFormatter.maximumFractionDigits(for: currencyCode, localeIdentifier: localeIdentifier)
+        let maximumFractionDigits = defaultFormatter(currencyCode: currencyCode, localeIdentifier: localeIdentifier).maximumFractionDigits
         
         return Int(majorUnitAmount * pow(Double(10), Double(maximumFractionDigits)))
     }
@@ -43,7 +43,7 @@ public final class AmountFormatter {
     ///   - currencyCode: The code of the currency.
     ///   - localeIdentifier: The identifier of the locale. If nil, device's current locale is used.
     public static func minorUnitAmount(from majorUnitAmount: Decimal, currencyCode: String, localeIdentifier: String? = nil) -> Int {
-        let maximumFractionDigits = AmountFormatter.maximumFractionDigits(for: currencyCode, localeIdentifier: localeIdentifier)
+        let maximumFractionDigits = defaultFormatter(currencyCode: currencyCode, localeIdentifier: localeIdentifier).maximumFractionDigits
         
         let roundTowardsZero = NSDecimalNumberHandler(roundingMode: majorUnitAmount.isSignMinus ? .up : .down,
                                                       scale: 0,
@@ -64,10 +64,7 @@ public final class AmountFormatter {
     ///   - currencyCode: The code of the currency.
     ///   - localeIdentifier: The identifier of the locale. If nil, device's current locale is used.
     public static func decimalAmount(_ amount: Int, currencyCode: String, localeIdentifier: String? = nil) -> NSDecimalNumber {
-        let defaultFormatter = AmountFormatter.defaultFormatter(currencyCode: currencyCode, localeIdentifier: localeIdentifier)
-        let maximumFractionDigits = AmountFormatter.maximumFractionDigits(for: currencyCode, localeIdentifier: localeIdentifier)
-        defaultFormatter.maximumFractionDigits = maximumFractionDigits
-        
+        let maximumFractionDigits = defaultFormatter(currencyCode: currencyCode, localeIdentifier: localeIdentifier).maximumFractionDigits
         let decimalMinorAmount = NSDecimalNumber(value: amount)
         return decimalMinorAmount.multiplying(byPowerOf10: Int16(-maximumFractionDigits))
     }
@@ -79,15 +76,18 @@ public final class AmountFormatter {
         if let localeIdentifier = localeIdentifier {
             formatter.locale = Locale(identifier: localeIdentifier)
         }
+        if let maxDigits = maximumFractionDigits(for: currencyCode, localeIdentifier: localeIdentifier) {
+            formatter.maximumFractionDigits = maxDigits
+        }
         return formatter
     }
     
-    private static func maximumFractionDigits(for currencyCode: String, localeIdentifier: String?) -> Int {
+    private static func maximumFractionDigits(for currencyCode: String, localeIdentifier: String?) -> Int? {
         // For some currency codes iOS returns the wrong number of minor units.
         // The below overrides are obtained from https://en.wikipedia.org/wiki/ISO_4217
         
         switch currencyCode {
-        case "CLP", "COP":
+        case "ISK", "CLP", "COP":
             // iOS returns 0, which is in accordance with ISO-4217, but conflicts with the Adyen backend.
             return 2
         case "MRO":
@@ -103,8 +103,7 @@ public final class AmountFormatter {
             // iOS returns 2 instead.
             return 0
         default:
-            let formatter = defaultFormatter(currencyCode: currencyCode, localeIdentifier: localeIdentifier)
-            return formatter.maximumFractionDigits
+            return nil
         }
     }
 

--- a/Adyen/Formatters/AmountFormatter.swift
+++ b/Adyen/Formatters/AmountFormatter.swift
@@ -87,19 +87,10 @@ public final class AmountFormatter {
         // The below overrides are obtained from https://en.wikipedia.org/wiki/ISO_4217
         
         switch currencyCode {
-        case "ISK", "CLP", "COP":
+        case "ISK", "CLP", "COP", "MRU", "RSD", "GHS":
             // iOS returns 0, which is in accordance with ISO-4217, but conflicts with the Adyen backend.
             return 2
-        case "MRO":
-            // iOS returns 0 instead.
-            return 1
-        case "RSD":
-            // iOS returns 0 instead.
-            return 2
-        case "CVE":
-            // iOS returns 2 instead.
-            return 0
-        case "GHC":
+        case "CVE", "IDR":
             // iOS returns 2 instead.
             return 0
         default:

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -7,8 +7,8 @@
 @_spi(AdyenInternal) import Adyen
 import AdyenActions
 import AdyenCard
-import AdyenDropIn
 import AdyenComponents
+import AdyenDropIn
 import Foundation
 import PassKit
 
@@ -222,10 +222,10 @@ internal struct DemoAppSettings: Codable {
                                                       brand: ConfigurationConstants.appName)
             var config = ApplePayComponent.Configuration(payment: applePayPayment,
                                                          merchantIdentifier:
-                                                            ConfigurationConstants.current.applePayConfiguration.merchantIdentifier)
+                                                         ConfigurationConstants.current.applePayConfiguration.merchantIdentifier)
             config.allowOnboarding = applePayConfiguration.allowOnboarding
             return config
-        } catch let error {
+        } catch {
             AdyenAssertion.assertionFailure(message: error.localizedDescription)
         }
         return nil

--- a/Tests/Adyen Tests/Utilities/AmountFormatterTests.swift
+++ b/Tests/Adyen Tests/Utilities/AmountFormatterTests.swift
@@ -34,8 +34,8 @@ class AmountFormatterTests: XCTestCase {
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: 218521.213969269, currencyCode: "CLF"), 2185212139)
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: -218521.213969269, currencyCode: "CLF"), -2185212139)
         
-        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: 218521.213969269, currencyCode: "ISK"), 218521)
-        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: -218521.213969269, currencyCode: "ISK"), -218521)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: 218521.213969269, currencyCode: "ISK"), 21852121)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: -218521.213969269, currencyCode: "ISK"), -21852121)
     }
     
     func testConversionFromDecimalToMinorAmounts() {
@@ -63,8 +63,8 @@ class AmountFormatterTests: XCTestCase {
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(218521.213969269), currencyCode: "CLF"), 2185212139)
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-218521.213969269), currencyCode: "CLF"), -2185212139)
         
-        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(218521.213969269), currencyCode: "ISK"), 218521)
-        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-218521.213969269), currencyCode: "ISK"), -218521)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(218521.213969269), currencyCode: "ISK"), 21852121)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-218521.213969269), currencyCode: "ISK"), -21852121)
     }
     
     func testDifferentLocales() {
@@ -73,11 +73,11 @@ class AmountFormatterTests: XCTestCase {
         if Available.iOS13 {
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "USD", localeIdentifier: "fr_FR"), "1 234,56 $US")
             
-            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "ko_KR"), "CVE 123,456.00")
-            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "fr_FR"), "123 456,00 CVE")
+            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "ko_KR"), "CVE 123,456")
+            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "fr_FR"), "123 456 CVE")
             
-            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "123.456 ISK")
-            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK"), "ISK 123,456")
+            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "1.234,56 ISK")
+            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK"), "ISK 1,234.56")
         } else {
             // pre iOS 13 formatting seems to add a character that looks exactly like a space but is not a space.
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "USD", localeIdentifier: "fr_FR"), "1 234,56 $US")
@@ -104,9 +104,9 @@ class AmountFormatterTests: XCTestCase {
         
         var amountCVE = Amount(value: 12345, currencyCode: "CVE", localeIdentifier: "ko_KR")
         if Available.iOS13 {
-            XCTAssertEqual(amountCVE.formatted, "CVE 12,345.00")
+            XCTAssertEqual(amountCVE.formatted, "CVE 12,345")
             amountCVE.localeIdentifier = "fr_FR"
-            XCTAssertEqual(amountCVE.formatted, "12 345,00 CVE")
+            XCTAssertEqual(amountCVE.formatted, "12 345 CVE")
         } else {
             // pre iOS 13 formatting seems to add a character that looks exactly like a space but is not a space.
             XCTAssertEqual(amountCVE.formatted, "CVE12,345.00")
@@ -137,8 +137,8 @@ class AmountFormatterTests: XCTestCase {
             let comps = [
                 ("US$", "1,234.56"),
                 ("$US", "1 234,56"),
-                ("CVE", "123,456.00"),
-                ("CVE", "123 456,00"),
+                ("CVE", "123,456"),
+                ("CVE", "123 456"),
                 ("€", "1,234.56"),
                 ("€", "1 234,56")
             ]


### PR DESCRIPTION
<changed>

## Changed

* The [minor units](https://docs.adyen.com/development-resources/currency-codes/) for the following currencies:

| Currency code  | Minor units |
|----------------|-------------|
| ISK                     | 2                   |
| RSD                   | 2                   |
| MRU                  | 2                   |
| GHS                   | 2                   |

</changed>