### PR TITLE
chore: Prevent palApiClient from releasing

### DIFF
--- a/Demo/Common/Helpers/APIClientHelper.swift
+++ b/Demo/Common/Helpers/APIClientHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -9,7 +9,10 @@ import AdyenNetworking
 
 internal protocol APIClientAware {
     var apiClient: APIClientProtocol { get }
+    var palApiClient: APIClientProtocol { get }
 }
+
+// MARK: - Api Client
 
 extension APIClientAware {
 
@@ -22,7 +25,7 @@ extension APIClientAware {
         setApiClient(apiClient)
         return apiClient
     }
-
+    
     private func getApiClient() -> APIClientProtocol? {
         objc_getAssociatedObject(self, &AssociatedKeys.apiClient) as? APIClientProtocol
     }
@@ -47,6 +50,37 @@ extension APIClientAware {
     }
 }
 
+// MARK: - Pal Api Client
+
+extension APIClientAware {
+    
+    var palApiClient: APIClientProtocol {
+        if let apiClient = getPalApiClient() {
+            return apiClient
+        }
+
+        let apiClient = generatePalApiClient()
+        setPalApiClient(apiClient)
+        return apiClient
+    }
+    
+    private func getPalApiClient() -> APIClientProtocol? {
+        objc_getAssociatedObject(self, &AssociatedKeys.palApiClient) as? APIClientProtocol
+    }
+
+    private func setPalApiClient(_ newValue: APIClientProtocol) {
+        objc_setAssociatedObject(self, &AssociatedKeys.palApiClient, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+    
+    private func generatePalApiClient() -> APIClientProtocol {
+        let context = DemoAPIContext(environment: ConfigurationConstants.classicAPIEnvironment)
+        return DefaultAPIClient(apiContext: context)
+    }
+}
+
+// MARK: - AssociatedKeys
+
 private enum AssociatedKeys {
     internal static var apiClient = "apiClient"
+    internal static var palApiClient = "palApiClient"
 }

--- a/Demo/Common/Helpers/APIClientHelper.swift
+++ b/Demo/Common/Helpers/APIClientHelper.swift
@@ -7,34 +7,9 @@
 import Adyen
 import AdyenNetworking
 
-internal protocol APIClientAware {
-    var apiClient: APIClientProtocol { get }
-    var palApiClient: APIClientProtocol { get }
-}
-
-// MARK: - Api Client
-
-extension APIClientAware {
-
-    var apiClient: APIClientProtocol {
-        if let apiClient = getApiClient() {
-            return apiClient
-        }
-
-        let apiClient = generateApiClient()
-        setApiClient(apiClient)
-        return apiClient
-    }
+enum ApiClientHelper {
     
-    private func getApiClient() -> APIClientProtocol? {
-        objc_getAssociatedObject(self, &AssociatedKeys.apiClient) as? APIClientProtocol
-    }
-
-    private func setApiClient(_ newValue: APIClientProtocol) {
-        objc_setAssociatedObject(self, &AssociatedKeys.apiClient, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-    }
-
-    private func generateApiClient() -> APIClientProtocol {
+    static func generateApiClient() -> APIClientProtocol {
         guard CommandLine.arguments.contains("-UITests"),
               let paymentMethodsUrl = Bundle.main.url(forResource: "payment_methods_response", withExtension: "json"),
               let sessionsUrl = Bundle.main.url(forResource: "session_response", withExtension: "json"),
@@ -48,39 +23,9 @@ extension APIClientAware {
         apiClient.mockedResults = [.success(paymentMethodsResponse), .success(sessionResponse)]
         return apiClient
     }
-}
-
-// MARK: - Pal Api Client
-
-extension APIClientAware {
     
-    var palApiClient: APIClientProtocol {
-        if let apiClient = getPalApiClient() {
-            return apiClient
-        }
-
-        let apiClient = generatePalApiClient()
-        setPalApiClient(apiClient)
-        return apiClient
-    }
-    
-    private func getPalApiClient() -> APIClientProtocol? {
-        objc_getAssociatedObject(self, &AssociatedKeys.palApiClient) as? APIClientProtocol
-    }
-
-    private func setPalApiClient(_ newValue: APIClientProtocol) {
-        objc_setAssociatedObject(self, &AssociatedKeys.palApiClient, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-    }
-    
-    private func generatePalApiClient() -> APIClientProtocol {
+    static func generatePalApiClient() -> APIClientProtocol {
         let context = DemoAPIContext(environment: ConfigurationConstants.classicAPIEnvironment)
         return DefaultAPIClient(apiContext: context)
     }
-}
-
-// MARK: - AssociatedKeys
-
-private enum AssociatedKeys {
-    internal static var apiClient = "apiClient"
-    internal static var palApiClient = "palApiClient"
 }

--- a/Demo/Common/IntegrationExamples/Components/ApplePayComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/Components/ApplePayComponentAdvancedFlowExample.swift
@@ -17,6 +17,8 @@ internal final class ApplePayComponentAdvancedFlowExample: InitialDataAdvancedFl
     internal var applePayComponent: ApplePayComponent?
     internal weak var presenter: PresenterExampleProtocol?
 
+    internal lazy var apiClient = ApiClientHelper.generateApiClient()
+    
     // MARK: - Initializers
 
     internal init() {}

--- a/Demo/Common/IntegrationExamples/Components/ApplePayComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Components/ApplePayComponentExample.swift
@@ -15,6 +15,8 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
     internal var session: AdyenSession?
     internal weak var presenter: PresenterExampleProtocol?
     internal var applePayComponent: ApplePayComponent?
+    
+    internal lazy var apiClient = ApiClientHelper.generateApiClient()
 
     // MARK: - Initializers
 

--- a/Demo/Common/IntegrationExamples/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/Components/CardComponentAdvancedFlowExample.swift
@@ -19,6 +19,8 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
     internal var cardComponent: PresentableComponent?
 
     internal weak var presenter: PresenterExampleProtocol?
+    
+    internal lazy var apiClient = ApiClientHelper.generateApiClient()
 
     // MARK: - Action Handling
 

--- a/Demo/Common/IntegrationExamples/Components/CardComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Components/CardComponentExample.swift
@@ -17,6 +17,8 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
 
     private var session: AdyenSession?
     private var cardComponent: PresentableComponent?
+    
+    internal lazy var apiClient = ApiClientHelper.generateApiClient()
 
     // MARK: - Initializers
 

--- a/Demo/Common/IntegrationExamples/DropIn/DropInAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/DropIn/DropInAdvancedFlowExample.swift
@@ -13,6 +13,9 @@ internal final class DropInAdvancedFlowExample: InitialDataAdvancedFlowProtocol 
     internal weak var presenter: PresenterExampleProtocol?
 
     private var dropInComponent: DropInComponent?
+    
+    internal lazy var apiClient = ApiClientHelper.generateApiClient()
+    private lazy var palApiClient = ApiClientHelper.generatePalApiClient()
 
     // MARK: - Initializers
 

--- a/Demo/Common/IntegrationExamples/DropIn/DropInExample.swift
+++ b/Demo/Common/IntegrationExamples/DropIn/DropInExample.swift
@@ -22,6 +22,9 @@ internal final class DropInExample: InitialDataFlowProtocol {
     private var session: AdyenSession?
     private var dropInComponent: DropInComponent?
     
+    internal lazy var apiClient = ApiClientHelper.generateApiClient()
+    private lazy var palApiClient = ApiClientHelper.generatePalApiClient()
+    
     // MARK: - Initializers
 
     internal init() {}

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataAdvancedFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataAdvancedFlowProtocol.swift
@@ -8,8 +8,9 @@
 import AdyenNetworking
 import AdyenSession
 
-internal protocol InitialDataAdvancedFlowProtocol: AnyObject, APIClientAware {
+internal protocol InitialDataAdvancedFlowProtocol: AnyObject {
     var context: AdyenContext { get }
+    var apiClient: APIClientProtocol { get }
     func requestPaymentMethods(order: PartialPaymentOrder?,
                                completion: @escaping (Result<PaymentMethods, Error>) -> Void)
 }

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataAdvancedFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataAdvancedFlowProtocol.swift
@@ -10,7 +10,6 @@ import AdyenSession
 
 internal protocol InitialDataAdvancedFlowProtocol: AnyObject, APIClientAware {
     var context: AdyenContext { get }
-    var palApiClient: APIClientProtocol { get }
     func requestPaymentMethods(order: PartialPaymentOrder?,
                                completion: @escaping (Result<PaymentMethods, Error>) -> Void)
 }
@@ -23,11 +22,6 @@ extension InitialDataAdvancedFlowProtocol {
         return AdyenContext(apiContext: ConfigurationConstants.apiContext,
                             payment: ConfigurationConstants.current.payment,
                             analyticsConfiguration: analyticsConfiguration)
-    }
-
-    internal var palApiClient: APIClientProtocol {
-        let context = DemoAPIContext(environment: ConfigurationConstants.classicAPIEnvironment)
-        return DefaultAPIClient(apiContext: context)
     }
 
     internal func requestPaymentMethods(order: PartialPaymentOrder?,

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
@@ -8,8 +8,9 @@
 import AdyenNetworking
 import AdyenSession
 
-internal protocol InitialDataFlowProtocol: AnyObject, APIClientAware {
+internal protocol InitialDataFlowProtocol: AnyObject {
     var context: AdyenContext { get }
+    var apiClient: APIClientProtocol { get }
     func requestAdyenSessionConfiguration(completion: @escaping (Result<AdyenSession.Configuration, Error>) -> Void)
 }
 

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
@@ -10,7 +10,6 @@ import AdyenSession
 
 internal protocol InitialDataFlowProtocol: AnyObject, APIClientAware {
     var context: AdyenContext { get }
-    var palApiClient: APIClientProtocol { get }
     func requestAdyenSessionConfiguration(completion: @escaping (Result<AdyenSession.Configuration, Error>) -> Void)
 }
 
@@ -22,11 +21,6 @@ extension InitialDataFlowProtocol {
         return AdyenContext(apiContext: ConfigurationConstants.apiContext,
                             payment: ConfigurationConstants.current.payment,
                             analyticsConfiguration: analyticsConfiguration)
-    }
-
-    internal var palApiClient: APIClientProtocol {
-        let context = DemoAPIContext(environment: ConfigurationConstants.classicAPIEnvironment)
-        return DefaultAPIClient(apiContext: context)
     }
 
     internal func requestAdyenSessionConfiguration(completion: @escaping (Result<AdyenSession.Configuration, Error>) -> Void) {


### PR DESCRIPTION
## Issue
- The spinner does not disappear on the Demo app when trying to delete a stored payment method from drop-in
- The call to remove the stored payment method succeeds but because the palApiClient is released before the response returns the UI is not updated

## Steps to reproduce
- Make a card payment and store the payment method
- Open drop-in again and delete the payment method
