### PR TITLE
fix: Correctly read potential localization overrides from the main bundle

### DIFF
--- a/Adyen/Utilities/Localization.swift
+++ b/Adyen/Utilities/Localization.swift
@@ -34,10 +34,8 @@ public func localizedString(_ key: LocalizationKey, _ parameters: LocalizationPa
     switch parameters?.mode {
     case let .enforced(locale: enforcedLocale):
         translationAttempt = enforceLocalizedString(key: key.key, locale: enforcedLocale)
-    case .natural:
+    case .natural, .none:
         translationAttempt = attempt(buildPossibleInputs(key.key, parameters))
-    case .none:
-        break
     }
 
     // Use fallback in case attempt result is nil or empty


### PR DESCRIPTION
## Summary
<fixed>
When you define custom localizations in your app bundle using Localizable.strings, they are now applied correctly.
</fixed>


See: https://github.com/Adyen/adyen-ios/issues/1445