### PR TITLE
[Twint] Alert presentation fix

### DIFF
--- a/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
+++ b/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -24,7 +24,7 @@ public final class PresentableComponentWrapper: PresentableComponent,
     /// The wrapped component.
     public let component: Component
     
-    public let requiresModalPresentation: Bool = true
+    public var requiresModalPresentation: Bool = true
     
     @_spi(AdyenInternal)
     public var navBarType: NavigationBarType

--- a/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
+++ b/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
@@ -93,7 +93,7 @@ import Foundation
         private func presentAppChooser(installedApps: [TWAppConfiguration], code: String) {
             let appChooserViewController = Twint.controller(for: installedApps) { [weak self] selectedApp in
                 self?.invokeTwintAppWithCode(app: selectedApp ?? installedApps[0],
-                                            code: code)
+                                             code: code)
             } cancelHandler: { [weak self] in
                 guard let self else { return }
                 self.delegate?.didFail(with: ComponentError.cancelled, from: self)
@@ -111,6 +111,7 @@ import Foundation
                 viewController: viewController,
                 navBarType: .custom(toolBar)
             )
+            presentableComponent.requiresModalPresentation = false
             toolBar.isHidden = true
             presentationDelegate.present(component: presentableComponent)
         }
@@ -121,10 +122,15 @@ import Foundation
                 message: error,
                 preferredStyle: .alert
             )
-            alert.addAction(.init(
-                title: localizedString(.dismissButton, configuration.localizationParameters),
-                style: .default
-            )
+            alert.addAction(
+                .init(
+                    title: localizedString(.dismissButton, configuration.localizationParameters),
+                    style: .default, 
+                    handler: { _ in
+                        // TODO: Is this the right thing to do here? - we have to let drop-in know to hide the spinner without dismissing drop-in
+                        self.delegate?.didFail(with: ComponentError.cancelled, from: self)
+                    }
+                )
             )
             if let presentationDelegate {
                 self.present(alert, presentationDelegate: presentationDelegate)

--- a/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
+++ b/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
@@ -99,8 +99,8 @@ import Foundation
                 self.delegate?.didFail(with: ComponentError.cancelled, from: self)
             }
             
-            if let viewcontroller = appChooserViewController, let delegate = presentationDelegate {
-                present(viewcontroller, presentationDelegate: delegate)
+            if let viewController = appChooserViewController, let delegate = presentationDelegate {
+                present(viewController, presentationDelegate: delegate)
             }
         }
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Made `PresentableComponentWrapper.requiresModalPresentation` variable so a component can present UIViewControllers without wrapping them into a sheet (needed for UIAlertController)
- Cancelling when Twint does not find installed apps

![Simulator Screenshot - iPhone 14 - 2024-03-01 at 14 57 01](https://github.com/Adyen/adyen-ios/assets/4838877/e1c51b7c-861d-4918-a087-9f46d7bbecef){width=300}
