### PR TITLE
chore: Reusing encoded header to prevent signature mismatch

### DIFF
--- a/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryption.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryption.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -48,8 +48,6 @@ internal struct JSONWebEncryption {
         }
     }
     
-    internal let header: Header
-    
     internal let encryptedKey: Data
     
     internal let encryptedPayload: Data
@@ -60,21 +58,20 @@ internal struct JSONWebEncryption {
     
     internal let compactRepresentation: String
     
-    internal init(header: Header,
+    internal init(encodedHeader: Data,
                   encryptedKey: Data,
                   encryptedPayload: Data,
                   initializationVector: Data,
-                  authenticationTag: Data) throws {
-        self.header = header
+                  authenticationTag: Data) {
         self.encryptedKey = encryptedKey
         self.encryptedPayload = encryptedPayload
         self.initializationVector = initializationVector
         self.authenticationTag = authenticationTag
-        self.compactRepresentation = try [AdyenCoder.encode(header).base64URLString(),
-                                          encryptedKey.base64URLString(),
-                                          initializationVector.base64URLString(),
-                                          encryptedPayload.base64URLString(),
-                                          authenticationTag.base64URLString()].joined(separator: ".")
+        self.compactRepresentation = [encodedHeader.base64URLString(),
+                                      encryptedKey.base64URLString(),
+                                      initializationVector.base64URLString(),
+                                      encryptedPayload.base64URLString(),
+                                      authenticationTag.base64URLString()].joined(separator: ".")
     }
 
 }

--- a/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryptionGenerator.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryptionGenerator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -36,10 +36,10 @@ internal struct JSONWebEncryptionGenerator: AnyJSONWebEncryptionGenerator {
                                               additionalAuthenticationData: additionalAuthenticationData)
         let contentEncryptionOutput = try contentEncryptionAlgorithm.encrypt(input: contentEncryptionInput)
         
-        return try JSONWebEncryption(header: header,
-                                     encryptedKey: encryptedKey,
-                                     encryptedPayload: contentEncryptionOutput.encryptedPayload,
-                                     initializationVector: initializationVector,
-                                     authenticationTag: contentEncryptionOutput.authenticationTag)
+        return JSONWebEncryption(encodedHeader: encodedHeader,
+                                 encryptedKey: encryptedKey,
+                                 encryptedPayload: contentEncryptionOutput.encryptedPayload,
+                                 initializationVector: initializationVector,
+                                 authenticationTag: contentEncryptionOutput.authenticationTag)
     }
 }


### PR DESCRIPTION
## Summary
- reusing `encodedHeader` to prevent accidental (future) issues by re-encoding the header
