### PR TITLE
Fix `didCancel` call on DropIn [no tests]

### DIFF
--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -237,14 +237,11 @@ public final class DropInComponent: NSObject,
     }
 
     internal func userDidCancel(_ component: Component) {
-        stopLoading()
-        component.cancelIfNeeded()
-
         if let component = (component as? PaymentComponent) ?? selectedPaymentComponent, paymentInProgress {
             delegate?.didCancel(component: component, from: self)
         }
 
-        paymentInProgress = false
+        stopLoading()
     }
 
     public func stopLoading() {


### PR DESCRIPTION
# Open PR

## Changes

<fixed>

* Fixed a problem where, when the shopper cancelled a payment in progress, `DropInComponentDelegate` didn't call `didCancel`.

</fixed>