### PR TITLE
change: v5 Xcode 15 fixes

### DIFF
--- a/Adyen.docc/Installation.md
+++ b/Adyen.docc/Installation.md
@@ -6,7 +6,7 @@ Adyen Components for iOS are available through either CocoaPods, Carthage or Swi
 
 - iOS 12.0+
 - Xcode 11.0+
-- Swift 5.1
+- Swift 5.7
 
 ### CocoaPods
 

--- a/Adyen.docc/Installation.md
+++ b/Adyen.docc/Installation.md
@@ -4,7 +4,7 @@ Adyen Components for iOS are available through either CocoaPods, Carthage or Swi
 
 ### Requirements
 
-- iOS 11.0+
+- iOS 12.0+
 - Xcode 11.0+
 - Swift 5.1
 

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -79,6 +79,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Encryption' do |plugin|
+    plugin.dependency 'Adyen/Core'
     plugin.source_files = 'AdyenEncryption/**/*.swift'
   end
 

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   s.author = { 'Adyen' => 'support@adyen.com' }
   s.source = { :git => 'https://github.com/Adyen/adyen-ios.git', :tag => "#{s.version}" }
   s.platform = :ios
-  s.ios.deployment_target = '11.0'
-  s.swift_version = '5.1'
+  s.ios.deployment_target = '12.0'
+  s.swift_version = '5.7'
   s.frameworks = 'Foundation'
   s.default_subspecs = 'Core', 'Components', 'Actions', 'Card', 'Encryption', 'DropIn', 'Session'
   s.pod_target_xcconfig = {'SWIFT_SUPPRESS_WARNINGS' => 'YES' }

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -7326,7 +7326,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Adyen. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7365,7 +7365,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Adyen. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7550,7 +7550,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Adyen/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7582,7 +7582,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Adyen/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7607,7 +7607,7 @@
 				CURRENT_PROJECT_VERSION = 6;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7628,7 +7628,7 @@
 				CURRENT_PROJECT_VERSION = 6;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7652,7 +7652,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AdyenCard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7679,7 +7679,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AdyenCard/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7707,7 +7707,7 @@
 				DEVELOPMENT_TEAM = B2NYSS5932;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Demo/UIKit/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7734,7 +7734,7 @@
 				DEVELOPMENT_TEAM = B2NYSS5932;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Demo/UIKit/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7761,7 +7761,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AdyenDropIn/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7790,7 +7790,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AdyenDropIn/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7819,7 +7819,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AdyenComponents/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7851,7 +7851,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AdyenComponents/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7883,7 +7883,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AdyenActions/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7915,7 +7915,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AdyenActions/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7947,7 +7947,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AdyenEncryption/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -7979,7 +7979,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AdyenEncryption/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8011,7 +8011,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Adyen. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8045,7 +8045,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2022 Adyen. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8250,7 +8250,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = AdyenWeChatPay/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8293,7 +8293,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = AdyenWeChatPay/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -515,8 +515,8 @@
 		E9E3DAD1221EEE2100697074 /* CardExpiryDateValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DAD0221EEE2100697074 /* CardExpiryDateValidator.swift */; };
 		E9E3DAD3221EEFF700697074 /* CardExpiryDateValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DAD2221EEFF700697074 /* CardExpiryDateValidatorTests.swift */; };
 		E9E3DAFF2225488900697074 /* Completion.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DAFE2225488900697074 /* Completion.swift */; };
-		E9E3DB03222548E100697074 /* Coder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DB02222548E100697074 /* Coder.swift */; };
-		E9E3DB062226B3B200697074 /* CoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DB052226B3B200697074 /* CoderTests.swift */; };
+		E9E3DB03222548E100697074 /* AdyenCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DB02222548E100697074 /* AdyenCoder.swift */; };
+		E9E3DB062226B3B200697074 /* AdyenCoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DB052226B3B200697074 /* AdyenCoderTests.swift */; };
 		F90E95F02726B625007E382B /* DropInComponentExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90E95EF2726B625007E382B /* DropInComponentExtensions.swift */; };
 		F90E95F227280BD5007E382B /* CoreListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90E95F127280BD5007E382B /* CoreListDataSource.swift */; };
 		F90E95F62728106D007E382B /* DiffableListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F90E95F52728106D007E382B /* DiffableListDataSource.swift */; };
@@ -864,7 +864,7 @@
 		F9CCA3D1296ECCEE00AD643D /* XCTestCase+FormAddressItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92F6DC026B04B63004BD516 /* XCTestCase+FormAddressItem.swift */; };
 		F9CCA3D2296ECCFA00AD643D /* XCTestCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96AE51A26038602009F82BD /* XCTestCaseExtension.swift */; };
 		F9CCA3D3296ECD0700AD643D /* PostalAddressMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92F6DBD26AFF336004BD516 /* PostalAddressMocks.swift */; };
-		F9CCA3D5296ECD3000AD643D /* Coder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DB02222548E100697074 /* Coder.swift */; };
+		F9CCA3D5296ECD3000AD643D /* AdyenCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DB02222548E100697074 /* AdyenCoder.swift */; };
 		F9CCA3D6296ECD3C00AD643D /* PresentationDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9639B5124E29E340073F38A /* PresentationDelegateMock.swift */; };
 		F9CCA3D7296ECDB200AD643D /* XCTestCase+Coder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EACBC5288013990082B360 /* XCTestCase+Coder.swift */; };
 		F9CCA3DA296ECDF900AD643D /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = F9CCA3D9296ECDF900AD643D /* SnapshotTesting */; };
@@ -1755,8 +1755,8 @@
 		E9E3DAF822241D6000697074 /* CardPayload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardPayload.swift; sourceTree = "<group>"; };
 		E9E3DAF922241D6000697074 /* CardEncryptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardEncryptor.swift; sourceTree = "<group>"; };
 		E9E3DAFE2225488900697074 /* Completion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Completion.swift; sourceTree = "<group>"; };
-		E9E3DB02222548E100697074 /* Coder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coder.swift; sourceTree = "<group>"; };
-		E9E3DB052226B3B200697074 /* CoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoderTests.swift; sourceTree = "<group>"; };
+		E9E3DB02222548E100697074 /* AdyenCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenCoder.swift; sourceTree = "<group>"; };
+		E9E3DB052226B3B200697074 /* AdyenCoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenCoderTests.swift; sourceTree = "<group>"; };
 		F90E95EF2726B625007E382B /* DropInComponentExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropInComponentExtensions.swift; sourceTree = "<group>"; };
 		F90E95F127280BD5007E382B /* CoreListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreListDataSource.swift; sourceTree = "<group>"; };
 		F90E95F52728106D007E382B /* DiffableListDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableListDataSource.swift; sourceTree = "<group>"; };
@@ -3098,7 +3098,7 @@
 				E270FDE7225CC4A7006C2CD0 /* Observable */,
 				F96286BC256BDEB000043FE3 /* CoreBundleExtension.swift */,
 				E97B972222B238C400505476 /* Analytics.swift */,
-				E9E3DB02222548E100697074 /* Coder.swift */,
+				E9E3DB02222548E100697074 /* AdyenCoder.swift */,
 				E9E3DAFE2225488900697074 /* Completion.swift */,
 				E9021DA9225789B1009CF7F4 /* Localization.swift */,
 				F96F44DC23BE487500871C1F /* LocalizationParameters.swift */,
@@ -4199,7 +4199,7 @@
 				F9BA21C52474113500D36A63 /* AmountFormatterTests.swift */,
 				E702BE182602525E00280682 /* AssertsTests.swift */,
 				F9838D22263193E000963483 /* BalanceCheckerTests.swift */,
-				E9E3DB052226B3B200697074 /* CoderTests.swift */,
+				E9E3DB052226B3B200697074 /* AdyenCoderTests.swift */,
 				81D8E2E82A5C06AC00BC12FD /* KeyboardObserverTests.swift */,
 				E7768BDB26B416C3000851B3 /* DateValidationTests.swift */,
 				F9BA21BE246D36AC00D36A63 /* LazyOptionalTests.swift */,
@@ -6438,7 +6438,7 @@
 				F9354BEF23A7C87600A6760B /* ImageStyle.swift in Sources */,
 				F9FE253B2625AED6001874BB /* PartialPaymentComponent.swift in Sources */,
 				81C4006D2A41A2BC007EC51C /* FormAddressPickerItemView.swift in Sources */,
-				E9E3DB03222548E100697074 /* Coder.swift in Sources */,
+				E9E3DB03222548E100697074 /* AdyenCoder.swift in Sources */,
 				A0C9B59B288AE34600D6BDAB /* InstallmentOptions.swift in Sources */,
 				81BA08412A4AD97400308160 /* FormValidatableValueItemView.swift in Sources */,
 				E9093401228C54CD00C9F04B /* LogoURLProvider.swift in Sources */,
@@ -6569,7 +6569,7 @@
 				E74D918325AF3FE600743B0C /* CardBrandProviderTests.swift in Sources */,
 				E773EA3C2523432B00119499 /* CardTypeProviderMock.swift in Sources */,
 				C97C16AC280702B200534419 /* TelemetryFlavorTests.swift in Sources */,
