### PR TITLE
Trigger didOpenExternalApplication on BrowserComponent

### DIFF
--- a/AdyenActions/Components/Redirect/BrowserComponent.swift
+++ b/AdyenActions/Components/Redirect/BrowserComponent.swift
@@ -83,4 +83,9 @@ extension BrowserComponent: SFSafariViewControllerDelegate, UIAdaptivePresentati
         self.delegate?.didCancel()
     }
 
+    /// Called when the user opens the current page in the default browser by tapping the toolbar button.
+    internal func safariViewControllerWillOpenInBrowser(_ controller: SFSafariViewController) {
+        self.delegate?.didOpenExternalApplication()
+    }
+
 }


### PR DESCRIPTION
# Open PR

## Changes

<new>

* For redirect payment methods, when the shopper opens the current payment web page in the default browser by selecting the toolbar button, `RedirectComponent` now triggers `ActionComponentDelegate.didOpenExternalApplication`.

</new>