### PR TITLE
fix: cashapp missing customer Id

### DIFF
--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -37,8 +37,8 @@ Pod::Spec.new do |s|
   s.subspec 'CashAppPay' do |plugin|
     plugin.source_files = 'AdyenCashAppPay/**/*.swift'
     plugin.dependency 'Adyen/Core'
-    plugin.dependency 'CashAppPayKit', '0.3.3'
-    plugin.dependency 'CashAppPayKitUI', '0.3.3'
+    plugin.dependency 'CashAppPayKit', '0.5.1'
+    plugin.dependency 'CashAppPayKitUI', '0.5.1'
   end
 
   s.subspec 'Card' do |plugin|

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -8555,7 +8555,7 @@
 			repositoryURL = "https://github.com/cashapp/cash-app-pay-ios-sdk";
 			requirement = {
 				kind = exactVersion;
-				version = 0.3.0;
+				version = 0.5.1;
 			};
 		};
 		E72375CC27AAB7760020DCF9 /* XCRemoteSwiftPackageReference "adyen-wechatpay-ios" */ = {

--- a/AdyenCashAppPay/CashAppPayComponent.swift
+++ b/AdyenCashAppPay/CashAppPayComponent.swift
@@ -173,7 +173,7 @@ public final class CashAppPayComponent: PaymentComponent,
         let onFileGrant = grants.first { $0.type == .EXTENDED }
         let oneTimeGrant = grants.first { $0.type == .ONE_TIME }
         let cashtag = onFileGrant != nil ? customerProfile?.cashtag : nil
-        let customerId = onFileGrant?.customerID
+        let customerId = customerProfile?.id
     
         return CashAppPayDetails(paymentMethod: cashAppPayPaymentMethod,
                                  grantId: oneTimeGrant?.id,

--- a/Package.swift
+++ b/Package.swift
@@ -70,7 +70,7 @@ let package = Package(
         .package(
             name: "PayKit",
             url: "https://github.com/cashapp/cash-app-pay-ios-sdk",
-            .exact(Version(0, 3, 3))
+            .exact(Version(0, 5, 1))
         )
     ],
     targets: [

--- a/Tests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
+++ b/Tests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
@@ -191,7 +191,7 @@ import XCTest
                 
                 XCTAssertEqual(details.grantId, "grantId1")
                 XCTAssertNil(details.cashtag)
-                XCTAssertNil(details.customerId)
+                XCTAssertEqual(details.customerId, "testId")
                 XCTAssertNil(details.onFileGrantId)
 
                 sut.finalizeIfNeeded(with: true, completion: {


### PR DESCRIPTION
<fixed>

## Fixed

- Cash App payments are no longer refused because of the missing `customerId` field in the `/payments/details` request.

</fixed>