### PR TITLE
`chore` Converting platform to enum

### DIFF
--- a/Adyen/Analytics/Models/TelemetryData.swift
+++ b/Adyen/Analytics/Models/TelemetryData.swift
@@ -14,14 +14,24 @@ import UIKit
 public struct TelemetryContext {
     
     internal let version: String
-    internal let platform: String
+    internal let platform: Platform
     
     public init(
         version: String = adyenSdkVersion,
-        platform: String = "ios"
+        platform: Platform = .iOS
     ) {
         self.version = version
         self.platform = platform
+    }
+}
+
+@_spi(AdyenInternal)
+public extension TelemetryContext {
+
+    enum Platform: String {
+        case iOS = "ios"
+        case reactNative = "react-native"
+        case flutter = "flutter"
     }
 }
 
@@ -84,7 +94,7 @@ internal struct TelemetryData: Encodable {
         self.amount = amount
         
         self.version = context.version
-        self.platform = context.platform
+        self.platform = context.platform.rawValue
 
         switch flavor {
         case let .dropIn(type, paymentMethods):

--- a/Tests/Adyen Tests/Analytics/AnalyticsProviderTests.swift
+++ b/Tests/Adyen Tests/Analytics/AnalyticsProviderTests.swift
@@ -163,7 +163,6 @@ class AnalyticsProviderTests: XCTestCase {
     func testTelemetryRequest() throws {
         // Given
         
-        let amount = Amount(value: 1, currencyCode: "EUR")
         let checkoutAttemptId = self.checkoutAttemptIdMockValue
         
         let telemetryExpectation = expectation(description: "Telemetry request is triggered")
@@ -214,13 +213,13 @@ class AnalyticsProviderTests: XCTestCase {
                 XCTAssertEqual(telemetryRequest.amount, amount)
                 XCTAssertEqual(telemetryRequest.checkoutAttemptId, checkoutAttemptId)
                 XCTAssertEqual(telemetryRequest.version, "version")
-                XCTAssertEqual(telemetryRequest.platform, "platform")
+                XCTAssertEqual(telemetryRequest.platform, "react-native")
                 telemetryExpectation.fulfill()
             }
         }
         
         var analyticsConfiguration = AnalyticsConfiguration()
-        analyticsConfiguration.context = .init(version: "version", platform: "platform")
+        analyticsConfiguration.context = .init(version: "version", platform: .reactNative)
         
         let analyticsProvider = AnalyticsProvider(
             apiClient: apiClient,
@@ -245,7 +244,7 @@ class AnalyticsProviderTests: XCTestCase {
             amount: .init(value: 1, currencyCode: "EUR"),
             context: .init(
                 version: "version",
-                platform: "platform"
+                platform: .flutter
             )
         )
         
@@ -255,12 +254,12 @@ class AnalyticsProviderTests: XCTestCase {
         )
         
         let encodedRequest = try JSONEncoder().encode(request)
-        var decodedRequest = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedRequest) as? [String: Any])
+        let decodedRequest = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedRequest) as? [String: Any])
         
         let expectedDecodedRequest = [
             "locale": "en_US",
             "paymentMethods": telemetryData.paymentMethods,
-            "platform": "platform",
+            "platform": "flutter",
             "component": "",
             "flavor": "dropInComponent",
             "channel": "iOS",


### PR DESCRIPTION
## Summary
- To prevent typos and match Android behavior `platform` is now an enum