### PR TITLE
improvement: Adding documentation for custom display information

### DIFF
--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   Generate:
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   Generate:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
       with:

--- a/Adyen.docc/API Reference.md
+++ b/Adyen.docc/API Reference.md
@@ -43,11 +43,11 @@ The Adyen DropIn/Components SDK API Reference.
 - ``ApplePayStyle``
 
 ## Payment Methods
+``PaymentMethods``
 
 ### Basic Payment Methods
 
 - ``PaymentMethod``
-- ``PaymentMethods``
 - ``StoredPaymentMethod``
 - ``IssuerListPaymentMethod``
 - ``AwaitPaymentMethod``

--- a/Adyen.docc/AdvancedFlow.md
+++ b/Adyen.docc/AdvancedFlow.md
@@ -118,29 +118,31 @@ This optional method is invoked after a redirect to an external application has 
 
 When `/payments` or `/payments/details` responds with a non-final result and an `action`, you can use one of the following techniques.
 
-### Using Drop-in
+@TabNavigator {
+    @Tab(Drop-in) {  
+        In case of Drop-in integration you must use build-in action handler on the current instance of ``DropInComponent``:
 
-In case of Drop-in integration you must use build-in action handler on the current instance of ``DropInComponent``:
+        ```swift
+        let action = try JSONDecoder().decode(Action.self, from: actionData)
+        dropInComponent.handle(action)
+        ```
+    }
+    
+    @Tab(Components) {  
+        In case of using individual components, create and persist an instance of ``AdyenActionComponent``:
 
-```swift
-let action = try JSONDecoder().decode(Action.self, from: actionData)
-dropInComponent.handle(action)
-```
+        ```swift
+        lazy var actionComponent: AdyenActionComponent = {
+            let handler = AdyenActionComponent(context: context)
+            handler.delegate = self
+            handler.presentationDelegate = self
+            return handler
+        }()
+        ```
+    }
+}
 
-### Using components
-
-In case of using individual components, create and persist an instance of ``AdyenActionComponent``:
-
-```swift
-lazy var actionComponent: AdyenActionComponent = {
-    let handler = AdyenActionComponent(context: context)
-    handler.delegate = self
-    handler.presentationDelegate = self
-    return handler
-}()
-```
-
-Than use it to handle the action:
+Then use it to handle the action:
 
 ```swift
 let action = try JSONDecoder().decode(Action.self, from: actionData)

--- a/Adyen.docc/AdvancedFlow.md
+++ b/Adyen.docc/AdvancedFlow.md
@@ -18,7 +18,9 @@ let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: respons
 
 All Components need an ``APIContext``. An instance of `APIContext` wraps your client key and an environment.
 Please read more [here](https://docs.adyen.com/development-resources/client-side-authentication) about the client key and how to get.
-Use **Environment.test** for environment. When you're ready to accept live payments, change the value to one of our [live environments](https://adyen.github.io/adyen-ios/Docs/Structs/Environment.html)
+
+Use ``Environment.test`` during testing. When you're ready to accept live payments, change the value to one of our [live environments](<doc:Environment>).
+
 We recommend creating a new context for each payment attempt.
 
 ```swift

--- a/Adyen.docc/Adyen.md
+++ b/Adyen.docc/Adyen.md
@@ -1,4 +1,4 @@
-# ``Adyen``
+# Adyen
 
 Adyen Components for iOS allows you to accept in-app payments by providing you with the building blocks you need to create a checkout experience.
 
@@ -14,9 +14,9 @@ Adyen Components for iOS allows you to accept in-app payments by providing you w
 
 - <doc:Components>
 
-### Three API
+### Advanced Flow
 
-- <doc:ThreeAPIs>
+- <doc:AdvancedFlow>
 
 ## Customization
 

