### PR TITLE
`chore` Fix compatibility tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,11 @@ jobs:
         include:
         
         - version: '16.4'
-          displayname: 'iPhone 14'
+          runtime: 'iOS-16-4'
+          device: 'iPhone 14'
+          displayname: 'iPhone-14'
           os: 'macos-13-xl'
-          needs_custom_sim: false # Takes the shipped simulator that comes with Xcode 14
+          needs_custom_sim: true
         
         - version: '15.0'
           runtime: 'iOS-15-0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         include:
         
-        - version: '16.2'
-          runtime: 'iOS-16-2'
-          device: 'iPhone 13'
-          displayname: 'iPhone-13'
-          os: 'macos-12'
-          needs_custom_sim: true
+        - version: '16.4'
+          runtime: 'iOS-16-4'
+          device: 'iPhone 14'
+          displayname: 'iPhone-14'
+          os: 'macos-13-xl'
+          needs_custom_sim: false # Takes the shipped simulator that comes with Xcode 14
         
         - version: '15.0'
           runtime: 'iOS-15-0'
@@ -53,10 +53,15 @@ jobs:
       run: |
         sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
 
-    - name: Prepare ${{ matrix.version }}
+    - name: Download simulator if needed (${{ matrix.version }})
       if: matrix.needs_custom_sim
       run: |
         xcversion simulators --install="iOS ${version}"
+      env:
+        version: ${{ matrix.version }}
+
+    - name: Create simulator ${{ matrix.version }}
+      run: |
         xcrun simctl list devices ${version}
         xcrun simctl create ${displayname} "${device}" "com.apple.CoreSimulator.SimRuntime.${runtime}"
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           runtime: 'iOS-16-2'
           device: 'iPhone 13'
           displayname: 'iPhone-13'
-          os: 'macos-12-xl'
+          os: 'macos-12'
           needs_custom_sim: true
         
         - version: '15.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         include:
         
-        - version: '16.4'
-          runtime: 'iOS-16-4'
-          device: 'iPhone 14'
-          displayname: 'iPhone-14'
-          os: 'macos-13-xl'
+        - version: '16.2'
+          runtime: 'iOS-16-2'
+          device: 'iPhone 13'
+          displayname: 'iPhone-13'
+          os: 'macos-12-xl'
           needs_custom_sim: true
         
         - version: '15.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
           device: 'iPhone 14'
           displayname: 'iPhone-14'
           os: 'macos-13-xl'
+          xcode_version: '14.3'
           needs_custom_sim: false # Takes the shipped simulator that comes with Xcode 14
         
         - version: '15.0'
@@ -27,6 +28,7 @@ jobs:
           device: 'iPhone 13'
           displayname: 'iPhone-13'
           os: 'macos-12-xl'
+          xcode_version: '13.4.1'
           needs_custom_sim: true
         
         - version: '14.2'
@@ -34,6 +36,7 @@ jobs:
           displayname: 'iPhone-12'
           runtime: 'iOS-14-2'
           os: 'macos-12-xl'
+          xcode_version: '13.4.1'
           needs_custom_sim: true
           
         - version: '13.7'
@@ -41,6 +44,7 @@ jobs:
           device: 'iPhone 11'
           displayname: 'iPhone-11'
           os: 'macos-12-xl'
+          xcode_version: '13.4.1'
           needs_custom_sim: true
           
     steps:
@@ -52,6 +56,12 @@ jobs:
     - name: Prepare custom devices
       run: |
         sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
+
+    - name: Select Xcode ${{ matrix.xcode_version}}
+      run: |
+        sudo xcode-select -s /Applications/Xcode_${xcode_version}.app/Contents/Developer
+      env:
+        xcode_version: ${{ matrix.xcode_version }}
 
     - name: Download simulator if needed (${{ matrix.version }})
       if: matrix.needs_custom_sim

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
           device: 'iPhone 13'
           displayname: 'iPhone-13'
           os: 'macos-12-xl'
-          xcode_version: '13.4.1'
           needs_custom_sim: true
         
         - version: '14.2'
@@ -36,7 +35,6 @@ jobs:
           displayname: 'iPhone-12'
           runtime: 'iOS-14-2'
           os: 'macos-12-xl'
-          xcode_version: '13.4.1'
           needs_custom_sim: true
           
         - version: '13.7'
@@ -44,7 +42,6 @@ jobs:
           device: 'iPhone 11'
           displayname: 'iPhone-11'
           os: 'macos-12-xl'
-          xcode_version: '13.4.1'
           needs_custom_sim: true
           
     steps:
@@ -57,7 +54,8 @@ jobs:
       run: |
         sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
 
-    - name: Select Xcode ${{ matrix.xcode_version}}
+    - name: Select Xcode ${{ matrix.xcode_version }}
+      if: matrix.xcode_version != ''
       run: |
         ls /Applications/Xcode_*.app
         sudo xcode-select -s /Applications/Xcode_${xcode_version}.app/Contents/Developer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
 
     - name: Select Xcode ${{ matrix.xcode_version}}
       run: |
+        ls /Applications/Xcode_*.app
         sudo xcode-select -s /Applications/Xcode_${xcode_version}.app/Contents/Developer
       env:
         xcode_version: ${{ matrix.xcode_version }}


### PR DESCRIPTION
## Background
Github upgraded the macos-13 runners to have a different Xcode version selected by default

## Changes
 - the `iOS 16.4` compatibility test now specified the xcode version `14.3` it wants to run on
