### PR TITLE
`bugfix` `v4` Submit action is still disabled after CVC is filled

### DIFF
--- a/AdyenCard/Components/Stored Card/StoredCardAlertManager.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardAlertManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -29,20 +29,9 @@ internal final class StoredCardAlertManager: NSObject, UITextFieldDelegate, APIC
         
         self.publicKeyProvider = PublicKeyProvider(apiContext: apiContext)
     }
-    
-    // MARK: - CVC length
-
-    private var cvvLength: Int {
-        switch CardType(rawValue: paymentMethod.brand) {
-        case .americanExpress:
-            return 4
-        default:
-            return 3
-        }
-    }
 
     // MARK: - Alert Controller
-    
+        
     internal private(set) lazy var alertController: UIAlertController = {
         let title = localizedString(.cardStoredTitle, localizationParameters)
         let displayInformation = paymentMethod.localizedDisplayInformation(using: localizationParameters)
@@ -50,12 +39,14 @@ internal final class StoredCardAlertManager: NSObject, UITextFieldDelegate, APIC
         
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alertController.addTextField(configurationHandler: { [weak self] textField in
+            guard let self else { return }
             textField.textAlignment = .center
             textField.keyboardType = .numberPad
-            textField.placeholder = localizedString(.cardCvcItemPlaceholder, self?.localizationParameters)
-            textField.accessibilityLabel = localizedString(.cardCvcItemTitle, self?.localizationParameters)
+            textField.placeholder = localizedString(.cardCvcItemPlaceholder, self.localizationParameters)
+            textField.accessibilityLabel = localizedString(.cardCvcItemTitle, self.localizationParameters)
             textField.accessibilityIdentifier = "AdyenCard.StoredCardAlertManager.textField"
             textField.delegate = self
+            textField.addTarget(self, action: #selector(self.textDidChange(textField:)), for: .editingChanged)
         })
         
         let cancelActionTitle = localizedString(.cancelButton, localizationParameters)
@@ -126,33 +117,16 @@ internal final class StoredCardAlertManager: NSObject, UITextFieldDelegate, APIC
     
     // MARK: - UITextFieldDelegate
     
-    internal func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard let textFieldText = textField.text else {
-            return false
-        }
+    @objc
+    private func textDidChange(textField: UITextField) {
+        guard var text = textField.text else { return }
         
-        let newString = (textFieldText as NSString).replacingCharacters(in: range, with: string)
-        if newString.count > cvvLength {
-            return false
-        }
+        let formatter = CardSecurityCodeFormatter(cardType: .init(rawValue: paymentMethod.brand))
+        let validator = CardSecurityCodeValidator(cardType: .init(rawValue: paymentMethod.brand))
         
-        defer {
-            let isValidLength = newString.count == cvvLength
-            submitAction.isEnabled = isValidLength
-        }
+        text = formatter.formattedValue(for: text)
         
-        let isDeleting = (string.count == 0 && range.length == 1)
-        if isDeleting {
-            return true
-        }
-        
-        let newCharacters = CharacterSet(charactersIn: string)
-        let isNumber = CharacterSet.decimalDigits.isSuperset(of: newCharacters)
-        if isNumber {
-            return true
-        }
-        
-        return false
+        textField.text = text
+        submitAction.isEnabled = validator.isValid(text)
     }
-    
 }

--- a/AdyenCard/Formatters/CardSecurityCodeFormatter.swift
+++ b/AdyenCard/Formatters/CardSecurityCodeFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -24,6 +24,13 @@ public final class CardSecurityCodeFormatter: NumericFormatter, Observer {
     public init(publisher: AdyenObservable<CardType?>) {
         super.init()
         bind(publisher, to: self, at: \.cardType)
+    }
+    
+    /// Initiate new instance of CardSecurityCodeValidator with a fixed ``CardType``
+    /// - Parameter cardType: The card type to format the security code for
+    public init(cardType: CardType) {
+        super.init()
+        self.cardType = cardType
     }
     
     /// :nodoc:

--- a/AdyenCard/Validators/CardSecurityCodeValidator.swift
+++ b/AdyenCard/Validators/CardSecurityCodeValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -25,6 +25,14 @@ public final class CardSecurityCodeValidator: NumericStringValidator, Observer {
         observe(publisher) { [weak self] cardType in
             self?.updateExpectedLength(from: cardType)
         }
+    }
+    
+    /// Initiate new instance of CardSecurityCodeValidator with a fixed ``CardType``
+    /// - Parameter cardType: The card type to validate the security code for
+    public init(cardType: CardType) {
+        super.init(minimumLength: 3, maximumLength: 4)
+
+        updateExpectedLength(from: cardType)
     }
     
     private func updateExpectedLength(from cardType: CardType?) {

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/AdyenTests/Adyen Tests/Utilities/AmountFormatterTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Utilities/AmountFormatterTests.swift
@@ -76,8 +76,8 @@ class AmountFormatterTests: XCTestCase {
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "ko_KR"), "CVE 123,456")
             XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "CVE", localeIdentifier: "fr_FR"), "123 456 CVE")
 