--- a/Adyen.docc/Components.md
+++ b/Adyen.docc/Components.md
@@ -36,7 +36,9 @@ In order to have more flexibility over the checkout flow, you can use our Compon
 
 All Components need an ``AdyenContext``. An instance of ``AdyenContext`` wraps your client key, environment, payment, analytics configuration and so on.
 Please read more [here](https://docs.adyen.com/development-resources/client-side-authentication) about the client key and how to get one.
-Use **Environment.test** for environment. When you're ready to accept live payments, change the value to one of our [live environments](https://adyen.github.io/adyen-ios/Docs/Structs/Environment.html).
+
+Use ``Environment.test`` during testing. When you're ready to accept live payments, change the value to one of our [live environments](<doc:Environment>).
+
 We recommend creating a new context for each payment attempt.
 
 ```swift

--- a/Adyen.docc/Contributing.md
+++ b/Adyen.docc/Contributing.md
@@ -4,5 +4,3 @@ We strongly encourage you to join us in contributing to this repository so every
 * New features and functionality
 * Resolved bug fixes and issues
 * Any general improvements
-
-Read our [**contribution guidelines**](CONTRIBUTING.md) to find out how.

--- a/Adyen.docc/Customization.md
+++ b/Adyen.docc/Customization.md
@@ -45,7 +45,10 @@ The following examples provide custom information to show for a specific payment
 
 @TabNavigator {
     @Tab(Drop-in) {  
+        
+        
         ```swift
+        // Override the (regular) payment method of type `.scheme` with custom display information
         paymentMethods.overrideDisplayInformation(
             ofRegularPaymentMethod: .scheme,
             with: .init(
@@ -56,6 +59,7 @@ The following examples provide custom information to show for a specific payment
         ```
         
         ```swift
+        // Override the (regular) `.giftcard` payment method if the brand is "genericgiftcard"
         paymentMethods.overrideDisplayInformation(
             ofRegularPaymentMethod: .giftcard,
             with: .init(
@@ -93,4 +97,4 @@ The following examples provide custom information to show for a specific payment
     }
 }
 
-For a full list of customization options can be found in the API Reference.
+For a full list of customization options can be found in the <doc:API-Reference>.

--- a/Adyen.docc/Customization.md
+++ b/Adyen.docc/Customization.md
@@ -2,37 +2,95 @@
 
 Both the Drop-in and the Components offer a number of customization options to allow you to match the appearance of your app.
 
-## Drop-in
+## Styling
 
 For example, to change the section header titles and form field titles in the Drop-in to red, and turn the submit button's background to black with white foreground:
-```swift
-var style = DropInComponent.Style()
-style.listComponent.sectionHeader.title.color = .red
-style.formComponent.textField.title.color = .red
-style.formComponent.mainButtonItem.button.backgroundColor = .black
-style.formComponent.mainButtonItem.button.title.color = .white
 
-let configuration = DropInComponent.Configuration(style: style)
-let component = DropInComponent(paymentMethods: paymentMethods,
-                                context: context,
-                                configuration: configuration)
-```
+@TabNavigator {
+    @Tab(Drop-in) { 
+        ```swift
+        var style = DropInComponent.Style()
+        style.listComponent.sectionHeader.title.color = .red
+        style.formComponent.textField.title.color = .red
+        style.formComponent.mainButtonItem.button.backgroundColor = .black
+        style.formComponent.mainButtonItem.button.title.color = .white
 
-## Components
+        let configuration = DropInComponent.Configuration(style: style)
+        let component = DropInComponent(paymentMethods: paymentMethods,
+                                        context: context,
+                                        configuration: configuration)
+        ```
+    }
+    
+    @Tab(Components) { 
+        ```swift
+        var style = FormComponentStyle()
+        style.backgroundColor = .black
+        style.header.title.color = .white
+        style.textField.title.color = .white
+        style.textField.text.color = .white
+        style.switch.title.color = .white
 
-To create a black Card Component with white text:
-```swift
-var style = FormComponentStyle()
-style.backgroundColor = .black
-style.header.title.color = .white
-style.textField.title.color = .white
-style.textField.text.color = .white
-style.switch.title.color = .white
+        let config = CardComponent.Configuration(style: style)
+        let component = CardComponent(paymentMethod: paymentMethod,
+                                      context: context,
+                                      configuration: config)
+        ```
+    }
+}
 
-let config = CardComponent.Configuration(style: style)
-let component = CardComponent(paymentMethod: paymentMethod,
-                              context: context,
-                              configuration: config)
-```
+## Custom Payment Method Display Information
+
+The following examples provide custom information to show for a specific payment method
+
+@TabNavigator {
+    @Tab(Drop-in) {  
+        ```swift
+        paymentMethods.overrideDisplayInformation(
+            ofRegularPaymentMethod: .scheme,
+            with: .init(
+                title: "Custom Cards title",
+                subtitle: "Custom Cards description"
+            )
+        )
+        ```
+        
+        ```swift
+        paymentMethods.overrideDisplayInformation(
+            ofRegularPaymentMethod: .giftcard,
+            with: .init(
+                title: "Custom Giftcard title",
+                subtitle: "Custom Giftcard subtitle"
+                ),
+            where: { (paymentMethod: GiftCardPaymentMethod) -> Bool in
+                paymentMethod.brand == "genericgiftcard"
+            }
+        )
+        ```
+        
+        To override the display information for stored payment methods use:
+        
+        ```swift
+        paymentMethods.overrideDisplayInformation(
+            ofStoredPaymentMethod: ...
+        )
+        ```
+    }
+    
+    @Tab(Components) {
+        For components you can either set the `merchantProvidedDisplayInformation` directly before creating the component or use the same approach as with **Drop-In**.
+        ```swift
+        cardPaymentMethod.merchantProvidedDisplayInformation = .init(
+            title: "Custom Card Title"
+        )
+        
+        let component = CardComponent(
+            paymentMethod: cardPaymentMethod,
+            context: context,
+            configuration: config
+        )
+        ```
+    }
+}
 
 For a full list of customization options can be found in the API Reference.

--- a/Adyen.docc/DropIn.md
+++ b/Adyen.docc/DropIn.md
@@ -2,13 +2,15 @@
 
 The Drop-in handles the presentation of available payment methods and the subsequent entry of a customer's payment details. It is initialized with the payment methods of the `/sessions` response, and handles the entire checkout flow under the hood for most of use cases.
 
-If the simplified checkout flow with the `/sessions` endpoint does not work for you, or you prefer to have more control over the whole flow, please refer to [**implementation via the three endpoints**](DropInThreeAPIs.md).
+If the simplified checkout flow with the `/sessions` endpoint does not work for you, or you prefer to have more control over the whole flow, please refer to [Advanced Flow](AdvancedFlow.md).
 
 ## Setting up the Drop-in
 
 All Components need an ``AdyenContext``. An instance of ``AdyenContext`` wraps your client key, environment, payment, analytics configuration and so on.
 Please read more [here](https://docs.adyen.com/development-resources/client-side-authentication) about the client key and how to get one.
-Use **Environment.test** for environment. When you're ready to accept live payments, change the value to one of our [live environments](https://adyen.github.io/adyen-ios/Docs/Structs/Environment.html).
+
+Use ``Environment.test`` during testing. When you're ready to accept live payments, change the value to one of our [live environments](<doc:Environment>).
+
 We recommend creating a new context for each payment attempt.
 
 ```swift

--- a/Adyen.docc/Localization.md
+++ b/Adyen.docc/Localization.md
@@ -24,14 +24,14 @@ For example, if your app uses English and Spanish, your project folder should ha
 For example, if you want to override the payment button text to **Subscribe for [AMOUNT]**.
 
 - English, in the `en-US.lproj/Localizable.string` file:
-~~~
+```
 "adyen.submitButton.formatted" = "Subscribe for %@";
-~~~
+```
 
 - Spanish, in the `es-ES.lproj/Localizable.string` file:
-~~~
+```
 "adyen.submitButton.formatted" = "Suscríbete por %@";
-~~~
+```
 
 ### Custom localization file name
 
@@ -45,12 +45,12 @@ To use a custom localization file name, key format, or bundle, you must configur
 
 In the following example, the SDK looks for the key `adyen_submitButton_formatted` in the `YOUR_LOCALIZATION_FILE.strings` file in **CommonLibrary** bundle. 
 
-~~~~swift
+```swift
 let parameters = LocalizationParameters(bundle: Bundle(for: MyCommonLibraryClass.type),
                                         tableName: "YOUR_LOCALIZATION_FILE",
                                         keySeparator: "_")
 configuration.localizationParameters = parameters // Any Component.
-~~~~
+```
 
 ## Enforcing locale
 

--- a/Adyen.docc/Support.md
+++ b/Adyen.docc/Support.md
@@ -8,4 +8,4 @@ For other questions, contact our [support team](https://support.adyen.com/hc/en-
 
 - [Complete Documentation](https://docs.adyen.com/developers/checkout/ios)
 
-- [Components API Reference](https://adyen.github.io/adyen-ios/Docs/index.html)
+- [SDK Documentation](<doc:Adyen>)

--- a/Scripts/generate_docc_documentation.sh
+++ b/Scripts/generate_docc_documentation.sh
@@ -53,7 +53,7 @@ $TEMP_PROJECT_PATH/Sources/$FRAMEWORK_NAME/Adyen/Utilities/CoreBundleSPMExtensio
 # Go back to Temp project root
 cd $TEMP_PROJECT_PATH
 
-echo "// swift-tools-version: 5.6
+echo "// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
## Summary
- Adds documentation for custom `merchantDisplayInformation`
- Fixed broken documentation links
- Switched to macos-13 runner to be able to use [@TabNavigator](https://www.swift.org/documentation/docc/tabnavigator) (Introduced with Swift 5.8)