-				E9E3DB062226B3B200697074 /* CoderTests.swift in Sources */,
+				E9E3DB062226B3B200697074 /* AdyenCoderTests.swift in Sources */,
 				F99D4603262D647400880D72 /* AddressViewModelTests.swift in Sources */,
 				E9E3DABE221EA47800697074 /* StringExtensionsTests.swift in Sources */,
 				F95B6D9025231880002C9062 /* PhoneNumberValidatorTests.swift in Sources */,
@@ -7071,7 +7071,7 @@
 				F9CCA3C4296ECB9900AD643D /* AtomeComponentUITests.swift in Sources */,
 				F9CCA3C9296ECB9900AD643D /* OnlineBankingComponentUITests.swift in Sources */,
 				0022095D29A4C67700B2BACD /* AnalyticsProviderMock.swift in Sources */,
-				F9CCA3D5296ECD3000AD643D /* Coder.swift in Sources */,
+				F9CCA3D5296ECD3000AD643D /* AdyenCoder.swift in Sources */,
 				F9CCA3D6296ECD3C00AD643D /* PresentationDelegateMock.swift in Sources */,
 				F9CCA3DF296ED20D00AD643D /* XCTestCaseExtensions.swift in Sources */,
 				F9CCA3CD296ECC8800AD643D /* Dummy.swift in Sources */,

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -181,6 +181,8 @@
 		81E031942A0A75F200EA965E /* ConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A67461F264262F000E9184D /* ConfigurationView.swift */; };
 		81E031952A0A75F800EA965E /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A54600E264433CD00724A87 /* SearchBar.swift */; };
 		81EA6C122A44836E0071A141 /* FormAddressItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81EA6C112A44836E0071A141 /* FormAddressItemTests.swift */; };
+		81FAFB442AAF715F00828999 /* Adyen.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C0E03322097917008616F6 /* Adyen.framework */; };
+		81FAFB452AAF715F00828999 /* Adyen.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E2C0E03322097917008616F6 /* Adyen.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A009837D279859DC007E68C4 /* ACHDirectDebitComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A009837C279859DC007E68C4 /* ACHDirectDebitComponentTests.swift */; };
 		A009837F27986B50007E68C4 /* BankDetailsEncryptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A009837E27986B50007E68C4 /* BankDetailsEncryptorTests.swift */; };
 		A0113D9B2763887800AD395C /* ActionNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0113D9A2763887800AD395C /* ActionNavigationBar.swift */; };
@@ -931,6 +933,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		81FAFB462AAF715F00828999 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E2C0E02A22097917008616F6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E2C0E03222097917008616F6;
+			remoteInfo = Adyen;
+		};
 		A020EC4A29E6EC4C0050B2FE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E2C0E02A22097917008616F6 /* Project object */;
@@ -1179,6 +1188,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		81FAFB482AAF715F00828999 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				81FAFB452AAF715F00828999 /* Adyen.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E2C0E0A8220B0827008616F6 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2173,6 +2193,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				81FAFB442AAF715F00828999 /* Adyen.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5432,10 +5453,12 @@
 				F92326A925A3669E002C5BC4 /* Frameworks */,
 				F92326AA25A3669E002C5BC4 /* Resources */,
 				E7388FC1260B68C400291DE7 /* Format and lint */,
+				81FAFB482AAF715F00828999 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				81FAFB472AAF715F00828999 /* PBXTargetDependency */,
 			);
 			name = AdyenEncryption;
 			productName = AdyenEncryption;
@@ -7075,6 +7098,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		81FAFB472AAF715F00828999 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E2C0E03222097917008616F6 /* Adyen */;
+			targetProxy = 81FAFB462AAF715F00828999 /* PBXContainerItemProxy */;
+		};
 		A020EC4B29E6EC4C0050B2FE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A04F8C1D29E5950100F3F62B /* AdyenCashAppPay */;

--- a/Adyen/Utilities/AdyenCoder.swift
+++ b/Adyen/Utilities/AdyenCoder.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// An object that provides helper functions for coding and decoding responses.
 @_spi(AdyenInternal)
