### PR TITLE
`chore` Fix `keyWindow` warnings

### DIFF
--- a/Adyen/UI/List/ListItem.swift
+++ b/Adyen/UI/List/ListItem.swift
@@ -81,7 +81,8 @@ public class ListItem: FormItem {
     
     /// Indicate to the ``ListViewController`` to start loading / show the loading indicator for this specific item
     ///
-    /// To stop the loading for the whole list either  call  ListViewController.``ListViewController/stopLoading()`` or ListItem.``ListItem/stopLoading()``
+    /// To stop the loading for the whole list either  call  ListViewController.``ListViewController/stopLoading()``
+    /// or ListItem.``ListItem/stopLoading()``
     public func startLoading() {
         setLoading(true)
     }

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -107,7 +107,9 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
                 completionHandler(.success(encodedFingerprint))
 
             case let .failure(error):
-                let encodedError = try AdyenCoder.encodeBase64(ThreeDS2Component.Fingerprint(threeDS2SDKError: error.base64Representation()))
+                let encodedError = try AdyenCoder.encodeBase64(ThreeDS2Component.Fingerprint(
+                    threeDS2SDKError: error.base64Representation())
+                )
                 completionHandler(.success(encodedError))
             }
         } catch {

--- a/Demo/Common/Helpers/APIClientHelper.swift
+++ b/Demo/Common/Helpers/APIClientHelper.swift
@@ -7,9 +7,9 @@
 import Adyen
 import AdyenNetworking
 
-enum ApiClientHelper {
+internal enum ApiClientHelper {
     
-    static func generateApiClient() -> APIClientProtocol {
+    internal static func generateApiClient() -> APIClientProtocol {
         guard CommandLine.arguments.contains("-UITests"),
               let paymentMethodsUrl = Bundle.main.url(forResource: "payment_methods_response", withExtension: "json"),
               let sessionsUrl = Bundle.main.url(forResource: "session_response", withExtension: "json"),
@@ -24,7 +24,7 @@ enum ApiClientHelper {
         return apiClient
     }
     
-    static func generatePalApiClient() -> APIClientProtocol {
+    internal static func generatePalApiClient() -> APIClientProtocol {
         let context = DemoAPIContext(environment: ConfigurationConstants.classicAPIEnvironment)
         return DefaultAPIClient(apiContext: context)
     }

--- a/Demo/Common/Networking/PaymentsRequest.swift
+++ b/Demo/Common/Networking/PaymentsRequest.swift
@@ -145,7 +145,7 @@ internal struct PaymentsResponse: Response {
         case amount
     }
     
-    var isAccepted: Bool {
+    internal var isAccepted: Bool {
         switch resultCode {
         case .authorised, .received, .pending:
             return true

--- a/Tests/Actions Tests/ActionComponent/AdyenActionComponentTests.swift
+++ b/Tests/Actions Tests/ActionComponent/AdyenActionComponentTests.swift
@@ -59,10 +59,10 @@ class AdyenActionComponentTests: XCTestCase {
     }
     """
 
-    func testRedirectToHttpWebLink() {
+    func testRedirectToHttpWebLink() throws {
         let sut = AdyenActionComponent(context: Dummy.context)
         let delegate = ActionComponentDelegateMock()
-        sut.presentationDelegate = UIViewController.findTopPresenter()
+        sut.presentationDelegate = try XCTUnwrap(UIViewController.topPresenter() as? PresentationDelegate)
         sut.delegate = delegate
 
         delegate.onDidOpenExternalApplication = { _ in
@@ -72,28 +72,22 @@ class AdyenActionComponentTests: XCTestCase {
         let action = Action.redirect(RedirectAction(url: URL(string: "https://www.adyen.com")!, paymentData: "test_data"))
         sut.handle(action)
 
-        wait(for: .seconds(2))
-
-        let topPresentedViewController = UIViewController.findTopPresenter()
-        XCTAssertNotNil(topPresentedViewController as? SFSafariViewController)
+        try waitUntilTopPresenter(isOfType: SFSafariViewController.self)
     }
 
-    func testAwaitAction() {
+    func testAwaitAction() throws {
         let sut = AdyenActionComponent(context: Dummy.context)
-        sut.presentationDelegate = UIViewController.findTopPresenter()
+        sut.presentationDelegate = try XCTUnwrap(UIViewController.topPresenter() as? PresentationDelegate)
 
         let action = Action.await(AwaitAction(paymentData: "SOME_DATA", paymentMethodType: .blik))
         sut.handle(action)
         
-        wait(for: .seconds(2))
-        
         let waitExpectation = expectation(description: "Expect AwaitViewController to be presented")
         
-        let topPresentedViewController = UIViewController.findTopPresenter()
-        XCTAssertNotNil(topPresentedViewController as? AdyenActions.AwaitViewController)
+        try waitUntilTopPresenter(isOfType: AdyenActions.AwaitViewController.self)
 
         (sut.presentationDelegate as! UIViewController).dismiss(animated: true) {
-            let topPresentedViewController = UIViewController.findTopPresenter()
+            let topPresentedViewController = try? UIViewController.topPresenter()
             XCTAssertNil(topPresentedViewController as? AdyenActions.AwaitViewController)
 
             waitExpectation.fulfill()
@@ -133,32 +127,23 @@ class AdyenActionComponentTests: XCTestCase {
         waitForExpectations(timeout: 10, handler: nil)
     }
 
-    func testVoucherAction() {
+    func testVoucherAction() throws {
         let sut = AdyenActionComponent(context: Dummy.context)
-        sut.presentationDelegate = UIViewController.findTopPresenter()
+        sut.presentationDelegate = try XCTUnwrap(UIViewController.topPresenter() as? PresentationDelegate)
         
         let action = try! JSONDecoder().decode(VoucherAction.self, from: voucherAction.data(using: .utf8)!)
         sut.handle(Action.voucher(action))
         
-        wait(for: .seconds(2))
-        
         let waitExpectation = expectation(description: "Expect VoucherViewController to be presented")
-        let topPresentedViewController = UIViewController.findTopPresenter()
-        XCTAssertNotNil(topPresentedViewController?.view as? VoucherView)
-
-        (sut.presentationDelegate as! UIViewController).dismiss(animated: true) {
-            let topPresentedViewController = UIViewController.findTopPresenter()
-            XCTAssertNil(topPresentedViewController as? VoucherViewController)
-
+        let voucherViewController = try waitUntilTopPresenter(isOfType: ADYViewController.self)
+        XCTAssertNotNil(voucherViewController.view as? VoucherView)
+        
+        let presentationDelegate = try XCTUnwrap(sut.presentationDelegate as? UIViewController)
+        presentationDelegate.dismiss(animated: true) {
+            XCTAssertNotEqual(voucherViewController, try? UIViewController.topPresenter())
             waitExpectation.fulfill()
         }
 
         waitForExpectations(timeout: 10, handler: nil)
-    }
-}
-
-extension UIViewController: PresentationDelegate {
-    public func present(component: PresentableComponent) {
-        self.present(component.viewController, animated: true, completion: nil)
     }
 }

--- a/Tests/Actions Tests/Await/AwaitComponentTests.swift
+++ b/Tests/Actions Tests/Await/AwaitComponentTests.swift
@@ -117,14 +117,14 @@ class AwaitComponentTests: XCTestCase {
         let presentationDelegate = PresentationDelegateMock()
         let waitExpectation = expectation(description: "Wait for the presentationDelegate to be called.")
         presentationDelegate.doPresent = { [weak self] component in
+            guard let self = self else { return }
+            
             XCTAssertNotNil(component.viewController as? AwaitViewController)
             let viewController = component.viewController as! AwaitViewController
 
-            UIApplication.shared.keyWindow?.rootViewController = viewController
+            self.setupRootViewController(viewController)
 
             let view = viewController.awaitView
-            
-            self?.wait(for: .milliseconds(300))
 
             XCTAssertEqual(view.messageLabel.textColor, UIColor.red)
             XCTAssertEqual(view.messageLabel.textAlignment, .center)

--- a/Tests/Actions Tests/Redirect/RedirectComponentTests.swift
+++ b/Tests/Actions Tests/Redirect/RedirectComponentTests.swift
@@ -12,16 +12,16 @@ import XCTest
 
 class RedirectComponentTests: XCTestCase {
     
-    override func tearDown() {
-        super.tearDown()
-        UIApplication.shared.keyWindow?.rootViewController?.dismiss(animated: false)
-        wait(for: .milliseconds(300))
+    override func setUp(completion: @escaping (Error?) -> Void) {
+        UIApplication.shared.adyen.mainKeyWindow?.rootViewController?.dismiss(animated: false) {
+            super.setUp(completion: completion)
+        }
     }
     
-    override func setUp() {
-        super.setUp()
-        UIApplication.shared.keyWindow?.rootViewController?.dismiss(animated: false)
-        wait(for: .milliseconds(300))
+    override func tearDown(completion: @escaping (Error?) -> Void) {
+        UIApplication.shared.adyen.mainKeyWindow?.rootViewController?.dismiss(animated: false) {
+            super.tearDown(completion: completion)
+        }
     }
 
     func testUIConfiguration() {
@@ -131,7 +131,7 @@ class RedirectComponentTests: XCTestCase {
         waitForExpectations(timeout: 10, handler: nil)
     }
     
-    func testOpenUniversalLinkFailure() {
+    func testOpenUniversalLinkFailure() throws {
         let sut = RedirectComponent(context: Dummy.context)
         let delegate = ActionComponentDelegateMock()
         sut.delegate = delegate
@@ -139,13 +139,12 @@ class RedirectComponentTests: XCTestCase {
         sut.appLauncher = appLauncher
         let presentingViewControllerMock = PresentingViewControllerMock()
         sut.presentationDelegate = presentingViewControllerMock
-        let topViewController: UIViewController! = UIViewController.findTopPresenter()
+        let topViewController = try UIViewController.topPresenter()
         topViewController.present(presentingViewControllerMock, animated: false, completion: nil)
         
         let safariVCExpectation = expectation(description: "Expect SFSafariViewController() to be presented")
         presentingViewControllerMock.onPresent = { viewController, animated, completion in
-            XCTAssertNotNil(viewController as? SFSafariViewController)
-            XCTAssertEqual(animated, true)
+            XCTAssertTrue(viewController is SFSafariViewController)
             completion?()
             safariVCExpectation.fulfill()
         }
@@ -171,9 +170,9 @@ class RedirectComponentTests: XCTestCase {
         waitForExpectations(timeout: 10, handler: nil)
     }
 
-    func testOpenHttpWebLink() {
+    func testOpenHttpWebLink() throws {
         let sut = RedirectComponent(context: Dummy.context)
-        sut.presentationDelegate = UIViewController.findTopPresenter()
+        sut.presentationDelegate = try UIViewController.topPresenter()
         let delegate = ActionComponentDelegateMock()
         sut.delegate = delegate
         let appLauncher = AppLauncherMock()
@@ -194,15 +193,12 @@ class RedirectComponentTests: XCTestCase {
         let action = RedirectAction(url: URL(string: "https://www.adyen.com?returnUrlQueryString=anything")!, paymentData: "test_data")
         sut.handle(action)
         
-        wait(for: .seconds(2))
-        
-        let topPresentedViewController = UIViewController.findTopPresenter()
-        XCTAssertNotNil(topPresentedViewController as? SFSafariViewController)
+        try waitUntilTopPresenter(isOfType: SFSafariViewController.self)
     }
 
-    func testOpenHttpWebLinkAndDragedDown() {
+    func testOpenHttpWebLinkAndDragedDown() throws {
         let sut = RedirectComponent(context: Dummy.context)
-        sut.presentationDelegate = UIViewController.findTopPresenter()
+        sut.presentationDelegate = try UIViewController.topPresenter()
         let delegate = ActionComponentDelegateMock()
         sut.delegate = delegate
 
@@ -215,13 +211,11 @@ class RedirectComponentTests: XCTestCase {
             XCTAssertEqual(error as! ComponentError, ComponentError.cancelled)
             waitExpectation.fulfill()
         }
-        
-        wait(for: .seconds(2))
 
-        let topPresentedViewController = UIViewController.findTopPresenter() as? SFSafariViewController
-        XCTAssertNotNil(topPresentedViewController)
+        let topPresentedViewController = try waitUntilTopPresenter(isOfType: SFSafariViewController.self)
 
-        topPresentedViewController!.presentationController?.delegate?.presentationControllerDidDismiss?(topPresentedViewController!.presentationController!)
+        let presentationController = try XCTUnwrap(topPresentedViewController.presentationController)
+        presentationController.delegate?.presentationControllerDidDismiss?(presentationController)
 
         waitForExpectations(timeout: 10, handler: nil)
     }
@@ -350,15 +344,4 @@ class RedirectComponentTests: XCTestCase {
         
         waitForExpectations(timeout: 2)
     }
-}
-
-extension UIViewController {
-    public static func findTopPresenter() -> UIViewController? {
-        guard let viewController = UIApplication.shared.keyWindow?.rootViewController else {
-            AdyenAssertion.assertionFailure(message: "Application's keyWindow is not set or have no rootViewController")
-            return nil
-        }
-        return viewController.adyen.topPresenter
-    }
-
 }

--- a/Tests/Actions Tests/Voucher/BoletoVoucherShareableVoucherViewProviderTests.swift
+++ b/Tests/Actions Tests/Voucher/BoletoVoucherShareableVoucherViewProviderTests.swift
@@ -21,7 +21,7 @@ class BoletoVoucherShareableVoucherViewProviderTests: XCTestCase {
 
         let sut = viewProvider.provideView(with: action, logo: nil)
 
-        UIApplication.shared.keyWindow?.rootViewController?.view = sut
+        setupRootViewController(ADYViewController(view: sut))
 
         let textLabel: UILabel! = sut.findView(by: "adyen.voucher.textLabel")
         XCTAssertEqual(textLabel.text, "Thank you for your purchase, please use the following information to complete your payment.")

--- a/Tests/Actions Tests/Voucher/DokuVoucherUITests.swift
+++ b/Tests/Actions Tests/Voucher/DokuVoucherUITests.swift
@@ -19,7 +19,7 @@ class DokuVoucherUITests: XCTestCase {
 
         let sut = viewControllerProvider.provideView(with: action, logo: nil)
 
-        UIApplication.shared.keyWindow?.rootViewController?.view = sut
+        setupRootViewController(ADYViewController(view: sut))
 
         let textLabel: UILabel! = sut.findView(by: "adyen.voucher.textLabel")
         XCTAssertEqual(textLabel.text, "Thank you for your purchase, please use the following information to complete your payment. -- Test")
@@ -57,7 +57,7 @@ class DokuVoucherUITests: XCTestCase {
 
         let sut = viewProvider.provideView(with: action, logo: nil)
 
-        UIApplication.shared.keyWindow?.rootViewController?.view = sut
+        setupRootViewController(ADYViewController(view: sut))
 
         let textLabel: UILabel! = sut.findView(by: "adyen.voucher.textLabel")
         XCTAssertEqual(textLabel.text, "Thank you for your purchase, please use the following information to complete your payment.")
@@ -95,7 +95,7 @@ class DokuVoucherUITests: XCTestCase {
 
         let sut = viewProvider.provideView(with: action, logo: nil)
 
-        UIApplication.shared.keyWindow?.rootViewController?.view = sut
+        setupRootViewController(ADYViewController(view: sut))
 
         let textLabel: UILabel! = sut.findView(by: "adyen.voucher.textLabel")
         XCTAssertEqual(textLabel.text, "Thank you for your purchase, please use the following information to complete your payment.")

--- a/Tests/Actions Tests/Voucher/EContextATMShareableVoucherViewProviderTests.swift
+++ b/Tests/Actions Tests/Voucher/EContextATMShareableVoucherViewProviderTests.swift
@@ -23,7 +23,7 @@ class EContextATMShareableVoucherViewProviderTests: XCTestCase {
 
         let sut = viewProvider.provideView(with: action, logo: nil)
 
-        UIApplication.shared.keyWindow?.rootViewController?.view = sut
+        setupRootViewController(ADYViewController(view: sut))
 
         let textLabel: UILabel! = sut.findView(by: "adyen.voucher.textLabel")
         XCTAssertEqual(textLabel.text, "Thank you for your purchase, please use the following information to complete your payment. -- Test")

--- a/Tests/Actions Tests/Voucher/EContextStoresVoucherViewControllerProviderTests.swift
+++ b/Tests/Actions Tests/Voucher/EContextStoresVoucherViewControllerProviderTests.swift
@@ -23,7 +23,7 @@ class EContextStoresVoucherViewControllerProviderTests: XCTestCase {
 
         let sut = viewProvider.provideView(with: action, logo: nil)
 
-        UIApplication.shared.keyWindow?.rootViewController?.view = sut
+        setupRootViewController(ADYViewController(view: sut))
 
         let textLabel: UILabel! = sut.findView(by: "adyen.voucher.textLabel")
         XCTAssertEqual(textLabel.text, "Thank you for your purchase, please use the following information to complete your payment. -- Test")

--- a/Tests/Actions Tests/Voucher/MultibancoShareableVoucherViewProviderTests.swift
+++ b/Tests/Actions Tests/Voucher/MultibancoShareableVoucherViewProviderTests.swift
@@ -23,7 +23,7 @@ class MultibancoShareableVoucherViewProviderTests: XCTestCase {
 
         let sut = viewProvider.provideView(with: action, logo: nil)
 
-        UIApplication.shared.keyWindow?.rootViewController?.view = sut
+        setupRootViewController(ADYViewController(view: sut))
 
         let textLabel: UILabel! = sut.findView(by: "adyen.voucher.textLabel")
         XCTAssertEqual(textLabel.text, "Thank you for your purchase, please use the following information to complete your payment.")

--- a/Tests/Actions Tests/Voucher/OXXOShareableVoucherViewProviderTests.swift
+++ b/Tests/Actions Tests/Voucher/OXXOShareableVoucherViewProviderTests.swift
@@ -23,7 +23,7 @@ class OXXOShareableVoucherViewProviderTests: XCTestCase {
 
         let sut = viewProvider.provideView(with: action, logo: nil)
 
-        UIApplication.shared.keyWindow?.rootViewController?.view = sut
+        setupRootViewController(ADYViewController(view: sut))
 
         let textLabel: UILabel! = sut.findView(by: "adyen.voucher.textLabel")
         XCTAssertEqual(textLabel.text, "Thank you for your purchase, please use the following information to complete your payment.")

--- a/Tests/Actions Tests/Voucher/VoucherComponentTests.swift
+++ b/Tests/Actions Tests/Voucher/VoucherComponentTests.swift
@@ -97,7 +97,7 @@ class VoucherComponentTests: XCTestCase {
             let component = component as! PresentableComponentWrapper
             XCTAssert(component.component === sut)
             
-            UIApplication.shared.keyWindow?.rootViewController = component.viewController
+            setupRootViewController(component.viewController)
             
             let view = sut.view
             
@@ -113,13 +113,12 @@ class VoucherComponentTests: XCTestCase {
             
             wait(for: .milliseconds(300))
             
-            let alertSheet = UIViewController.findTopPresenter() as? UIAlertController
-            XCTAssertNotNil(alertSheet)
-            XCTAssertEqual(alertSheet?.actions.count, 4)
-            XCTAssertEqual(alertSheet?.actions[0].title, "Copy code")
-            XCTAssertEqual(alertSheet?.actions[1].title, "Download PDF")
-            XCTAssertEqual(alertSheet?.actions[2].title, "Read instructions")
-            XCTAssertEqual(alertSheet?.actions[3].title, "Cancel")
+            let alertSheet = try! XCTUnwrap(UIViewController.topPresenter() as? UIAlertController)
+            XCTAssertEqual(alertSheet.actions.count, 4)
+            XCTAssertEqual(alertSheet.actions[0].title, "Copy code")
+            XCTAssertEqual(alertSheet.actions[1].title, "Download PDF")
+            XCTAssertEqual(alertSheet.actions[2].title, "Read instructions")
+            XCTAssertEqual(alertSheet.actions[3].title, "Cancel")
             
             presentationDelegateExpectation.fulfill()
         }
@@ -137,7 +136,7 @@ class VoucherComponentTests: XCTestCase {
             let component = component as! PresentableComponentWrapper
             XCTAssert(component.component === sut)
             
-            UIApplication.shared.keyWindow?.rootViewController = component.viewController
+            self.setupRootViewController(component.viewController)
             
             let view = sut.view
             
@@ -151,14 +150,12 @@ class VoucherComponentTests: XCTestCase {
             
             optionsButton.sendActions(for: .touchUpInside)
             
-            wait(for: .milliseconds(300))
-            
-            let alertSheet = UIViewController.findTopPresenter() as? UIAlertController
+            let alertSheet = try! waitUntilTopPresenter(isOfType: UIAlertController.self)
             XCTAssertNotNil(alertSheet)
-            XCTAssertEqual(alertSheet?.actions.count, 3)
-            XCTAssertEqual(alertSheet?.actions[0].title, "Copy code")
-            XCTAssertEqual(alertSheet?.actions[1].title, "Save as image")
-            XCTAssertEqual(alertSheet?.actions[2].title, "Cancel")
+            XCTAssertEqual(alertSheet.actions.count, 3)
+            XCTAssertEqual(alertSheet.actions[0].title, "Copy code")
+            XCTAssertEqual(alertSheet.actions[1].title, "Save as image")
+            XCTAssertEqual(alertSheet.actions[2].title, "Cancel")
             
             presentationDelegateExpectation.fulfill()
         }

--- a/Tests/Adyen Tests/UI/Form/FormItems/Error Item/FormErrorItemTests.swift
+++ b/Tests/Adyen Tests/UI/Form/FormItems/Error Item/FormErrorItemTests.swift
@@ -14,7 +14,7 @@ class FormErrorItemTests: XCTestCase {
     func testHidingAndShowing() throws {
         let formViewController = FormViewController(style: FormComponentStyle())
 
-        UIApplication.shared.keyWindow?.rootViewController? = formViewController
+        setupRootViewController(formViewController)
 
         let expectation = XCTestExpectation(description: "Dummy Expectation")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {

--- a/Tests/Adyen Tests/UI/Form/FormItems/Picker/FormPickerItemTests.swift
+++ b/Tests/Adyen Tests/UI/Form/FormItems/Picker/FormPickerItemTests.swift
@@ -61,8 +61,7 @@ class FormPickerItemTests: XCTestCase {
         
         wait(for: [presentViewControllerExpectation], timeout: 1)
         
-        UIApplication.shared.keyWindow?.rootViewController? = presentedViewController!
-        self.wait(for: .milliseconds(300))
+        setupRootViewController(presentedViewController!)
         
         let searchViewController = presentedViewController!.viewControllers.first as! SearchViewController
         searchViewController.viewModel.interfaceState.results?.first?.selectionHandler?()

--- a/Tests/Adyen Tests/UI/View Controllers/AddressInputFormViewControllerTests.swift
+++ b/Tests/Adyen Tests/UI/View Controllers/AddressInputFormViewControllerTests.swift
@@ -11,14 +11,6 @@ import XCTest
 
 class AddressInputFormViewControllerTests: XCTestCase {
     
-    override class func setUp() {
-        UIApplication.shared.keyWindow?.layer.speed = 10
-    }
-    
-    override class func tearDown() {
-        UIApplication.shared.keyWindow?.layer.speed = 1
-    }
-    
     func testAddressNL() throws {
         // Given
         let viewController = AddressInputFormViewController(
@@ -81,11 +73,9 @@ class AddressInputFormViewControllerTests: XCTestCase {
             )
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = viewController
-
+        setupRootViewController(viewController)
+        
         // When
-        wait(for: .milliseconds(5))
-
         let view: UIView = viewController.view
 
         let houseNumberItemView: FormTextInputItemView = try XCTUnwrap(view.findView(with: "AddressInputFormViewController.billingAddress.houseNumberOrName"))
@@ -136,9 +126,7 @@ class AddressInputFormViewControllerTests: XCTestCase {
             )
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = UINavigationController(rootViewController: viewController)
-
-        wait(for: .milliseconds(5))
+        setupRootViewController(UINavigationController(rootViewController: viewController))
         
         let view: UIView = viewController.view
 
@@ -171,9 +159,7 @@ class AddressInputFormViewControllerTests: XCTestCase {
             )
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = UINavigationController(rootViewController: viewController)
-
-        wait(for: .milliseconds(5))
+        setupRootViewController(UINavigationController(rootViewController: viewController))
 
         let view: UIView = viewController.view
 
@@ -231,9 +217,7 @@ class AddressInputFormViewControllerTests: XCTestCase {
             )
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = UINavigationController(rootViewController: viewController)
-
-        wait(for: .milliseconds(5))
+        setupRootViewController(UINavigationController(rootViewController: viewController))
         
         let view: UIView = viewController.view
         let searchItemView: FormSearchButtonItemView = try XCTUnwrap(view.findView(with: "AddressInputFormViewController.searchBar"))
@@ -253,8 +237,7 @@ class AddressInputFormViewControllerTests: XCTestCase {
             )
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = UINavigationController(rootViewController: viewController)
-        self.wait(for: .milliseconds(5))
+        setupRootViewController(UINavigationController(rootViewController: viewController))
         
         XCTAssertEqual(
             viewController.navigationItem.rightBarButtonItem?.isEnabled,
@@ -272,8 +255,7 @@ class AddressInputFormViewControllerTests: XCTestCase {
             )
         )
 
-        UIApplication.shared.keyWindow?.rootViewController = UINavigationController(rootViewController: viewController)
-        self.wait(for: .milliseconds(5))
+        setupRootViewController(UINavigationController(rootViewController: viewController))
         
         XCTAssertEqual(
             viewController.navigationItem.rightBarButtonItem?.isEnabled,
@@ -301,8 +283,7 @@ class AddressInputFormViewControllerTests: XCTestCase {
             )
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = UINavigationController(rootViewController: viewController)
-        self.wait(for: .milliseconds(5))
+        setupRootViewController(UINavigationController(rootViewController: viewController))
         
         XCTAssertEqual(
             viewController.navigationItem.rightBarButtonItem?.isEnabled,
@@ -320,11 +301,8 @@ class AddressInputFormViewControllerTests: XCTestCase {
             )
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = viewController
-        wait(for: .milliseconds(5))
-        
-        UIApplication.shared.keyWindow?.rootViewController = UIViewController()
-        wait(for: .milliseconds(5))
+        setupRootViewController(viewController)
+        setupRootViewController(UIViewController())
 
         XCTAssertEqual(
             viewController.billingAddressItem.value.street,

--- a/Tests/Adyen Tests/UI/View Controllers/AddressInputFormViewControllerTests.swift
+++ b/Tests/Adyen Tests/UI/View Controllers/AddressInputFormViewControllerTests.swift
@@ -107,12 +107,10 @@ class AddressInputFormViewControllerTests: XCTestCase {
         let doneButton = try XCTUnwrap(viewController.navigationItem.rightBarButtonItem)
         try doneButton.tap()
         
-        wait(for: .milliseconds(50))
-        
-        XCTAssertTrue(houseNumberItemView.alertLabel.isHidden)
-        XCTAssertFalse(addressItemView.alertLabel.isHidden)
-        XCTAssertFalse(cityItemView.alertLabel.isHidden)
-        XCTAssertFalse(postalCodeItemView.alertLabel.isHidden)
+        wait(until: houseNumberItemView.alertLabel, at: \.isHidden, is: true)
+        wait(until: addressItemView.alertLabel, at: \.isHidden, is: false)
+        wait(until: cityItemView.alertLabel, at: \.isHidden, is: false)
+        wait(until: postalCodeItemView.alertLabel, at: \.isHidden, is: false)
     }
 
     func testAddressUK() throws {

--- a/Tests/Adyen Tests/UI/View Controllers/FormPickerSearchViewControllerTests.swift
+++ b/Tests/Adyen Tests/UI/View Controllers/FormPickerSearchViewControllerTests.swift
@@ -47,8 +47,7 @@ class FormPickerSearchViewControllerTests: XCTestCase {
         }
         
         // Allow setup in viewDidLoad
-        UIApplication.shared.keyWindow?.rootViewController = pickerSearchViewController
-        wait(for: .milliseconds(300))
+        setupRootViewController(pickerSearchViewController)
         
         let searchViewController = pickerSearchViewController.viewControllers.first as! SearchViewController
         guard case let .showingResults(results) = searchViewController.viewModel.interfaceState else {
@@ -73,8 +72,7 @@ class FormPickerSearchViewControllerTests: XCTestCase {
         ) { _ in }
         
         // Allow setup in viewDidLoad
-        UIApplication.shared.keyWindow?.rootViewController = pickerSearchViewController
-        wait(for: .milliseconds(300))
+        setupRootViewController(pickerSearchViewController)
         
         let searchViewController = pickerSearchViewController.viewControllers.first as! SearchViewController
         
@@ -112,8 +110,7 @@ class FormPickerSearchViewControllerTests: XCTestCase {
         ) { _ in }
         
         // Allow setup in viewDidLoad
-        UIApplication.shared.keyWindow?.rootViewController = pickerSearchViewController
-        wait(for: .milliseconds(300))
+        setupRootViewController(pickerSearchViewController)
         
         let searchViewController = pickerSearchViewController.viewControllers.first as! SearchViewController
         

--- a/Tests/Adyen Tests/UI/View Controllers/SearchViewControllerTests.swift
+++ b/Tests/Adyen Tests/UI/View Controllers/SearchViewControllerTests.swift
@@ -132,8 +132,7 @@ class SearchViewControllerTests: XCTestCase {
         )
         
         // Allow setup in viewDidLoad
-        UIApplication.shared.keyWindow?.rootViewController = searchViewController
-        wait(for: .milliseconds(300))
+        setupRootViewController(searchViewController)
         
         searchViewController.searchBar.delegate?.searchBar?(
             searchViewController.searchBar,
@@ -162,8 +161,7 @@ class SearchViewControllerTests: XCTestCase {
             emptyView: emptyView
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = searchViewController
-        wait(for: .milliseconds(300))
+        setupRootViewController(searchViewController)
         
         // When
         viewModel.interfaceState = .empty(searchTerm: testSearchTerm)
@@ -189,8 +187,7 @@ class SearchViewControllerTests: XCTestCase {
             emptyView: emptyView
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = searchViewController
-        wait(for: .milliseconds(300))
+        setupRootViewController(searchViewController)
         
         // When
         viewModel.interfaceState = .loading
@@ -217,8 +214,7 @@ class SearchViewControllerTests: XCTestCase {
             emptyView: emptyView
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = searchViewController
-        wait(for: .milliseconds(300))
+        setupRootViewController(searchViewController)
         
         // When
         viewModel.interfaceState = .showingResults(results: resultItems)

--- a/Tests/Adyen Tests/UI/Views/LoadingViewTests.swift
+++ b/Tests/Adyen Tests/UI/Views/LoadingViewTests.swift
@@ -18,6 +18,7 @@ class LoadingViewTests: XCTestCase {
         super.setUp()
         let contentView = UIView()
         sut = LoadingView(contentView: contentView)
+        sut.spinnerAppearanceDelay = .milliseconds(1)
 
         viewController = UIViewController()
         viewController.view.addSubview(sut)
@@ -26,26 +27,19 @@ class LoadingViewTests: XCTestCase {
     }
 
     func testShowingSpinnerDelay() throws {
-        UIApplication.shared.keyWindow?.rootViewController = viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(viewController)
         
         sut.showsActivityIndicator = true
         XCTAssertEqual(sut.showsActivityIndicator, false)
         
-        wait(for: .milliseconds(1100))
-        XCTAssertEqual(sut.showsActivityIndicator, true)
+        wait(until: sut, at: \.showsActivityIndicator, is: true)
     }
     
-    func testHiddingSpinner() throws {
-        UIApplication.shared.keyWindow?.rootViewController = viewController
-        
-        wait(for: .milliseconds(300))
+    func testHidingSpinner() throws {
+        setupRootViewController(viewController)
         
         sut.showsActivityIndicator = true
-        
-        wait(for: .milliseconds(300))
-        
+        wait(for: .milliseconds(2))
         sut.showsActivityIndicator = false
         XCTAssertEqual(sut.showsActivityIndicator, false)
         XCTAssertNil(sut.workItem)

--- a/Tests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/Card Tests/BCMCComponentTests.swift
@@ -47,11 +47,11 @@ class BCMCComponentTests: XCTestCase {
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context,
                                 configuration: CardComponent.Configuration())
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        
+        setupRootViewController(sut.viewController)
         
         XCTAssertEqual(sut.configuration.allowedCardTypes, nil)
         XCTAssertEqual(sut.supportedCardTypes, brands)
-        wait(for: .milliseconds(300))
         
         XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem"))
         XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem.cardTypeLogos"))
@@ -71,8 +71,7 @@ class BCMCComponentTests: XCTestCase {
         
         XCTAssertFalse(sut.cardViewController.items.numberContainerItem.showsSupportedCardLogos)
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-        wait(for: .milliseconds(30))
+        setupRootViewController(sut.viewController)
         
         let supportedCardLogosItemId = "AdyenCard.BCMCComponent.numberContainerItem.supportedCardLogosItem"
         
@@ -101,12 +100,11 @@ class BCMCComponentTests: XCTestCase {
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context,
                                 configuration: configuration)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        
+        setupRootViewController(sut.viewController)
         
         XCTAssertEqual(sut.configuration.allowedCardTypes, nil)
         XCTAssertEqual(sut.supportedCardTypes, brands)
-        
-        wait(for: .milliseconds(300))
         
         XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem"))
         XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem.cardTypeLogos"))
@@ -125,12 +123,11 @@ class BCMCComponentTests: XCTestCase {
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context,
                                 configuration: configuration)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        
+        setupRootViewController(sut.viewController)
         
         XCTAssertEqual(sut.configuration.allowedCardTypes, nil)
         XCTAssertEqual(sut.supportedCardTypes, brands)
-        
-        wait(for: .milliseconds(300))
         
         XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem"))
         XCTAssertNotNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem.cardTypeLogos"))
@@ -146,9 +143,8 @@ class BCMCComponentTests: XCTestCase {
         let paymentMethod = BCMCPaymentMethod(cardPaymentMethod: cardPaymentMethod)
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
         
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
         XCTAssertNotNil(cardNumberItemView)
@@ -167,7 +163,8 @@ class BCMCComponentTests: XCTestCase {
         let paymentMethod = BCMCPaymentMethod(cardPaymentMethod: cardPaymentMethod)
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        
+        setupRootViewController(sut.viewController)
         
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
         XCTAssertNotNil(cardNumberItemView)
@@ -175,9 +172,7 @@ class BCMCComponentTests: XCTestCase {
         let cardNumberItem = cardNumberItemView!.item
         self.populate(textItemView: cardNumberItemView!, with: "00000")
         
-        wait(for: .milliseconds(300))
-        
-        XCTAssertTrue(cardNumberItem.detectedBrandLogos.count == 0)
+        wait(until: cardNumberItem, at: \.detectedBrands.count, is: 0)
     }
     
     func testSubmitValidPaymentData() {
@@ -187,7 +182,8 @@ class BCMCComponentTests: XCTestCase {
                                 context: context)
         PublicKeyProvider.publicKeysCache[Dummy.apiContext.clientKey] = Dummy.publicKey
         sut.delegate = delegate
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+
+        setupRootViewController(sut.viewController)
         
         let didSubmitExpectation = XCTestExpectation(description: "Expect delegate.didSubmit() to be called")
         delegate.onDidSubmit = { paymentData, component in
@@ -213,8 +209,6 @@ class BCMCComponentTests: XCTestCase {
         
         let binResponse = BinLookupResponse(brands: [CardBrand(type: .bcmc, isSupported: true, cvcPolicy: .optional)])
         sut.cardViewController.update(binInfo: binResponse)
-
-        wait(for: .milliseconds(300))
         
         // Enter Card Number
         let cardNumberView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
@@ -243,7 +237,7 @@ class BCMCComponentTests: XCTestCase {
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context)
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         let expectationCardType = XCTestExpectation(description: "CardType Expectation")
         let mockedBrands = [CardBrand(type: .bcmc, cvcPolicy: .optional)]
@@ -257,8 +251,6 @@ class BCMCComponentTests: XCTestCase {
                                                      })
         sut.cardComponentDelegate = delegateMock
         
-        wait(for: .milliseconds(300))
-        
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
         self.populate(textItemView: cardNumberItemView!, with: "67034")
         
@@ -271,7 +263,7 @@ class BCMCComponentTests: XCTestCase {
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let expectationBin = XCTestExpectation(description: "Bin Expectation")
         expectationBin.expectedFulfillmentCount = 1
@@ -286,8 +278,6 @@ class BCMCComponentTests: XCTestCase {
                                                          XCTFail("form not submited yet onSubmitLastFour is called")
                                                      })
         sut.cardComponentDelegate = delegateMock
-
-        wait(for: .milliseconds(300))
         
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
         populate(textItemView: cardNumberItemView!, with: Dummy.bancontactCard.number!)
@@ -301,7 +291,7 @@ class BCMCComponentTests: XCTestCase {
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let expectationBin = XCTestExpectation(description: "Bin Expectation")
         expectationBin.expectedFulfillmentCount = 1
@@ -315,8 +305,6 @@ class BCMCComponentTests: XCTestCase {
                                                          XCTFail("form not submited yet onSubmitLastFour is called")
                                                      })
         sut.cardComponentDelegate = delegateMock
-
-        wait(for: .milliseconds(300))
         
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
         populate(textItemView: cardNumberItemView!, with: "6703 4444 4444")
@@ -341,7 +329,7 @@ class BCMCComponentTests: XCTestCase {
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let expectationBin = XCTestExpectation(description: "Bin Expectation")
         let delegateMock = CardComponentDelegateMock(
@@ -353,8 +341,6 @@ class BCMCComponentTests: XCTestCase {
         )
         
         sut.cardComponentDelegate = delegateMock
-
-        wait(for: .milliseconds(30))
         
         fillCard(on: sut.viewController.view, with: Dummy.bancontactCard, simulateKeyStrokes: true)
         wait(for: [expectationBinLookup], timeout: 1)
@@ -384,7 +370,7 @@ class BCMCComponentTests: XCTestCase {
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let expectationBin = XCTestExpectation(description: "Bin Expectation")
         expectationBin.expectedFulfillmentCount = 2
@@ -405,8 +391,6 @@ class BCMCComponentTests: XCTestCase {
         )
         
         sut.cardComponentDelegate = delegateMock
-
-        wait(for: .milliseconds(300))
         
         fillCard(on: sut.viewController.view, with: Dummy.bancontactCard, simulateKeyStrokes: true)
         wait(for: [expectationBinLookup], timeout: 1)
@@ -432,7 +416,7 @@ class BCMCComponentTests: XCTestCase {
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let expectationBin = XCTestExpectation(description: "Bin Expectation")
         expectationBin.expectedFulfillmentCount = 2
@@ -450,8 +434,6 @@ class BCMCComponentTests: XCTestCase {
                                                          expectationBin.fulfill()
                                                      })
         sut.cardComponentDelegate = delegateMock
-
-        wait(for: .milliseconds(300))
         
         fillCard(on: sut.viewController.view, with: Dummy.longBancontactCard, simulateKeyStrokes: true)
         wait(for: [expectationBinLookup], timeout: 1)
@@ -466,7 +448,7 @@ class BCMCComponentTests: XCTestCase {
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         let expectationCardType = XCTestExpectation(description: "CardType Expectation")
         let delegateMock = CardComponentDelegateMock(onBINDidChange: { _ in },
@@ -478,8 +460,6 @@ class BCMCComponentTests: XCTestCase {
                                                          XCTFail("form not submited yet onSubmitLastFour is called")
                                                      })
         sut.cardComponentDelegate = delegateMock
-        
-        wait(for: .milliseconds(300))
         
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
         self.populate(textItemView: cardNumberItemView!, with: "32145")
@@ -493,7 +473,7 @@ class BCMCComponentTests: XCTestCase {
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context)
         sut.delegate = delegate
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         delegate.onDidSubmit = { data, component in
             XCTFail("delegate.didSubmit() must not be called")
@@ -501,8 +481,6 @@ class BCMCComponentTests: XCTestCase {
         delegate.onDidFail = { _, _ in
             XCTFail("delegate.didFail() must not be called")
         }
-        
-        wait(for: .milliseconds(300))
         
         // Enter invalid Card Number
         let cardNumberView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
@@ -532,8 +510,8 @@ class BCMCComponentTests: XCTestCase {
         let sut = BCMCComponent(paymentMethod: paymentMethod,
                                 context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
+
         XCTAssertNil(sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.Test name"))
         XCTAssertEqual(sut.viewController.title, cardPaymentMethod.name)
     }

--- a/Tests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/Card Tests/BCMCComponentTests.swift
@@ -82,7 +82,7 @@ class BCMCComponentTests: XCTestCase {
         
         fillCard(on: sut.viewController.view, with: Dummy.bancontactCard)
         
-        var binResponse = BinLookupResponse(brands: [CardBrand(type: .bcmc, isSupported: true)])
+        let binResponse = BinLookupResponse(brands: [CardBrand(type: .bcmc, isSupported: true)])
         sut.cardViewController.update(binInfo: binResponse)
 
         wait(for: .milliseconds(30))

--- a/Tests/Card Tests/CardComponentTests.swift
+++ b/Tests/Card Tests/CardComponentTests.swift
@@ -35,14 +35,14 @@ class CardComponentTests: XCTestCase {
         sut = CardComponent(paymentMethod: method,
                             context: context,
                             configuration: configuration)
-        UIApplication.shared.keyWindow?.layer.speed = 10
+        
         try super.setUpWithError()
     }
 
     override func tearDownWithError() throws {
         configuration = nil
         sut = nil
-        UIApplication.shared.keyWindow?.layer.speed = 1
+        
         try super.tearDownWithError()
     }
 
@@ -140,9 +140,7 @@ class CardComponentTests: XCTestCase {
                                 context: context,
                                 configuration: configuration)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         let cardNumberItemView: FormTextItemView<FormCardNumberItem>? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
         let cardNumberItemTitleLabel: UILabel? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem.titleLabel")
@@ -235,9 +233,7 @@ class CardComponentTests: XCTestCase {
 
     func testBigTitle() {
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         XCTAssertNil(sut.viewController.view.findView(with: "AdyenCard.CardComponent.Test name"))
         XCTAssertEqual(sut.viewController.title, method.name)
@@ -249,9 +245,7 @@ class CardComponentTests: XCTestCase {
                                 context: context,
                                 configuration: configuration)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         let securityCodeView: FormCardSecurityCodeItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
 
@@ -260,9 +254,7 @@ class CardComponentTests: XCTestCase {
 
     func testShowCVVField() {
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         let securityCodeView: FormCardSecurityCodeItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
 
@@ -271,9 +263,7 @@ class CardComponentTests: XCTestCase {
 
     func testCVVHintChange() {
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         let cardNumberItemView: FormTextItemView<FormCardNumberItem>? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
         let securityCodeCvvHint: FormCardSecurityCodeItemView.HintView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem.cvvHintIcon")
@@ -301,7 +291,7 @@ class CardComponentTests: XCTestCase {
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let expectationBin = XCTestExpectation(description: "Bin Expectation")
         let expectationCardType = XCTestExpectation(description: "CardType Expectation")
@@ -318,8 +308,6 @@ class CardComponentTests: XCTestCase {
             expectationLastFour.fulfill()
         })
         sut.cardComponentDelegate = delegateMock
-
-        wait(for: .milliseconds(300))
         
         self.fillCard(on: sut.viewController.view, with: Dummy.bancontactCard)
         self.tapSubmitButton(on: sut.viewController.view)
@@ -346,8 +334,7 @@ class CardComponentTests: XCTestCase {
 
         // When
         
-        UIApplication.shared.keyWindow?.rootViewController = component.viewController
-        wait(for: .milliseconds(50))
+        setupRootViewController(component.viewController)
 
         // Then
         let view: UIView = component.cardViewController.view
@@ -360,14 +347,12 @@ class CardComponentTests: XCTestCase {
         billingAddressView.item.selectionHandler()
         wait(for: .milliseconds(50))
         
-        XCTAssertTrue(UIViewController.findTopPresenter()?.children.first is AddressLookupViewController)
+        try XCTAssertTrue(UIViewController.topPresenter().children.first is AddressLookupViewController)
     }
 
     func testCVVFormatterChange() {
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem>? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
         let cardNumberItemView: FormTextItemView<FormCardNumberItem>? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
@@ -399,13 +384,11 @@ class CardComponentTests: XCTestCase {
             configuration: configuration
         )
 
-        UIApplication.shared.keyWindow?.rootViewController = component.viewController
+        setupRootViewController(component.viewController)
 
         let switchView: UISwitch! = component.viewController.view.findView(with: "AdyenCard.CardComponent.storeDetailsItem.switch")
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem>? = component.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
         XCTAssertEqual(securityCodeItemView!.titleLabel.textColor!, .gray)
-        
-        wait(for: .milliseconds(300))
         
         self.focus(textItemView: securityCodeItemView!)
         
@@ -426,8 +409,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration)
 
         // When
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
 
         // Then
         let view: UIView = sut.viewController.view
@@ -568,7 +550,7 @@ class CardComponentTests: XCTestCase {
         let method = CardPaymentMethod(type: .bcmc, name: "Test name", fundingSource: .credit, brands: [.visa, .americanExpress, .masterCard, .maestro, .jcb, .chinaUnionPay])
         let sut = CardComponent(paymentMethod: method,
                                 context: context)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
         XCTAssertNotNil(cardNumberItemView)
@@ -577,8 +559,6 @@ class CardComponentTests: XCTestCase {
         let cardLogoView = cardNumberItemView!.detectedBrandsView
         XCTAssertNotNil(cardLogoView)
         let cardNumberItem = cardNumberItemView!.item
-
-        wait(for: .milliseconds(300))
         
         XCTAssertEqual(cardNumberItem.cardTypeLogos.count, 6)
         XCTAssertFalse(cardLogoView.primaryLogoView.isHidden)
@@ -587,7 +567,7 @@ class CardComponentTests: XCTestCase {
 
     func testShouldShowNoCardTypesOnInvalidPANEnter() {
         // Given
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
         XCTAssertNotNil(cardNumberItemView)
@@ -596,8 +576,6 @@ class CardComponentTests: XCTestCase {
         let cardLogoView = cardNumberItemView!.detectedBrandsView
         XCTAssertNotNil(cardLogoView)
         let cardNumberItem = cardNumberItemView!.item
-
-        wait(for: .milliseconds(300))
         
         self.populate(textItemView: cardNumberItemView!, with: "1231")
         
@@ -610,7 +588,7 @@ class CardComponentTests: XCTestCase {
 
     func testShouldShowCardTypesOnPANEnter() {
         // Given
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
         XCTAssertNotNil(cardNumberItemView)
@@ -619,8 +597,6 @@ class CardComponentTests: XCTestCase {
         let cardLogoView = cardNumberItemView!.detectedBrandsView
         XCTAssertNotNil(cardLogoView)
         let cardNumberItem = cardNumberItemView!.item
-
-        wait(for: .milliseconds(300))
         
         self.populate(textItemView: cardNumberItemView!, with: "3400")
         
@@ -642,7 +618,7 @@ class CardComponentTests: XCTestCase {
 
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let expectedVerificationAddress = PostalAddressMocks.newYorkPostalAddress
 
@@ -668,8 +644,6 @@ class CardComponentTests: XCTestCase {
             XCTAssertEqual(sut.cardViewController.view.isUserInteractionEnabled, true)
             XCTAssertEqual(sut.cardViewController.items.button.showsActivityIndicator, false)
         }
-
-        wait(for: .milliseconds(300))
 
         let view: UIView = sut.viewController.view
 
@@ -743,8 +717,7 @@ class CardComponentTests: XCTestCase {
 
         let viewController = component.viewController
         
-        UIApplication.shared.keyWindow?.rootViewController = viewController
-        wait(for: .milliseconds(50))
+        setupRootViewController(component.viewController)
         
         let view: UIView = viewController.view
         let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(with: "AdyenCard.CardComponent.expiryDateItem"))
@@ -776,7 +749,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration,
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: BinInfoProviderMock())
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
@@ -827,7 +800,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration,
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
@@ -884,7 +857,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration,
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
@@ -1297,15 +1270,11 @@ class CardComponentTests: XCTestCase {
         sut.cardViewController.items.postalCodeItem.value = "1501 NH"
 
         // show view controller
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         // When
         // hide view controller
-        UIApplication.shared.keyWindow?.rootViewController = UIViewController()
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(UIViewController())
 
         // Then
         XCTAssertTrue(sut.cardViewController.items.postalCodeItem.value.isEmpty)
@@ -1320,15 +1289,11 @@ class CardComponentTests: XCTestCase {
         sut.cardViewController.items.numberContainerItem.numberItem.value = "4111 1111 1111 1111"
         
         // show view controller
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         // When
         // hide view controller
-        UIApplication.shared.keyWindow?.rootViewController = UIViewController()
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(UIViewController())
 
         // Then
         XCTAssertTrue(sut.cardViewController.items.numberContainerItem.numberItem.value.isEmpty)
@@ -1343,15 +1308,13 @@ class CardComponentTests: XCTestCase {
         sut.cardViewController.items.expiryDateItem.value = "03/24"
 
         // show view controller
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         wait(for: .milliseconds(300))
         
         // When
         // hide view controller
-        UIApplication.shared.keyWindow?.rootViewController = UIViewController()
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(UIViewController())
 
         // Then
         XCTAssertTrue(sut.cardViewController.items.expiryDateItem.value.isEmpty)
@@ -1366,15 +1329,11 @@ class CardComponentTests: XCTestCase {
         sut.cardViewController.items.securityCodeItem.value = "935"
 
         // show view controller
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         // When
         // hide view controller
-        UIApplication.shared.keyWindow?.rootViewController = UIViewController()
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(UIViewController())
 
         // Then
         XCTAssertTrue(sut.cardViewController.items.securityCodeItem.value.isEmpty)
@@ -1390,15 +1349,13 @@ class CardComponentTests: XCTestCase {
         sut.cardViewController.items.holderNameItem.value = "Katrina del Mar"
 
         // show view controller
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         wait(for: .milliseconds(300))
         
         // When
         // hide view controller
-        UIApplication.shared.keyWindow?.rootViewController = UIViewController()
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(UIViewController())
 
         // Then
         XCTAssertTrue(sut.cardViewController.items.holderNameItem.value.isEmpty)
@@ -1413,15 +1370,11 @@ class CardComponentTests: XCTestCase {
         sut.cardViewController.items.storeDetailsItem.value = true
 
         // show view controller
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.viewController)
         
         // When
         // hide view controller
-        UIApplication.shared.keyWindow?.rootViewController = UIViewController()
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(UIViewController())
 
         // Then
         XCTAssertFalse(sut.cardViewController.items.storeDetailsItem.value)
@@ -1476,9 +1429,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration)
 
         // When
-        UIApplication.shared.keyWindow?.rootViewController = sut.cardViewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.cardViewController)
 
         // Then
         let view: UIView = sut.cardViewController.view
@@ -1510,9 +1461,7 @@ class CardComponentTests: XCTestCase {
                                          configuration: configuration)
 
         // When
-        UIApplication.shared.keyWindow?.rootViewController = prefilledSut.cardViewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(prefilledSut.cardViewController)
 
         // Then
         let view: UIView = prefilledSut.cardViewController.view
@@ -1543,9 +1492,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration)
 
         // When
-        UIApplication.shared.keyWindow?.rootViewController = sut.cardViewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.cardViewController)
 
         // Then
         let view: UIView = sut.cardViewController.view
@@ -1573,9 +1520,7 @@ class CardComponentTests: XCTestCase {
                                 configuration: configuration)
 
         // When
-        UIApplication.shared.keyWindow?.rootViewController = sut.cardViewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.cardViewController)
 
         // Then
         let view: UIView = sut.cardViewController.view
@@ -1613,7 +1558,7 @@ class CardComponentTests: XCTestCase {
         billingAddressView.item.selectionHandler()
         wait(for: .aMoment)
         
-        let presentedViewController = try XCTUnwrap(UIViewController.findTopPresenter()?.children.first as? UINavigationController)
+        let presentedViewController = try XCTUnwrap(UIViewController.topPresenter().children.first as? UINavigationController)
         XCTAssertTrue(presentedViewController.viewControllers.first is AddressInputFormViewController)
         
         let inputForm = try XCTUnwrap(presentedViewController.viewControllers.first as? AddressInputFormViewController)
@@ -1632,8 +1577,7 @@ class CardComponentTests: XCTestCase {
             configuration: configuration
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = component.viewController
-        wait(for: .milliseconds(50))
+        setupRootViewController(component.viewController)
         
         // Then
         let view: UIView = component.cardViewController.view
@@ -1646,10 +1590,10 @@ class CardComponentTests: XCTestCase {
         billingAddressView.item.selectionHandler()
         wait(for: .milliseconds(50))
         
-        let presentedViewController = UIViewController.findTopPresenter()?.children.first as? UINavigationController
-        XCTAssertTrue(presentedViewController?.viewControllers.first is AddressInputFormViewController)
+        let presentedViewController = try XCTUnwrap(UIViewController.topPresenter().children.first as? UINavigationController)
+        XCTAssertTrue(presentedViewController.viewControllers.first is AddressInputFormViewController)
         
-        let inputForm = try XCTUnwrap(presentedViewController?.viewControllers.first as? AddressInputFormViewController)
+        let inputForm = try XCTUnwrap(presentedViewController.viewControllers.first as? AddressInputFormViewController)
         XCTAssertEqual(inputForm.billingAddressItem.configuration.supportedCountryCodes, ["US", "JP"])
         XCTAssertEqual(inputForm.billingAddressItem.value, expectedBillingAddress)
     }
@@ -1665,8 +1609,7 @@ class CardComponentTests: XCTestCase {
             configuration: configuration
         )
         
-        UIApplication.shared.keyWindow?.rootViewController = component.viewController
-        wait(for: .milliseconds(50))
+        setupRootViewController(component.viewController)
         
         // Then
         let view: UIView = component.cardViewController.view
@@ -1675,10 +1618,9 @@ class CardComponentTests: XCTestCase {
         billingAddressView.item.selectionHandler()
         wait(for: .milliseconds(50))
         
-        let presentedViewController = UIViewController.findTopPresenter()?.children.first as? UINavigationController
-        XCTAssertTrue(presentedViewController?.viewControllers.first is AddressInputFormViewController)
+        let presentedViewController = try XCTUnwrap(UIViewController.topPresenter().children.first as? UINavigationController)
+        let inputForm = try XCTUnwrap(presentedViewController.viewControllers.first as? AddressInputFormViewController)
         
-        let inputForm = try XCTUnwrap(presentedViewController?.viewControllers.first as? AddressInputFormViewController)
         XCTAssertEqual(inputForm.billingAddressItem.configuration.supportedCountryCodes, ["UK"])
         XCTAssertEqual(inputForm.billingAddressItem.countryPickerItem.value?.identifier, "UK")
     }
@@ -1703,7 +1645,7 @@ class CardComponentTests: XCTestCase {
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         let view: UIView = sut.cardViewController.view
 
@@ -1768,7 +1710,7 @@ class CardComponentTests: XCTestCase {
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         let view: UIView = sut.cardViewController.view
 
@@ -1822,7 +1764,7 @@ class CardComponentTests: XCTestCase {
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         let view: UIView = sut.cardViewController.view
 
@@ -1878,7 +1820,7 @@ class CardComponentTests: XCTestCase {
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         let view: UIView = sut.cardViewController.view
 
@@ -2001,7 +1943,7 @@ class CardComponentTests: XCTestCase {
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let view: UIView = sut.cardViewController.view
 
@@ -2056,7 +1998,7 @@ class CardComponentTests: XCTestCase {
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let view: UIView = sut.cardViewController.view
 
@@ -2117,7 +2059,7 @@ class CardComponentTests: XCTestCase {
         let delegate = PaymentComponentDelegateMock()
         sut.delegate = delegate
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let view: UIView = sut.cardViewController.view
 

--- a/Tests/Card Tests/StoredCardAlertManagerTests.swift
+++ b/Tests/Card Tests/StoredCardAlertManagerTests.swift
@@ -84,9 +84,7 @@ class StoredCardAlertManagerTests: XCTestCase {
         let alertController = sut.alertController
         let textField = alertController.textFields!.first!
         
-        UIApplication.shared.keyWindow?.rootViewController?.present(alertController, animated: false, completion: nil)
-        
-        wait(for: .seconds(1))
+        presentOnRoot(alertController)
         
         let payAction = alertController.actions.first { $0.title == localizedSubmitButtonTitle(with: payment.amount, style: .immediate, sut.localizationParameters) }!
         let cancelAction = alertController.actions.first { $0.title == localizedString(.cancelButton, sut.localizationParameters) }!

--- a/Tests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/Card Tests/StoredCardComponentTests.swift
@@ -30,9 +30,7 @@ class StoredCardComponentTests: XCTestCase {
     func testUIWithClientKey() throws {
         let sut = StoredCardComponent(storedCardPaymentMethod: method, context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController?.present(sut.viewController, animated: false, completion: nil)
-
-        wait(for: .seconds(1))
+        presentOnRoot(sut.viewController)
         
         let alertController = sut.viewController as! UIAlertController
         let textField: UITextField! = alertController.textFields!.first
@@ -48,9 +46,8 @@ class StoredCardComponentTests: XCTestCase {
         let sut = StoredCardComponent(storedCardPaymentMethod: method, context: context)
         PublicKeyProvider.publicKeysCache[Dummy.apiContext.clientKey] = Dummy.publicKey
 
-        UIApplication.shared.keyWindow?.rootViewController?.present(sut.viewController, animated: false, completion: nil)
-
-        wait(for: .seconds(1))
+        presentOnRoot(sut.viewController)
+        
         let alertController = sut.viewController as! UIAlertController
         let textField: UITextField! = alertController.textFields!.first
         XCTAssertNotNil(textField)
@@ -91,9 +88,7 @@ class StoredCardComponentTests: XCTestCase {
         }
         sut.storedCardAlertManager.publicKeyProvider = publicKeyProvider
 
-        UIApplication.shared.keyWindow?.rootViewController?.present(sut.viewController, animated: false, completion: nil)
-
-        wait(for: .seconds(1))
+        presentOnRoot(sut.viewController)
         
         let alertController = sut.viewController as! UIAlertController
         let textField: UITextField! = alertController.textFields!.first
@@ -137,9 +132,7 @@ class StoredCardComponentTests: XCTestCase {
         }
         sut.storedCardAlertManager.publicKeyProvider = publicKeyProvider
 
-        UIApplication.shared.keyWindow?.rootViewController?.present(sut.viewController, animated: false, completion: nil)
-
-        wait(for: .seconds(1))
+        presentOnRoot(sut.viewController)
         
         let alertController = sut.viewController as! UIAlertController
         let textField: UITextField! = alertController.textFields!.first
@@ -169,9 +162,7 @@ class StoredCardComponentTests: XCTestCase {
                                              holderName: "holderName")
         let sut = StoredCardComponent(storedCardPaymentMethod: method, context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController?.present(sut.viewController, animated: false, completion: nil)
-
-        wait(for: .seconds(1))
+        presentOnRoot(sut.viewController)
         
         let alertController = sut.viewController as! UIAlertController
         let textField: UITextField! = alertController.textFields!.first
@@ -209,9 +200,7 @@ class StoredCardComponentTests: XCTestCase {
     func testCVCLimitForNonAMEX() throws {
         let sut = StoredCardComponent(storedCardPaymentMethod: method, context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController?.present(sut.viewController, animated: false, completion: nil)
-
-        wait(for: .seconds(1))
+        presentOnRoot(sut.viewController)
         
         let alertController = sut.viewController as! UIAlertController
         let textField: UITextField! = alertController.textFields!.first
@@ -242,9 +231,7 @@ class StoredCardComponentTests: XCTestCase {
     func testCVCLimitForUnknownCardType() throws {
         let sut = StoredCardComponent(storedCardPaymentMethod: method, context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController?.present(sut.viewController, animated: false, completion: nil)
-
-        wait(for: .seconds(1))
+        presentOnRoot(sut.viewController)
         
         let alertController = sut.viewController as! UIAlertController
         let textField: UITextField! = alertController.textFields!.first

--- a/Tests/Card Tests/StoredPaymentMethodComponentTests.swift
+++ b/Tests/Card Tests/StoredPaymentMethodComponentTests.swift
@@ -84,8 +84,8 @@ class StoredPaymentMethodComponentTests: XCTestCase {
         }
         sut.delegate = delegate
 
-        UIApplication.shared.keyWindow?.rootViewController?.present(sut.viewController, animated: false, completion: nil)
-
+        presentOnRoot(sut.viewController)
+        
         let uiExpectation = expectation(description: "Dummy Expectation")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
             let alertController = sut.viewController as! UIAlertController

--- a/Tests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -101,7 +101,7 @@ class ACHDirectDebitComponentTests: XCTestCase {
                                                                billingAddressCountryCodes: ["US", "UK"]),
                                           publicKeyProvider: PublicKeyProviderMock())
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         wait(for: .milliseconds(300))
         
         let nameItemView: FormTextItemView<FormTextInputItem>? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.holderNameItem")
@@ -170,7 +170,7 @@ class ACHDirectDebitComponentTests: XCTestCase {
                                           configuration: config,
                                           publicKeyProvider: PublicKeyProviderMock())
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 
@@ -191,7 +191,7 @@ class ACHDirectDebitComponentTests: XCTestCase {
                                           configuration: config,
                                           publicKeyProvider: PublicKeyProviderMock())
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         wait(for: .milliseconds(300))
         
         XCTAssertNil(sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.Test name"))
@@ -216,7 +216,7 @@ class ACHDirectDebitComponentTests: XCTestCase {
                                           configuration: config,
                                           publicKeyProvider: PublicKeyProviderMock())
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         wait(for: .milliseconds(300))
         
         XCTAssertFalse(sut.payButton.showsActivityIndicator)
@@ -231,7 +231,7 @@ class ACHDirectDebitComponentTests: XCTestCase {
                                           context: context,
                                           publicKeyProvider: PublicKeyProviderMock())
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         wait(for: .milliseconds(300))
         
         let payButtonItemViewButton: UIControl? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.payButtonItem.button")

--- a/Tests/Components Tests/Affirm/AffirmComponentTests.swift
+++ b/Tests/Components Tests/Affirm/AffirmComponentTests.swift
@@ -115,7 +115,7 @@ class AffirmComponentTests: XCTestCase {
         sut.delegate = delegate
         let expectedBillingAddress = PostalAddressMocks.newYorkPostalAddress
         let expectedDeliveryAddress = PostalAddressMocks.losAngelesPostalAddress
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         // Then
         let didSubmitExpectation = expectation(description: "PaymentComponentDelegate must be called when submit button is clicked.")
@@ -180,9 +180,8 @@ class AffirmComponentTests: XCTestCase {
         let prefillSut = AffirmComponent(paymentMethod: paymentMethod,
                                          context: context,
                                          configuration: config)
-        UIApplication.shared.keyWindow?.rootViewController = prefillSut.viewController
-
-        wait(for: .seconds(1))
+        
+        setupRootViewController(prefillSut.viewController)
 
         // Then
         let view: UIView = prefillSut.viewController.view
@@ -228,9 +227,8 @@ class AffirmComponentTests: XCTestCase {
         let prefillSut = AffirmComponent(paymentMethod: paymentMethod,
                                          context: context,
                                          configuration: config)
-        UIApplication.shared.keyWindow?.rootViewController = prefillSut.viewController
-
-        wait(for: .seconds(1))
+        
+        setupRootViewController(prefillSut.viewController)
 
         // Then
         let view: UIView = prefillSut.viewController.view
@@ -271,7 +269,7 @@ class AffirmComponentTests: XCTestCase {
 
     func testAffirm_givenNoShopperInformation_shouldNotPrefill() throws {
         // Given
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .seconds(1))
 

--- a/Tests/Components Tests/Apple Pay/PreApplePayComponentTests.swift
+++ b/Tests/Components Tests/Apple Pay/PreApplePayComponentTests.swift
@@ -60,9 +60,8 @@ class PreApplePayComponentTests: XCTestCase {
         let view = PreApplePayView(model: model)
         let viewController = UIViewController()
         viewController.view = view
-        UIApplication.shared.keyWindow?.rootViewController = viewController
         
-        wait(for: .milliseconds(300))
+        setupRootViewController(viewController)
         
         let hintLabel: UILabel? = viewController.view.findView(by: "hintLabel")
         XCTAssertEqual(hintLabel?.text, model.hint)
@@ -82,11 +81,11 @@ class PreApplePayComponentTests: XCTestCase {
     func testApplePayPresented() {
         let dismissExpectation = expectation(description: "Dismiss Expectation")
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         let presentationMock = PresentationDelegateMock()
         presentationMock.doPresent = { component in
-            UIApplication.shared.keyWindow?.rootViewController?.present(component: component)
+            self.presentOnRoot(component.viewController)
         }
         presentationMock.doDismiss = { completion in completion?() }
         sut.presentationDelegate = presentationMock
@@ -99,8 +98,8 @@ class PreApplePayComponentTests: XCTestCase {
         
         wait(for: .milliseconds(300))
         
-        XCTAssertTrue(UIApplication.shared.keyWindow?.rootViewController?.presentedViewController is PKPaymentAuthorizationViewController)
-        UIApplication.shared.keyWindow?.rootViewController?.presentedViewController?.dismiss(animated: false, completion: nil)
+        XCTAssertTrue(UIApplication.shared.adyen.mainKeyWindow?.rootViewController?.presentedViewController is PKPaymentAuthorizationViewController)
+        UIApplication.shared.adyen.mainKeyWindow?.rootViewController?.presentedViewController?.dismiss(animated: false, completion: nil)
 
         sut.finalizeIfNeeded(with: false) {
             dismissExpectation.fulfill()
@@ -110,10 +109,7 @@ class PreApplePayComponentTests: XCTestCase {
     }
     
     func testHintLabelAmount() {
-        UIApplication.shared.keyWindow?.rootViewController = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController?.present(component: sut)
-        
-        wait(for: .milliseconds(300))
+        presentOnRoot(sut.viewController)
         
         let hintLabel = self.sut.viewController.view.findView(by: "hintLabel") as? UILabel
         

--- a/Tests/Components Tests/BACS Direct Debit/BACSDirectDebitComponentTests.swift
+++ b/Tests/Components Tests/BACS Direct Debit/BACSDirectDebitComponentTests.swift
@@ -57,7 +57,7 @@ class BACSDirectDebitComponentTests: XCTestCase {
 
         let presenter: BACSInputPresenter = sut.inputPresenter as! BACSInputPresenter
         let expectedConsentTitle1 = presenter.itemsFactory.createConsentText(with: payment.amount)
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         wait(for: .milliseconds(200))
         
         XCTAssertEqual(presenter.amountConsentToggleItem?.title, expectedConsentTitle1)

--- a/Tests/Components Tests/BACS Direct Debit/DocumentComponentTests.swift
+++ b/Tests/Components Tests/BACS Direct Debit/DocumentComponentTests.swift
@@ -26,9 +26,7 @@ class DocumentComponentTests: XCTestCase {
             XCTAssertNotNil(component.viewController as? ADYViewController)
             let viewController = component.viewController as! ADYViewController
             
-            UIApplication.shared.keyWindow?.rootViewController = viewController
-            
-            wait(for: .milliseconds(300))
+            setupRootViewController(viewController)
             
             let pdfButton: UIButton? = viewController.view.findView(by: "mainButton")
             let messageLabel: UILabel? = viewController.view.findView(by: "messageLabel")

--- a/Tests/Components Tests/BLIK Component/BLIKComponentTests.swift
+++ b/Tests/Components Tests/BLIK Component/BLIKComponentTests.swift
@@ -65,7 +65,7 @@ class BLIKComponentTests: XCTestCase {
  
     func testVCTitle() {
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
         XCTAssertEqual(sut.viewController.title, method.name.uppercased())

--- a/Tests/Components Tests/Boleto/BoletoComponentTests.swift
+++ b/Tests/Components Tests/Boleto/BoletoComponentTests.swift
@@ -28,9 +28,7 @@ class BoletoComponentTests: XCTestCase {
         
         let viewController = component.viewController
         
-        UIApplication.shared.keyWindow?.rootViewController = viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(viewController)
         
         let firstNameField: UITextField? = viewController.view.findView(by: "firstNameItem.textField") as? UITextField
         let lastNameField: UITextField? = viewController.view.findView(by: "lastNameItem.textField") as? UITextField
@@ -82,9 +80,7 @@ class BoletoComponentTests: XCTestCase {
         
         let viewController = component.viewController
         
-        UIApplication.shared.keyWindow?.rootViewController = viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(viewController)
         
         let firstNameField: UITextField? = viewController.view.findView(by: "firstNameItem.textField") as? UITextField
         let lastNameField: UITextField? = viewController.view.findView(by: "lastNameItem.textField") as? UITextField
@@ -133,9 +129,7 @@ class BoletoComponentTests: XCTestCase {
         
         let viewController = component.viewController
         
-        UIApplication.shared.keyWindow?.rootViewController = viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(viewController)
         
         let emailSwitch: UISwitch? = viewController.view.findView(by: "sendCopyToEmailItem.switch") as? UISwitch
         let emailField: UITextField? = viewController.view.findView(by: "emailItem.textField") as? UITextField
@@ -159,9 +153,7 @@ class BoletoComponentTests: XCTestCase {
         
         let viewController = component.viewController
         
-        UIApplication.shared.keyWindow?.rootViewController = viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(viewController)
         
         let emailSwitchItem: FormToggleItemView = viewController.view.findView(by: "sendCopyToEmailItem") as! FormToggleItemView
         let emailSwitch: UISwitch = emailSwitchItem.findView(by: "sendCopyToEmailItem.switch") as! UISwitch

--- a/Tests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
+++ b/Tests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
@@ -76,7 +76,7 @@ import XCTest
             let config = CashAppPayConfiguration(redirectURL: URL(string: "test")!, showsStorePaymentMethodField: true, style: componentStyle)
             let sut = CashAppPayComponent(paymentMethod: paymentMethod, context: context, configuration: config)
             
-            UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+            setupRootViewController(sut.viewController)
             wait(for: .milliseconds(300))
             
             let storeDetailsItemView: FormToggleItemView? = sut.viewController.view.findView(with: "AdyenCashAppPay.CashAppPayComponent.storeDetailsItem")
@@ -97,7 +97,7 @@ import XCTest
             let config = CashAppPayConfiguration(redirectURL: URL(string: "test")!, showsStorePaymentMethodField: true)
             let sut = CashAppPayComponent(paymentMethod: paymentMethod, context: context, configuration: config)
             
-            UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+            setupRootViewController(sut.viewController)
             wait(for: .milliseconds(300))
             
             let storeDetailsToggleView: UIView? = sut.viewController.view.findView(with: "AdyenCashAppPay.CashAppPayComponent.storeDetailsItem")
@@ -110,7 +110,7 @@ import XCTest
             let config = CashAppPayConfiguration(redirectURL: URL(string: "test")!, showsStorePaymentMethodField: false)
             let sut = CashAppPayComponent(paymentMethod: paymentMethod, context: context, configuration: config)
             
-            UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+            setupRootViewController(sut.viewController)
             wait(for: .milliseconds(300))
             
             let storeDetailsToggleView: UIView? = sut.viewController.view.findView(with: "AdyenCashAppPay.CashAppPayComponent.storeDetailsItem")
@@ -122,10 +122,10 @@ import XCTest
             let config = CashAppPayConfiguration(redirectURL: URL(string: "test")!, showsStorePaymentMethodField: true)
             let sut = CashAppPayComponent(paymentMethod: paymentMethod, context: context, configuration: config)
             
-            UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+            setupRootViewController(sut.viewController)
             wait(for: .milliseconds(300))
 
-            UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+            setupRootViewController(sut.viewController)
             wait(for: .milliseconds(300))
             
             XCTAssertFalse(sut.cashAppPayButton.showsActivityIndicator)
@@ -179,7 +179,7 @@ import XCTest
             
             let delegate = PaymentComponentDelegateMock()
             sut.delegate = delegate
-            UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+            setupRootViewController(sut.viewController)
             
             let delegateExpectation = expectation(description: "PaymentComponentDelegate must be called when submit button is clicked.")
             let finalizationExpectation = expectation(description: "Component should finalize.")
@@ -212,7 +212,7 @@ import XCTest
             
             let delegate = PaymentComponentDelegateMock()
             sut.delegate = delegate
-            UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+            setupRootViewController(sut.viewController)
             
             let delegateExpectation = expectation(description: "PaymentComponentDelegate must be called when submit button is clicked.")
             let finalizationExpectation = expectation(description: "Component should finalize.")

--- a/Tests/Components Tests/Doku/DokuComponentTests.swift
+++ b/Tests/Components Tests/Doku/DokuComponentTests.swift
@@ -82,7 +82,7 @@ class DokuComponentTests: XCTestCase {
                                 context: context,
                                 configuration: DokuComponent.Configuration())
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
         
@@ -104,9 +104,8 @@ class DokuComponentTests: XCTestCase {
         let prefillSut = DokuComponent(paymentMethod: paymentMethod,
                                        context: context,
                                        configuration: config)
-        UIApplication.shared.keyWindow?.rootViewController = prefillSut.viewController
-
-        wait(for: .milliseconds(300))
+        
+        setupRootViewController(prefillSut.viewController)
 
         // Then
         let view: UIView = prefillSut.viewController.view
@@ -132,7 +131,7 @@ class DokuComponentTests: XCTestCase {
         let sut = DokuComponent(paymentMethod: paymentMethod,
                                 context: context,
                                 configuration: DokuComponent.Configuration())
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 

--- a/Tests/Components Tests/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/Components Tests/Gift Card/GiftCardComponentTests.swift
@@ -91,7 +91,7 @@ class GiftCardComponentTests: XCTestCase {
                                 publicKeyProvider: publicKeyProvider)
         
         // When
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         wait(for: .milliseconds(300))
         
         // Then
@@ -110,7 +110,7 @@ class GiftCardComponentTests: XCTestCase {
                                 publicKeyProvider: publicKeyProvider)
         
         // When
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         wait(for: .milliseconds(300))
         
         // Then
@@ -143,7 +143,7 @@ class GiftCardComponentTests: XCTestCase {
             onCheckBalanceExpectation.fulfill()
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 
@@ -163,7 +163,7 @@ class GiftCardComponentTests: XCTestCase {
 
     func testCheckBalanceCardNumberFormatting() throws {
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 
@@ -198,7 +198,7 @@ class GiftCardComponentTests: XCTestCase {
             onCheckBalanceExpectation.fulfill()
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 
@@ -236,7 +236,7 @@ class GiftCardComponentTests: XCTestCase {
             onCheckBalanceExpectation.fulfill()
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 
@@ -274,7 +274,7 @@ class GiftCardComponentTests: XCTestCase {
             onCheckBalanceExpectation.fulfill()
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 
@@ -325,7 +325,7 @@ class GiftCardComponentTests: XCTestCase {
             onSubmitExpectation.fulfill()
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 
@@ -377,7 +377,7 @@ class GiftCardComponentTests: XCTestCase {
             onShowConfirmationExpectation.fulfill()
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 
@@ -432,7 +432,7 @@ class GiftCardComponentTests: XCTestCase {
             XCTFail("readyToSubmitPaymentComponentDelegate.onShowConfirmation must not be called")
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 
@@ -487,7 +487,7 @@ class GiftCardComponentTests: XCTestCase {
             XCTFail("readyToSubmitPaymentComponentDelegate.onShowConfirmation must not be called")
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 
@@ -541,7 +541,7 @@ class GiftCardComponentTests: XCTestCase {
             XCTFail("readyToSubmitPaymentComponentDelegate.onShowConfirmation must not be called")
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 

--- a/Tests/Components Tests/IssuerList/IssuerListComponentTests.swift
+++ b/Tests/Components Tests/IssuerList/IssuerListComponentTests.swift
@@ -47,9 +47,7 @@ class IssuerListComponentTests: XCTestCase {
             expectation.fulfill()
         }
         
-        UIApplication.shared.keyWindow?.rootViewController = searchViewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(searchViewController)
 
         sut.delegate = mockDelegate
         listViewController.tableView(listViewController.tableView, didSelectRowAt: .init(item: 0, section: 0))

--- a/Tests/Components Tests/MB Way/MBWayComponentTests.swift
+++ b/Tests/Components Tests/MB Way/MBWayComponentTests.swift
@@ -65,7 +65,7 @@ class MBWayComponentTests: XCTestCase {
         let sut = MBWayComponent(paymentMethod: paymentMethod,
                                  context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
         
@@ -85,9 +85,8 @@ class MBWayComponentTests: XCTestCase {
         let prefillSut = MBWayComponent(paymentMethod: paymentMethod,
                                         context: context,
                                         configuration: config)
-        UIApplication.shared.keyWindow?.rootViewController = prefillSut.viewController
-
-        wait(for: .milliseconds(300))
+        
+        setupRootViewController(prefillSut.viewController)
 
         // Then
         let view: UIView = prefillSut.viewController.view
@@ -103,7 +102,7 @@ class MBWayComponentTests: XCTestCase {
         let sut = MBWayComponent(paymentMethod: paymentMethod,
                                  context: context,
                                  configuration: MBWayComponent.Configuration())
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 

--- a/Tests/Components Tests/QRCode/QRCodeActionComponentTests.swift
+++ b/Tests/Components Tests/QRCode/QRCodeActionComponentTests.swift
@@ -63,7 +63,7 @@ class QRCodeActionComponentTests: XCTestCase {
             XCTAssertNotNil(component.viewController as? QRCodeViewController)
             let viewController = component.viewController as! QRCodeViewController
             
-            UIApplication.shared.keyWindow?.rootViewController = viewController
+            self.setupRootViewController(viewController)
         }
         
         sut.presentationDelegate = presentationDelegate
@@ -108,8 +108,7 @@ class QRCodeActionComponentTests: XCTestCase {
         presentationDelegate.doPresent = { component in
             XCTAssertNotNil(component.viewController as? QRCodeViewController)
             let viewController = component.viewController as! QRCodeViewController
-            
-            UIApplication.shared.keyWindow?.rootViewController = viewController
+            self.setupRootViewController(viewController)
         }
         
         sut.presentationDelegate = presentationDelegate
@@ -131,9 +130,7 @@ class QRCodeActionComponentTests: XCTestCase {
             XCTAssertNotNil(component.viewController as? QRCodeViewController)
             let viewController = component.viewController as! QRCodeViewController
 
-            UIApplication.shared.keyWindow?.rootViewController = viewController
-
-            wait(for: .milliseconds(300))
+            setupRootViewController(viewController)
 
             let copyButton: SubmitButton? = viewController.view.findView(by: "copyCodeButton")
             XCTAssertNotNil(copyButton)
@@ -162,9 +159,10 @@ class QRCodeActionComponentTests: XCTestCase {
         presentationDelegate.doPresent = { [self] component in
             XCTAssertNotNil(component.viewController as? QRCodeViewController)
             let viewController = component.viewController as! QRCodeViewController
-            UIApplication.shared.keyWindow?.rootViewController = viewController
+            
+            setupRootViewController(viewController)
             viewController.qrCodeView.delegate = delgate
-            wait(for: .milliseconds(300))
+            
             let saveAsImageButton: SubmitButton? = viewController.view.findView(by: "saveAsImageButton")
             XCTAssertNotNil(saveAsImageButton)
             saveAsImageButton?.sendActions(for: .touchUpInside)

--- a/Tests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
+++ b/Tests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
@@ -89,7 +89,7 @@ class QiwiWalletComponentTests: XCTestCase {
         let config = QiwiWalletComponent.Configuration(style: style)
         let sut = QiwiWalletComponent(paymentMethod: method, context: context, configuration: config)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         wait(for: .milliseconds(300))
         
@@ -131,7 +131,7 @@ class QiwiWalletComponentTests: XCTestCase {
     func testBigTitle() {
         let sut = QiwiWalletComponent(paymentMethod: method, context: context, configuration: QiwiWalletComponent.Configuration())
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         wait(for: .milliseconds(300))
         
@@ -166,7 +166,7 @@ class QiwiWalletComponentTests: XCTestCase {
             XCTAssertEqual(sut.button.showsActivityIndicator, false)
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
         

--- a/Tests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
+++ b/Tests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
@@ -110,7 +110,7 @@ class SEPADirectDebitComponentTests: XCTestCase {
                                            context: context,
                                            configuration: configuration)
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         wait(for: .milliseconds(300))
         
@@ -160,7 +160,7 @@ class SEPADirectDebitComponentTests: XCTestCase {
         let sepaPaymentMethod = SEPADirectDebitPaymentMethod(type: .sepaDirectDebit, name: "Test name")
         let sut = SEPADirectDebitComponent(paymentMethod: sepaPaymentMethod, context: context)
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         wait(for: .milliseconds(300))
         
@@ -178,7 +178,7 @@ class SEPADirectDebitComponentTests: XCTestCase {
         let sepaPaymentMethod = SEPADirectDebitPaymentMethod(type: .sepaDirectDebit, name: "Test name")
         let sut = SEPADirectDebitComponent(paymentMethod: sepaPaymentMethod, context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
         
@@ -192,7 +192,7 @@ class SEPADirectDebitComponentTests: XCTestCase {
         let sepaPaymentMethod = SEPADirectDebitPaymentMethod(type: .sepaDirectDebit, name: "Test name")
         let sut = SEPADirectDebitComponent(paymentMethod: sepaPaymentMethod, context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
         
@@ -211,7 +211,7 @@ class SEPADirectDebitComponentTests: XCTestCase {
         let sepaPaymentMethod = SEPADirectDebitPaymentMethod(type: .sepaDirectDebit, name: "Test name")
         let sut = SEPADirectDebitComponent(paymentMethod: sepaPaymentMethod, context: context)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         let expectation = XCTestExpectation(description: "Dummy Expectation")
 

--- a/Tests/Components Tests/Seven Eleven Component/BasicPersonalInfoFormComponentTests.swift
+++ b/Tests/Components Tests/Seven Eleven Component/BasicPersonalInfoFormComponentTests.swift
@@ -91,7 +91,7 @@ class BasicPersonalInfoFormComponentTests: XCTestCase {
                                        context: Dummy.context,
                                        configuration: config)
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         wait(for: .milliseconds(300))
         
@@ -182,7 +182,7 @@ class BasicPersonalInfoFormComponentTests: XCTestCase {
             XCTAssertEqual(sut.button.showsActivityIndicator, false)
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         wait(for: .milliseconds(300))
         
@@ -210,7 +210,7 @@ class BasicPersonalInfoFormComponentTests: XCTestCase {
                                        context: Dummy.context,
                                        configuration: BasicPersonalInfoFormComponent.Configuration())
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
         
@@ -232,9 +232,8 @@ class BasicPersonalInfoFormComponentTests: XCTestCase {
         let prefillSut = SevenElevenComponent(paymentMethod: paymentMethod,
                                               context: Dummy.context,
                                               configuration: config)
-        UIApplication.shared.keyWindow?.rootViewController = prefillSut.viewController
-
-        wait(for: .milliseconds(300))
+        
+        setupRootViewController(prefillSut.viewController)
 
         // Then
         let view: UIView = prefillSut.viewController.view
@@ -265,7 +264,7 @@ class BasicPersonalInfoFormComponentTests: XCTestCase {
         let sut = SevenElevenComponent(paymentMethod: paymentMethod,
                                        context: Dummy.context,
                                        configuration: BasicPersonalInfoFormComponent.Configuration())
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
 
         wait(for: .milliseconds(300))
 

--- a/Tests/DropIn Tests/DropInActionTests.swift
+++ b/Tests/DropIn Tests/DropInActionTests.swift
@@ -35,9 +35,8 @@ class DropInActionsTests: XCTestCase {
                               configuration: config)
 
         let waitExpectation = expectation(description: "Expect SafariViewController to open")
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-        root.present(sut.viewController, animated: true, completion: {
+        
+        presentOnRoot(sut.viewController) {
             let action = Action.redirect(RedirectAction(url: URL(string: "https://www.adyen.com")!, paymentData: "test_data"))
             self.sut.handle(action)
 
@@ -45,7 +44,7 @@ class DropInActionsTests: XCTestCase {
                 XCTAssertNotNil(self.sut.viewController.adyen.topPresenter as? SFSafariViewController)
                 waitExpectation.fulfill()
             }
-        })
+        }
 
         waitForExpectations(timeout: 15, handler: nil)
     }
@@ -66,10 +65,7 @@ class DropInActionsTests: XCTestCase {
             waitExpectation.fulfill()
         }
 
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-
-        root.present(sut.viewController, animated: true) {
+        presentOnRoot(sut.viewController) {
             self.sut.didOpenExternalApplication(component: RedirectComponent(context: Dummy.context))
         }
 

--- a/Tests/DropIn Tests/DropInTestInternal.swift
+++ b/Tests/DropIn Tests/DropInTestInternal.swift
@@ -20,9 +20,7 @@ class DropInInternalTests: XCTestCase {
                                   context: Dummy.context,
                                   configuration: config)
 
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-        root.present(sut.viewController, animated: true, completion: nil)
+        presentOnRoot(sut.viewController)
 
         let waitExpectation = expectation(description: "Expect Drop-In to finalize")
 

--- a/Tests/DropIn Tests/DropInTests.swift
+++ b/Tests/DropIn Tests/DropInTests.swift
@@ -121,9 +121,6 @@ class DropInTests: XCTestCase {
           "groups" : []
         }
         """
-
-    var sut: DropInComponent!
-    var context: AdyenContext!
     
     override func run() {
         AdyenDependencyValues.runTestWithValues {
@@ -133,82 +130,70 @@ class DropInTests: XCTestCase {
         }
     }
     
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        context = Dummy.context
-    }
-
-    override func tearDownWithError() throws {
-        sut = nil
-        context = nil
-        try super.tearDownWithError()
-    }
-    
-    func testOpenDropInAsList() {
+    func testOpenDropInAsList() throws {
         let config = DropInComponent.Configuration()
 
         let paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethods.data(using: .utf8)!)
-        sut = DropInComponent(paymentMethods: paymentMethods,
-                              context: context,
-                              configuration: config)
+        let sut = DropInComponent(paymentMethods: paymentMethods,
+                                  context: Dummy.context,
+                                  configuration: config)
 
         presentOnRoot(sut.viewController)
 
-        let topVC = self.sut.viewController.findChild(of: ListViewController.self)
-        XCTAssertNotNil(topVC)
-        XCTAssertEqual(topVC!.sections.count, 1)
-        XCTAssertEqual(topVC!.sections[0].items.count, 2)
+        let topVC = try XCTUnwrap(sut.viewController.findChild(of: ListViewController.self))
+        XCTAssertEqual(topVC.sections.count, 1)
+        XCTAssertEqual(topVC.sections[0].items.count, 2)
     }
 
-    func testOpenDropInAsOneClickPayment() {
+    func testOpenDropInAsOneClickPayment() throws {
         let config = DropInComponent.Configuration()
 
-        let paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsOneClick.data(using: .utf8)!)
-        sut = DropInComponent(paymentMethods: paymentMethods,
-                              context: context,
-                              configuration: config)
+        let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsOneClick.data(using: .utf8)!)
+        let sut = DropInComponent(paymentMethods: paymentMethods,
+                                  context: Dummy.context,
+                                  configuration: config)
 
         presentOnRoot(sut.viewController)
         
-        XCTAssertNil(self.sut.viewController.findChild(of: ListViewController.self))
+        XCTAssertNil(sut.viewController.findChild(of: ListViewController.self))
     }
 
-    func testOpenDropInWithNoOneClickPayment() {
+    func testOpenDropInWithNoOneClickPayment() throws {
         let config = DropInComponent.Configuration(allowPreselectedPaymentView: false)
 
-        let paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsOneClick.data(using: .utf8)!)
-        sut = DropInComponent(paymentMethods: paymentMethods,
-                              context: context,
-                              configuration: config)
+        let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsOneClick.data(using: .utf8)!)
+        let sut = DropInComponent(paymentMethods: paymentMethods,
+                                  context: Dummy.context,
+                                  configuration: config)
 
         presentOnRoot(sut.viewController)
         
-        XCTAssertNotNil(self.sut.viewController.findChild(of: ListViewController.self))
+        XCTAssertNotNil(sut.viewController.findChild(of: ListViewController.self))
     }
 
-    func testOpenApplePay() {
+    func testOpenApplePay() throws {
         let config = DropInComponent.Configuration()
         config.applePay = .init(payment: Dummy.createTestApplePayPayment(), merchantIdentifier: "")
 
-        let paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethods.data(using: .utf8)!)
-        sut = DropInComponent(paymentMethods: paymentMethods,
-                              context: context,
-                              configuration: config)
+        let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethods.data(using: .utf8)!)
+        let sut = DropInComponent(paymentMethods: paymentMethods,
+                                  context: Dummy.context,
+                                  configuration: config)
 
         presentOnRoot(sut.viewController)
         
-        let topVC = self.sut.viewController.findChild(of: ListViewController.self)
-        topVC?.tableView(topVC!.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
+        let topVC = try XCTUnwrap(sut.viewController.findChild(of: ListViewController.self))
+        topVC.tableView(topVC.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
 
-        wait(for: .seconds(2))
-        let newtopVC = self.sut.viewController.findChild(of: ADYViewController.self)
-        XCTAssertEqual(newtopVC?.title, "Apple Pay")
+        wait(for: .seconds(1))
+        let newtopVC = try XCTUnwrap(sut.viewController.findChild(of: ADYViewController.self))
+        XCTAssertEqual(newtopVC.title, "Apple Pay")
     }
 
-    func testGiftCard() {
+    func testGiftCard() throws {
         let config = DropInComponent.Configuration()
 
-        var paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethods.data(using: .utf8)!)
+        var paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethods.data(using: .utf8)!)
         paymentMethods.paid = [
             OrderPaymentMethod(lastFour: "1234",
                                type: .card,
@@ -219,63 +204,61 @@ class DropInTests: XCTestCase {
                                transactionLimit: Amount(value: 3000, currencyCode: "CNY"),
                                amount: Amount(value: 3000, currencyCode: "CNY"))
         ]
-        sut = DropInComponent(paymentMethods: paymentMethods,
-                              context: context,
-                              configuration: config)
+        let sut = DropInComponent(paymentMethods: paymentMethods,
+                                  context: Dummy.context,
+                                  configuration: config)
 
         presentOnRoot(sut.viewController)
 
-        let topVC = self.sut.viewController.findChild(of: ListViewController.self)
-        XCTAssertNotNil(topVC)
-        XCTAssertEqual(topVC!.sections.count, 2)
-        XCTAssertEqual(topVC!.sections[0].items.count, 2)
-        XCTAssertTrue(topVC!.sections[0].footer!.title.contains("Select payment method for the remaining"))
+        let topVC = try XCTUnwrap(sut.viewController.findChild(of: ListViewController.self))
+        XCTAssertEqual(topVC.sections.count, 2)
+        XCTAssertEqual(topVC.sections[0].items.count, 2)
+        XCTAssertTrue(topVC.sections[0].footer!.title.contains("Select payment method for the remaining"))
     }
 
-    func testSinglePaymentMethodSkippingPaymentList() {
+    func testSinglePaymentMethodSkippingPaymentList() throws {
         let config = DropInComponent.Configuration(allowsSkippingPaymentList: true)
 
-        let paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsWithSingleNonInstant.data(using: .utf8)!)
-        sut = DropInComponent(paymentMethods: paymentMethods,
-                              context: context,
-                              configuration: config)
+        let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsWithSingleNonInstant.data(using: .utf8)!)
+        let sut = DropInComponent(paymentMethods: paymentMethods,
+                                  context: Dummy.context,
+                                  configuration: config)
         
         presentOnRoot(sut.viewController)
         
         // presented screen is SEPA (payment list is skipped)
-        let topVC = sut.viewController.findChild(of: SecuredViewController<FormViewController>.self)
-        XCTAssertNotNil(topVC)
-        XCTAssertEqual(topVC?.title, "SEPA Direct Debit")
+        let topVC = try XCTUnwrap(sut.viewController.findChild(of: SecuredViewController<FormViewController>.self))
+        XCTAssertEqual(topVC.title, "SEPA Direct Debit")
     }
     
-    func testSinglePaymentMethodNotSkippingPaymentList() {
+    func testSinglePaymentMethodNotSkippingPaymentList() throws {
         let config = DropInComponent.Configuration(allowsSkippingPaymentList: true)
 
-        let paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsWithSingleInstant.data(using: .utf8)!)
-        sut = DropInComponent(paymentMethods: paymentMethods,
-                              context: context,
-                              configuration: config)
+        let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsWithSingleInstant.data(using: .utf8)!)
+        let sut = DropInComponent(paymentMethods: paymentMethods,
+                                  context: Dummy.context,
+                                  configuration: config)
         
         presentOnRoot(sut.viewController)
         
         // presented screen should be payment list with 1 instant payment element
-        let topVC = sut.viewController.findChild(of: ListViewController.self)
-        XCTAssertNotNil(topVC)
-        XCTAssertEqual(topVC!.sections.count, 1)
-        XCTAssertEqual(topVC!.sections[0].items.count, 1)
+        let topVC = try XCTUnwrap(sut.viewController.findChild(of: ListViewController.self))
+        XCTAssertEqual(topVC.sections.count, 1)
+        XCTAssertEqual(topVC.sections[0].items.count, 1)
     }
 
-    func testFinaliseIfNeededEmptyList() {
+    func testFinaliseIfNeededEmptyList() throws {
         let config = DropInComponent.Configuration()
 
-        let paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsWithSingleInstant.data(using: .utf8)!)
-        sut = DropInComponent(paymentMethods: paymentMethods, context: Dummy.context, configuration: config)
+        let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsWithSingleInstant.data(using: .utf8)!)
+        let sut = DropInComponent(paymentMethods: paymentMethods,
+                                  context: Dummy.context,
+                                  configuration: config)
 
         presentOnRoot(sut.viewController)
         
         let waitExpectation = expectation(description: "Expect Drop-In to finalize")
 
-        wait(for: .seconds(1))
         sut.finalizeIfNeeded(with: true) {
             waitExpectation.fulfill()
         }
@@ -316,7 +299,7 @@ class DropInTests: XCTestCase {
         let topVC = try waitForViewController(ofType: ListViewController.self, toBecomeChildOf: sut.viewController)
         topVC.tableView(topVC.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
 
-        let safari = try waitUntilTopPresenter(isOfType: SFSafariViewController.self)
+        let safari = try waitUntilTopPresenter(isOfType: SFSafariViewController.self, timeout: 5)
         wait(for: .aMoment)
 
         let delegate = try XCTUnwrap(safari.delegate)

--- a/Tests/DropIn Tests/DropInTests.swift
+++ b/Tests/DropIn Tests/DropInTests.swift
@@ -152,11 +152,8 @@ class DropInTests: XCTestCase {
                               context: context,
                               configuration: config)
 
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-        root.present(sut.viewController, animated: true, completion: nil)
+        presentOnRoot(sut.viewController)
 
-        wait(for: .seconds(2))
         let topVC = self.sut.viewController.findChild(of: ListViewController.self)
         XCTAssertNotNil(topVC)
         XCTAssertEqual(topVC!.sections.count, 1)
@@ -171,11 +168,8 @@ class DropInTests: XCTestCase {
                               context: context,
                               configuration: config)
 
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-        root.present(sut.viewController, animated: true, completion: nil)
-
-        wait(for: .seconds(2))
+        presentOnRoot(sut.viewController)
+        
         XCTAssertNil(self.sut.viewController.findChild(of: ListViewController.self))
     }
 
@@ -187,11 +181,8 @@ class DropInTests: XCTestCase {
                               context: context,
                               configuration: config)
 
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-        root.present(sut.viewController, animated: true, completion: nil)
-
-        wait(for: .seconds(2))
+        presentOnRoot(sut.viewController)
+        
         XCTAssertNotNil(self.sut.viewController.findChild(of: ListViewController.self))
     }
 
@@ -204,11 +195,8 @@ class DropInTests: XCTestCase {
                               context: context,
                               configuration: config)
 
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-        root.present(sut.viewController, animated: true, completion: nil)
-
-        wait(for: .seconds(2))
+        presentOnRoot(sut.viewController)
+        
         let topVC = self.sut.viewController.findChild(of: ListViewController.self)
         topVC?.tableView(topVC!.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
 
@@ -235,11 +223,7 @@ class DropInTests: XCTestCase {
                               context: context,
                               configuration: config)
 
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-        root.present(sut.viewController, animated: true, completion: nil)
-
-        wait(for: .seconds(2))
+        presentOnRoot(sut.viewController)
 
         let topVC = self.sut.viewController.findChild(of: ListViewController.self)
         XCTAssertNotNil(topVC)
@@ -256,11 +240,7 @@ class DropInTests: XCTestCase {
                               context: context,
                               configuration: config)
         
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-        root.present(sut.viewController, animated: true, completion: nil)
-        
-        wait(for: .seconds(2))
+        presentOnRoot(sut.viewController)
         
         // presented screen is SEPA (payment list is skipped)
         let topVC = sut.viewController.findChild(of: SecuredViewController<FormViewController>.self)
@@ -276,11 +256,7 @@ class DropInTests: XCTestCase {
                               context: context,
                               configuration: config)
         
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-        root.present(sut.viewController, animated: true, completion: nil)
-        
-        wait(for: .seconds(2))
+        presentOnRoot(sut.viewController)
         
         // presented screen should be payment list with 1 instant payment element
         let topVC = sut.viewController.findChild(of: ListViewController.self)
@@ -295,10 +271,8 @@ class DropInTests: XCTestCase {
         let paymentMethods = try! JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsWithSingleInstant.data(using: .utf8)!)
         sut = DropInComponent(paymentMethods: paymentMethods, context: Dummy.context, configuration: config)
 
-        let root = UIViewController()
-        UIApplication.shared.keyWindow?.rootViewController = root
-        root.present(sut.viewController, animated: true, completion: nil)
-
+        presentOnRoot(sut.viewController)
+        
         let waitExpectation = expectation(description: "Expect Drop-In to finalize")
 
         wait(for: .seconds(1))

--- a/Tests/DropIn Tests/ModalViewControllerTests.swift
+++ b/Tests/DropIn Tests/ModalViewControllerTests.swift
@@ -39,7 +39,8 @@ class ModalViewControllerTests: XCTestCase {
             style: style,
             navBarType: .regular
         )
-        UIApplication.shared.keyWindow?.rootViewController = sut
+        setupRootViewController(sut)
+        
         sut.loadView()
         sut.viewDidLoad()
         

--- a/Tests/DropIn Tests/Payment Method List/PaymentMethodListComponentTests.swift
+++ b/Tests/DropIn Tests/Payment Method List/PaymentMethodListComponentTests.swift
@@ -55,9 +55,7 @@ class PaymentMethodListComponentTests: XCTestCase {
         let section = ComponentsSection(components: [storedComponent])
         let sut = PaymentMethodListComponent(context: Dummy.context, components: [section])
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.listViewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.listViewController)
         
         let cell = sut.listViewController.tableView.visibleCells[0] as! ListCell
         XCTAssertFalse(cell.showsActivityIndicator)
@@ -74,9 +72,7 @@ class PaymentMethodListComponentTests: XCTestCase {
                                         components: [storedComponent], footer: nil)
         let sut = PaymentMethodListComponent(context: Dummy.context, components: [section, ComponentsSection(components: [regularComponent])])
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.listViewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.listViewController)
         
         let sectionHeader = try XCTUnwrap(sut.listViewController.tableView.headerView(forSection: 0) as? ListHeaderView)
         sectionHeader.trailingButton.sendActions(for: .touchUpInside)
@@ -115,9 +111,7 @@ class PaymentMethodListComponentTests: XCTestCase {
                                         components: [storedComponent], footer: nil)
         let sut = PaymentMethodListComponent(context: Dummy.context, components: [section, ComponentsSection(components: [regularComponent])])
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.listViewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(sut.listViewController)
         
         let sectionHeader = try XCTUnwrap(sut.listViewController.tableView.headerView(forSection: 0) as? ListHeaderView)
         sectionHeader.trailingButton.sendActions(for: .touchUpInside)

--- a/Tests/DropIn Tests/PreselectedPaymentComponentTests.swift
+++ b/Tests/DropIn Tests/PreselectedPaymentComponentTests.swift
@@ -81,7 +81,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
     }
 
     func testSubmitButtonLoading() {
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton.button")
         XCTAssertFalse(button.showsActivityIndicator)
         sut.startLoading(for: component)
@@ -122,7 +122,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
         component = StoredPaymentMethodComponent(paymentMethod: getStoredCard(), context: Dummy.context)
         sut = PreselectedPaymentMethodComponent(component: component, title: "", style: formStyle, listItemStyle: listStyle)
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         let view = sut.viewController.view!
         let listView = view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.defaultComponent")
@@ -157,7 +157,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
     }
     
     func testPayButtonTitle() {
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         sut = PreselectedPaymentMethodComponent(component: component, title: "", style: .init(), listItemStyle: .init())
         
         let submitButtonContainer = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton")
@@ -170,7 +170,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
     }
 
     func testPayButtonTitleNoPayment() {
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         component = StoredPaymentMethodComponent(paymentMethod: getStoredCard(), context: Dummy.context(with: nil))
         sut = PreselectedPaymentMethodComponent(component: component, title: "", style: .init(), listItemStyle: .init())
 
@@ -187,7 +187,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
         component = StoredPaymentMethodComponent(paymentMethod: getStoredPaypal(), context: Dummy.context)
         sut = PreselectedPaymentMethodComponent(component: component, title: "", style: FormComponentStyle(), listItemStyle: ListItemStyle())
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         let listView: ListItemView? = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.defaultComponent")
         let listViewTitle: UILabel! = listView!.findView(by: "titleLabel")
@@ -201,7 +201,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
         component = StoredPaymentMethodComponent(paymentMethod: getStoredCard(), context: Dummy.context)
         sut = PreselectedPaymentMethodComponent(component: component, title: "", style: FormComponentStyle(), listItemStyle: ListItemStyle())
         
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         
         let listView = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.defaultComponent")
         let listViewTitle: UILabel! = listView!.findView(by: "titleLabel")

--- a/Tests/Helpers/UIViewController+Search.swift
+++ b/Tests/Helpers/UIViewController+Search.swift
@@ -36,3 +36,9 @@ public extension UIViewController {
         return rootViewController.adyen.topPresenter
     }
 }
+
+extension UIViewController: PresentationDelegate {
+    public func present(component: PresentableComponent) {
+        self.present(component.viewController, animated: false, completion: nil)
+    }
+}

--- a/Tests/Helpers/XCTestCase+RootViewController.swift
+++ b/Tests/Helpers/XCTestCase+RootViewController.swift
@@ -53,15 +53,6 @@ extension XCTestCase {
         }
         wait(for: [presentationExpectation], timeout: 1)
     }
-    
-    /// Returns the current rootViewController
-    ///
-    /// - Throws: If the key window can't be found
-    var rootViewController: UIViewController {
-        get throws {
-            try XCTUnwrap(UIApplication.shared.adyen.mainKeyWindow?.rootViewController)
-        }
-    }
 }
 
 extension DispatchTimeInterval {

--- a/Tests/Session Tests/SessionTests.swift
+++ b/Tests/Session Tests/SessionTests.swift
@@ -358,9 +358,7 @@ class SessionTests: XCTestCase {
                                               context: context,
                                               title: nil)
         
-        UIApplication.shared.keyWindow?.rootViewController = dropInComponent.viewController
-
-        wait(for: .milliseconds(300))
+        setupRootViewController(dropInComponent.viewController)
         
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
         let paymentMethod = expectedPaymentMethods.regular.last as! MBWayPaymentMethod
@@ -1004,9 +1002,7 @@ class SessionTests: XCTestCase {
         let cardComponent = CardComponent(paymentMethod: paymentMethod, context: context)
         cardComponent.delegate = sut
         
-        UIApplication.shared.keyWindow?.rootViewController = cardComponent.viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(cardComponent.viewController)
         
         XCTAssertNotNil(cardComponent.viewController.view.findView(with: "AdyenCard.CardComponent.storeDetailsItem"))
         XCTAssertTrue(cardComponent.configuration.showsStorePaymentMethodField)
@@ -1022,9 +1018,7 @@ class SessionTests: XCTestCase {
         let cardComponent = CardComponent(paymentMethod: paymentMethod, context: context)
         cardComponent.delegate = sut
         
-        UIApplication.shared.keyWindow?.rootViewController = cardComponent.viewController
-        
-        wait(for: .milliseconds(300))
+        setupRootViewController(cardComponent.viewController)
         
         XCTAssertNil(cardComponent.viewController.view.findView(with: "AdyenCard.CardComponent.storeDetailsItem"))
         XCTAssertFalse(cardComponent.configuration.showsStorePaymentMethodField)

--- a/UITests/Components/Atome/AtomeComponentUITests.swift
+++ b/UITests/Components/Atome/AtomeComponentUITests.swift
@@ -98,7 +98,7 @@ class AtomeComponentUITests: XCTestCase {
             didSubmitExpectation.fulfill()
         }
 
-        UIApplication.shared.keyWindow?.rootViewController = sut.viewController
+        setupRootViewController(sut.viewController)
         let view: UIView = sut.viewController.view
         
         let submitButton: UIControl = try XCTUnwrap(view.findView(by: AtomeViewIdentifier.payButton))


### PR DESCRIPTION
## Summary
- Moved to `setupRootViewController` & `presentOnRoot` instead of accessing the rootViewController of the window
- Fixing some unrelated warnings