-            if Available.iOS17 {
-                XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "1,234.56 kr.")
+            if #available(iOS 17.0, *) {
+                XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "1.234,56 kr.")
             } else {
                 XCTAssertEqual(AmountFormatter.formatted(amount: amount, currencyCode: "ISK", localeIdentifier: "is_IS"), "1.234,56 ISK")
             }

--- a/Tests/AdyenTests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/StoredCardComponentTests.swift
@@ -219,29 +219,30 @@ class StoredCardComponentTests: XCTestCase {
 
         textField.insertText("a")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 1), replacementString: "a"), false)
+        XCTAssertEqual(textField.text, "")
 
-        textField.text = "1"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 0, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "1")
 
-        textField.text = "11"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "11")
 
-        textField.text = "111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "111")
+        
         XCTAssertEqual(payAction.isEnabled, false)
 
-        textField.text = "1111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 3, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "1111")
         XCTAssertEqual(payAction.isEnabled, true)
 
-        textField.text = "11111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 4, length: 1), replacementString: "1"), false)
+        XCTAssertEqual(textField.text, "1111")
 
         alertController.dismiss(animated: false, completion: nil)
     }
@@ -270,24 +271,22 @@ class StoredCardComponentTests: XCTestCase {
         let textField: UITextField! = alertController.textFields!.first
         let payAction = alertController.actions.first { $0.title == localizedSubmitButtonTitle(with: payment.amount, style: .immediate, nil) }!
 
-        textField.text = "11"
+        textField.insertText("11")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "11")
+        
         XCTAssertEqual(payAction.isEnabled, false)
 
-        textField.text = "111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "111")
+        
         XCTAssertEqual(payAction.isEnabled, true)
 
-        textField.text = "1111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 3, length: 1), replacementString: "1"), false)
+        XCTAssertEqual(textField.text, "111")
         XCTAssertEqual(payAction.isEnabled, true)
-
-        textField.text = "11111"
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 4, length: 1), replacementString: "1"), false)
 
         alertController.dismiss(animated: false, completion: nil)
     }
@@ -316,19 +315,22 @@ class StoredCardComponentTests: XCTestCase {
         let textField: UITextField! = alertController.textFields!.first
         let payAction = alertController.actions.first { $0.title == localizedSubmitButtonTitle(with: payment.amount, style: .immediate, nil) }!
 
-        textField.text = "11"
+        textField.insertText("11")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 1, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "11")
+        
         XCTAssertEqual(payAction.isEnabled, false)
 
-        textField.text = "111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 2, length: 1), replacementString: "1"), true)
+        XCTAssertEqual(textField.text, "111")
+        
         XCTAssertEqual(payAction.isEnabled, true)
 
-        textField.text = "1111"
+        textField.insertText("1")
         textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.delegate!.textField!(textField, shouldChangeCharactersIn: NSRange(location: 3, length: 1), replacementString: "1"), false)
+        XCTAssertEqual(textField.text, "111")
+        XCTAssertEqual(payAction.isEnabled, true)
 
         alertController.dismiss(animated: false, completion: nil)
     }


### PR DESCRIPTION
## Summary
- Aligning stored card CVC validation with FormCardSecurityCodeItem
- Fixes a bug where the CVC validation prevented activation of the pay button in the stored card component when using the [Traditional Chiniese Caontonese keyboard](https://developer.apple.com/forums/thread/741038)
- Same changes as for [v5](https://github.com/Adyen/adyen-ios/pull/1499)

## Fixes
<fixed>

- For stored card payments using Drop-in, the pay button is now enabled correctly when entering the security code with the [Traditional Chinese Cantonese keyboard](https://developer.apple.com/forums/thread/741038)

</fixed>

--------

Fixes: https://github.com/Adyen/adyen-ios/issues/1498
Might also fix: https://github.com/Adyen/adyen-ios/issues/1188
