### PR TITLE
`chore` Card component test improvements

### DIFF
--- a/Tests/Actions Tests/Redirect/RedirectComponentTests.swift
+++ b/Tests/Actions Tests/Redirect/RedirectComponentTests.swift
@@ -114,7 +114,7 @@ class RedirectComponentTests: XCTestCase {
         
         let appLauncherExpectation = expectation(description: "Expect appLauncher.openUniversalAppUrl() to be called")
         appLauncher.onOpenUniversalAppUrl = { url, completion in
-            XCTAssertEqual(url, URL(string: "http://maps.apple.com")!)
+            XCTAssertEqual(url, URL(string: "https://maps.apple.com")!)
             completion?(true)
             appLauncherExpectation.fulfill()
         }
@@ -125,7 +125,7 @@ class RedirectComponentTests: XCTestCase {
             delegateExpectation.fulfill()
         }
         
-        let action = RedirectAction(url: URL(string: "http://maps.apple.com")!, paymentData: "test_data")
+        let action = RedirectAction(url: URL(string: "https://maps.apple.com")!, paymentData: "test_data")
         sut.handle(action)
         
         waitForExpectations(timeout: 10, handler: nil)
@@ -155,7 +155,7 @@ class RedirectComponentTests: XCTestCase {
         
         let appLauncherExpectation = expectation(description: "Expect appLauncher.openUniversalAppUrl() to be called")
         appLauncher.onOpenUniversalAppUrl = { url, completion in
-            XCTAssertEqual(url, URL(string: "http://maps.apple.com")!)
+            XCTAssertEqual(url, URL(string: "https://maps.apple.com")!)
             completion?(false)
             appLauncherExpectation.fulfill()
         }
@@ -164,7 +164,7 @@ class RedirectComponentTests: XCTestCase {
             XCTFail("delegate.didOpenExternalApplication() must not to be called")
         }
         
-        let action = RedirectAction(url: URL(string: "http://maps.apple.com")!, paymentData: "test_data")
+        let action = RedirectAction(url: URL(string: "https://maps.apple.com")!, paymentData: "test_data")
         sut.handle(action)
         
         waitForExpectations(timeout: 10, handler: nil)
@@ -263,7 +263,7 @@ class RedirectComponentTests: XCTestCase {
         sut.appLauncher = appLauncher
         let appLauncherExpectation = expectation(description: "Expect appLauncher.openUniversalAppUrl() to be called")
         appLauncher.onOpenUniversalAppUrl = { url, completion in
-            XCTAssertEqual(url, URL(string: "http://google.com")!)
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
             completion?(true)
             appLauncherExpectation.fulfill()
         }
@@ -278,7 +278,7 @@ class RedirectComponentTests: XCTestCase {
         }
         delegate.onDidFail = { _, _ in XCTFail("Should not call onDidFail") }
         
-        let action = RedirectAction(url: URL(string: "http://google.com")!, paymentData: nil, nativeRedirectData: "test_nativeRedirectData")
+        let action = RedirectAction(url: URL(string: "https://google.com")!, paymentData: nil, nativeRedirectData: "test_nativeRedirectData")
         sut.handle(action)
         XCTAssertTrue(RedirectComponent.applicationDidOpen(from: URL(string: "url://?queryParam=value")!))
         
@@ -292,7 +292,7 @@ class RedirectComponentTests: XCTestCase {
         sut.appLauncher = appLauncher
         let appLauncherExpectation = expectation(description: "Expect appLauncher.openUniversalAppUrl() to be called")
         appLauncher.onOpenUniversalAppUrl = { url, completion in
-            XCTAssertEqual(url, URL(string: "http://google.com")!)
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
             completion?(true)
             appLauncherExpectation.fulfill()
         }
@@ -306,7 +306,7 @@ class RedirectComponentTests: XCTestCase {
             XCTFail("Should not call onDidProvide")
         }
         
-        let action = RedirectAction(url: URL(string: "http://google.com")!, paymentData: nil, nativeRedirectData: "test_nativeRedirectData")
+        let action = RedirectAction(url: URL(string: "https://google.com")!, paymentData: nil, nativeRedirectData: "test_nativeRedirectData")
         sut.handle(action)
         XCTAssertFalse(RedirectComponent.applicationDidOpen(from: URL(string: "url://")!))
         
@@ -322,7 +322,7 @@ class RedirectComponentTests: XCTestCase {
         sut.appLauncher = appLauncher
         let appLauncherExpectation = expectation(description: "Expect appLauncher.openUniversalAppUrl() to be called")
         appLauncher.onOpenUniversalAppUrl = { url, completion in
-            XCTAssertEqual(url, URL(string: "http://google.com")!)
+            XCTAssertEqual(url, URL(string: "https://google.com")!)
             completion?(true)
             appLauncherExpectation.fulfill()
         }
@@ -338,7 +338,7 @@ class RedirectComponentTests: XCTestCase {
             redirectExpectation.fulfill()
         }
         
-        let action = RedirectAction(url: URL(string: "http://google.com")!, paymentData: nil, nativeRedirectData: "test_nativeRedirectData")
+        let action = RedirectAction(url: URL(string: "https://google.com")!, paymentData: nil, nativeRedirectData: "test_nativeRedirectData")
         sut.handle(action)
         XCTAssertTrue(RedirectComponent.applicationDidOpen(from: URL(string: "url://?queryParam=value")!))
         

--- a/Tests/Actions Tests/Voucher/VoucherViewTests.swift
+++ b/Tests/Actions Tests/Voucher/VoucherViewTests.swift
@@ -159,7 +159,7 @@ class VoucherViewTests: XCTestCase {
             identifier: "identifier",
             amount: "100",
             currency: "EUR",
-            logoUrl: URL(string: "http://adyen.com")!,
+            logoUrl: URL(string: "https://adyen.com")!,
             mainButton: "Main Button",
             secondaryButtonTitle: "Secondary Button",
             codeConfirmationTitle: "Code Copied!",

--- a/Tests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
+++ b/Tests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
@@ -43,8 +43,8 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
     
     func testSettingThreeDSRequestorAppURL() {
         let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration())
-        sut.threeDSRequestorAppURL = URL(string: "http://google.com")
-        XCTAssertEqual(sut.coreActionHandler.threeDSRequestorAppURL, URL(string: "http://google.com"))
+        sut.threeDSRequestorAppURL = URL(string: "https://google.com")
+        XCTAssertEqual(sut.coreActionHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
     }
 
     func testWrappedComponent() {
@@ -138,14 +138,14 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
 
         let transaction = AnyADYTransactionMock(parameters: authenticationRequestParameters)
         transaction.onPerformChallenge = { params, completion in
-            XCTAssertEqual(params.threeDSRequestorAppURL, URL(string: "http://google.com"))
+            XCTAssertEqual(params.threeDSRequestorAppURL, URL(string: "https://google.com"))
             completion(AnyChallengeResultMock(sdkTransactionIdentifier: "sdkTxId", transactionStatus: "Y"), nil)
         }
         service.mockedTransaction = transaction
 
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
         let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, service: service)
-        sut.threeDSRequestorAppURL = URL(string: "http://google.com")
+        sut.threeDSRequestorAppURL = URL(string: "https://google.com")
         sut.transaction = transaction
         sut.handle(challengeAction) { challengeResult in
             switch challengeResult {

--- a/Tests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
@@ -43,8 +43,8 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
     
     func testSettingThreeDSRequestorAppURL() {
         let sut = ThreeDS2CompactActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration())
-        sut.threeDSRequestorAppURL = URL(string: "http://google.com")
-        XCTAssertEqual(sut.coreActionHandler.threeDSRequestorAppURL, URL(string: "http://google.com"))
+        sut.threeDSRequestorAppURL = URL(string: "https://google.com")
+        XCTAssertEqual(sut.coreActionHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
     }
 
     func testWrappedComponent() {
@@ -98,14 +98,14 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
 
         let transaction = AnyADYTransactionMock(parameters: authenticationRequestParameters)
         transaction.onPerformChallenge = { params, completion in
-            XCTAssertEqual(params.threeDSRequestorAppURL, URL(string: "http://google.com"))
+            XCTAssertEqual(params.threeDSRequestorAppURL, URL(string: "https://google.com"))
             completion(AnyChallengeResultMock(sdkTransactionIdentifier: "sdkTxId", transactionStatus: "Y"), nil)
         }
         service.mockedTransaction = transaction
 
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
         let sut = ThreeDS2CompactActionHandler(context: Dummy.context, service: service)
-        sut.threeDSRequestorAppURL = URL(string: "http://google.com")
+        sut.threeDSRequestorAppURL = URL(string: "https://google.com")
         sut.transaction = transaction
         sut.handle(challengeAction) { challengeResult in
             switch challengeResult {

--- a/Tests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
+++ b/Tests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
@@ -288,31 +288,31 @@ class ThreeDS2ComponentTests: XCTestCase {
     
     func testSettingRequestorAppURL() throws {
         let sut = ThreeDS2Component(context: Dummy.context)
-        sut.configuration.requestorAppURL = URL(string: "http://google.com")
-        XCTAssertEqual(sut.threeDS2CompactFlowHandler.threeDSRequestorAppURL, URL(string: "http://google.com"))
-        XCTAssertEqual(sut.threeDS2ClassicFlowHandler.threeDSRequestorAppURL, URL(string: "http://google.com"))
+        sut.configuration.requestorAppURL = URL(string: "https://google.com")
+        XCTAssertEqual(sut.threeDS2CompactFlowHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
+        XCTAssertEqual(sut.threeDS2ClassicFlowHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
     }
     
     func testSettingRequestorAppURLWithInitializer() throws {
-        let configuration = ThreeDS2Component.Configuration(requestorAppURL: URL(string: "http://google.com"))
+        let configuration = ThreeDS2Component.Configuration(requestorAppURL: URL(string: "https://google.com"))
         let sut = ThreeDS2Component(context: Dummy.context,
                                     configuration: configuration)
-        XCTAssertEqual(sut.threeDS2CompactFlowHandler.threeDSRequestorAppURL, URL(string: "http://google.com"))
-        XCTAssertEqual(sut.threeDS2ClassicFlowHandler.threeDSRequestorAppURL, URL(string: "http://google.com"))
+        XCTAssertEqual(sut.threeDS2CompactFlowHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
+        XCTAssertEqual(sut.threeDS2ClassicFlowHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
     }
     
     func testSettingRequestorAppURLWithInitializerAndInjectedHandlers() throws {
         let threeDS2CompactFlowHandler = AnyThreeDS2ActionHandlerMock()
         let threeDS2ClassicFlowHandler = AnyThreeDS2ActionHandlerMock()
         let redirectComponent = AnyRedirectComponentMock()
-        let configuration = ThreeDS2Component.Configuration(requestorAppURL: URL(string: "http://google.com"))
+        let configuration = ThreeDS2Component.Configuration(requestorAppURL: URL(string: "https://google.com"))
         let sut = ThreeDS2Component(context: Dummy.context,
                                     threeDS2CompactFlowHandler: threeDS2CompactFlowHandler,
                                     threeDS2ClassicFlowHandler: threeDS2ClassicFlowHandler,
                                     redirectComponent: redirectComponent,
                                     configuration: configuration)
-        XCTAssertEqual(sut.threeDS2CompactFlowHandler.threeDSRequestorAppURL, URL(string: "http://google.com"))
-        XCTAssertEqual(sut.threeDS2ClassicFlowHandler.threeDSRequestorAppURL, URL(string: "http://google.com"))
+        XCTAssertEqual(sut.threeDS2CompactFlowHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
+        XCTAssertEqual(sut.threeDS2ClassicFlowHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
     }
 
     func testChallengeSuccess() throws {

--- a/Tests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -76,8 +76,8 @@ import XCTest
             let sut = ThreeDS2PlusDACoreActionHandler(context: Dummy.context,
                                                       appearanceConfiguration: ADYAppearanceConfiguration(),
                                                       delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations)
-            sut.threeDSRequestorAppURL = URL(string: "http://google.com")
-            XCTAssertEqual(sut.threeDSRequestorAppURL, URL(string: "http://google.com"))
+            sut.threeDSRequestorAppURL = URL(string: "https://google.com")
+            XCTAssertEqual(sut.threeDSRequestorAppURL, URL(string: "https://google.com"))
         }
         
         @available(iOS 14.0, *)
@@ -169,7 +169,7 @@ import XCTest
 
             let transaction = AnyADYTransactionMock(parameters: authenticationRequestParameters)
             transaction.onPerformChallenge = { params, completion in
-                XCTAssertEqual(params.threeDSRequestorAppURL, URL(string: "http://google.com"))
+                XCTAssertEqual(params.threeDSRequestorAppURL, URL(string: "https://google.com"))
                 completion(AnyChallengeResultMock(sdkTransactionIdentifier: "sdkTxId", transactionStatus: "Y"), nil)
             }
             service.mockedTransaction = transaction
@@ -194,7 +194,7 @@ import XCTest
             let sut = ThreeDS2PlusDACoreActionHandler(context: Dummy.context,
                                                       service: service,
                                                       delegatedAuthenticationService: authenticationServiceMock)
-            sut.threeDSRequestorAppURL = URL(string: "http://google.com")
+            sut.threeDSRequestorAppURL = URL(string: "https://google.com")
             sut.transaction = transaction
             sut.delegatedAuthenticationState.isDeviceRegistrationFlow = true
             sut.handle(challengeAction, event: analyticsEvent) { challengeResult in

--- a/Tests/Card Tests/CardComponentTests.swift
+++ b/Tests/Card Tests/CardComponentTests.swift
@@ -12,47 +12,51 @@ import XCTest
 
 class CardComponentTests: XCTestCase {
 
-    var context = Dummy.context
-    let payment = Dummy.payment
-    var configuration: CardComponent.Configuration!
-    var sut: CardComponent!
-
-    let method = CardPaymentMethod(type: .bcmc, name: "Test name", fundingSource: .credit, brands: [.visa, .americanExpress, .masterCard])
-
-    let storedMethod = StoredCardPaymentMethod(type: .card,
-                                               name: "Test name",
-                                               identifier: "id",
-                                               fundingSource: .credit,
-                                               supportedShopperInteractions: [.shopperPresent],
-                                               brand: .visa,
-                                               lastFour: "1234",
-                                               expiryMonth: "12",
-                                               expiryYear: "22",
-                                               holderName: "holderName")
-
-    override func setUpWithError() throws {
-        configuration = CardComponent.Configuration()
-        sut = CardComponent(paymentMethod: method,
-                            context: context,
-                            configuration: configuration)
-        
-        try super.setUpWithError()
+    var context: AdyenContext {
+        Dummy.context
     }
-
-    override func tearDownWithError() throws {
-        configuration = nil
-        sut = nil
-        
-        try super.tearDownWithError()
+    var payment: Payment {
+        Dummy.payment
     }
-
+    
+    var method: CardPaymentMethod {
+        .init(
+            type: .bcmc,
+            name: "Test name",
+            fundingSource: .credit,
+            brands: [.visa, .americanExpress, .masterCard]
+        )
+    }
+    
+    var storedMethod: StoredCardPaymentMethod {
+        .init(
+            type: .card,
+            name: "Test name",
+            identifier: "id",
+            fundingSource: .credit,
+            supportedShopperInteractions: [.shopperPresent],
+            brand: .visa,
+            lastFour: "1234",
+            expiryMonth: "12",
+            expiryYear: "22",
+            holderName: "holderName"
+        )
+    }
+    
     func testRequiresKeyboardInput() {
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+        
         let navigationViewController = DropInNavigationController(rootComponent: sut, style: NavigationStyle(), cancelHandler: { _, _ in })
 
         XCTAssertTrue((navigationViewController.topViewController as! WrapperViewController).requiresKeyboardInput)
     }
 
     func testLocalizationWithCustomTableName() {
+        var configuration = CardComponent.Configuration()
         configuration.showsHolderNameField = true
         configuration.localizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
         let sut = CardComponent(paymentMethod: method,
@@ -78,6 +82,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testLocalizationWithCustomKeySeparator() {
+        var configuration = CardComponent.Configuration()
         configuration.showsHolderNameField = true
         configuration.localizationParameters = LocalizationParameters(tableName: "AdyenUIHostCustomSeparator", keySeparator: "_")
         let sut = CardComponent(paymentMethod: method,
@@ -134,6 +139,7 @@ class CardComponentTests: XCTestCase {
         cardComponentStyle.toggle.title.textAlignment = .left
         cardComponentStyle.toggle.backgroundColor = .magenta
 
+        var configuration = CardComponent.Configuration()
         configuration.showsHolderNameField = true
         configuration.style = cardComponentStyle
         let sut = CardComponent(paymentMethod: method,
@@ -233,6 +239,12 @@ class CardComponentTests: XCTestCase {
 
     func testBigTitle() {
 
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+        
         setupRootViewController(sut.viewController)
         
         XCTAssertNil(sut.viewController.view.findView(with: "AdyenCard.CardComponent.Test name"))
@@ -240,6 +252,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testHideCVVField() {
+        var configuration = CardComponent.Configuration()
         configuration.showsSecurityCodeField = false
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
@@ -254,6 +267,12 @@ class CardComponentTests: XCTestCase {
 
     func testShowCVVField() {
 
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+        
         setupRootViewController(sut.viewController)
         
         let securityCodeView: FormCardSecurityCodeItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
@@ -263,6 +282,12 @@ class CardComponentTests: XCTestCase {
 
     func testCVVHintChange() {
 
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+        
         setupRootViewController(sut.viewController)
         
         let cardNumberItemView: FormTextItemView<FormCardNumberItem>? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
@@ -287,7 +312,7 @@ class CardComponentTests: XCTestCase {
 
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
-                                configuration: configuration,
+                                configuration: CardComponent.Configuration(),
                                 publicKeyProvider: PublicKeyProviderMock(),
                                 binProvider: cardTypeProviderMock)
 
@@ -345,13 +370,21 @@ class CardComponentTests: XCTestCase {
         XCTAssertEqual(expectedBillingAddress, billingAddress)
         
         billingAddressView.item.selectionHandler()
-        wait(for: .milliseconds(50))
         
-        try XCTAssertTrue(UIViewController.topPresenter().children.first is AddressLookupViewController)
+        try waitForViewController(
+            ofType: AddressLookupViewController.self,
+            toBecomeChildOf: UIViewController.topPresenter()
+        )
     }
 
     func testCVVFormatterChange() {
 
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+        
         setupRootViewController(sut.viewController)
         
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem>? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
@@ -368,7 +401,7 @@ class CardComponentTests: XCTestCase {
 
     }
 
-    func testTintColorCustomization() {
+    func testTintColorCustomization() throws {
         
         var configuration = CardComponent.Configuration()
         
@@ -386,23 +419,22 @@ class CardComponentTests: XCTestCase {
 
         setupRootViewController(component.viewController)
 
-        let switchView: UISwitch! = component.viewController.view.findView(with: "AdyenCard.CardComponent.storeDetailsItem.switch")
-        let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem>? = component.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
-        XCTAssertEqual(securityCodeItemView!.titleLabel.textColor!, .gray)
+        let switchView: UISwitch = try XCTUnwrap(component.viewController.view.findView(with: "AdyenCard.CardComponent.storeDetailsItem.switch"))
+        let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem> = try XCTUnwrap(component.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem"))
+        XCTAssertEqual(securityCodeItemView.titleLabel.textColor!, .gray)
         
-        self.focus(textItemView: securityCodeItemView!)
+        self.focus(textItemView: securityCodeItemView)
         
-        wait(for: .milliseconds(300))
-        
-        XCTAssertEqual(switchView.onTintColor, .systemYellow)
-        XCTAssertEqual(securityCodeItemView!.titleLabel.textColor!, .systemYellow)
-        XCTAssertEqual(securityCodeItemView!.separatorView.backgroundColor!.cgColor, UIColor.systemYellow.cgColor)
+        wait(until: switchView, at: \.onTintColor, is: .systemYellow)
+        wait(until: securityCodeItemView, at: \.titleLabel.textColor, is: .systemYellow)
+        wait(until: securityCodeItemView, at: \.separatorView.backgroundColor?.cgColor, is: UIColor.systemYellow.cgColor)
     }
 
     func testSuccessTintColorCustomization() throws {
         // Given
         var style = FormComponentStyle(tintColor: .systemYellow)
         style.textField.title.color = .gray
+        var configuration = CardComponent.Configuration()
         configuration.style = style
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
@@ -414,14 +446,12 @@ class CardComponentTests: XCTestCase {
         // Then
         let view: UIView = sut.viewController.view
 
-        let securityCodeItemView: FormCardSecurityCodeItemView? = try XCTUnwrap(view.findView(with: "AdyenCard.CardComponent.securityCodeItem"))
-        XCTAssertEqual(securityCodeItemView?.titleLabel.textColor, .gray)
+        let securityCodeItemView: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(with: "AdyenCard.CardComponent.securityCodeItem"))
+        XCTAssertEqual(securityCodeItemView.titleLabel.textColor, .gray)
 
-        populate(textItemView: securityCodeItemView!, with: "123")
-        wait(for: .milliseconds(300))
+        populate(textItemView: securityCodeItemView, with: "123")
 
-        let successIcon: UIImageView? = try XCTUnwrap(securityCodeItemView?.cardHintView)
-        XCTAssertEqual(successIcon?.tintColor, .systemYellow)
+        wait(until: securityCodeItemView, at: \.cardHintView.tintColor, is: .systemYellow)
     }
 
     func testFormViewControllerDelegate() {
@@ -434,7 +464,7 @@ class CardComponentTests: XCTestCase {
         
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
-                                configuration: configuration,
+                                configuration: CardComponent.Configuration(),
                                 publicKeyProvider: publicKeyProvider,
                                 binProvider: BinInfoProviderMock())
 
@@ -471,6 +501,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testStoredCardPaymentLocalization() throws {
+        var configuration = CardComponent.Configuration()
         configuration.localizationParameters = LocalizationParameters(tableName: "AdyenUIHostCustomSeparator", keySeparator: "_")
         let sut = CardComponent(paymentMethod: storedMethod,
                                 context: context,
@@ -487,6 +518,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testStoredCardPaymentLocalizationWithNoCVV() throws {
+        var configuration = CardComponent.Configuration()
         configuration.stored.showsSecurityCodeField = false
         configuration.localizationParameters = LocalizationParameters(tableName: "AdyenUIHostCustomSeparator", keySeparator: "_")
         let sut = CardComponent(paymentMethod: storedMethod,
@@ -504,6 +536,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testStoredCardPaymentWithNoCVV() throws {
+        var configuration = CardComponent.Configuration()
         configuration.stored.showsSecurityCodeField = false
         let sut = CardComponent(paymentMethod: storedMethod,
                                 context: context,
@@ -520,6 +553,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testStoredCardPaymentWithNoCVVAndNoPayment() {
+        var configuration = CardComponent.Configuration()
         configuration.stored.showsSecurityCodeField = false
         let context = Dummy.context(with: nil)
         let sut = CardComponent(paymentMethod: storedMethod,
@@ -536,6 +570,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testOneClickPayment() {
+        var configuration = CardComponent.Configuration()
         configuration.stored.showsSecurityCodeField = false
         let sut = CardComponent(paymentMethod: storedMethod,
                                 context: context,
@@ -565,50 +600,30 @@ class CardComponentTests: XCTestCase {
         XCTAssertTrue(cardLogoView.secondaryLogoView.isHidden)
     }
 
-    func testShouldShowNoCardTypesOnInvalidPANEnter() {
+    func testShouldShowCardTypesOnPANEnter() throws {
         // Given
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+        
         setupRootViewController(sut.viewController)
 
-        let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
-        XCTAssertNotNil(cardNumberItemView)
-        let textItemView: FormTextItemView<FormCardNumberItem>? = cardNumberItemView!.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
-        XCTAssertNotNil(textItemView)
-        let cardLogoView = cardNumberItemView!.detectedBrandsView
-        XCTAssertNotNil(cardLogoView)
-        let cardNumberItem = cardNumberItemView!.item
+        let cardNumberItemView: FormCardNumberItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem"))
+        let cardLogoView = cardNumberItemView.detectedBrandsView
+        let cardNumberItem = cardNumberItemView.item
         
-        self.populate(textItemView: cardNumberItemView!, with: "1231")
+        self.populate(textItemView: cardNumberItemView, with: "3400")
         
-        wait(for: .milliseconds(300))
-        
-        XCTAssertEqual(cardNumberItem.cardTypeLogos.count, 3)
-        XCTAssertFalse(cardLogoView.primaryLogoView.isHidden)
-        XCTAssertTrue(cardLogoView.secondaryLogoView.isHidden)
-    }
-
-    func testShouldShowCardTypesOnPANEnter() {
-        // Given
-        setupRootViewController(sut.viewController)
-
-        let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
-        XCTAssertNotNil(cardNumberItemView)
-        let textItemView: FormTextItemView<FormCardNumberItem>? = cardNumberItemView!.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
-        XCTAssertNotNil(textItemView)
-        let cardLogoView = cardNumberItemView!.detectedBrandsView
-        XCTAssertNotNil(cardLogoView)
-        let cardNumberItem = cardNumberItemView!.item
-        
-        self.populate(textItemView: cardNumberItemView!, with: "3400")
-        
-        wait(for: .milliseconds(300))
-        
-        XCTAssertEqual(cardNumberItem.cardTypeLogos.count, 3)
-        XCTAssertFalse(cardLogoView.primaryLogoView.isHidden)
-        XCTAssertTrue(cardLogoView.secondaryLogoView.isHidden)
+        wait(until: cardNumberItem, at: \.cardTypeLogos.count, is: 3)
+        wait(until: cardLogoView, at: \.primaryLogoView.isHidden, is: false)
+        wait(until: cardLogoView, at: \.secondaryLogoView.isHidden, is: true)
     }
 
     func testSubmit() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .full
         let sut = CardComponent(paymentMethod: method,
                                 context: Dummy.context(with: nil),
@@ -662,6 +677,12 @@ class CardComponentTests: XCTestCase {
     
     func testCardNumberShouldPassFocusToDate() throws {
         // Given
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+        
         setupRootViewController(sut.viewController)
 
         let cardNumberItemView: FormCardNumberItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem"))
@@ -722,26 +743,22 @@ class CardComponentTests: XCTestCase {
         let view: UIView = viewController.view
         let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(with: "AdyenCard.CardComponent.expiryDateItem"))
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem> = try XCTUnwrap(view.findView(with: "AdyenCard.CardComponent.securityCodeItem"))
-
-        wait(for: .milliseconds(300))
         
         expiryDateItemView.becomeFirstResponder()
         self.append(textItemView: expiryDateItemView, with: "3")
         
-        wait(for: .milliseconds(300))
+        wait(until: expiryDateItemView, at: \.textField.isFirstResponder, is: true)
         
-        XCTAssertTrue(expiryDateItemView.textField.isFirstResponder)
         self.append(textItemView: expiryDateItemView, with: "3")
         self.append(textItemView: expiryDateItemView, with: "0")
         
-        wait(for: .milliseconds(300))
-        
+        wait(until: expiryDateItemView, at: \.textField.isFirstResponder, is: false)
         XCTAssertTrue(securityCodeItemView.textField.isFirstResponder)
-        XCTAssertFalse(expiryDateItemView.textField.isFirstResponder)
     }
 
-    func testPostalCode() {
+    func testPostalCode() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .postalCode
 
         let sut = CardComponent(paymentMethod: method,
@@ -771,23 +788,23 @@ class CardComponentTests: XCTestCase {
             sut.stopLoadingIfNeeded()
             delegateExpectation.fulfill()
         }
-
-        wait(for: .milliseconds(300))
         
         self.fillCard(on: sut.viewController.view, with: Dummy.visaCard)
 
-        let postalCodeItemView: FormTextItemView<FormPostalCodeItem>? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.postalCodeItem")
-        XCTAssertEqual(postalCodeItemView!.titleLabel.text, "Postal code")
-        XCTAssertTrue(postalCodeItemView!.alertLabel.isHidden)
-        self.populate(textItemView: postalCodeItemView!, with: "12345")
+        let postalCodeItemView: FormTextItemView<FormPostalCodeItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.CardComponent.postalCodeItem"))
+        XCTAssertEqual(postalCodeItemView.titleLabel.text, "Postal code")
+        XCTAssertTrue(postalCodeItemView.alertLabel.isHidden)
+        
+        self.populate(textItemView: postalCodeItemView, with: "12345")
 
         self.tapSubmitButton(on: sut.viewController.view)
 
         waitForExpectations(timeout: 10)
     }
 
-    func testKCP() {
+    func testKCP() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.koreanAuthenticationMode = .auto
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
@@ -820,31 +837,31 @@ class CardComponentTests: XCTestCase {
             delegateExpectation.fulfill()
         }
         
-        wait(for: .milliseconds(300))
+        let taxNumberItemView: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.CardComponent.additionalAuthCodeItem"))
+        let passwordItemView: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.CardComponent.additionalAuthPasswordItem"))
         
-        let taxNumberItemView: FormTextInputItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.additionalAuthCodeItem")
-        let passwordItemView: FormTextInputItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.additionalAuthPasswordItem")
-        XCTAssertTrue(taxNumberItemView!.isHidden)
-        XCTAssertTrue(passwordItemView!.isHidden)
+        wait(until: taxNumberItemView, at: \.isHidden, is: true)
+        wait(until: passwordItemView, at: \.isHidden, is: true)
 
         self.fillCard(on: sut.viewController.view, with: Dummy.kcpCard)
-        
-        wait(for: .milliseconds(500))
 
-        XCTAssertEqual(passwordItemView!.titleLabel.text, "First 2 digits of card password")
-        XCTAssertEqual(taxNumberItemView!.titleLabel.text, "Birthdate or Corporate registration number")
-        XCTAssertFalse(taxNumberItemView!.isHidden)
-        XCTAssertFalse(passwordItemView!.isHidden)
-        self.populate(textItemView: taxNumberItemView!, with: "121212")
-        self.populate(textItemView: passwordItemView!, with: "12")
+        wait(until: taxNumberItemView, at: \.titleLabel.text, is: "Birthdate or Corporate registration number")
+        wait(until: taxNumberItemView, at: \.isHidden, is: false)
+        
+        wait(until: passwordItemView, at: \.titleLabel.text, is: "First 2 digits of card password")
+        wait(until: passwordItemView, at: \.isHidden, is: false)
+
+        self.populate(textItemView: taxNumberItemView, with: "121212")
+        self.populate(textItemView: passwordItemView, with: "12")
 
         self.tapSubmitButton(on: sut.viewController.view)
         
         waitForExpectations(timeout: 10)
     }
 
-    func testBrazilSSNAuto() {
+    func testBrazilSSNAuto() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.socialSecurityNumberMode = .auto
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
@@ -874,30 +891,28 @@ class CardComponentTests: XCTestCase {
             delegateExpectation.fulfill()
         }
 
-        wait(for: .milliseconds(300))
-        let brazilSSNItemView: FormTextInputItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.socialSecurityNumberItem")
-        XCTAssertTrue(brazilSSNItemView!.isHidden)
+        let brazilSSNItemView: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.CardComponent.socialSecurityNumberItem"))
+        XCTAssertTrue(brazilSSNItemView.isHidden)
 
         fillCard(on: sut.viewController.view, with: Dummy.visaCard)
 
-        wait(for: .milliseconds(500))
-        XCTAssertEqual(brazilSSNItemView!.titleLabel.text, "CPF/CNPJ")
-        XCTAssertFalse(brazilSSNItemView!.isHidden)
-        populate(textItemView: brazilSSNItemView!, with: "123.123.123-12")
+        wait(until: brazilSSNItemView, at: \.titleLabel.text, is: "CPF/CNPJ")
+        wait(until: brazilSSNItemView, at: \.isHidden, is: false)
+        
+        populate(textItemView: brazilSSNItemView, with: "123.123.123-12")
 
         tapSubmitButton(on: sut.viewController.view)
         
         let newResponse = BinLookupResponse(brands: [CardBrand(type: .elo, showSocialSecurityNumber: false)])
         sut.cardViewController.update(binInfo: newResponse)
 
-        wait(for: .milliseconds(900))
-
-        XCTAssertTrue(brazilSSNItemView!.isHidden)
+        wait(until: brazilSSNItemView, at: \.isHidden, is: true)
 
         waitForExpectations(timeout: 20, handler: nil)
     }
     
     func testBrazilSSNDisabled() {
+        var configuration = CardComponent.Configuration()
         configuration.socialSecurityNumberMode = .hide
 
         let sut = CardComponent(paymentMethod: method,
@@ -916,6 +931,7 @@ class CardComponentTests: XCTestCase {
     
     func testBrazilSSNEnabled() {
         let method = CardPaymentMethod(type: .bcmc, name: "Test name", fundingSource: .credit, brands: [.visa, .americanExpress, .masterCard, .elo])
+        var configuration = CardComponent.Configuration()
         configuration.socialSecurityNumberMode = .show
 
         let sut = CardComponent(paymentMethod: method,
@@ -933,6 +949,12 @@ class CardComponentTests: XCTestCase {
     }
 
     func testLuhnCheck() {
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+        
         let brands = [CardBrand(type: .visa, isLuhnCheckEnabled: true),
                       CardBrand(type: .masterCard, isLuhnCheckEnabled: false)]
 
@@ -953,7 +975,7 @@ class CardComponentTests: XCTestCase {
 
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
-                                configuration: configuration)
+                                configuration: CardComponent.Configuration())
         
         XCTAssertTrue(sut.cardViewController.items.numberContainerItem.showsSupportedCardLogos)
         
@@ -971,10 +993,7 @@ class CardComponentTests: XCTestCase {
         let binResponse = BinLookupResponse(brands: [CardBrand(type: .visa, isSupported: true)])
         sut.cardViewController.update(binInfo: binResponse)
 
-        wait(for: .milliseconds(30))
-        
-        supportedCardLogosItem = try XCTUnwrap(sut.viewController.view.findView(with: supportedCardLogosItemId))
-        XCTAssertTrue(supportedCardLogosItem.isHidden)
+        wait(until: supportedCardLogosItem, at: \.isHidden, is: true)
     }
 
     func testCVCDisplayMode() {
@@ -1021,6 +1040,12 @@ class CardComponentTests: XCTestCase {
     }
 
     func testExpiryDateOptionality() {
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+        
         let brands = [CardBrand(type: .visa, expiryDatePolicy: .required),
                       CardBrand(type: .americanExpress, expiryDatePolicy: .optional),
                       CardBrand(type: .masterCard, expiryDatePolicy: .hidden)]
@@ -1067,6 +1092,7 @@ class CardComponentTests: XCTestCase {
         let cardBasedInstallmentOptions: [CardType: InstallmentOptions] = [.visa:
             InstallmentOptions(maxInstallmentMonth: 8, includesRevolving: true)]
         let defaultInstallmentOptions = InstallmentOptions(monthValues: [3, 6, 9, 12], includesRevolving: false)
+        var configuration = CardComponent.Configuration()
         configuration.installmentConfiguration = InstallmentConfiguration(cardBasedOptions: cardBasedInstallmentOptions,
                                                                           defaultOptions: defaultInstallmentOptions)
         let cardTypeProviderMock = BinInfoProviderMock()
@@ -1108,6 +1134,7 @@ class CardComponentTests: XCTestCase {
     
     func testInstallmentsWithDefaultOptions() {
         let defaultInstallmentOptions = InstallmentOptions(monthValues: [3, 6, 9, 12], includesRevolving: false)
+        var configuration = CardComponent.Configuration()
         configuration.installmentConfiguration = InstallmentConfiguration(defaultOptions: defaultInstallmentOptions)
         let cardTypeProviderMock = BinInfoProviderMock()
 
@@ -1142,6 +1169,7 @@ class CardComponentTests: XCTestCase {
     func testInstallmentsWitCardBasedOptions() {
         let cardBasedInstallmentOptions: [CardType: InstallmentOptions] = [.visa:
             InstallmentOptions(maxInstallmentMonth: 8, includesRevolving: true)]
+        var configuration = CardComponent.Configuration()
         configuration.installmentConfiguration = InstallmentConfiguration(cardBasedOptions: cardBasedInstallmentOptions)
         let cardTypeProviderMock = BinInfoProviderMock()
 
@@ -1188,6 +1216,7 @@ class CardComponentTests: XCTestCase {
     func testInstallmentsWithAmountShown() {
         let cardBasedInstallmentOptions: [CardType: InstallmentOptions] = [.visa:
             InstallmentOptions(maxInstallmentMonth: 8, includesRevolving: true)]
+        var configuration = CardComponent.Configuration()
         configuration.installmentConfiguration = InstallmentConfiguration(cardBasedOptions: cardBasedInstallmentOptions, showInstallmentAmount: true)
         let cardTypeProviderMock = BinInfoProviderMock()
 
@@ -1240,7 +1269,7 @@ class CardComponentTests: XCTestCase {
         let sut = CardComponent(
             paymentMethod: method,
             context: context,
-            configuration: configuration
+            configuration: CardComponent.Configuration()
         )
 
         setupRootViewController(sut.viewController)
@@ -1254,10 +1283,9 @@ class CardComponentTests: XCTestCase {
 
         // valid card but still active. logos should be hidden
         populate(textItemView: cardNumberItemView, with: Dummy.visaCard.number!)
-        wait(for: .seconds(5))
-        XCTAssertTrue(logoItemView.isHidden)
+        wait(until: logoItemView, at: \.isHidden, is: true)
 
-        // with valid card and inactive, logos should hide
+        // with valid card and inactive, logos should still be hidden
         numberItem.isActive = false
         wait(for: .aMoment)
         XCTAssertTrue(logoItemView.isHidden)
@@ -1267,13 +1295,49 @@ class CardComponentTests: XCTestCase {
         numberItem.isActive = true
         wait(until: logoItemView, at: \.isHidden, is: false)
         numberItem.isActive = false
-        wait(for: .aMoment)
+        wait(for: .aMoment) // Logo item view should still be hidden after waiting a bit
         XCTAssertFalse(logoItemView.isHidden)
+    }
+    
+    func testStorePaymentMethodFieldVisibility() throws {
+        
+        // Given
+        
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+
+        let cardViewController = sut.cardViewController
+        
+        // Field should be visible and disabled by default
+        
+        XCTAssertFalse(cardViewController.items.storeDetailsItem.value)
+        XCTAssertTrue(cardViewController.items.storeDetailsItem.isVisible)
+        
+        // Enable storing when field visible
+        
+        sut.update(storePaymentMethodFieldValue: true)
+        XCTAssertTrue(cardViewController.items.storeDetailsItem.value)
+        
+        // Hiding field should disable storing
+        
+        sut.update(storePaymentMethodFieldVisibility: false)
+        XCTAssertFalse(cardViewController.items.storeDetailsItem.isVisible)
+        XCTAssertFalse(cardViewController.items.storeDetailsItem.value)
+        
+        // Enabling storing while field is hidden should be ignored
+        
+        sut.update(storePaymentMethodFieldValue: true)
+        XCTAssertFalse(cardViewController.items.storeDetailsItem.isVisible)
+        XCTAssertFalse(cardViewController.items.storeDetailsItem.value)
     }
 
     func testClearShouldResetPostalCodeItemToEmptyValue() throws {
         // Given
 
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .postalCode
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
@@ -1293,6 +1357,7 @@ class CardComponentTests: XCTestCase {
 
     func testClearShouldResetNumberItemToEmptyValue() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .postalCode
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
@@ -1312,6 +1377,7 @@ class CardComponentTests: XCTestCase {
 
     func testClearShouldResetExpiryDateItemToEmptyValue() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .postalCode
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
@@ -1320,8 +1386,6 @@ class CardComponentTests: XCTestCase {
 
         // show view controller
         setupRootViewController(sut.viewController)
-        
-        wait(for: .milliseconds(300))
         
         // When
         // hide view controller
@@ -1333,6 +1397,7 @@ class CardComponentTests: XCTestCase {
 
     func testClearShouldResetSecurityCodeItemToEmptyValue() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .postalCode
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
@@ -1352,6 +1417,7 @@ class CardComponentTests: XCTestCase {
 
     func testClearShouldResetHolderNameItemToEmptyValue() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.showsHolderNameField = true
         configuration.billingAddress.mode = .postalCode
         let sut = CardComponent(paymentMethod: method,
@@ -1361,8 +1427,6 @@ class CardComponentTests: XCTestCase {
 
         // show view controller
         setupRootViewController(sut.viewController)
-        
-        wait(for: .milliseconds(300))
         
         // When
         // hide view controller
@@ -1374,6 +1438,7 @@ class CardComponentTests: XCTestCase {
 
     func testClearShouldDisableStoreDetailsItem() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .postalCode
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
@@ -1431,6 +1496,7 @@ class CardComponentTests: XCTestCase {
 
     func testCardPrefillingGivenBillingAddressInFullModeShouldPrefillItems() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.showsHolderNameField = true
         configuration.billingAddress.mode = .full
         configuration.shopperInformation = shopperInformation
@@ -1463,6 +1529,7 @@ class CardComponentTests: XCTestCase {
 
     func testCardPrefillingGivenBillingAddressInPostalCodeModeShouldPrefillItems() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.showsHolderNameField = true
         configuration.billingAddress.mode = .postalCode
         configuration.shopperInformation = shopperInformation
@@ -1495,6 +1562,7 @@ class CardComponentTests: XCTestCase {
 
     func testCardPrefillingGivenNoShopperInformationAndFullAddressModeShouldNotPrefillItems() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.showsHolderNameField = true
         configuration.billingAddress.mode = .full
 
@@ -1523,6 +1591,7 @@ class CardComponentTests: XCTestCase {
 
     func testCardPrefillingGivenNoShopperInformationAndPostalCodeModeShouldNotPrefillItems() throws {
         // Given
+        var configuration = CardComponent.Configuration()
         configuration.showsHolderNameField = true
         configuration.billingAddress.mode = .postalCode
 
@@ -1550,6 +1619,7 @@ class CardComponentTests: XCTestCase {
     }
     
     func testAddressWithSupportedCountries() throws {
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .full
         configuration.billingAddress.countryCodes = ["UK"]
 
@@ -1567,9 +1637,12 @@ class CardComponentTests: XCTestCase {
         let billingAddressView: FormAddressPickerItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.billingAddress))
         
         billingAddressView.item.selectionHandler()
-        wait(for: .aMoment)
         
-        let presentedViewController = try XCTUnwrap(UIViewController.topPresenter().children.first as? UINavigationController)
+        let presentedViewController = try waitForViewController(
+            ofType: UINavigationController.self,
+            toBecomeChildOf: UIViewController.topPresenter()
+        )
+        
         XCTAssertTrue(presentedViewController.viewControllers.first is AddressInputFormViewController)
         
         let inputForm = try XCTUnwrap(presentedViewController.viewControllers.first as? AddressInputFormViewController)
@@ -1578,6 +1651,7 @@ class CardComponentTests: XCTestCase {
     }
     
     func testAddressWithSupportedCountriesWithMatchingPrefill() throws {
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .full
         configuration.billingAddress.countryCodes = ["US", "JP"]
         configuration.shopperInformation = shopperInformation
@@ -1599,9 +1673,12 @@ class CardComponentTests: XCTestCase {
         XCTAssertEqual(expectedBillingAddress, billingAddress)
         
         billingAddressView.item.selectionHandler()
-        wait(for: .milliseconds(50))
         
-        let presentedViewController = try XCTUnwrap(UIViewController.topPresenter().children.first as? UINavigationController)
+        let presentedViewController = try waitForViewController(
+            ofType: UINavigationController.self,
+            toBecomeChildOf: UIViewController.topPresenter()
+        )
+        
         XCTAssertTrue(presentedViewController.viewControllers.first is AddressInputFormViewController)
         
         let inputForm = try XCTUnwrap(presentedViewController.viewControllers.first as? AddressInputFormViewController)
@@ -1610,6 +1687,7 @@ class CardComponentTests: XCTestCase {
     }
     
     func testAddressWithSupportedCountriesWithNonMatchingPrefill() throws {
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .full
         configuration.billingAddress.countryCodes = ["UK"]
         configuration.shopperInformation = shopperInformation
@@ -1627,9 +1705,12 @@ class CardComponentTests: XCTestCase {
         
         let billingAddressView: FormAddressPickerItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.billingAddress))
         billingAddressView.item.selectionHandler()
-        wait(for: .milliseconds(50))
         
-        let presentedViewController = try XCTUnwrap(UIViewController.topPresenter().children.first as? UINavigationController)
+        let presentedViewController = try waitForViewController(
+            ofType: UINavigationController.self,
+            toBecomeChildOf: UIViewController.topPresenter()
+        )
+        
         let inputForm = try XCTUnwrap(presentedViewController.viewControllers.first as? AddressInputFormViewController)
         
         XCTAssertEqual(inputForm.billingAddressItem.configuration.supportedCountryCodes, ["UK"])
@@ -1637,6 +1718,7 @@ class CardComponentTests: XCTestCase {
     }
     
     func testOptionalInvalidFullAddressWithCertainSchemes() throws {
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .full
         configuration.billingAddress.countryCodes = ["US"]
         configuration.billingAddress.requirementPolicy = .optionalForCardTypes([.visa])
@@ -1659,8 +1741,6 @@ class CardComponentTests: XCTestCase {
         setupRootViewController(sut.viewController)
         
         let view: UIView = sut.cardViewController.view
-
-        wait(for: .milliseconds(300))
         
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
         let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
@@ -1678,7 +1758,7 @@ class CardComponentTests: XCTestCase {
             stateOrProvince: "AZ"
         )
         
-        wait(for: .milliseconds(800))
+        wait(until: billingAddressView, at: \.isValid, is: true)
         
         let delegateExpectation = expectation(description: "PaymentComponentDelegate must be called when submit button is clicked.")
         delegate.onDidFail = { error, component in XCTFail("should not fail") }
@@ -1701,6 +1781,7 @@ class CardComponentTests: XCTestCase {
     }
     
     func testOptionalValidFullAddressWithCertainSchemes() throws {
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .full
         configuration.billingAddress.countryCodes = ["US"]
         configuration.billingAddress.requirementPolicy = .optionalForCardTypes([.visa])
@@ -1724,8 +1805,6 @@ class CardComponentTests: XCTestCase {
         setupRootViewController(sut.viewController)
         
         let view: UIView = sut.cardViewController.view
-
-        wait(for: .milliseconds(300))
         
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
         let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
@@ -1734,8 +1813,6 @@ class CardComponentTests: XCTestCase {
         populate(textItemView: securityCodeField, with: "737")
         populate(textItemView: numberField, with: "4111 1120 1426 7661")
         populate(textItemView: expiryDateField, with: "12/30")
-        
-        wait(for: .milliseconds(800))
         
         let delegateExpectation = expectation(description: "PaymentComponentDelegate must be called when submit button is clicked.")
         delegate.onDidFail = { error, component in XCTFail("should not fail") }
@@ -1755,6 +1832,7 @@ class CardComponentTests: XCTestCase {
     }
     
     func testOptionalValidPostalAddressWithCertainSchemes() throws {
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .postalCode
         configuration.billingAddress.countryCodes = ["US"]
         configuration.billingAddress.requirementPolicy = .optionalForCardTypes([.visa])
@@ -1778,21 +1856,16 @@ class CardComponentTests: XCTestCase {
         setupRootViewController(sut.viewController)
         
         let view: UIView = sut.cardViewController.view
-
-        wait(for: .milliseconds(300))
         
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
         let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
-        
         let postalCodeField: FormTextItemView<FormPostalCodeItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.zipCode))
         
         populate(textItemView: securityCodeField, with: "737")
         populate(textItemView: numberField, with: "4111 1120 1426 7661")
         populate(textItemView: expiryDateField, with: "12/30")
         populate(textItemView: postalCodeField, with: "123")
-        
-        wait(for: .milliseconds(800))
         
         let delegateExpectation = expectation(description: "PaymentComponentDelegate must be called when submit button is clicked.")
         delegate.onDidFail = { error, component in XCTFail("should not fail") }
@@ -1812,6 +1885,7 @@ class CardComponentTests: XCTestCase {
     }
     
     func testOptionalInvalidPostalAddressWithCertainSchemes() throws {
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .postalCode
         configuration.billingAddress.countryCodes = ["US"]
         configuration.billingAddress.requirementPolicy = .optionalForCardTypes([.visa])
@@ -1834,18 +1908,17 @@ class CardComponentTests: XCTestCase {
         setupRootViewController(sut.viewController)
         
         let view: UIView = sut.cardViewController.view
-
-        wait(for: .milliseconds(300))
         
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
         let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
+        let postalCodeField: FormTextItemView<FormPostalCodeItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.zipCode))
         
         populate(textItemView: securityCodeField, with: "737")
         populate(textItemView: numberField, with: "4111 1120 1426 7661")
         populate(textItemView: expiryDateField, with: "12/30")
         
-        wait(for: .milliseconds(800))
+        wait(until: postalCodeField, at: \.isValid, is: true)
         
         let delegateExpectation = expectation(description: "PaymentComponentDelegate must be called when submit button is clicked.")
         delegate.onDidFail = { error, component in XCTFail("should not fail") }
@@ -1870,7 +1943,7 @@ class CardComponentTests: XCTestCase {
         let context = Dummy.context(with: analyticsProviderMock)
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
-                                configuration: configuration)
+                                configuration: CardComponent.Configuration())
 
         // When
         sut.cardViewController.viewWillAppear(false)
@@ -1881,6 +1954,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testCardHolderNameValidatorWithEmptyName() {
+        var configuration = CardComponent.Configuration()
         configuration.showsHolderNameField = true
         configuration.localizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
 
@@ -1897,6 +1971,7 @@ class CardComponentTests: XCTestCase {
         let context = AdyenContext(apiContext: Dummy.apiContext, payment: Payment(amount: amount, countryCode: "US"))
 
         // When
+        var configuration = CardComponent.Configuration()
         configuration.localizationParameters = LocalizationParameters(locale: "ko-KR")
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
@@ -1912,6 +1987,7 @@ class CardComponentTests: XCTestCase {
         let context = AdyenContext(apiContext: Dummy.apiContext, payment: Payment(amount: amount, countryCode: "US"))
 
         // When
+        var configuration = CardComponent.Configuration()
         configuration.localizationParameters = LocalizationParameters(enforcedLocale: "ru-RU")
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
@@ -1923,6 +1999,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testCardHolderNameValidatorWithMinimumLength() {
+        var configuration = CardComponent.Configuration()
         configuration.showsHolderNameField = true
         configuration.localizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
 
@@ -1936,6 +2013,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testOptionalApartmentNameNil() throws {
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .full
         configuration.billingAddress.countryCodes = ["US"]
 
@@ -1958,8 +2036,6 @@ class CardComponentTests: XCTestCase {
 
         let view: UIView = sut.cardViewController.view
 
-        wait(for: .milliseconds(300))
-
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
         let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
@@ -1971,8 +2047,6 @@ class CardComponentTests: XCTestCase {
         populate(textItemView: expiryDateField, with: "12/30")
 
         billingAddressView.item.value = PostalAddress(city: "Seattle", postalCode: "123", stateOrProvince: "AZ", street: "Test Street")
-        
-        wait(for: .milliseconds(800))
 
         let delegateExpectation = expectation(description: "PaymentComponentDelegate must be called when submit button is clicked.")
         delegate.onDidFail = { error, component in XCTFail("should not fail") }
@@ -1991,6 +2065,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testOptionalApartmentNameNonNil() throws {
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .full
         configuration.billingAddress.countryCodes = ["US"]
 
@@ -2012,8 +2087,6 @@ class CardComponentTests: XCTestCase {
         setupRootViewController(sut.viewController)
 
         let view: UIView = sut.cardViewController.view
-
-        wait(for: .milliseconds(300))
 
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
         let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
@@ -2033,8 +2106,6 @@ class CardComponentTests: XCTestCase {
             street: "Test Street"
         )
 
-        wait(for: .milliseconds(800))
-
         let delegateExpectation = expectation(description: "PaymentComponentDelegate must be called when submit button is clicked.")
         delegate.onDidFail = { error, component in XCTFail("should not fail") }
         delegate.onDidSubmit = { data, component in
@@ -2052,6 +2123,7 @@ class CardComponentTests: XCTestCase {
     }
 
     func testNoStateOrProvincePresentInBillingAddress() throws {
+        var configuration = CardComponent.Configuration()
         configuration.billingAddress.mode = .full
         configuration.billingAddress.countryCodes = ["GB"]
 
@@ -2074,8 +2146,6 @@ class CardComponentTests: XCTestCase {
 
         let view: UIView = sut.cardViewController.view
 
-        wait(for: .milliseconds(300))
-
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
         let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
@@ -2092,8 +2162,6 @@ class CardComponentTests: XCTestCase {
             postalCode: "123",
             street: "Test Street"
         )
-
-        wait(for: .milliseconds(800))
 
         let delegateExpectation = expectation(description: "PaymentComponentDelegate must be called when submit button is clicked.")
         delegate.onDidFail = { error, component in XCTFail("should not fail") }
@@ -2114,17 +2182,17 @@ class CardComponentTests: XCTestCase {
     func testExpiryFieldValues() {
         let sut = CardComponent(paymentMethod: method,
                                 context: context,
-                                configuration: configuration)
+                                configuration: CardComponent.Configuration())
         
         let expiryDateItem = sut.cardViewController.items.expiryDateItem
+        
         XCTAssertNil(expiryDateItem.expiryMonth)
         XCTAssertNil(expiryDateItem.expiryYear)
         
         fillCard(on: sut.viewController.view, with: Dummy.visaCard)
-        wait(for: .milliseconds(200))
         
-        XCTAssertEqual(expiryDateItem.expiryYear, "2030")
-        XCTAssertEqual(expiryDateItem.expiryMonth, "03")
+        wait(until: expiryDateItem, at: \.expiryYear, is: "2030")
+        wait(until: expiryDateItem, at: \.expiryMonth, is: "03")
     }
 
     // MARK: - Private

--- a/Tests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
+++ b/Tests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
@@ -33,7 +33,7 @@ class FormCardNumberItemTests: XCTestCase {
     func testInternalBinLookup() {
 
         let cardTypeLogos = supportedCardTypes.map {
-            FormCardLogosItem.CardTypeLogo(url: URL(string: "http://google.com")!, type: $0)
+            FormCardLogosItem.CardTypeLogo(url: URL(string: "https://google.com")!, type: $0)
         }
         let item = FormCardNumberItem(cardTypeLogos: cardTypeLogos)
         XCTAssertEqual(item.cardTypeLogos.count, 5)
@@ -118,7 +118,7 @@ class FormCardNumberItemTests: XCTestCase {
                                    .success(BinLookupResponse(brands: []))]
 
         let cardTypeLogos = supportedCardTypes.map {
-            FormCardLogosItem.CardTypeLogo(url: URL(string: "http://google.com")!, type: $0)
+            FormCardLogosItem.CardTypeLogo(url: URL(string: "https://google.com")!, type: $0)
         }
         let item = FormCardNumberItem(cardTypeLogos: cardTypeLogos)
         XCTAssertEqual(item.cardTypeLogos.count, 5)
@@ -135,7 +135,7 @@ class FormCardNumberItemTests: XCTestCase {
         apiClient.mockedResults = [.failure(Dummy.error), .failure(Dummy.error)]
 
         let cardTypeLogos = supportedCardTypes.map {
-            FormCardLogosItem.CardTypeLogo(url: URL(string: "http://google.com")!, type: $0)
+            FormCardLogosItem.CardTypeLogo(url: URL(string: "https://google.com")!, type: $0)
         }
         let item = FormCardNumberItem(cardTypeLogos: cardTypeLogos)
         XCTAssertEqual(item.cardTypeLogos.count, 5)

--- a/Tests/Helpers/XCTestCase+Wait.swift
+++ b/Tests/Helpers/XCTestCase+Wait.swift
@@ -22,7 +22,7 @@ extension XCTestCase {
             dummyExpectation.fulfill()
         }
 
-        wait(for: [dummyExpectation], timeout: 100)
+        wait(for: [dummyExpectation], timeout: 1_000)
     }
     
     /// Waits until  a certain condition is met
@@ -36,18 +36,20 @@ extension XCTestCase {
     ///   - message: an optional message on failure
     func wait(
         until expectation: () -> Bool,
-        timeout: TimeInterval = 2,
+        timeout: TimeInterval = 10,
         message: String? = nil
     ) {
-        var timeLeft = Int(timeout * 1000)
-        let incrementInterval = 10
+        let thresholdDate = Date().addingTimeInterval(timeout)
+        let pauseInterval = DispatchTimeInterval.milliseconds(10)
         
-        while timeLeft > 0, expectation() == false {
-            wait(for: .milliseconds(incrementInterval))
-            timeLeft -= incrementInterval
+        var isMatchingExpectation = expectation()
+        
+        while thresholdDate.timeIntervalSinceNow > 0, !isMatchingExpectation {
+            wait(for: pauseInterval)
+            isMatchingExpectation = expectation()
         }
         
-        XCTAssertTrue(expectation(), message ?? "Expectation should be met before timeout \(timeout)s")
+        XCTAssertTrue(isMatchingExpectation, message ?? "Expectation should be met before timeout \(timeout)s")
     }
     
     /// Waits until  a keyPath of a target matches an expected value
@@ -64,7 +66,7 @@ extension XCTestCase {
         until target: Target,
         at keyPath: KeyPath<Target, Value>,
         is expectedValue: Value,
-        timeout: TimeInterval = 2,
+        timeout: TimeInterval = 10,
         line: Int = #line
     ) {
         wait(
@@ -87,7 +89,7 @@ extension XCTestCase {
     func waitForViewController<T: UIViewController>(
         ofType: T.Type,
         toBecomeChildOf viewController: UIViewController,
-        timeout: TimeInterval = 2
+        timeout: TimeInterval = 10
     ) throws -> T {
         
         wait(
@@ -111,7 +113,7 @@ extension XCTestCase {
     @discardableResult
     func waitUntilTopPresenter<T: UIViewController>(
         isOfType: T.Type,
-        timeout: TimeInterval = 2
+        timeout: TimeInterval = 10
     ) throws -> T {
         
         wait(


### PR DESCRIPTION
## Summary
- Replacing all `http://` dummy URL schemes with `https://`
- Improved `CardComponentTests`
  - Adding `testStorePaymentMethodFieldVisibility`
  - Removing almost all explicit waiting (except for 2 places where it makes sense) from 
