### PR TITLE
Improve TrackableComponent extension

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		A09ADA112807142600BF6802 /* SessionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09ADA102807142600BF6802 /* SessionRequest.swift */; };
 		A09ADA122807142600BF6802 /* SessionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09ADA102807142600BF6802 /* SessionRequest.swift */; };
 		A09C704327032870004C01AA /* FormCardLogosItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09C704227032870004C01AA /* FormCardLogosItemView.swift */; };
+		A09FB2EB2B8399B700270D51 /* TrackableComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09FB2EA2B8399B700270D51 /* TrackableComponent.swift */; };
 		A0B180312A2DE445003C608E /* MealVoucherDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B180302A2DE445003C608E /* MealVoucherDetails.swift */; };
 		A0BC64E628F062E400CED2A1 /* AdyenSessionAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BC64E528F062E400CED2A1 /* AdyenSessionAware.swift */; };
 		A0C9B59B288AE34600D6BDAB /* InstallmentOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F41E5526CBCA6E0089AD6C /* InstallmentOptions.swift */; };
@@ -1522,6 +1523,7 @@
 		A07B2CF126A5D4FE0008185C /* BrazilSocialSecurityNumberFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrazilSocialSecurityNumberFormatterTests.swift; sourceTree = "<group>"; };
 		A09ADA102807142600BF6802 /* SessionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRequest.swift; sourceTree = "<group>"; };
 		A09C704227032870004C01AA /* FormCardLogosItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardLogosItemView.swift; sourceTree = "<group>"; };
+		A09FB2EA2B8399B700270D51 /* TrackableComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackableComponent.swift; sourceTree = "<group>"; };
 		A0B180302A2DE445003C608E /* MealVoucherDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealVoucherDetails.swift; sourceTree = "<group>"; };
 		A0BC64E528F062E400CED2A1 /* AdyenSessionAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenSessionAware.swift; sourceTree = "<group>"; };
 		A0D48FB727109B0200C0B82C /* ArrayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayHelpers.swift; sourceTree = "<group>"; };
@@ -4567,6 +4569,7 @@
 				E226F54A229803130013A463 /* DropInComponentDelegate.swift */,
 				E7D418B0286E4C5900E9A7F4 /* PaymentAwareComponent.swift */,
 				A0BC64E528F062E400CED2A1 /* AdyenSessionAware.swift */,
+				A09FB2EA2B8399B700270D51 /* TrackableComponent.swift */,
 			);
 			path = "Core Protocols";
 			sourceTree = "<group>";
@@ -6667,6 +6670,7 @@
 				C982FFDC2694792F00AED849 /* AffirmPaymentMethod.swift in Sources */,
 				F9B798C923AB697100A2103C /* FormComponentStyle.swift in Sources */,
 				E708591F261F1CB800D0153B /* FormVerticalStackItemView.swift in Sources */,
+				A09FB2EB2B8399B700270D51 /* TrackableComponent.swift in Sources */,
 				E7275BF9255012F600907CF9 /* FormLabelItem.swift in Sources */,
 				E2D12BEF221D560800EF682F /* FormValueItem.swift in Sources */,
 				E76EC6882412581E009C6E2F /* FormTextInputItem.swift in Sources */,

--- a/Adyen/Core/Core Protocols/PresentableComponent.swift
+++ b/Adyen/Core/Core Protocols/PresentableComponent.swift
@@ -59,32 +59,3 @@ public extension PresentableComponent {
     var navBarType: NavigationBarType { .regular }
     
 }
-
-@_spi(AdyenInternal)
-public protocol TrackableComponent: Component {
-    
-    /// Sends the initial data and retrieves the checkout attempt id
-    func sendInitialAnalytics()
-}
-
-@_spi(AdyenInternal)
-extension TrackableComponent where Self: ViewControllerDelegate {
-    
-    public func viewDidLoad(viewController: UIViewController) {
-        sendInitialAnalytics()
-    }
-}
-
-@_spi(AdyenInternal)
-extension TrackableComponent where Self: PaymentMethodAware {
-    
-    public func sendInitialAnalytics() {
-        // initial call is not needed again if inside dropIn
-        guard !_isDropIn else { return }
-        let flavor: AnalyticsFlavor = .components(type: paymentMethod.type)
-        let amount = context.payment?.amount
-        let additionalFields = AdditionalAnalyticsFields(amount: amount, sessionId: AnalyticsForSession.sessionId)
-        context.analyticsProvider?.sendInitialAnalytics(with: flavor,
-                                                         additionalFields: additionalFields)
-    }
-}

--- a/Adyen/Core/Core Protocols/TrackableComponent.swift
+++ b/Adyen/Core/Core Protocols/TrackableComponent.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// A component that can send analytics events.
 @_spi(AdyenInternal)

--- a/Adyen/Core/Core Protocols/TrackableComponent.swift
+++ b/Adyen/Core/Core Protocols/TrackableComponent.swift
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2024 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+/// A component that can send analytics events.
+@_spi(AdyenInternal)
+public protocol TrackableComponent: Component {
+    
+    /// Analytics flavor to determine the component / dropIn that initiates the events.
+    var analyticsFlavor: AnalyticsFlavor { get }
+    
+    /// Sends the initial data and retrieves the checkout attempt id
+    func sendInitialAnalytics()
+}
+
+@_spi(AdyenInternal)
+extension TrackableComponent where Self: ViewControllerDelegate {
+    
+    public func viewDidLoad(viewController: UIViewController) {
+        sendInitialAnalytics()
+    }
+}
+
+// Generic extension to send events for all components and dropIn.
+@_spi(AdyenInternal)
+extension TrackableComponent {
+    
+    public func sendInitialAnalytics() {
+        // initial call is not needed again if inside dropIn
+        guard !_isDropIn else { return }
+        let amount = context.payment?.amount
+        let additionalFields = AdditionalAnalyticsFields(amount: amount, sessionId: AnalyticsForSession.sessionId)
+        context.analyticsProvider?.sendInitialAnalytics(with: analyticsFlavor,
+                                                         additionalFields: additionalFields)
+    }
+}
+
+@_spi(AdyenInternal)
+extension TrackableComponent where Self: PaymentMethodAware {
+    
+    public var analyticsFlavor: AnalyticsFlavor {
+        .components(type: paymentMethod.type)
+    }
+}

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -158,12 +158,8 @@ extension DropInComponent: ReadyToSubmitPaymentComponentDelegate {
 
 @_spi(AdyenInternal)
 extension DropInComponent: TrackableComponent {
-    
-    public func sendInitialAnalytics() {
+    public var analyticsFlavor: AnalyticsFlavor {
         let paymentMethodTypes = paymentMethods.regular.map(\.type.rawValue)
-        let flavor = AnalyticsFlavor.dropIn(paymentMethods: paymentMethodTypes)
-        let amount = context.payment?.amount
-        let additionalFields = AdditionalAnalyticsFields(amount: amount, sessionId: AnalyticsForSession.sessionId)
-        context.analyticsProvider?.sendInitialAnalytics(with: flavor, additionalFields: additionalFields)
+        return .dropIn(paymentMethods: paymentMethodTypes)
     }
 }


### PR DESCRIPTION
Adds the flavor property to the `TrackableComponent` so components and dropIn can supply only this value on their own and benefit from a default extension for the analytic event functions.