### PR TITLE
`bugfix` Submit action is still disabled after CVC is filled

### DIFF
--- a/AdyenCard/Components/Stored Card/StoredCardAlertManager.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardAlertManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -29,17 +29,6 @@ internal final class StoredCardAlertManager: NSObject, UITextFieldDelegate, Adye
         
         self.publicKeyProvider = PublicKeyProvider(apiContext: context.apiContext)
     }
-    
-    // MARK: - CVC length
-
-    private var cvvLength: Int {
-        switch paymentMethod.brand {
-        case .americanExpress:
-            return 4
-        default:
-            return 3
-        }
-    }
 
     // MARK: - Alert Controller
     
@@ -50,12 +39,14 @@ internal final class StoredCardAlertManager: NSObject, UITextFieldDelegate, Adye
         
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alertController.addTextField(configurationHandler: { [weak self] textField in
+            guard let self else { return }
             textField.textAlignment = .center
             textField.keyboardType = .numberPad
-            textField.placeholder = localizedString(.cardCvcItemPlaceholder, self?.localizationParameters)
-            textField.accessibilityLabel = localizedString(.cardCvcItemTitle, self?.localizationParameters)
+            textField.placeholder = localizedString(.cardCvcItemPlaceholder, self.localizationParameters)
+            textField.accessibilityLabel = localizedString(.cardCvcItemTitle, self.localizationParameters)
             textField.accessibilityIdentifier = "AdyenCard.StoredCardAlertManager.textField"
             textField.delegate = self
+            textField.addTarget(self, action: #selector(self.textDidChange(textField:)), for: .editingChanged)
         })
         
         let cancelActionTitle = localizedString(.cancelButton, localizationParameters)
@@ -126,33 +117,16 @@ internal final class StoredCardAlertManager: NSObject, UITextFieldDelegate, Adye
     
     // MARK: - UITextFieldDelegate
     
-    internal func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard let textFieldText = textField.text else {
-            return false
-        }
+    @objc
+    private func textDidChange(textField: UITextField) {
+        guard var text = textField.text else { return }
         
-        let newString = (textFieldText as NSString).replacingCharacters(in: range, with: string)
-        if newString.count > cvvLength {
-            return false
-        }
+        let formatter = CardSecurityCodeFormatter(cardType: paymentMethod.brand)
+        let validator = CardSecurityCodeValidator(cardType: paymentMethod.brand)
         
-        defer {
-            let isValidLength = cvvLength == newString.count
-            submitAction.isEnabled = isValidLength
-        }
+        text = formatter.formattedValue(for: text)
         
-        let isDeleting = (string.count == 0 && range.length == 1)
-        if isDeleting {
-            return true
-        }
-        
-        let newCharacters = CharacterSet(charactersIn: string)
-        let isNumber = CharacterSet.decimalDigits.isSuperset(of: newCharacters)
-        if isNumber {
-            return true
-        }
-        
-        return false
+        textField.text = text
+        submitAction.isEnabled = validator.isValid(text)
     }
-    
 }

--- a/AdyenCard/Formatters/CardSecurityCodeFormatter.swift
+++ b/AdyenCard/Formatters/CardSecurityCodeFormatter.swift
@@ -26,6 +26,13 @@ public final class CardSecurityCodeFormatter: NumericFormatter {
         bind(publisher, to: self, at: \.cardType)
     }
     
+    /// Initiate new instance of CardSecurityCodeValidator with a fixed ``CardType``
+    /// - Parameter cardType: The card type to format the security code for
+    public init(cardType: CardType) {
+        super.init()
+        self.cardType = cardType
+    }
+    
     override public func formattedValue(for value: String) -> String {
         let value = super.formattedValue(for: value)
         

--- a/AdyenCard/Validators/CardSecurityCodeValidator.swift
+++ b/AdyenCard/Validators/CardSecurityCodeValidator.swift
@@ -27,6 +27,14 @@ public final class CardSecurityCodeValidator: NumericStringValidator, AdyenObser
         }
     }
     
