### PR TITLE
ConfigurationConstants.returnUrl now returns a url

### DIFF
--- a/AdyenActions/AdyenActionComponent.swift
+++ b/AdyenActions/AdyenActionComponent.swift
@@ -69,10 +69,10 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
         
         public struct Twint {
             
-            public var returnUrl: String
+            public var returnUrlScheme: String
             
-            public init(returnUrl: String) {
-                self.returnUrl = returnUrl
+            public init(returnUrlScheme: String) {
+                self.returnUrlScheme = returnUrlScheme
             }
         }
         
@@ -225,7 +225,7 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
                 context: context,
                 configuration: .init(
                     style: configuration.style.awaitComponentStyle,
-                    returnUrl: twintConfiguration.returnUrl,
+                    returnUrlScheme: twintConfiguration.returnUrlScheme,
                     localizationParameters: configuration.localizationParameters
                 )
             )

--- a/AdyenActions/AdyenActionComponent.swift
+++ b/AdyenActions/AdyenActionComponent.swift
@@ -69,10 +69,31 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
         
         public struct Twint {
             
-            public var returnUrlScheme: String
+            /// The callback app scheme invoked once the Twint app is done with the payment
+            public var callbackAppScheme: String
             
-            public init(returnUrlScheme: String) {
-                self.returnUrlScheme = returnUrlScheme
+            /// Initializes a new instance
+            ///
+            /// - Parameter callbackAppScheme: The callback app scheme invoked once the Twint app is done with the payment
+            ///
+            /// - Important: The value of ``callbackAppScheme`` is  required to only provide the scheme,
+            /// without a host/path/... (e.g. "my-app", not a url "my-app://...")
+            public init(callbackAppScheme: String) {
+                if !Self.isCallbackSchemeValid(callbackAppScheme) {
+                    assertionFailure("Format of provided callbackAppScheme '\(callbackAppScheme)' is incorrect.")
+                }
+                
+                self.callbackAppScheme = callbackAppScheme
+            }
+            
+            /// Validating whether or not the provided `callbackAppScheme` only contains a scheme
+            private static func isCallbackSchemeValid(_ callbackAppScheme: String) -> Bool {
+                if let url = URL(string: callbackAppScheme), url.scheme != nil {
+                    // If the scheme is not nil it means that more information than just the scheme was provided
+                    return false
+                }
+                
+                return true
             }
         }
         
@@ -225,7 +246,7 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
                 context: context,
                 configuration: .init(
                     style: configuration.style.awaitComponentStyle,
-                    returnUrlScheme: twintConfiguration.returnUrlScheme,
+                    callbackAppScheme: twintConfiguration.callbackAppScheme,
                     localizationParameters: configuration.localizationParameters
                 )
             )

--- a/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
+++ b/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
@@ -36,21 +36,27 @@ import Foundation
             /// The localization parameters, leave it nil to use the default parameters.
             public var localizationParameters: LocalizationParameters?
             
-            public let returnUrl: String
+            /// The return url scheme
+            ///
+            /// - Important: This value is  required to only provide the scheme, without a host/path/.... (e.g. "my-app", not a url "my-app://...")
+            public let returnUrlScheme: String
 
             /// Initializes an instance of `Configuration`
             ///
             /// - Parameters:
             ///   - style: The Component UI style.
+            ///   - returnUrlScheme: The url scheme of the app
             ///   - localizationParameters: The localization parameters, leave it nil to use the default parameters.
+            ///
+            /// - Important: This value of ``returnUrlScheme`` is  required to only provide the scheme, without a host/path/... (e.g. "my-app", not a url "my-app://...")
             public init(
                 style: AwaitComponentStyle = .init(),
-                returnUrl: String,
+                returnUrlScheme: String,
                 localizationParameters: LocalizationParameters? = nil
             ) {
                 self.style = style
                 self.localizationParameters = localizationParameters
-                self.returnUrl = returnUrl
+                self.returnUrlScheme = returnUrlScheme
             }
         }
 
@@ -108,7 +114,7 @@ import Foundation
             let error = twint.pay(
                 withCode: action.sdkData.token,
                 appConfiguration: app,
-                callback: configuration.returnUrl
+                callback: configuration.returnUrlScheme
             )
             
             if let error {

--- a/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
+++ b/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
@@ -36,27 +36,27 @@ import Foundation
             /// The localization parameters, leave it nil to use the default parameters.
             public var localizationParameters: LocalizationParameters?
             
-            /// The return url scheme
+            /// The callback app scheme invoked once the Twint app is done with the payment
             ///
             /// - Important: This value is  required to only provide the scheme, without a host/path/.... (e.g. "my-app", not a url "my-app://...")
-            public let returnUrlScheme: String
+            public let callbackAppScheme: String
 
             /// Initializes an instance of `Configuration`
             ///
             /// - Parameters:
             ///   - style: The Component UI style.
-            ///   - returnUrlScheme: The url scheme of the app
+            ///   - callbackAppScheme: The callback app scheme invoked once the Twint app is done with the payment
             ///   - localizationParameters: The localization parameters, leave it nil to use the default parameters.
             ///
-            /// - Important: This value of ``returnUrlScheme`` is  required to only provide the scheme, without a host/path/... (e.g. "my-app", not a url "my-app://...")
+            /// - Important: The value of ``callbackAppScheme`` is  required to only provide the scheme, without a host/path/... (e.g. "my-app", not a url "my-app://...")
             public init(
                 style: AwaitComponentStyle = .init(),
-                returnUrlScheme: String,
+                callbackAppScheme: String,
                 localizationParameters: LocalizationParameters? = nil
             ) {
                 self.style = style
                 self.localizationParameters = localizationParameters
-                self.returnUrlScheme = returnUrlScheme
+                self.callbackAppScheme = callbackAppScheme
             }
         }
 
