### PR TITLE
change: v4 Updated minor units for ISK and few other currencies

### DIFF
--- a/Tests/AdyenTests/Adyen Tests/Utilities/AmountFormatterTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Utilities/AmountFormatterTests.swift
@@ -34,8 +34,8 @@ class AmountFormatterTests: XCTestCase {
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: 218521.213969269, currencyCode: "CLF"), 2185212139)
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: -218521.213969269, currencyCode: "CLF"), -2185212139)
         
-        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: 218521.213969269, currencyCode: "ISK"), 218521)
-        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: -218521.213969269, currencyCode: "ISK"), -218521)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: 218521.213969269, currencyCode: "ISK"), 21852121)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: -218521.213969269, currencyCode: "ISK"), -21852121)
     }
     
     func testConversionFromDecimalToMinorAmounts() {
@@ -63,8 +63,8 @@ class AmountFormatterTests: XCTestCase {
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(218521.213969269), currencyCode: "CLF"), 2185212139)
         XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-218521.213969269), currencyCode: "CLF"), -2185212139)
         
-        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(218521.213969269), currencyCode: "ISK"), 218521)
-        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-218521.213969269), currencyCode: "ISK"), -218521)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(218521.213969269), currencyCode: "ISK"), 21852121)
+        XCTAssertEqual(AmountFormatter.minorUnitAmount(from: Decimal(-218521.213969269), currencyCode: "ISK"), -21852121)
     }
     
     func testDifferentLocales() {
@@ -73,11 +73,11 @@ class AmountFormatterTests: XCTestCase {
         if Available.iOS13 {
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "USD", localeIdentifier: "fr_FR"), "1 234,56 $US")
             
-            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "ko_KR"), "CVE 123,456.00")
-            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "fr_FR"), "123 456,00 CVE")
+            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "ko_KR"), "CVE 123,456")
+            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "fr_FR"), "123 456 CVE")
             
-            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "123.456 ISK")
-            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK"), "ISK 123,456")
+            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "1.234,56 ISK")
+            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK"), "ISK 1,234.56")
         } else {
             // pre iOS 13 formatting seems to add a character that looks exactly like a space but is not a space.
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "USD", localeIdentifier: "fr_FR"), "1 234,56 $US")
@@ -104,9 +104,9 @@ class AmountFormatterTests: XCTestCase {
         
         var amountCVE = Amount(value: 12345, currencyCode: "CVE", localeIdentifier: "ko_KR")
         if Available.iOS13 {
-            XCTAssertEqual(amountCVE.formatted, "CVE 12,345.00")
+            XCTAssertEqual(amountCVE.formatted, "CVE 12,345")
             amountCVE.localeIdentifier = "fr_FR"
-            XCTAssertEqual(amountCVE.formatted, "12 345,00 CVE")
+            XCTAssertEqual(amountCVE.formatted, "12 345 CVE")
         } else {
             // pre iOS 13 formatting seems to add a character that looks exactly like a space but is not a space.
             XCTAssertEqual(amountCVE.formatted, "CVE12,345.00")
@@ -137,8 +137,8 @@ class AmountFormatterTests: XCTestCase {
             let comps = [
                 ("US$", "1,234.56"),
                 ("$US", "1 234,56"),
-                ("CVE", "123,456.00"),
-                ("CVE", "123 456,00"),
+                ("CVE", "123,456"),
+                ("CVE", "123 456"),
                 ("€", "1,234.56"),
                 ("€", "1 234,56")
             ]


### PR DESCRIPTION
## Changed

* The [minor units](https://docs.adyen.com/development-resources/currency-codes/) for the following currencies:

| Currency code  | Minor units |
|----------------|-------------|
| ISK            | 2           |
| RSD            | 2           |
| MRU            | 2           |
| GHS            | 2           |