+    /// Initiate new instance of CardSecurityCodeValidator with a fixed ``CardType``
+    /// - Parameter cardType: The card type to validate the security code for
+    public init(cardType: CardType) {
+        super.init(minimumLength: 3, maximumLength: 4)
+        
+        updateExpectedLength(from: cardType)
+    }
+    
     private func updateExpectedLength(from cardType: CardType?) {
         let length = cardType == .americanExpress ? 4 : 3
         maximumLength = length

--- a/Tests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/Card Tests/StoredCardComponentTests.swift
@@ -170,29 +170,30 @@ class StoredCardComponentTests: XCTestCase {
 
         textField.insertText("a")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 1), replacementString: "a"), false)
+        XCTAssertEqual(textField.text, "")
 
-        textField.text = "1"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "1")
 
-        textField.text = "11"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "11")
 
-        textField.text = "111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "111")
+        
         XCTAssertEqual(payAction.isEnabled, false)
 
-        textField.text = "1111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 3, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "1111")
         XCTAssertEqual(payAction.isEnabled, true)
 
-        textField.text = "11111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 4, length: 1), replacementString: "1"), false)
+        XCTAssertEqual(textField.text, "1111")
 
         alertController.dismiss(animated: false, completion: nil)
     }
@@ -206,50 +207,20 @@ class StoredCardComponentTests: XCTestCase {
         let textField: UITextField! = alertController.textFields!.first
         let payAction = alertController.actions.first { $0.title == localizedSubmitButtonTitle(with: context.payment?.amount, style: .immediate, nil) }!
 
-        textField.text = "11"
+        textField.insertText("11")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 1), replacementString: "1"), true)
-        XCTAssertEqual(payAction.isEnabled, false)
+        XCTAssertEqual(textField.text, "11")
 
-        textField.text = "111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 1), replacementString: "1"), true)
-        XCTAssertEqual(payAction.isEnabled, true)
-
-        textField.text = "1111"
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 3, length: 1), replacementString: "1"), false)
-        XCTAssertEqual(payAction.isEnabled, true)
-
-        textField.text = "11111"
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 4, length: 1), replacementString: "1"), false)
-
-        alertController.dismiss(animated: false, completion: nil)
-    }
-
-    func testCVCLimitForUnknownCardType() throws {
-        let sut = StoredCardComponent(storedCardPaymentMethod: method, context: context)
-
-        presentOnRoot(sut.viewController)
+        XCTAssertEqual(textField.text, "111")
         
-        let alertController = sut.viewController as! UIAlertController
-        let textField: UITextField! = alertController.textFields!.first
-        let payAction = alertController.actions.first { $0.title == localizedSubmitButtonTitle(with: context.payment?.amount, style: .immediate, nil) }!
-
-        textField.text = "11"
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 1), replacementString: "1"), true)
-        XCTAssertEqual(payAction.isEnabled, false)
-
-        textField.text = "111"
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 1), replacementString: "1"), true)
         XCTAssertEqual(payAction.isEnabled, true)
 
-        textField.text = "1111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 3, length: 1), replacementString: "1"), false)
+        XCTAssertEqual(textField.text, "111")
+        XCTAssertEqual(payAction.isEnabled, true)
 
         alertController.dismiss(animated: false, completion: nil)
     }


### PR DESCRIPTION
## Summary
- Aligning stored card CVC validation with FormCardSecurityCodeItem
- Fixes a bug where the CVC validation prevented activation of the pay button in the stored card component when using the [Traditional Chinese Cantonese keyboard](https://developer.apple.com/forums/thread/741038)

## Fixes
<fixed>

- For stored card payments using Drop-in, the pay button is now enabled correctly when entering the security code with the [Traditional Chinese Cantonese keyboard](https://developer.apple.com/forums/thread/741038)

</fixed>

--------

Fixes: https://github.com/Adyen/adyen-ios/issues/1498
Might also fix: https://github.com/Adyen/adyen-ios/issues/1188