@@ -114,7 +114,7 @@ import Foundation
             let error = twint.pay(
                 withCode: action.sdkData.token,
                 appConfiguration: app,
-                callback: configuration.returnUrlScheme
+                callback: configuration.callbackAppScheme
             )
             
             if let error {

--- a/Demo/Common/IntegrationExamples/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/Components/CardComponentAdvancedFlowExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -27,7 +27,7 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
     private lazy var adyenActionComponent: AdyenActionComponent = {
         let handler = AdyenActionComponent(context: context)
         handler.configuration.threeDS.delegateAuthentication = ConfigurationConstants.delegatedAuthenticationConfigurations
-        handler.configuration.threeDS.requestorAppURL = URL(string: ConfigurationConstants.returnUrl)
+        handler.configuration.threeDS.requestorAppURL = ConfigurationConstants.returnUrl
         handler.delegate = self
         handler.presentationDelegate = self
         return handler

--- a/Demo/Common/IntegrationExamples/DropIn/DropInAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/DropIn/DropInAdvancedFlowExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -65,7 +65,7 @@ internal final class DropInAdvancedFlowExample: InitialDataAdvancedFlowProtocol 
 
         configuration.applePay = try? ConfigurationConstants.current.applePayConfiguration()
         configuration.actionComponent.threeDS.delegateAuthentication = ConfigurationConstants.delegatedAuthenticationConfigurations
-        configuration.actionComponent.threeDS.requestorAppURL = URL(string: ConfigurationConstants.returnUrl)
+        configuration.actionComponent.threeDS.requestorAppURL = ConfigurationConstants.returnUrl
         configuration.card = ConfigurationConstants.current.cardDropInConfiguration
         return configuration
     }

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
@@ -48,7 +48,7 @@ extension InitialDataFlowProtocol {
                     requestorAppURL: ConfigurationConstants.returnUrl,
                     delegateAuthentication: ConfigurationConstants.delegatedAuthenticationConfigurations
                 ),
-                twint: .init(returnUrlScheme: ConfigurationConstants.returnUrl.scheme!)
+                twint: .init(callbackAppScheme: ConfigurationConstants.returnUrl.scheme!)
             )
         )
         return configuration

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
@@ -45,10 +45,10 @@ extension InitialDataFlowProtocol {
             context: context,
             actionComponent: .init(
                 threeDS: .init(
-                    requestorAppURL: URL(string: ConfigurationConstants.returnUrl),
+                    requestorAppURL: ConfigurationConstants.returnUrl,
                     delegateAuthentication: ConfigurationConstants.delegatedAuthenticationConfigurations
                 ),
-                twint: .init(returnUrl: ConfigurationConstants.returnUrl)
+                twint: .init(returnUrlScheme: ConfigurationConstants.returnUrl.scheme!)
             )
         )
         return configuration

