### PR TITLE
Provide human-friendly error on PublicKeyProvider

### DIFF
--- a/Adyen/Utilities/PublicKeyProvider/PublicKeyProvider.swift
+++ b/Adyen/Utilities/PublicKeyProvider/PublicKeyProvider.swift
@@ -75,7 +75,10 @@ public final class PublicKeyProvider: AnyPublicKeyProvider {
             cachedPublicKey = response.cardPublicKey
             completion(.success(response.cardPublicKey))
         case let .failure(error):
-            completion(.failure(Error.invalidClientKey))
+            if error is DecodingError {
+                completion(.failure(Error.invalidClientKey))
+            }
+            completion(.failure(error))
         }
     }
 

--- a/Adyen/Utilities/PublicKeyProvider/PublicKeyProvider.swift
+++ b/Adyen/Utilities/PublicKeyProvider/PublicKeyProvider.swift
@@ -75,7 +75,15 @@ public final class PublicKeyProvider: AnyPublicKeyProvider {
             cachedPublicKey = response.cardPublicKey
             completion(.success(response.cardPublicKey))
         case let .failure(error):
-            completion(.failure(error))
+            completion(.failure(Error.invalidClientKey))
+        }
+    }
+
+    public enum Error: Swift.Error, LocalizedError {
+        case invalidClientKey
+
+        public var errorDescription: String? {
+            return "Client key not found on the selected environment."
         }
     }
 }

--- a/Adyen/Utilities/PublicKeyProvider/PublicKeyProvider.swift
+++ b/Adyen/Utilities/PublicKeyProvider/PublicKeyProvider.swift
@@ -76,7 +76,8 @@ public final class PublicKeyProvider: AnyPublicKeyProvider {
             completion(.success(response.cardPublicKey))
         case let .failure(error):
             if error is DecodingError {
-                completion(.failure(Error.invalidClientKey))
+                // Disclaimer: This error check is not 100% reliable. Need to improve the endpoint. 
+                return completion(.failure(Error.invalidClientKey))
             }
             completion(.failure(error))
         }


### PR DESCRIPTION
# WIP

## Changes

<fixed>

* Now `PublicKeyProvider` returns a human-friendly error when clientKey is invalid or mismatched with the environment.

</fixed>

**Before:**
![Screenshot 2024-03-06 at 10 55 17](https://github.com/Adyen/adyen-ios/assets/2648655/3c46b867-ffe5-43e4-a35d-c7905f6942e9)

**After:**
![Screenshot 2024-03-06 at 10 53 33](https://github.com/Adyen/adyen-ios/assets/2648655/b2ebe235-a943-438a-8df7-abd1247c9188)