-public enum Coder {
+public enum AdyenCoder {
     
     // MARK: - Decoding
     

--- a/Adyen/Utilities/Coder.swift
+++ b/Adyen/Utilities/Coder.swift
@@ -64,6 +64,7 @@ public enum Coder {
     private static let encoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .sortedKeys
         
         return encoder
     }()

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -81,7 +81,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
     private func createFingerprint(_ action: ThreeDS2FingerprintAction,
                                    completionHandler: @escaping (Result<String, Error>) -> Void) {
         do {
-            let token = try Coder.decodeBase64(action.fingerprintToken) as ThreeDS2Component.FingerprintToken
+            let token = try AdyenCoder.decodeBase64(action.fingerprintToken) as ThreeDS2Component.FingerprintToken
 
             let serviceParameters = ADYServiceParameters()
             serviceParameters.directoryServerIdentifier = token.directoryServerIdentifier
@@ -101,7 +101,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
         do {
             switch transaction(messageVersion: messageVersion) {
             case let .success(transaction):
-                let encodedFingerprint = try Coder.encodeBase64(ThreeDS2Component.Fingerprint(
+                let encodedFingerprint = try AdyenCoder.encodeBase64(ThreeDS2Component.Fingerprint(
                     authenticationRequestParameters: transaction.authenticationParameters,
                     delegatedAuthenticationSDKOutput: nil
                 ))
@@ -109,7 +109,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
                 completionHandler(.success(encodedFingerprint))
 
             case let .failure(error):
-                let encodedError = try Coder.encodeBase64(ThreeDS2Component.Fingerprint(threeDS2SDKError: error.base64Representation()))
+                let encodedError = try AdyenCoder.encodeBase64(ThreeDS2Component.Fingerprint(threeDS2SDKError: error.base64Representation()))
                 completionHandler(.success(encodedError))
             }
         } catch {
@@ -144,7 +144,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
 
         let token: ThreeDS2Component.ChallengeToken
         do {
-            token = try Coder.decodeBase64(challengeAction.challengeToken) as ThreeDS2Component.ChallengeToken
+            token = try AdyenCoder.decodeBase64(challengeAction.challengeToken) as ThreeDS2Component.ChallengeToken
         } catch {
             return didFail(with: error, completionHandler: completionHandler)
         }

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
@@ -102,8 +102,8 @@
         
         private func addSDKOutputIfNeeded(toFingerprintResult fingerprintResult: String, _ fingerprintAction: ThreeDS2FingerprintAction, completionHandler: @escaping (Result<String, Error>) -> Void) {
             do {
-                let token = try Coder.decodeBase64(fingerprintAction.fingerprintToken) as ThreeDS2Component.FingerprintToken
-                let fingerprintResult: ThreeDS2Component.Fingerprint = try Coder.decodeBase64(fingerprintResult)
+                let token = try AdyenCoder.decodeBase64(fingerprintAction.fingerprintToken) as ThreeDS2Component.FingerprintToken
+                let fingerprintResult: ThreeDS2Component.Fingerprint = try AdyenCoder.decodeBase64(fingerprintResult)
                 performDelegatedAuthentication(token) { [weak self] result in
                     guard let self else { return }
                     self.delegatedAuthenticationState.isDeviceRegistrationFlow = result.successResult == nil
@@ -141,7 +141,7 @@
                 let fingerprintResult = fingerprintResult.withDelegatedAuthenticationSDKOutput(
                     delegatedAuthenticationSDKOutput: authenticationSDKOutput
                 )
-                let encodedFingerprintResult = try Coder.encodeBase64(fingerprintResult)
+                let encodedFingerprintResult = try AdyenCoder.encodeBase64(fingerprintResult)
                 return encodedFingerprintResult
             } catch {
                 didFail(with: error, completionHandler: completionHandler)
@@ -174,7 +174,7 @@
                                           completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void) {
             let token: ThreeDS2Component.ChallengeToken
             do {
-                token = try Coder.decodeBase64(challengeAction.challengeToken) as ThreeDS2Component.ChallengeToken
+                token = try AdyenCoder.decodeBase64(challengeAction.challengeToken) as ThreeDS2Component.ChallengeToken
             } catch {
                 return didFail(with: error, completionHandler: completionHandler)
             }

--- a/AdyenActions/Components/3DS2/ThreeDSResult.swift
+++ b/AdyenActions/Components/3DS2/ThreeDSResult.swift
@@ -27,8 +27,7 @@ public struct ThreeDSResult: Decodable {
                               delegatedAuthenticationSDKOutput: nil,
                               threeDS2SDKError: threeDS2SDKError,
                               transStatus: transStatus)
-        let payloadData = try JSONEncoder().encode(payload)
-        self.payload = payloadData.base64EncodedString()
+        self.payload = try Coder.encode(payload).base64EncodedString()
     }
     
     internal init(from challengeResult: AnyChallengeResult,
@@ -39,10 +38,8 @@ public struct ThreeDSResult: Decodable {
                               delegatedAuthenticationSDKOutput: delegatedAuthenticationSDKOutput,
                               threeDS2SDKError: threeDS2SDKError,
                               transStatus: challengeResult.transactionStatus)
-        
-        let payloadData = try JSONEncoder().encode(payload)
 
-        self.payload = payloadData.base64EncodedString()
+        self.payload = try Coder.encode(payload).base64EncodedString()
     }
 
     public init(from decoder: Decoder) throws {
@@ -56,8 +53,7 @@ public struct ThreeDSResult: Decodable {
                                  delegatedAuthenticationSDKOutput: delegatedAuthenticationSDKOutput,
                                  threeDS2SDKError: oldPayload.threeDS2SDKError,
                                  transStatus: oldPayload.transStatus)
-        let newPayloadData = try JSONEncoder().encode(newPayload)
-        return .init(payload: newPayloadData.base64EncodedString())
+        return .init(payload: try Coder.encode(newPayload).base64EncodedString())
     }
 
     internal init(authenticated: Bool, authorizationToken: String?) throws {

--- a/AdyenActions/Components/3DS2/ThreeDSResult.swift
+++ b/AdyenActions/Components/3DS2/ThreeDSResult.swift
@@ -27,7 +27,7 @@ public struct ThreeDSResult: Decodable {
                               delegatedAuthenticationSDKOutput: nil,
                               threeDS2SDKError: threeDS2SDKError,
                               transStatus: transStatus)
-        self.payload = try Coder.encode(payload).base64EncodedString()
+        self.payload = try AdyenCoder.encode(payload).base64EncodedString()
     }
     
     internal init(from challengeResult: AnyChallengeResult,
@@ -39,7 +39,7 @@ public struct ThreeDSResult: Decodable {
                               threeDS2SDKError: threeDS2SDKError,
                               transStatus: challengeResult.transactionStatus)
 
-        self.payload = try Coder.encode(payload).base64EncodedString()
+        self.payload = try AdyenCoder.encode(payload).base64EncodedString()
     }
 
     public init(from decoder: Decoder) throws {
@@ -48,12 +48,12 @@ public struct ThreeDSResult: Decodable {
     }
     
     internal func withDelegatedAuthenticationSDKOutput(delegatedAuthenticationSDKOutput: String?) throws -> ThreeDSResult {
-        let oldPayload: Payload = try Coder.decodeBase64(payload)
+        let oldPayload: Payload = try AdyenCoder.decodeBase64(payload)
         let newPayload = Payload(authorisationToken: oldPayload.authorisationToken,
                                  delegatedAuthenticationSDKOutput: delegatedAuthenticationSDKOutput,
                                  threeDS2SDKError: oldPayload.threeDS2SDKError,
                                  transStatus: oldPayload.transStatus)
-        return .init(payload: try Coder.encode(newPayload).base64EncodedString())
+        return .init(payload: try AdyenCoder.encode(newPayload).base64EncodedString())
     }
 
     internal init(authenticated: Bool, authorizationToken: String?) throws {

--- a/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryption.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryption.swift
@@ -70,7 +70,7 @@ internal struct JSONWebEncryption {
         self.encryptedPayload = encryptedPayload
         self.initializationVector = initializationVector
         self.authenticationTag = authenticationTag
-        self.compactRepresentation = try [Coder.encode(header).base64URLString(),
+        self.compactRepresentation = try [AdyenCoder.encode(header).base64URLString(),
                                           encryptedKey.base64URLString(),
                                           initializationVector.base64URLString(),
                                           encryptedPayload.base64URLString(),

--- a/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryption.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryption.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+@_spi(AdyenInternal) import Adyen
 
 internal struct JSONWebEncryption {
     internal struct Header: Encodable {
@@ -69,7 +70,7 @@ internal struct JSONWebEncryption {
         self.encryptedPayload = encryptedPayload
         self.initializationVector = initializationVector
         self.authenticationTag = authenticationTag
-        self.compactRepresentation = try [JSONEncoder().encode(header).base64URLString(),
+        self.compactRepresentation = try [Coder.encode(header).base64URLString(),
                                           encryptedKey.base64URLString(),
                                           initializationVector.base64URLString(),
                                           encryptedPayload.base64URLString(),

--- a/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryptionGenerator.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryptionGenerator.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+@_spi(AdyenInternal) import Adyen
 
 internal protocol AnyJSONWebEncryptionGenerator {
     func generate(withPayload: Data,
@@ -22,7 +23,7 @@ internal struct JSONWebEncryptionGenerator: AnyJSONWebEncryptionGenerator {
         let contentEncryptionKey = try generateRandomData(length: contentEncryptionAlgorithm.keyLength)
         let encryptedKey = try keyEncryptionAlgorithm.encrypt(contentEncryptionKey, withKey: publicRSAKey)
         
-        let encodedHeader = try JSONEncoder().encode(header)
+        let encodedHeader = try Coder.encode(header) as Data
         
         let initializationVector = try generateRandomData(length: contentEncryptionAlgorithm.initializationVectorLength)
         guard let additionalAuthenticationData = encodedHeader.base64URLString().data(using: .ascii) else {

--- a/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryptionGenerator.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryptionGenerator.swift
@@ -23,7 +23,7 @@ internal struct JSONWebEncryptionGenerator: AnyJSONWebEncryptionGenerator {
         let contentEncryptionKey = try generateRandomData(length: contentEncryptionAlgorithm.keyLength)
         let encryptedKey = try keyEncryptionAlgorithm.encrypt(contentEncryptionKey, withKey: publicRSAKey)
         
-        let encodedHeader = try Coder.encode(header) as Data
+        let encodedHeader = try AdyenCoder.encode(header) as Data
         
         let initializationVector = try generateRandomData(length: contentEncryptionAlgorithm.initializationVectorLength)
         guard let additionalAuthenticationData = encodedHeader.base64URLString().data(using: .ascii) else {

--- a/AdyenEncryption/Payload/Payload.swift
+++ b/AdyenEncryption/Payload/Payload.swift
@@ -13,6 +13,6 @@ internal protocol Payload: Encodable {
 
 extension Payload {
     internal func jsonData() throws -> Data {
-        return try Coder.encode(self)
+        return try AdyenCoder.encode(self)
     }
 }

--- a/AdyenEncryption/Payload/Payload.swift
+++ b/AdyenEncryption/Payload/Payload.swift
@@ -13,6 +13,6 @@ internal protocol Payload: Encodable {
 
 extension Payload {
     internal func jsonData() throws -> Data {
-        return try AdyenCoder.encode(self)
+        try AdyenCoder.encode(self)
     }
 }

--- a/AdyenEncryption/Payload/Payload.swift
+++ b/AdyenEncryption/Payload/Payload.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+@_spi(AdyenInternal) import Adyen
 
 internal protocol Payload: Encodable {
     func jsonData() throws -> Data
@@ -12,6 +13,6 @@ internal protocol Payload: Encodable {
 
 extension Payload {
     internal func jsonData() throws -> Data {
-        try JSONEncoder().encode(self)
+        return try Coder.encode(self)
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Adyen",
     defaultLocalization: "en-us",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v12)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -87,7 +87,9 @@ let package = Package(
         ),
         .target(
             name: "AdyenEncryption",
-            dependencies: [],
+            dependencies: [
+                .target(name: "Adyen")
+	    ],
             path: "AdyenEncryption",
             exclude: [
                 "Info.plist"

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ A full list of customization options can be found in the [API Reference][referen
 
 - iOS 12.0+
 - Xcode 11.0+
-- Swift 5.1
+- Swift 5.7
 
 ## See also
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ A full list of customization options can be found in the [API Reference][referen
 
 ## Requirements
 
-- iOS 11.0+
+- iOS 12.0+
 - Xcode 11.0+
 - Swift 5.1
 

--- a/Scripts/test-CocoaPods-integration.sh
+++ b/Scripts/test-CocoaPods-integration.sh
@@ -45,7 +45,7 @@ mkdir -p $PROJECT_NAME && cd $PROJECT_NAME
 swift package init
 
 # Create the Package.swift.
-echo "// swift-tools-version:5.3
+echo "// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -53,7 +53,7 @@ import PackageDescription
 let package = Package(
     name: \"TempProject\",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v12)
     ],
     products: [
         .library(
@@ -81,7 +81,7 @@ swift package generate-xcodeproj
 
 if [ "$INCLUDE_WECHAT" == false ]
 then
-  echo "platform :ios, '11.0'
+  echo "platform :ios, '12.0'
 
   target '$PROJECT_NAME' do
     use_frameworks!
@@ -104,7 +104,7 @@ then
    end
   " >> Podfile
 else
-  echo "platform :ios, '11.0'
+  echo "platform :ios, '12.0'
 
   target '$PROJECT_NAME' do
     use_frameworks!

--- a/Scripts/test-SPM-integration.sh
+++ b/Scripts/test-SPM-integration.sh
@@ -13,7 +13,7 @@ mkdir -p $PROJECT_NAME && cd $PROJECT_NAME
 swift package init
 
 # Create the Package.swift.
-echo "// swift-tools-version:5.3
+echo "// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -22,7 +22,7 @@ let package = Package(
     name: \"TempProject\",
     defaultLocalization: \"en-US\",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v12)
     ],
     products: [
         .library(

--- a/Tests/Actions Tests/Voucher/BoletoVoucherShareableVoucherViewProviderTests.swift
+++ b/Tests/Actions Tests/Voucher/BoletoVoucherShareableVoucherViewProviderTests.swift
@@ -16,7 +16,7 @@ class BoletoVoucherShareableVoucherViewProviderTests: XCTestCase {
             environment: Dummy.apiContext.environment
         )
 
-        let boletoDecoded = try Coder.decode(boletoAction) as BoletoVoucherAction
+        let boletoDecoded = try AdyenCoder.decode(boletoAction) as BoletoVoucherAction
         let action: VoucherAction = .boletoBancairoSantander(boletoDecoded)
 
         let sut = viewProvider.provideView(with: action, logo: nil)

--- a/Tests/Actions Tests/Voucher/DokuVoucherUITests.swift
+++ b/Tests/Actions Tests/Voucher/DokuVoucherUITests.swift
@@ -14,7 +14,7 @@ class DokuVoucherUITests: XCTestCase {
         let viewControllerProvider = VoucherShareableViewProvider(style: VoucherComponentStyle(), environment: Dummy.apiContext.environment)
         viewControllerProvider.localizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
 
-        let dokuAction = try Coder.decode(dokuIndomaretAction) as DokuVoucherAction
+        let dokuAction = try AdyenCoder.decode(dokuIndomaretAction) as DokuVoucherAction
         let action: VoucherAction = .dokuIndomaret(dokuAction)
 
         let sut = viewControllerProvider.provideView(with: action, logo: nil)
@@ -52,7 +52,7 @@ class DokuVoucherUITests: XCTestCase {
     func testDokuIndomaretVoucher() throws {
         let viewProvider = VoucherShareableViewProvider(style: VoucherComponentStyle(), environment: Dummy.apiContext.environment)
 
-        let dokuAction = try Coder.decode(dokuIndomaretAction) as DokuVoucherAction
+        let dokuAction = try AdyenCoder.decode(dokuIndomaretAction) as DokuVoucherAction
         let action: VoucherAction = .dokuIndomaret(dokuAction)
 
         let sut = viewProvider.provideView(with: action, logo: nil)
@@ -90,7 +90,7 @@ class DokuVoucherUITests: XCTestCase {
     func testDokuAlfamartVoucher() throws {
         let viewProvider = VoucherShareableViewProvider(style: VoucherComponentStyle(), environment: Dummy.apiContext.environment)
 
-        let dokuAction = try Coder.decode(dokuAlfamartAction) as DokuVoucherAction
+        let dokuAction = try AdyenCoder.decode(dokuAlfamartAction) as DokuVoucherAction
         let action: VoucherAction = .dokuAlfamart(dokuAction)
 
         let sut = viewProvider.provideView(with: action, logo: nil)

--- a/Tests/Actions Tests/Voucher/EContextATMShareableVoucherViewProviderTests.swift
+++ b/Tests/Actions Tests/Voucher/EContextATMShareableVoucherViewProviderTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class EContextATMShareableVoucherViewProviderTests: XCTestCase {
 
     func testCustomLocalization() throws {
-        let econtextAction = try Coder.decode(econtextATMAction) as EContextATMVoucherAction
+        let econtextAction = try AdyenCoder.decode(econtextATMAction) as EContextATMVoucherAction
         let action: VoucherAction = .econtextATM(econtextAction)
 
         let viewProvider = VoucherShareableViewProvider(

--- a/Tests/Actions Tests/Voucher/EContextStoresVoucherViewControllerProviderTests.swift
+++ b/Tests/Actions Tests/Voucher/EContextStoresVoucherViewControllerProviderTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class EContextStoresVoucherViewControllerProviderTests: XCTestCase {
 
     func testCustomLocalization() throws {
-        let econtextAction = try Coder.decode(econtextStoresAction) as EContextStoresVoucherAction
+        let econtextAction = try AdyenCoder.decode(econtextStoresAction) as EContextStoresVoucherAction
         let action: VoucherAction = .econtextStores(econtextAction)
 
         let viewProvider = VoucherShareableViewProvider(

--- a/Tests/Actions Tests/Voucher/MultibancoShareableVoucherViewProviderTests.swift
+++ b/Tests/Actions Tests/Voucher/MultibancoShareableVoucherViewProviderTests.swift
@@ -18,7 +18,7 @@ class MultibancoShareableVoucherViewProviderTests: XCTestCase {
             environment: Dummy.apiContext.environment
         )
 
-        let multibancoDecoded = try Coder.decode(multibancoVoucher) as MultibancoVoucherAction
+        let multibancoDecoded = try AdyenCoder.decode(multibancoVoucher) as MultibancoVoucherAction
         let action: VoucherAction = .multibanco(multibancoDecoded)
 
         let sut = viewProvider.provideView(with: action, logo: nil)

--- a/Tests/Actions Tests/Voucher/OXXOShareableVoucherViewProviderTests.swift
+++ b/Tests/Actions Tests/Voucher/OXXOShareableVoucherViewProviderTests.swift
@@ -18,7 +18,7 @@ class OXXOShareableVoucherViewProviderTests: XCTestCase {
             environment: Dummy.apiContext.environment
         )
 
-        let oxxoDecoded = try Coder.decode(oxxoAction) as OXXOVoucherAction
+        let oxxoDecoded = try AdyenCoder.decode(oxxoAction) as OXXOVoucherAction
         let action: VoucherAction = .oxxo(oxxoDecoded)
 
         let sut = viewProvider.provideView(with: action, logo: nil)

--- a/Tests/Actions Tests/Voucher/VoucherComponentTests.swift
+++ b/Tests/Actions Tests/Voucher/VoucherComponentTests.swift
@@ -24,7 +24,7 @@ class VoucherComponentTests: XCTestCase {
     }
 
     func testDokuVoucherComponent() throws {
-        let action = try Coder.decode(dokuIndomaretAction) as VoucherAction
+        let action = try AdyenCoder.decode(dokuIndomaretAction) as VoucherAction
 
         let presentationDelegateExpectation = expectation(description: "Expect presentationDelegate.present() to be called.")
         presentationDelegate.doPresent = { [self] component in
@@ -46,7 +46,7 @@ class VoucherComponentTests: XCTestCase {
     }
     
     func testEContextATMVoucherComponent() throws {
-        let action = try Coder.decode(econtextATMAction) as VoucherAction
+        let action = try AdyenCoder.decode(econtextATMAction) as VoucherAction
         
         let presentationDelegateExpectation = expectation(description: "Expect presentationDelegate.present() to be called.")
         presentationDelegate.doPresent = { [self] component in
@@ -68,7 +68,7 @@ class VoucherComponentTests: XCTestCase {
     }
     
     func testBoletoVoucherComponent() throws {
-        let action = try Coder.decode(boletoAction) as VoucherAction
+        let action = try AdyenCoder.decode(boletoAction) as VoucherAction
         
         let presentationDelegateExpectation = expectation(description: "Expect presentationDelegate.present() to be called.")
         presentationDelegate.doPresent = { [self] component in
@@ -90,7 +90,7 @@ class VoucherComponentTests: XCTestCase {
     }
     
     func testOXXOVoucherComponent() throws {
-        let action = try Coder.decode(oxxoAction) as VoucherAction
+        let action = try AdyenCoder.decode(oxxoAction) as VoucherAction
         
         let presentationDelegateExpectation = expectation(description: "Expect presentationDelegate.present() to be called.")
         presentationDelegate.doPresent = { [self] component in
@@ -130,7 +130,7 @@ class VoucherComponentTests: XCTestCase {
     }
     
     func testMultibancoVoucherComponent() throws {
-        let action = try Coder.decode(multibancoVoucher) as VoucherAction
+        let action = try AdyenCoder.decode(multibancoVoucher) as VoucherAction
         
         let presentationDelegateExpectation = expectation(description: "Expect presentationDelegate.present() to be called.")
         presentationDelegate.doPresent = { [self] component in
@@ -169,7 +169,7 @@ class VoucherComponentTests: XCTestCase {
     }
     
     func testEContextStoresVoucherComponent() throws {
-        let action = try Coder.decode(econtextStoresAction) as VoucherAction
+        let action = try AdyenCoder.decode(econtextStoresAction) as VoucherAction
         
         let presentationDelegateExpectation = expectation(description: "Expect presentationDelegate.present() to be called.")
         presentationDelegate.doPresent = { [self] component in

--- a/Tests/Adyen Tests/Core/PaymentMethodTests.swift
+++ b/Tests/Adyen Tests/Core/PaymentMethodTests.swift
@@ -77,7 +77,7 @@ class PaymentMethodTests: XCTestCase {
                 mealVoucherSodexo
             ]
         ]
-        return try Coder.decode(dictionary) as PaymentMethods
+        return try AdyenCoder.decode(dictionary) as PaymentMethods
     }
     
     func testDecodingPaymentMethods() throws {
@@ -589,7 +589,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - Card
     
     func testDecodingCreditCardPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(creditCardDictionary) as CardPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(creditCardDictionary) as CardPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "scheme")
         XCTAssertEqual(paymentMethod.name, "Credit Card")
         XCTAssertEqual(paymentMethod.fundingSource!, .credit)
@@ -597,7 +597,7 @@ class PaymentMethodTests: XCTestCase {
     }
     
     func testDecodingDebitCardPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(debitCardDictionary) as CardPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(debitCardDictionary) as CardPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "scheme")
         XCTAssertEqual(paymentMethod.name, "Credit Card")
         XCTAssertEqual(paymentMethod.fundingSource!, .debit)
@@ -605,7 +605,7 @@ class PaymentMethodTests: XCTestCase {
     }
     
     func testDecodingBCMCCardPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(bcmcCardDictionary) as CardPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(bcmcCardDictionary) as CardPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "bcmc")
         XCTAssertEqual(paymentMethod.name, "Bancontact card")
         XCTAssertEqual(paymentMethod.brands, [])
@@ -615,14 +615,14 @@ class PaymentMethodTests: XCTestCase {
         var dictionary = creditCardDictionary
         dictionary.removeValue(forKey: "brands")
         
-        let paymentMethod = try Coder.decode(dictionary) as CardPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(dictionary) as CardPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "scheme")
         XCTAssertEqual(paymentMethod.name, "Credit Card")
         XCTAssertTrue(paymentMethod.brands.isEmpty)
     }
     
     func testDecodingStoredCreditCardPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(storedCreditCardDictionary) as StoredCardPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(storedCreditCardDictionary) as StoredCardPaymentMethod
         let expectedLocalizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
         XCTAssertEqual(paymentMethod.type.rawValue, "scheme")
         XCTAssertEqual(paymentMethod.name, "VISA")
@@ -638,7 +638,7 @@ class PaymentMethodTests: XCTestCase {
     }
     
     func testDecodingStoredDebitCardPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(storedDebitCardDictionary) as StoredCardPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(storedDebitCardDictionary) as StoredCardPaymentMethod
         let expectedLocalizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
         XCTAssertEqual(paymentMethod.type.rawValue, "scheme")
         XCTAssertEqual(paymentMethod.name, "VISA")
@@ -671,7 +671,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - Issuer List
     
     func testDecodingIssuerListPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(issuerListDictionary) as IssuerListPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(issuerListDictionary) as IssuerListPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "ideal")
         XCTAssertEqual(paymentMethod.name, "iDEAL")
         
@@ -685,7 +685,7 @@ class PaymentMethodTests: XCTestCase {
     }
 
     func testDecodingIssuerListPaymentMethodWithoutDetailsObject() throws {
-        let paymentMethod = try Coder.decode(issuerListDictionaryWithoutDetailsObject) as IssuerListPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(issuerListDictionaryWithoutDetailsObject) as IssuerListPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "ideal_100")
         XCTAssertEqual(paymentMethod.name, "iDEAL_100")
 
@@ -706,7 +706,7 @@ class PaymentMethodTests: XCTestCase {
     ] as [String: Any]
     
     func testDecodingSEPADirectDebitPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(sepaDirectDebitDictionary) as SEPADirectDebitPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(sepaDirectDebitDictionary) as SEPADirectDebitPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "sepadirectdebit")
         XCTAssertEqual(paymentMethod.name, "SEPA Direct Debit")
     }
@@ -714,7 +714,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - Stored PayPal
     
     func testDecodingPayPalPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(storedPayPalDictionary) as StoredPayPalPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(storedPayPalDictionary) as StoredPayPalPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "paypal")
         XCTAssertEqual(paymentMethod.identifier, "9314881977134903")
         XCTAssertEqual(paymentMethod.name, "PayPal")
@@ -725,7 +725,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - Apple Pay
     
     func testDecodingApplePayPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(applePayDictionary) as ApplePayPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(applePayDictionary) as ApplePayPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "applepay")
         XCTAssertEqual(paymentMethod.name, "Apple Pay")
     }
@@ -733,7 +733,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - Bancontact
     
     func testDecodingBancontactPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(bcmcCardDictionary) as BCMCPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(bcmcCardDictionary) as BCMCPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "bcmc")
         XCTAssertEqual(paymentMethod.name, "Bancontact card")
     }
@@ -741,7 +741,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - GiroPay
     
     func testDecodingGiropayPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(giroPayDictionaryWithOptionalDetails) as InstantPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(giroPayDictionaryWithOptionalDetails) as InstantPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "giropay")
         XCTAssertEqual(paymentMethod.name, "GiroPay")
     }
@@ -749,7 +749,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - Seven Eleven
 
     func testDecodingSevenElevenPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(sevenElevenDictionary) as SevenElevenPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(sevenElevenDictionary) as SevenElevenPaymentMethod
         XCTAssertEqual(paymentMethod.name, "7-Eleven")
         XCTAssertEqual(paymentMethod.type.rawValue, "econtext_seven_eleven")
     }
@@ -757,7 +757,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - E-Context Online
 
     func testDecodingEContextOnlinePaymentMethod() throws {
-        let paymentMethod = try Coder.decode(econtextOnline) as EContextPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(econtextOnline) as EContextPaymentMethod
         XCTAssertEqual(paymentMethod.name, "Online Banking")
         XCTAssertEqual(paymentMethod.type.rawValue, "econtext_online")
     }
@@ -765,7 +765,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - OXXO
 
     func testDecodingOXXOPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(oxxo) as OXXOPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(oxxo) as OXXOPaymentMethod
         XCTAssertEqual(paymentMethod.name, "OXXO")
         XCTAssertEqual(paymentMethod.type.rawValue, "oxxo")
     }
@@ -773,7 +773,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - E-Context ATM
 
     func testDecodingEContextATMPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(econtextATM) as EContextPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(econtextATM) as EContextPaymentMethod
         XCTAssertEqual(paymentMethod.name, "Pay-easy ATM")
         XCTAssertEqual(paymentMethod.type.rawValue, "econtext_atm")
     }
@@ -781,7 +781,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - E-Context Stores
 
     func testDecodingEContextStoresPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(econtextStores) as EContextPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(econtextStores) as EContextPaymentMethod
         XCTAssertEqual(paymentMethod.name, "Convenience Stores")
         XCTAssertEqual(paymentMethod.type.rawValue, "econtext_stores")
     }
@@ -789,7 +789,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - Stored Bancontact
     
     func testDecodingStoredBancontactPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(storedBcmcDictionary) as StoredBCMCPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(storedBcmcDictionary) as StoredBCMCPaymentMethod
         let expectedLocalizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
         XCTAssertEqual(paymentMethod.type.rawValue, "bcmc")
         XCTAssertEqual(paymentMethod.brand, "bcmc")
@@ -809,7 +809,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - MBWay
 
     func testDecodingMBWayPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(mbway) as MBWayPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(mbway) as MBWayPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "mbway")
         XCTAssertEqual(paymentMethod.name, "MB WAY")
     }
@@ -817,7 +817,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - Doku wallet
 
     func testDecodingDokuWalletPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(dokuWallet) as DokuPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(dokuWallet) as DokuPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "doku_wallet")
         XCTAssertEqual(paymentMethod.name, "DOKU wallet")
     }
@@ -841,7 +841,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - GiftCard
 
     func testDecodingGiftCardPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(giftCard) as GiftCardPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(giftCard) as GiftCardPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "giftcard")
         XCTAssertEqual(paymentMethod.name, "Generic GiftCard")
         XCTAssertEqual(paymentMethod.displayInformation(using: nil).logoName, "genericgiftcard")
@@ -849,7 +849,7 @@ class PaymentMethodTests: XCTestCase {
     }
     
     func testDecodingMealVoucherPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(mealVoucherSodexo) as MealVoucherPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(mealVoucherSodexo) as MealVoucherPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "mealVoucher_FR_sodexo")
         XCTAssertEqual(paymentMethod.name, "Sodexo")
         XCTAssertEqual(paymentMethod.displayInformation(using: nil).title, "Sodexo")
@@ -859,7 +859,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - Boleto
     
     func testDecodingBoletoPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(boleto) as BoletoPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(boleto) as BoletoPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "boletobancario_santander")
         XCTAssertEqual(paymentMethod.name, "Boleto Bancario")
         XCTAssertEqual(paymentMethod.displayInformation(using: nil).logoName, "boletobancario_santander")
@@ -869,7 +869,7 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - BACS Direct Debit
 
     func testDecodingBACSDirectDebitPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(bacsDirectDebit) as BACSDirectDebitPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(bacsDirectDebit) as BACSDirectDebitPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "directdebit_GB")
         XCTAssertEqual(paymentMethod.name, "BACS Direct Debit")
     }
@@ -877,13 +877,13 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - ACH Direct Debit
 
     func testDecodingACHDirectDebitPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(achDirectDebit) as ACHDirectDebitPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(achDirectDebit) as ACHDirectDebitPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "ach")
         XCTAssertEqual(paymentMethod.name, "ACH Direct Debit")
     }
     
     func testDecodingStoredACHDirectDebitPaymentMethod() throws {
-        let paymentMethod = try Coder.decode(storedACHDictionary) as StoredACHDirectDebitPaymentMethod
+        let paymentMethod = try AdyenCoder.decode(storedACHDictionary) as StoredACHDirectDebitPaymentMethod
         XCTAssertEqual(paymentMethod.type.rawValue, "ach")
         XCTAssertEqual(paymentMethod.name, "ACH Direct Debit")
         XCTAssertEqual(paymentMethod.bankAccountNumber, "123456789")

--- a/Tests/Adyen Tests/Utilities/AdyenCoderTests.swift
+++ b/Tests/Adyen Tests/Utilities/AdyenCoderTests.swift
@@ -7,10 +7,10 @@
 @_spi(AdyenInternal) @testable import Adyen
 import XCTest
 
-class CoderTests: XCTestCase {
+class AdyenCoderTests: XCTestCase {
     
-    func testDecodeWithString() {
-        let sampleObject = try! Coder.decode(sampleObjectRawString) as SampleObject
+    func testDecodeWithString() throws {
+        let sampleObject = try AdyenCoder.decode(sampleObjectRawString) as SampleObject
         
         XCTAssertEqual(sampleObject.string, "someString")
         XCTAssertEqual(sampleObject.integer, 99)
@@ -18,9 +18,9 @@ class CoderTests: XCTestCase {
         XCTAssertEqual(sampleObject.nestedObject.nestedValue, "value")
     }
     
-    func testDecodeWithData() {
+    func testDecodeWithData() throws {
         let data = sampleObjectRawString.data(using: .utf8)!
-        let sampleObject = try! Coder.decode(data) as SampleObject
+        let sampleObject = try AdyenCoder.decode(data) as SampleObject
         
         XCTAssertEqual(sampleObject.string, "someString")
         XCTAssertEqual(sampleObject.integer, 99)
@@ -28,14 +28,14 @@ class CoderTests: XCTestCase {
         XCTAssertEqual(sampleObject.nestedObject.nestedValue, "value")
     }
     
-    func testEncodeToString() {
-        let encodedString = try! Coder.encode(sampleObject) as String
+    func testEncodeToString() throws {
+        let encodedString = try AdyenCoder.encode(sampleObject) as String
         
         XCTAssertEqual(encodedString, sampleObjectRawString)
     }
     
-    func testEncodeToData() {
-        let encodedData = try! Coder.encode(sampleObject) as Data
+    func testEncodeToData() throws {
+        let encodedData = try AdyenCoder.encode(sampleObject) as Data
         let expectedData = sampleObjectRawString.data(using: .utf8)
         
         XCTAssertEqual(encodedData, expectedData)

--- a/Tests/Adyen Tests/Utilities/AmountFormatterTests.swift
+++ b/Tests/Adyen Tests/Utilities/AmountFormatterTests.swift
@@ -76,7 +76,12 @@ class AmountFormatterTests: XCTestCase {
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "ko_KR"), "CVE 123,456")
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "fr_FR"), "123 456 CVE")
             
-            XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "1.234,56 ISK")
+            if Available.iOS17 {
+                XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "1.234,56 kr.")
+            } else {
+                XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "1.234,56 ISK")
+            }
+            
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK"), "ISK 1,234.56")
         } else {
             // pre iOS 13 formatting seems to add a character that looks exactly like a space but is not a space.

--- a/Tests/Adyen Tests/Utilities/CoderTests.swift
+++ b/Tests/Adyen Tests/Utilities/CoderTests.swift
@@ -43,7 +43,7 @@ class CoderTests: XCTestCase {
     
     // MARK: - Private
     
-    private let sampleObjectRawString = "{\"nested\":{\"nestedValue\":\"value\"},\"string\":\"someString\",\"some_integer\":99,\"date\":\"2015-02-28T21:30:00Z\"}"
+    private let sampleObjectRawString = "{\"date\":\"2015-02-28T21:30:00Z\",\"nested\":{\"nestedValue\":\"value\"},\"some_integer\":99,\"string\":\"someString\"}"
     
     private lazy var sampleObject: SampleObject = {
         let nestedObject = NestedObject(nestedValue: "value")

--- a/Tests/Adyen Tests/Utilities/LogoGeneratorTests.swift
+++ b/Tests/Adyen Tests/Utilities/LogoGeneratorTests.swift
@@ -14,7 +14,7 @@ class LogoURLProviderTests: XCTestCase {
     let scale = Int(UIScreen.main.scale)
 
     func testCardLogo() {
-        let paymentMethod = try! Coder.decode(creditCardDictionary) as CardPaymentMethod
+        let paymentMethod = try! AdyenCoder.decode(creditCardDictionary) as CardPaymentMethod
         let logo = LogoURLProvider.logoURL(
             withName: paymentMethod.displayInformation(using: nil).logoName,
             environment: Dummy.apiContext.environment
@@ -23,7 +23,7 @@ class LogoURLProviderTests: XCTestCase {
     }
 
     func testSize() {
-        let paymentMethod = try! Coder.decode(creditCardDictionary) as CardPaymentMethod
+        let paymentMethod = try! AdyenCoder.decode(creditCardDictionary) as CardPaymentMethod
         let logo = LogoURLProvider.logoURL(
             withName: paymentMethod.displayInformation(using: nil).logoName,
             environment: Dummy.apiContext.environment,
@@ -47,7 +47,7 @@ class LogoURLProviderTests: XCTestCase {
     }
 
     func testGiftCardLogo() {
-        let paymentMethod = try! Coder.decode(giftCard) as GiftCardPaymentMethod
+        let paymentMethod = try! AdyenCoder.decode(giftCard) as GiftCardPaymentMethod
         let logo = LogoURLProvider.logoURL(
             withName: paymentMethod.displayInformation(using: nil).logoName,
             environment: Dummy.apiContext.environment

--- a/Tests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
+++ b/Tests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
@@ -69,7 +69,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
             authenticationRequestParameters: authenticationRequestParameters,
             delegatedAuthenticationSDKOutput: nil
         )
-        let expectedFingerprint = try Coder.encodeBase64(fingerprint)
+        let expectedFingerprint = try AdyenCoder.encodeBase64(fingerprint)
         
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
         let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, service: service)
@@ -202,7 +202,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
                             let threeDS2SDKError: String?
                         }
                         // Check if there is a threeDS2SDKError in the payload.
-                        let payload: Payload? = try? Coder.decodeBase64(threeDSResult.payload)
+                        let payload: Payload? = try? AdyenCoder.decodeBase64(threeDSResult.payload)
                         XCTAssertNotNil(payload?.threeDS2SDKError)
                     default:
                         XCTFail()

--- a/Tests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
@@ -162,7 +162,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
                             let threeDS2SDKError: String?
                         }
                         // Check if there is a threeDS2SDKError in the payload.
-                        let payload: Payload? = try? Coder.decodeBase64(threeDSResult.payload)
+                        let payload: Payload? = try? AdyenCoder.decodeBase64(threeDSResult.payload)
                         XCTAssertNotNil(payload?.threeDS2SDKError)
                     default:
                         XCTFail()

--- a/Tests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -105,7 +105,7 @@ import XCTest
             sut.handle(fingerprintAction, event: analyticsEvent) { fingerprintResult in
                 switch fingerprintResult {
                 case let .success(fingerprintString):
-                    let fingerprint: ThreeDS2Component.Fingerprint = try! Coder.decodeBase64(fingerprintString)
+                    let fingerprint: ThreeDS2Component.Fingerprint = try! AdyenCoder.decodeBase64(fingerprintString)
                     XCTAssertEqual(fingerprint, expectedFingerprint)
                 case .failure:
                     XCTFail()
@@ -225,7 +225,7 @@ import XCTest
                         let threeDS2SDKError: String?
                     }
 
-                    let payload: Payload? = try? Coder.decodeBase64(result.payload)
+                    let payload: Payload? = try? AdyenCoder.decodeBase64(result.payload)
                     XCTAssertNotNil(payload?.threeDS2SDKError)
                 case .failure:
                     XCTFail()

--- a/Tests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/Card Tests/BCMCComponentTests.swift
@@ -192,8 +192,7 @@ class BCMCComponentTests: XCTestCase {
         let didSubmitExpectation = XCTestExpectation(description: "Expect delegate.didSubmit() to be called")
         delegate.onDidSubmit = { paymentData, component in
             
-            let encoder = JSONEncoder()
-            let data = try! encoder.encode(paymentData.paymentMethod.encodable)
+            let data = try! AdyenCoder.encode(paymentData.paymentMethod.encodable) as Data
             
             let resultJson = try! JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions(rawValue: 0)) as! [String: Any]
             

--- a/Tests/Card Tests/CardComponentTests.swift
+++ b/Tests/Card Tests/CardComponentTests.swift
@@ -842,7 +842,7 @@ class CardComponentTests: XCTestCase {
             XCTAssertNotNil(paymentDetails)
 
             XCTAssertNotEqual(paymentDetails?.password, "12")
-            XCTAssertTrue(paymentDetails!.password!.starts(with: "eyJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiYWxnIjoiUlNBLU9BRVAtMjU2IiwidmVyc2lvbiI6IjEifQ"))
+            XCTAssertTrue(paymentDetails!.password!.starts(with: "eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwidmVyc2lvbiI6IjEifQ"))
             XCTAssertEqual(paymentDetails?.taxNumber, "121212")
 
             sut.stopLoadingIfNeeded()

--- a/Tests/Card Tests/StoredCardAlertManagerTests.swift
+++ b/Tests/Card Tests/StoredCardAlertManagerTests.swift
@@ -26,7 +26,7 @@ class StoredCardAlertManagerTests: XCTestCase {
     ] as [String: Any]
     
     func testLocalizationWithCustomTableName() throws {
-        let method = try Coder.decode(storedCardDictionary) as StoredCardPaymentMethod
+        let method = try AdyenCoder.decode(storedCardDictionary) as StoredCardPaymentMethod
         let amount = Amount(value: 3, currencyCode: "EUR")
         let sut = StoredCardAlertManager(paymentMethod: method,
                                          context: Dummy.context,
@@ -50,7 +50,7 @@ class StoredCardAlertManagerTests: XCTestCase {
     }
     
     func testLocalizationWithCustomKeySeparator() throws {
-        let method = try Coder.decode(storedCardDictionary) as StoredCardPaymentMethod
+        let method = try AdyenCoder.decode(storedCardDictionary) as StoredCardPaymentMethod
         let amount = Amount(value: 3, currencyCode: "EUR")
         let sut = StoredCardAlertManager(paymentMethod: method,
                                          context: Dummy.context,
@@ -74,7 +74,7 @@ class StoredCardAlertManagerTests: XCTestCase {
     }
     
     func testResetFieldsAfterCancel() {
-        let method = try! Coder.decode(storedCardDictionary) as StoredCardPaymentMethod
+        let method = try! AdyenCoder.decode(storedCardDictionary) as StoredCardPaymentMethod
         let payment = Payment(amount: Amount(value: 174, currencyCode: "EUR"), countryCode: "NL")
         let sut = StoredCardAlertManager(paymentMethod: method,
                                          context: Dummy.context,

--- a/Tests/Card Tests/Utilities/CardEncryptorCardTests.swift
+++ b/Tests/Card Tests/Utilities/CardEncryptorCardTests.swift
@@ -187,7 +187,6 @@ class CardEncryptorCardTests: XCTestCase {
 
     func testEncryptBIN() {
         let encrypted = try! CardEncryptor.encrypt(bin: "55000000", with: Dummy.publicKey)
-        XCTAssertNotNil(encrypted)
-        XCTAssertTrue(encrypted.hasPrefix("eyJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiYWxnIjoiUlNBLU9BRVAtMjU2IiwidmVyc2lvbiI6IjEifQ"))
+        XCTAssertTrue(encrypted.hasPrefix("eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwidmVyc2lvbiI6IjEifQ"))
     }
 }

--- a/Tests/Components Tests/Apple Pay/ApplePayDetailsTest.swift
+++ b/Tests/Components Tests/Apple Pay/ApplePayDetailsTest.swift
@@ -19,8 +19,7 @@ class ApplePayDetailsTest: XCTestCase {
                                   shippingContact: nil,
                                   shippingMethod: nil)
         
-        let encoder = JSONEncoder()
-        let data = try encoder.encode(sut.encodable)
+        let data = try AdyenCoder.encode(sut.encodable) as Data
         
         let resultJson = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions(rawValue: 0)) as? [String: Any]
         

--- a/Tests/Components Tests/IssuerList/IssuerListComponentTests.swift
+++ b/Tests/Components Tests/IssuerList/IssuerListComponentTests.swift
@@ -18,7 +18,7 @@ class IssuerListComponentTests: XCTestCase {
         try super.setUpWithError()
         context = Dummy.context
 
-        paymentMethod = try! Coder.decode(issuerListDictionary) as IssuerListPaymentMethod
+        paymentMethod = try! AdyenCoder.decode(issuerListDictionary) as IssuerListPaymentMethod
         sut = IssuerListComponent(paymentMethod: paymentMethod, context: context)
     }
 

--- a/Tests/Components Tests/Online Banking/OnlineBankingComponentTests.swift
+++ b/Tests/Components Tests/Online Banking/OnlineBankingComponentTests.swift
@@ -17,7 +17,7 @@ class OnlineBankingComponentTests: XCTestCase {
     private var analyticsProviderMock: AnalyticsProviderMock!
 
     override func setUpWithError() throws {
-        paymentMethod = try! Coder.decode(onlineBankingDictionary) as OnlineBankingPaymentMethod
+        paymentMethod = try! AdyenCoder.decode(onlineBankingDictionary) as OnlineBankingPaymentMethod
         analyticsProviderMock = AnalyticsProviderMock()
         context = AdyenContext(apiContext: Dummy.apiContext, payment: nil, analyticsProvider: analyticsProviderMock)
         style = FormComponentStyle()

--- a/Tests/Components Tests/UPIComponent/UPIComponentTests.swift
+++ b/Tests/Components Tests/UPIComponent/UPIComponentTests.swift
@@ -17,7 +17,7 @@ class UPIComponentTests: XCTestCase {
     private var analyticsProviderMock: AnalyticsProviderMock!
 
     override func setUpWithError() throws {
-        paymentMethod = try! Coder.decode(upi) as UPIPaymentMethod
+        paymentMethod = try! AdyenCoder.decode(upi) as UPIPaymentMethod
         analyticsProviderMock = AnalyticsProviderMock()
         context = AdyenContext(apiContext: Dummy.apiContext, payment: nil, analyticsProvider: analyticsProviderMock)
         style = FormComponentStyle()

--- a/Tests/DropIn Tests/ComponentManagerTests.swift
+++ b/Tests/DropIn Tests/ComponentManagerTests.swift
@@ -17,7 +17,7 @@ import XCTest
 class ComponentManagerTests: XCTestCase {
 
     var paymentMethods: PaymentMethods {
-        try! Coder.decode(dictionary) as PaymentMethods
+        try! AdyenCoder.decode(dictionary) as PaymentMethods
     }
     
     let dictionary = [

--- a/Tests/DropIn Tests/PreselectedPaymentComponentTests.swift
+++ b/Tests/DropIn Tests/PreselectedPaymentComponentTests.swift
@@ -214,11 +214,11 @@ class PreselectedPaymentComponentTests: XCTestCase {
     }
     
     func getStoredCard() -> StoredCardPaymentMethod {
-        try! Coder.decode(storedCreditCardDictionary) as StoredCardPaymentMethod
+        try! AdyenCoder.decode(storedCreditCardDictionary) as StoredCardPaymentMethod
     }
     
     func getStoredPaypal() -> StoredPayPalPaymentMethod {
-        try! Coder.decode(storedPayPalDictionary) as StoredPayPalPaymentMethod
+        try! AdyenCoder.decode(storedPayPalDictionary) as StoredPayPalPaymentMethod
     }
     
 }

--- a/Tests/Helpers/XCTestCase+Available.swift
+++ b/Tests/Helpers/XCTestCase+Available.swift
@@ -40,5 +40,13 @@ extension XCTestCase {
                 return false
             }
         }
+        
+        static var iOS17: Bool {
+            if #available(iOS 17.0, *) {
+                return true
+            } else {
+                return false
+            }
+        }
     }
 }

--- a/Tests/Helpers/XCTestCase+Coder.swift
+++ b/Tests/Helpers/XCTestCase+Coder.swift
@@ -8,7 +8,7 @@
 import AdyenComponents
 import XCTest
 
-internal extension Coder {
+internal extension AdyenCoder {
 
     static func decode<T: Decodable>(_ dictionary: [String: Any]) throws -> T {
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])

--- a/Tests/Session Tests/SessionTests.swift
+++ b/Tests/Session Tests/SessionTests.swift
@@ -45,7 +45,7 @@ class SessionTests: XCTestCase {
                 issuerListDictionary
             ]
         ]
-        let expectedPaymentMethods = try Coder.decode(dictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(dictionary) as PaymentMethods
         apiClient.mockedResults = [.success(SessionSetupResponse(countryCode: "US",
                                                                  shopperLocale: "US",
                                                                  paymentMethods: expectedPaymentMethods,
@@ -77,7 +77,7 @@ class SessionTests: XCTestCase {
     }
     
     func testDidSubmitWithNoActionAndNoOrder() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let paymentMethod = expectedPaymentMethods.regular.last as! MBWayPaymentMethod
         let data = PaymentComponentData(
@@ -113,7 +113,7 @@ class SessionTests: XCTestCase {
         let sessionDelegateMock = SessionDelegateMock()
         sessionDelegateMock.handlerMock = sessionAdvancedHandlerMock
 
-        let paymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let paymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: paymentMethods, delegate: sessionDelegateMock)
 
         let paymentMethod = try XCTUnwrap(paymentMethods.regular.last as? MBWayPaymentMethod)
@@ -141,7 +141,7 @@ class SessionTests: XCTestCase {
         let sessionDelegateMock = SessionDelegateMock()
         sessionDelegateMock.handlerMock = sessionAdvancedHandlerMock
 
-        let paymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let paymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: paymentMethods, delegate: sessionDelegateMock)
 
         let paymentMethod = try XCTUnwrap(paymentMethods.regular.last as? MBWayPaymentMethod)
@@ -177,7 +177,7 @@ class SessionTests: XCTestCase {
     ]
     
     func testDidSubmitWithActionAndNoOrder() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let paymentMethod = expectedPaymentMethods.regular.last as! MBWayPaymentMethod
         let data = PaymentComponentData(
@@ -249,7 +249,7 @@ class SessionTests: XCTestCase {
     }
     
     func testDidSubmitWithOrderAndNoAction() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let paymentMethod = expectedPaymentMethods.regular.last as! MBWayPaymentMethod
         let data = PaymentComponentData(
@@ -322,7 +322,7 @@ class SessionTests: XCTestCase {
     }
     
     func testDidSubmitFailure() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let paymentMethod = expectedPaymentMethods.regular.last as! MBWayPaymentMethod
         let data = PaymentComponentData(
@@ -352,7 +352,7 @@ class SessionTests: XCTestCase {
     }
     
     func testDidSubmitOrderRefused() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         
         let dropInComponent = DropInComponent(paymentMethods: expectedPaymentMethods,
                                               context: context,
@@ -431,7 +431,7 @@ class SessionTests: XCTestCase {
     }
     
     func testCheckBalanceCheckSuccess() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let paymentMethod = expectedPaymentMethods.regular.first as! GiftCardPaymentMethod
         let details = GiftCardDetails(paymentMethod: paymentMethod, encryptedCardNumber: "card", encryptedSecurityCode: "cvc")
@@ -457,7 +457,7 @@ class SessionTests: XCTestCase {
     }
     
     func testBalanceCheckZeroBalance() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let paymentMethod = expectedPaymentMethods.regular.first as! GiftCardPaymentMethod
         let details = GiftCardDetails(paymentMethod: paymentMethod, encryptedCardNumber: "card", encryptedSecurityCode: "cvc")
@@ -482,7 +482,7 @@ class SessionTests: XCTestCase {
     }
     
     func testBalanceCheckFailure() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let paymentMethod = expectedPaymentMethods.regular.first as! GiftCardPaymentMethod
         let details = GiftCardDetails(paymentMethod: paymentMethod, encryptedCardNumber: "card", encryptedSecurityCode: "cvc")
@@ -505,7 +505,7 @@ class SessionTests: XCTestCase {
     }
     
     func testRequestOrderSuccess() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let apiClient = APIClientMock()
         sut.apiClient = SessionAPIClient(apiClient: apiClient, session: sut)
@@ -529,7 +529,7 @@ class SessionTests: XCTestCase {
     }
     
     func testRequestOrderFailure() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let apiClient = APIClientMock()
         sut.apiClient = SessionAPIClient(apiClient: apiClient, session: sut)
@@ -549,7 +549,7 @@ class SessionTests: XCTestCase {
     }
     
     func testCancelOrderSuccess() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let apiClient = APIClientMock()
         sut.apiClient = SessionAPIClient(apiClient: apiClient, session: sut)
@@ -565,7 +565,7 @@ class SessionTests: XCTestCase {
     }
     
     func testCancelOrderFailure() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let apiClient = APIClientMock()
         sut.apiClient = SessionAPIClient(apiClient: apiClient, session: sut)
@@ -590,7 +590,7 @@ class SessionTests: XCTestCase {
             didSubmitExpectation.fulfill()
         }
         
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods,
                                         delegate: sessionDelegate)
         let paymentMethod = expectedPaymentMethods.regular.last as! MBWayPaymentMethod
@@ -618,7 +618,7 @@ class SessionTests: XCTestCase {
             didProvideExpectation.fulfill()
         }
         
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, delegate: sessionDelegate)
         let data = try ActionComponentData(
             details: RedirectDetails(
@@ -637,7 +637,7 @@ class SessionTests: XCTestCase {
         let dropIn = DropInComponent(paymentMethods: paymenMethods,
                                      context: context,
                                      configuration: config)
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sessionHandlerMock = SessionAdvancedHandlerMock()
         let sessionDelegate = SessionDelegateMock()
         sessionDelegate.handlerMock = sessionHandlerMock
@@ -707,7 +707,7 @@ class SessionTests: XCTestCase {
     }
     
     func testResultCodeAuthorised() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sessionDelegate = SessionDelegateMock()
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, delegate: sessionDelegate)
         let apiClient = APIClientMock()
@@ -740,7 +740,7 @@ class SessionTests: XCTestCase {
     }
     
     func testResultCodePending() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sessionDelegate = SessionDelegateMock()
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, delegate: sessionDelegate)
         let apiClient = APIClientMock()
@@ -773,7 +773,7 @@ class SessionTests: XCTestCase {
     }
     
     func testResultCodeRefused() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sessionDelegate = SessionDelegateMock()
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, delegate: sessionDelegate)
         let apiClient = APIClientMock()
@@ -806,7 +806,7 @@ class SessionTests: XCTestCase {
     }
     
     func testResultCodeCancelled() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sessionDelegate = SessionDelegateMock()
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, delegate: sessionDelegate)
         let apiClient = APIClientMock()
@@ -839,7 +839,7 @@ class SessionTests: XCTestCase {
     }
     
     func testResultCodeReceived() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sessionDelegate = SessionDelegateMock()
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, delegate: sessionDelegate)
         let apiClient = APIClientMock()
@@ -872,7 +872,7 @@ class SessionTests: XCTestCase {
     }
     
     func testResultCodePresentToShopper() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sessionDelegate = SessionDelegateMock()
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, delegate: sessionDelegate)
         let apiClient = APIClientMock()
@@ -909,7 +909,7 @@ class SessionTests: XCTestCase {
     }
     
     func testResultCodeError() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sessionDelegate = SessionDelegateMock()
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, delegate: sessionDelegate)
         let apiClient = APIClientMock()
@@ -942,7 +942,7 @@ class SessionTests: XCTestCase {
     }
     
     func testResultCodeErrorFromAnotherCode() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sessionDelegate = SessionDelegateMock()
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, delegate: sessionDelegate)
         let apiClient = APIClientMock()
@@ -975,7 +975,7 @@ class SessionTests: XCTestCase {
     }
     
     func testInstallmentsFromSessionConfig() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let config = try! JSONDecoder().decode(SessionSetupResponse.Configuration.self, from: sessionConfigJson.data(using: .utf8)!)
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, configuration: config)
         let paymentMethod = expectedPaymentMethods.regular[1] as! CardPaymentMethod
@@ -994,7 +994,7 @@ class SessionTests: XCTestCase {
     }
     
     func testStorePaymentMethodFieldNotNil() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let config = try! JSONDecoder().decode(SessionSetupResponse.Configuration.self, from: sessionConfigJson.data(using: .utf8)!)
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, configuration: config)
         let paymentMethod = expectedPaymentMethods.regular[1] as! CardPaymentMethod
@@ -1013,7 +1013,7 @@ class SessionTests: XCTestCase {
     }
     
     func testStorePaymentMethodFieldNil() throws {
-        let expectedPaymentMethods = try Coder.decode(paymentMethodsDictionary) as PaymentMethods
+        let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods, configuration: .init(installmentOptions: nil, enableStoreDetails: false))
         let paymentMethod = expectedPaymentMethods.regular[1] as! CardPaymentMethod
         var cardConfig = CardComponent.Configuration()

--- a/UITests/Components/IssuerList/IssuerListComponentUITests.swift
+++ b/UITests/Components/IssuerList/IssuerListComponentUITests.swift
@@ -27,7 +27,7 @@ final class IssuerListComponentUITests: XCTestCase {
     
     private func initializeComponent() {
         context = Dummy.context
-        paymentMethod = try! Coder.decode(issuerListDictionary) as IssuerListPaymentMethod
+        paymentMethod = try! AdyenCoder.decode(issuerListDictionary) as IssuerListPaymentMethod
         sut = IssuerListComponent(paymentMethod: paymentMethod, context: context)
         searchViewController = sut.viewController as? SearchViewController
         listViewController = searchViewController.resultsListViewController

--- a/UITests/Components/Online Banking/OnlineBankingComponentUITests.swift
+++ b/UITests/Components/Online Banking/OnlineBankingComponentUITests.swift
@@ -17,7 +17,7 @@ class OnlineBankingComponentUITests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        paymentMethod = try! Coder.decode(onlineBankingDictionary) as OnlineBankingPaymentMethod
+        paymentMethod = try! AdyenCoder.decode(onlineBankingDictionary) as OnlineBankingPaymentMethod
         context = AdyenContext(apiContext: Dummy.apiContext, payment: nil)
         style = FormComponentStyle()
     }


### PR DESCRIPTION
## Changes

<changed>

* Added support for [Xcode 15](https://developer.apple.com/xcode/) 
  * iOS 11 is no longer supported because it's [not supported by Xcode 15](https://developer.apple.com/support/xcode/).

</changed>

- Replacing usages of `JSONEncoder` with `AdyenCoder`
  - Sorting JSON keys (as the sorting of keys changed with iOS 17)
  - Adding Adyen dependency to AdyenEncryption
- Adjusted currency testing for ISK (Formatting changed with iOS 17)