--- a/Demo/Common/Networking/PaymentsRequest.swift
+++ b/Demo/Common/Networking/PaymentsRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -55,7 +55,7 @@ internal struct PaymentsRequest: APIRequest {
         try container.encode("iOS", forKey: .channel)
         try container.encode(ConfigurationConstants.reference, forKey: .reference)
         try container.encode(currentConfiguration.countryCode, forKey: .countryCode)
-        try container.encode(ConfigurationConstants.returnUrl, forKey: .returnUrl)
+        try container.encode(ConfigurationConstants.returnUrl.absoluteString, forKey: .returnUrl)
         try container.encode(ConfigurationConstants.shopperReference, forKey: .shopperReference)
         try container.encode(ConfigurationConstants.additionalData, forKey: .additionalData)
         try container.encode(currentConfiguration.merchantAccount, forKey: .merchantAccount)

--- a/Demo/Common/Networking/SessionRequest.swift
+++ b/Demo/Common/Networking/SessionRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -34,7 +34,7 @@ internal struct SessionRequest: APIRequest {
         try container.encode(ConfigurationConstants.shopperReference, forKey: .shopperReference)
         try container.encode(currentConfiguration.merchantAccount, forKey: .merchantAccount)
         try container.encode(currentConfiguration.amount, forKey: .amount)
-        try container.encode(ConfigurationConstants.returnUrl, forKey: .returnUrl)
+        try container.encode(ConfigurationConstants.returnUrl.absoluteString, forKey: .returnUrl)
         try container.encode(ConfigurationConstants.reference, forKey: .reference)
         try container.encode("iOS", forKey: .channel)
         try container.encode(ConfigurationConstants.additionalData, forKey: .additionalData)

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -250,7 +250,7 @@ internal struct DemoAppSettings: Codable {
         if dropInSettings.cashAppPayEnabled {
             dropInConfig.cashAppPay = .init(redirectURL: ConfigurationConstants.returnUrl)
         }
-        dropInConfig.actionComponent.twint = .init(returnUrlScheme: ConfigurationConstants.returnUrl.scheme!)
+        dropInConfig.actionComponent.twint = .init(callbackAppScheme: ConfigurationConstants.returnUrl.scheme!)
 
         return dropInConfig
     }

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -15,19 +15,19 @@ import PassKit
 internal enum ConfigurationConstants {
     // swiftlint:disable explicit_acl
     // swiftlint:disable line_length
-
+    
     /// Please use your own web server between your app and adyen checkout API.
     static let demoServerEnvironment = DemoCheckoutAPIEnvironment.test
     
     static let classicAPIEnvironment = DemoClassicAPIEnvironment.test
-
+    
     static let componentsEnvironment = Environment.test
-
+    
     static let appName = "Adyen Demo"
-
+    
     static let reference = "Test Order Reference - iOS UIHost"
-
-    static let returnUrl = "ui-host://payments"
+    
+    static var returnUrl: URL { .init(string: "ui-host://payments")! }
     
     static let shopperReference = "iOS Checkout Shopper"
 
@@ -248,9 +248,9 @@ internal struct DemoAppSettings: Codable {
 
         dropInConfig.paymentMethodsList.allowDisablingStoredPaymentMethods = dropInSettings.allowDisablingStoredPaymentMethods
         if dropInSettings.cashAppPayEnabled {
-            dropInConfig.cashAppPay = .init(redirectURL: URL(string: ConfigurationConstants.returnUrl)!)
+            dropInConfig.cashAppPay = .init(redirectURL: ConfigurationConstants.returnUrl)
         }
-        dropInConfig.actionComponent.twint = .init(returnUrl: ConfigurationConstants.returnUrl)
+        dropInConfig.actionComponent.twint = .init(returnUrlScheme: ConfigurationConstants.returnUrl.scheme!)
 
         return dropInConfig
     }

--- a/Tests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests.swift
+++ b/Tests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests.swift
@@ -25,7 +25,7 @@ private extension TWAppConfiguration {
 
 private extension TwintSDKActionComponent.Configuration {
     static var dummy: Self {
-        .init(returnUrl: "ui-host://")
+        .init(callbackAppScheme: "ui-host")
     }
 }
 
@@ -110,7 +110,7 @@ final class TwintSDKActionTests: XCTestCase {
             XCTAssertEqual(code, TwintSDKAction.dummy.sdkData.token)
             XCTAssertEqual(appConfiguration.appDisplayName, TWAppConfiguration.dummy.appDisplayName)
             XCTAssertEqual(appConfiguration.appURLScheme, TWAppConfiguration.dummy.appURLScheme)
-            XCTAssertEqual(callbackAppScheme, TwintSDKActionComponent.Configuration.dummy.returnUrl)
+            XCTAssertEqual(callbackAppScheme, TwintSDKActionComponent.Configuration.dummy.callbackAppScheme)
             return nil
         } handleController: { installedAppConfigurations, selectionHandler, cancelHandler in
             XCTFail("Twint controller should not have been shown")
@@ -165,7 +165,7 @@ final class TwintSDKActionTests: XCTestCase {
             XCTAssertEqual(code, TwintSDKAction.dummy.sdkData.token)
             XCTAssertEqual(appConfiguration.appDisplayName, TWAppConfiguration.dummy.appDisplayName)
             XCTAssertEqual(appConfiguration.appURLScheme, TWAppConfiguration.dummy.appURLScheme)
-            XCTAssertEqual(callbackAppScheme, TwintSDKActionComponent.Configuration.dummy.returnUrl)
+            XCTAssertEqual(callbackAppScheme, TwintSDKActionComponent.Configuration.dummy.callbackAppScheme)
             return nil
         } handleController: { installedAppConfigurations, selectionHandler, cancelHandler in
             XCTAssertEqual(installedAppConfigurations, expectedAppConfigurations)
@@ -176,7 +176,7 @@ final class TwintSDKActionTests: XCTestCase {
             XCTFail("Handle open should not have been called")
             return false
         }
-
+        
         let twintActionComponent = TwintSDKActionComponent(
             context: Dummy.context,
             configuration: .dummy,
@@ -309,7 +309,6 @@ final class TwintSDKActionTests: XCTestCase {
             enforceOrder: true
         )
     }
-    
     
     func testPayError() throws {
         // TODO: handlePay returns an error


### PR DESCRIPTION
## Summary
- ConfigurationConstants.returnUrl now returns an actual URL
- Passing the ConfigurationConstants.returnUrl.scheme to the Twint action
