### PR TITLE
`allowOnboarding` is now assigned.

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -99,6 +99,7 @@ extension ApplePayComponent {
                 throw ApplePayComponent.Error.emptyMerchantIdentifier
             }
             self.paymentRequest = paymentRequest
+            self.allowOnboarding = allowOnboarding
             
             self.merchantIdentifier = paymentRequest.merchantIdentifier
             self.applePayPayment = try ApplePayPayment(countryCode: paymentRequest.countryCode,


### PR DESCRIPTION
<fixed>

* For Apple Pay, when the `allowOnboarding` property of `ApplePayConfiguration.init` is set to **true**, the onboarding check now correctly runs.  

</fixed>