### PR TITLE
Feature: Installment amount display

### DIFF
--- a/Adyen/Core/Components/Installment/InstallmentOptions.swift
+++ b/Adyen/Core/Components/Installment/InstallmentOptions.swift
@@ -85,41 +85,48 @@ public struct InstallmentConfiguration: Decodable {
     /// Options that are specific to given card types
     public let cardBasedOptions: [CardType: InstallmentOptions]?
     
-    /// Determines whether to show the money amount in the installment selection.
+    /// Determines whether to show the amount next to the installment value.
     /// For example, `3 months X 500 USD` or `3 months`.
-    /// For now it is disabled due to making the dividing calculations in the client.
+    /// Amount is calculated by simple division.
     @_spi(AdyenInternal)
-    public let showInstallmentPrice: Bool
+    public var showInstallmentAmount: Bool
     
     /// Creates a new installment configuration by providing both the card type based options
     ///  and default options for the rest of the card types.
     /// - Parameters:
     ///   - cardBasedOptions: Options based on the card type. Must not be empty.
     ///   - defaultOptions: Default options for cards that are not specified in `cardBasedOptions`.
-    public init(cardBasedOptions: [CardType: InstallmentOptions], defaultOptions: InstallmentOptions) {
+    ///   - showInstallmentAmount: Determines whether to show the amount next to the installment value.
+    public init(cardBasedOptions: [CardType: InstallmentOptions], 
+                defaultOptions: InstallmentOptions,
+                showInstallmentAmount: Bool = false) {
         assert(!cardBasedOptions.isEmpty, "This dictionary must not be empty.")
         self.cardBasedOptions = cardBasedOptions
         self.defaultOptions = defaultOptions
-        self.showInstallmentPrice = false
+        self.showInstallmentAmount = showInstallmentAmount
     }
     
     /// Creates a new installment configuration by providing the card based options.
     /// - Parameters:
     ///   - cardBasedOptions:  Options based on the card type. Must not be empty.
-    public init(cardBasedOptions: [CardType: InstallmentOptions]) {
+    ///   - showInstallmentAmount: Determines whether to show the amount next to the installment value.
+    public init(cardBasedOptions: [CardType: InstallmentOptions], 
+                showInstallmentAmount: Bool = false) {
         assert(!cardBasedOptions.isEmpty, "This dictionary must not be empty.")
         self.defaultOptions = nil
         self.cardBasedOptions = cardBasedOptions
-        self.showInstallmentPrice = false
+        self.showInstallmentAmount = showInstallmentAmount
     }
     
     /// Creates a new installment configuration by providing the default options.
     /// - Parameters:
     ///   - defaultOptions: Default options to apply to all card types.
-    public init(defaultOptions: InstallmentOptions) {
+    ///   - showInstallmentAmount: Determines whether to show the amount next to the installment value.
+    public init(defaultOptions: InstallmentOptions, 
+                showInstallmentAmount: Bool = false) {
         self.defaultOptions = defaultOptions
         self.cardBasedOptions = nil
-        self.showInstallmentPrice = false
+        self.showInstallmentAmount = showInstallmentAmount
     }
     
     @_spi(AdyenInternal)
@@ -139,7 +146,7 @@ public struct InstallmentConfiguration: Decodable {
         }
         self.defaultOptions = defaultOptions
         self.cardBasedOptions = cardBased
-        self.showInstallmentPrice = false
+        self.showInstallmentAmount = false
     }
     
     private enum Constants {

--- a/AdyenCard/Form/Installments/FormCardInstallmentsItem.swift
+++ b/AdyenCard/Form/Installments/FormCardInstallmentsItem.swift
@@ -43,7 +43,7 @@ internal final class FormCardInstallmentsItem: BaseFormPickerItem<InstallmentEle
             values.append(InstallmentElement(kind: .plan(.revolving), localizationParameters: localizationParameters))
         }
         
-        let showAmount = installmentConfiguration.showInstallmentPrice
+        let showAmount = installmentConfiguration.showInstallmentAmount
         let monthValues = currentInstallmentOptions.regularInstallmentMonths.map {
             InstallmentElement(
                 kind: .month(InstallmentElement.InstallmentMonth(monthValue: Int($0),

--- a/AdyenSession/API/Session Setup/SessionSetupRequest.swift
+++ b/AdyenSession/API/Session Setup/SessionSetupRequest.swift
@@ -89,5 +89,28 @@ extension SessionSetupResponse {
         internal let installmentOptions: InstallmentConfiguration?
         
         internal let enableStoreDetails: Bool
+        
+        internal init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            
+            self.enableStoreDetails = try container.decodeIfPresent(Bool.self, forKey: .enableStoreDetails) ?? false
+            
+            var installmentOptions = try container.decodeIfPresent(InstallmentConfiguration.self, forKey: .installmentOptions)
+            let showInstallmentAmount = try container.decodeIfPresent(Bool.self, forKey: .showInstallmentAmount) ?? false
+            // this flag doesn't come under the installments object, so we decode it here and put it under installments
+            installmentOptions?.showInstallmentAmount = showInstallmentAmount
+            self.installmentOptions = installmentOptions
+        }
+        
+        internal init(installmentOptions: InstallmentConfiguration? = nil, enableStoreDetails: Bool) {
+            self.installmentOptions = installmentOptions
+            self.enableStoreDetails = enableStoreDetails
+        }
+        
+        private enum CodingKeys: String, CodingKey {
+            case installmentOptions
+            case enableStoreDetails
+            case showInstallmentAmount
+        }
     }
 }

--- a/Demo/Common/Configuration/CardComponentSettingsView.swift
+++ b/Demo/Common/Configuration/CardComponentSettingsView.swift
@@ -32,6 +32,17 @@ internal struct CardSettingsView: View {
                     Toggle(isOn: $viewModel.showsSecurityCodeField) {
                         Text("Security Code")
                     }
+                    Toggle(isOn: $viewModel.installmentsEnabled) {
+                        Text("Installments")
+                        Text("(Example values for installments)")
+                            .foregroundColor(.gray)
+                            .font(.footnote)
+                    }
+                    if viewModel.installmentsEnabled {
+                        Toggle(isOn: $viewModel.showInstallmentAmount) {
+                            Text("Installment Amount")
+                        }
+                    }
                 }
                 Section(header: Text("Input Modes")) {
                     Picker("Billing Address mode", selection: $viewModel.addressMode) {

--- a/Demo/Common/Configuration/ConfigurationViewModel.swift
+++ b/Demo/Common/Configuration/ConfigurationViewModel.swift
@@ -30,6 +30,8 @@ internal final class ConfigurationViewModel: ObservableObject {
     @Published internal var allowOnboarding: Bool = false
     @Published internal var analyticsIsEnabled: Bool = true
     @Published internal var cashAppPayEnabled: Bool = false
+    @Published internal var installmentsEnabled: Bool = false
+    @Published internal var showInstallmentAmount: Bool = false
 
     private let onDone: (DemoAppSettings) -> Void
     private let configuration: DemoAppSettings
@@ -64,6 +66,8 @@ internal final class ConfigurationViewModel: ObservableObject {
         self.allowOnboarding = configuration.applePaySettings.allowOnboarding
         self.analyticsIsEnabled = configuration.analyticsSettings.isEnabled
         self.cashAppPayEnabled = configuration.dropInSettings.cashAppPayEnabled
+        self.installmentsEnabled = configuration.cardSettings.enableInstallments
+        self.showInstallmentAmount = configuration.cardSettings.showsIntallmentAmount
     }
     
     internal func doneTapped() {
@@ -87,7 +91,9 @@ internal final class ConfigurationViewModel: ObservableObject {
                 showsSecurityCodeField: showsSecurityCodeField,
                 addressMode: addressMode,
                 socialSecurityNumberMode: socialSecurityNumberMode,
-                koreanAuthenticationMode: koreanAuthenticationMode
+                koreanAuthenticationMode: koreanAuthenticationMode,
+                enableInstallments: installmentsEnabled,
+                showsIntallmentAmount: showInstallmentAmount
             ),
             dropInSettings: DropInSettings(allowDisablingStoredPaymentMethods: allowDisablingStoredPaymentMethods,
                                                      allowsSkippingPaymentList: allowsSkippingPaymentList,

--- a/Demo/Common/Configuration/ConfigurationViewModel.swift
+++ b/Demo/Common/Configuration/ConfigurationViewModel.swift
@@ -67,7 +67,7 @@ internal final class ConfigurationViewModel: ObservableObject {
         self.analyticsIsEnabled = configuration.analyticsSettings.isEnabled
         self.cashAppPayEnabled = configuration.dropInSettings.cashAppPayEnabled
         self.installmentsEnabled = configuration.cardSettings.enableInstallments
-        self.showInstallmentAmount = configuration.cardSettings.showsIntallmentAmount
+        self.showInstallmentAmount = configuration.cardSettings.showsInstallmentAmount
     }
     
     internal func doneTapped() {
@@ -93,7 +93,7 @@ internal final class ConfigurationViewModel: ObservableObject {
                 socialSecurityNumberMode: socialSecurityNumberMode,
                 koreanAuthenticationMode: koreanAuthenticationMode,
                 enableInstallments: installmentsEnabled,
-                showsIntallmentAmount: showInstallmentAmount
+                showsInstallmentAmount: showInstallmentAmount
             ),
             dropInSettings: DropInSettings(allowDisablingStoredPaymentMethods: allowDisablingStoredPaymentMethods,
                                                      allowsSkippingPaymentList: allowsSkippingPaymentList,

--- a/Demo/Common/Networking/SessionRequest.swift
+++ b/Demo/Common/Networking/SessionRequest.swift
@@ -40,12 +40,14 @@ internal struct SessionRequest: APIRequest {
         try container.encode(ConfigurationConstants.additionalData, forKey: .additionalData)
         try container.encode(ConfigurationConstants.lineItems, forKey: .lineItems)
         
-        // Toggle these for installments (nice to add these in the settings)
-        //        let installmentOptions = ["card": InstallmentOptions(monthValues: [2, 3, 5], includesRevolving: false),
-        //                                  "visa": InstallmentOptions(monthValues: [3, 6, 9], includesRevolving: true)]
-        //
-        //        try container.encode(installmentOptions, forKey: .installmentOptions)
-        //        try container.encode(true, forKey: .showInstallmentAmount)
+        if ConfigurationConstants.current.cardSettings.enableInstallments {
+            let installmentOptions = ["card": InstallmentOptions(monthValues: [2, 3, 5], includesRevolving: false),
+                                      "visa": InstallmentOptions(monthValues: [3, 6, 9], includesRevolving: true)]
+    
+            try container.encode(installmentOptions, forKey: .installmentOptions)
+            try container.encode(ConfigurationConstants.current.cardSettings.showsIntallmentAmount,
+                                 forKey: .showInstallmentAmount)
+        }
 
         if ConfigurationConstants.current.cardSettings.showsStorePaymentMethodField {
             AdyenAssertion.assert(message: "API version should be v70 or above to apply card component's store payment method field",

--- a/Demo/Common/Networking/SessionRequest.swift
+++ b/Demo/Common/Networking/SessionRequest.swift
@@ -45,7 +45,7 @@ internal struct SessionRequest: APIRequest {
                                       "visa": InstallmentOptions(monthValues: [3, 6, 9], includesRevolving: true)]
     
             try container.encode(installmentOptions, forKey: .installmentOptions)
-            try container.encode(ConfigurationConstants.current.cardSettings.showsIntallmentAmount,
+            try container.encode(ConfigurationConstants.current.cardSettings.showsInstallmentAmount,
                                  forKey: .showInstallmentAmount)
         }
 

--- a/Demo/Common/Networking/SessionRequest.swift
+++ b/Demo/Common/Networking/SessionRequest.swift
@@ -45,6 +45,7 @@ internal struct SessionRequest: APIRequest {
         //                                  "visa": InstallmentOptions(monthValues: [3, 6, 9], includesRevolving: true)]
         //
         //        try container.encode(installmentOptions, forKey: .installmentOptions)
+        //        try container.encode(true, forKey: .showInstallmentAmount)
 
         if ConfigurationConstants.current.cardSettings.showsStorePaymentMethodField {
             AdyenAssertion.assert(message: "API version should be v70 or above to apply card component's store payment method field",
@@ -70,6 +71,7 @@ internal struct SessionRequest: APIRequest {
         case installmentOptions
         case storePaymentMethodMode
         case recurringProcessingModel
+        case showInstallmentAmount
     }
     
 }

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -97,7 +97,7 @@ internal struct CardSettings: Codable {
     internal var socialSecurityNumberMode: CardComponent.FieldVisibility = .auto
     internal var koreanAuthenticationMode: CardComponent.FieldVisibility = .auto
     internal var enableInstallments = false
-    internal var showsIntallmentAmount = false
+    internal var showsInstallmentAmount = false
     
     internal enum AddressFormType: String, Codable, CaseIterable {
         case lookup
@@ -147,7 +147,7 @@ internal struct DemoAppSettings: Codable {
         let visaInstallmentOptions = InstallmentOptions(monthValues: [3, 4, 6], includesRevolving: false)
         return InstallmentConfiguration(cardBasedOptions: [.visa: visaInstallmentOptions],
                                                             defaultOptions: defaultInstallmentOptions,
-                                                            showInstallmentAmount: cardSettings.showsIntallmentAmount)
+                                                            showInstallmentAmount: cardSettings.showsInstallmentAmount)
     }
     
     internal static let defaultConfiguration = DemoAppSettings(
@@ -170,7 +170,7 @@ internal struct DemoAppSettings: Codable {
                                                            socialSecurityNumberMode: .auto,
                                                            koreanAuthenticationMode: .auto,
                                                            enableInstallments: false,
-                                                           showsIntallmentAmount: false)
+                                                           showsInstallmentAmount: false)
 
     internal static let defaultDropInSettings = DropInSettings(allowDisablingStoredPaymentMethods: false,
                                                                allowsSkippingPaymentList: false,

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -96,6 +96,8 @@ internal struct CardSettings: Codable {
     internal var addressMode: AddressFormType = .none
     internal var socialSecurityNumberMode: CardComponent.FieldVisibility = .auto
     internal var koreanAuthenticationMode: CardComponent.FieldVisibility = .auto
+    internal var enableInstallments = false
+    internal var showsIntallmentAmount = false
     
     internal enum AddressFormType: String, Codable, CaseIterable {
         case lookup
@@ -137,6 +139,17 @@ internal struct DemoAppSettings: Codable {
     internal var amount: Amount { Amount(value: value, currencyCode: currencyCode, localeIdentifier: nil) }
     internal var payment: Payment { Payment(amount: amount, countryCode: countryCode) }
     
+    private var installmentConfiguration: InstallmentConfiguration? {
+        guard cardSettings.enableInstallments else {
+            return nil
+        }
+        let defaultInstallmentOptions = InstallmentOptions(monthValues: [2, 3, 4], includesRevolving: true)
+        let visaInstallmentOptions = InstallmentOptions(monthValues: [3, 4, 6], includesRevolving: false)
+        return InstallmentConfiguration(cardBasedOptions: [.visa: visaInstallmentOptions],
+                                                            defaultOptions: defaultInstallmentOptions,
+                                                            showInstallmentAmount: cardSettings.showsIntallmentAmount)
+    }
+    
     internal static let defaultConfiguration = DemoAppSettings(
         countryCode: "NL",
         value: 17408,
@@ -155,7 +168,9 @@ internal struct DemoAppSettings: Codable {
                                                            showsSecurityCodeField: true,
                                                            addressMode: .none,
                                                            socialSecurityNumberMode: .auto,
-                                                           koreanAuthenticationMode: .auto)
+                                                           koreanAuthenticationMode: .auto,
+                                                           enableInstallments: false,
+                                                           showsIntallmentAmount: false)
 
     internal static let defaultDropInSettings = DropInSettings(allowDisablingStoredPaymentMethods: false,
                                                                allowsSkippingPaymentList: false,
@@ -199,6 +214,7 @@ internal struct DemoAppSettings: Codable {
                      koreanAuthenticationMode: cardSettings.koreanAuthenticationMode,
                      socialSecurityNumberMode: cardSettings.socialSecurityNumberMode,
                      storedCardConfiguration: storedCardConfig,
+                     installmentConfiguration: installmentConfiguration,
                      billingAddress: billingAddressConfig)
     }
 
@@ -215,6 +231,7 @@ internal struct DemoAppSettings: Codable {
                      koreanAuthenticationMode: cardSettings.koreanAuthenticationMode,
                      socialSecurityNumberMode: cardSettings.socialSecurityNumberMode,
                      storedCardConfiguration: storedCardConfig,
+                     installmentConfiguration: installmentConfiguration,
                      billingAddress: billingAddressConfig)
 
     }

--- a/Tests/Card Tests/CardComponentTests.swift
+++ b/Tests/Card Tests/CardComponentTests.swift
@@ -986,8 +986,7 @@ class CardComponentTests: XCTestCase {
         
         XCTAssertTrue(sut.cardViewController.items.numberContainerItem.showsSupportedCardLogos)
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-        wait(for: .milliseconds(30))
+        setupRootViewController(sut.viewController)
         
         let supportedCardLogosItemId = "AdyenCard.CardComponent.numberContainerItem.supportedCardLogosItem"
         
@@ -1095,9 +1094,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration,
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         let installmentItemView: FormCardInstallmentsItemView? = sut.cardViewController.view.findView(with: "AdyenCard.CardComponent.installmentsItem")
         XCTAssertEqual(installmentItemView!.titleLabel.text, "Number of installments")
@@ -1137,9 +1134,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration,
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         let installmentItemView: FormCardInstallmentsItemView? = sut.cardViewController.view.findView(with: "AdyenCard.CardComponent.installmentsItem")
         XCTAssertEqual(installmentItemView!.titleLabel.text, "Number of installments")
@@ -1173,9 +1168,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration,
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         let installmentItemView: FormCardInstallmentsItemView? = sut.cardViewController.view.findView(with: "AdyenCard.CardComponent.installmentsItem")
         XCTAssertEqual(installmentItemView!.titleLabel.text, "Number of installments")
@@ -1221,9 +1214,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration,
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         let installmentItemView: FormCardInstallmentsItemView? = sut.cardViewController.view.findView(with: "AdyenCard.CardComponent.installmentsItem")
         XCTAssertEqual(installmentItemView!.titleLabel.text, "Number of installments")


### PR DESCRIPTION
<new>

## New

- When you offer installment payments, you can now show the number of installments and the amount of each installment in the picker. For example, **3x $20**.
     - For Sessions flow, when you make a `/sessions` request, include [`showInstallmentAmount`](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions#request-showInstallmentAmount): **true** and [`installmentOptions`](https://docs.adyen.com/api-explorer/Checkout/latest/post/sessions#request-installmentOptions). We use these values to show installment options in the picker.
   - For Advanced flow, in the `InstallmentConfiguration` object, set `showInstallmentAmount` to **true** when you initialize it.

</new>