### PR TITLE
Allow configuration of showing country flags

### DIFF
--- a/Adyen.docc/Customization.md
+++ b/Adyen.docc/Customization.md
@@ -14,6 +14,7 @@ For example, to change the section header titles and form field titles in the Dr
         style.formComponent.textField.title.color = .red
         style.formComponent.mainButtonItem.button.backgroundColor = .black
         style.formComponent.mainButtonItem.button.title.color = .white
+        style.formComponent.addressStyle.showCountryFlags = false // Hiding flags from the country picker
 
         let configuration = DropInComponent.Configuration(style: style)
         let component = DropInComponent(paymentMethods: paymentMethods,
@@ -30,6 +31,7 @@ For example, to change the section header titles and form field titles in the Dr
         style.textField.title.color = .white
         style.textField.text.color = .white
         style.switch.title.color = .white
+        style.addressStyle.showCountryFlags = false // Hiding flags from the country picker
 
         let config = CardComponent.Configuration(style: style)
         let component = CardComponent(paymentMethod: paymentMethod,

--- a/Adyen/UI/Form/Items/Address/AddressStyle.swift
+++ b/Adyen/UI/Form/Items/Address/AddressStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -30,6 +30,9 @@ public struct AddressStyle: FormValueItemStyle {
 
     /// The color of form view item's separator line.
     public var separatorColor: UIColor? { textField.separatorColor }
+    
+    /// Whether or not to show country flags in the country picker
+    public var showCountryFlags: Bool = true
     
     /// Initializes the form address item configuration.
     /// - Parameters:

--- a/Adyen/UI/Form/Items/Address/FormAddressItem.swift
+++ b/Adyen/UI/Form/Items/Address/FormAddressItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -108,7 +108,7 @@ public final class FormAddressItem: FormValueItem<PostalAddress, AddressStyle>, 
         return FormRegionPickerItem(
             preselectedRegion: defaultCountry,
             selectableRegions: countries,
-            shouldShowCountryFlags: true,
+            shouldShowCountryFlags: configuration.style.showCountryFlags,
             validationFailureMessage: localizedString(
                 .countryFieldInvalid,
                 configuration.localizationParameters

--- a/Adyen/UI/Styles/FormComponentStyle.swift
+++ b/Adyen/UI/Styles/FormComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -13,12 +13,22 @@ public struct FormComponentStyle: TintableStyle {
     public var backgroundColor = UIColor.Adyen.componentBackground
 
     /// The section header style.
-    public var sectionHeader = TextStyle(font: .preferredFont(forTextStyle: .headline),
-                                         color: UIColor.Adyen.componentLabel,
-                                         textAlignment: .natural)
+    public var sectionHeader = TextStyle(
+        font: .preferredFont(forTextStyle: .headline),
+        color: UIColor.Adyen.componentLabel,
+        textAlignment: .natural
+    ) {
+        didSet {
+            addressStyle.title = sectionHeader
+        }
+    }
     
     /// The text field style.
-    public var textField = FormTextItemStyle()
+    public var textField = FormTextItemStyle() {
+        didSet {
+            addressStyle.textField = textField
+        }
+    }
     
     /// The toggle style.
     public var toggle = FormToggleItemStyle()
@@ -54,10 +64,7 @@ public struct FormComponentStyle: TintableStyle {
     )
 
     /// The address style generated based on other field's value.
-    public var addressStyle: AddressStyle {
-        .init(title: sectionHeader,
-              textField: textField)
-    }
+    public var addressStyle: AddressStyle
 
     /// The error message indicator style.
     public var errorStyle = FormErrorItemStyle()
@@ -101,6 +108,7 @@ public struct FormComponentStyle: TintableStyle {
         self.secondaryButtonItem = secondaryButton
         self.hintLabel = helper
         self.sectionHeader = sectionHeader
+        self.addressStyle = .init(title: sectionHeader, textField: textField)
     }
     
     /// Initializes the Form UI style.
@@ -117,16 +125,20 @@ public struct FormComponentStyle: TintableStyle {
         self.toggle = toggle
         self.mainButtonItem = FormButtonItemStyle(button: mainButton)
         self.secondaryButtonItem = FormButtonItemStyle(button: secondaryButton)
+        self.addressStyle = .init(title: sectionHeader, textField: textField)
     }
     
     /// Initializes the form style with the default style and custom tint for all elements.
     /// - Parameter tintColor: The color for tinting buttons. textfields, icons and switches.
     public init(tintColor: UIColor) {
+        self.addressStyle = .init(title: sectionHeader, textField: textField)
         setTintColor(tintColor)
     }
     
     /// Initializes the form style with the default style.
-    public init() { /* public */ }
+    public init() {
+        self.addressStyle = .init(title: sectionHeader, textField: textField)
+    }
 
     private mutating func setTintColor(_ value: UIColor?) {
         guard let tintColor = value else { return }

--- a/Demo/Common/Configuration/CardComponentSettingsView.swift
+++ b/Demo/Common/Configuration/CardComponentSettingsView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -42,6 +42,9 @@ internal struct CardSettingsView: View {
                         Toggle(isOn: $viewModel.showInstallmentAmount) {
                             Text("Installment Amount")
                         }
+                    }
+                    Toggle(isOn: $viewModel.showCountryFlags) {
+                        Text("Show country flags")
                     }
                 }
                 Section(header: Text("Input Modes")) {

--- a/Demo/Common/Configuration/ConfigurationViewModel.swift
+++ b/Demo/Common/Configuration/ConfigurationViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -32,6 +32,7 @@ internal final class ConfigurationViewModel: ObservableObject {
     @Published internal var cashAppPayEnabled: Bool = false
     @Published internal var installmentsEnabled: Bool = false
     @Published internal var showInstallmentAmount: Bool = false
+    @Published internal var showCountryFlags: Bool = true
 
     private let onDone: (DemoAppSettings) -> Void
     private let configuration: DemoAppSettings
@@ -68,6 +69,7 @@ internal final class ConfigurationViewModel: ObservableObject {
         self.cashAppPayEnabled = configuration.dropInSettings.cashAppPayEnabled
         self.installmentsEnabled = configuration.cardSettings.enableInstallments
         self.showInstallmentAmount = configuration.cardSettings.showsInstallmentAmount
+        self.showCountryFlags = configuration.cardConfiguration.style.addressStyle.showCountryFlags
     }
     
     internal func doneTapped() {
@@ -84,7 +86,8 @@ internal final class ConfigurationViewModel: ObservableObject {
             value: Int(value) ?? configuration.value,
             currencyCode: currencyCode,
             apiVersion: Int(apiVersion) ?? configuration.apiVersion,
-            merchantAccount: merchantAccount, cardSettings: CardSettings(
+            merchantAccount: merchantAccount,
+            cardSettings: CardSettings(
                 showsHolderNameField: showsHolderNameField,
                 showsStorePaymentMethodField: showsStorePaymentMethodField,
                 showsStoredCardSecurityCodeField: showsStoredCardSecurityCodeField,
@@ -93,7 +96,8 @@ internal final class ConfigurationViewModel: ObservableObject {
                 socialSecurityNumberMode: socialSecurityNumberMode,
                 koreanAuthenticationMode: koreanAuthenticationMode,
                 enableInstallments: installmentsEnabled,
-                showsInstallmentAmount: showInstallmentAmount
+                showsInstallmentAmount: showInstallmentAmount,
+                showsCountryFlags: showCountryFlags
             ),
             dropInSettings: DropInSettings(allowDisablingStoredPaymentMethods: allowDisablingStoredPaymentMethods,
                                            allowsSkippingPaymentList: allowsSkippingPaymentList,

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -101,6 +101,7 @@ internal struct CardSettings: Codable {
     internal var koreanAuthenticationMode: CardComponent.FieldVisibility = .auto
     internal var enableInstallments = false
     internal var showsInstallmentAmount = false
+    internal var showsCountryFlags = true
     
     internal enum AddressFormType: String, Codable, CaseIterable {
         case lookup
@@ -176,7 +177,8 @@ internal struct DemoAppSettings: Codable {
                                                            socialSecurityNumberMode: .auto,
                                                            koreanAuthenticationMode: .auto,
                                                            enableInstallments: false,
-                                                           showsInstallmentAmount: false)
+                                                           showsInstallmentAmount: false,
+                                                           showsCountryFlags: true)
 
     internal static let defaultDropInSettings = DropInSettings(allowDisablingStoredPaymentMethods: false,
                                                                allowsSkippingPaymentList: false,
@@ -213,8 +215,12 @@ internal struct DemoAppSettings: Codable {
 
         var billingAddressConfig = BillingAddressConfiguration()
         billingAddressConfig.mode = cardComponentAddressFormType(from: cardSettings.addressMode)
+        
+        var style = FormComponentStyle()
+        style.addressStyle.showCountryFlags = cardSettings.showsCountryFlags
 
-        return .init(showsHolderNameField: cardSettings.showsHolderNameField,
+        return .init(style: style,
+                     showsHolderNameField: cardSettings.showsHolderNameField,
                      showsStorePaymentMethodField: cardSettings.showsStorePaymentMethodField,
                      showsSecurityCodeField: cardSettings.showsSecurityCodeField,
                      koreanAuthenticationMode: cardSettings.koreanAuthenticationMode,
@@ -243,8 +249,14 @@ internal struct DemoAppSettings: Codable {
     }
 
     internal var dropInConfiguration: DropInComponent.Configuration {
-        let dropInConfig = DropInComponent.Configuration(allowsSkippingPaymentList: dropInSettings.allowsSkippingPaymentList,
-                                                         allowPreselectedPaymentView: dropInSettings.allowPreselectedPaymentView)
+        var style = DropInComponent.Style()
+        style.formComponent.addressStyle.showCountryFlags = cardSettings.showsCountryFlags
+        
+        let dropInConfig = DropInComponent.Configuration(
+            style: style,
+            allowsSkippingPaymentList: dropInSettings.allowsSkippingPaymentList,
+            allowPreselectedPaymentView: dropInSettings.allowPreselectedPaymentView
+        )
 
         dropInConfig.paymentMethodsList.allowDisablingStoredPaymentMethods = dropInSettings.allowDisablingStoredPaymentMethods
         if dropInSettings.cashAppPayEnabled {

--- a/Tests/Adyen Tests/UI/Form/FormItems/Address/FormAddressPickerItemTests.swift
+++ b/Tests/Adyen Tests/UI/Form/FormItems/Address/FormAddressPickerItemTests.swift
@@ -9,6 +9,22 @@ import XCTest
 
 class FormAddressPickerItemTests: XCTestCase {
     
+    func test_addressStyle_reflectsComponentStyleChanges() {
+        
+        var style = FormComponentStyle()
+        XCTAssertEqual(style.addressStyle.title, style.sectionHeader)
+        XCTAssertEqual(style.addressStyle.textField.title, style.textField.title)
+        
+        let expectedSectonHeaderStyle = TextStyle(font: .systemFont(ofSize: 200), color: .yellow)
+        let expectedTextFieldStyle = FormTextItemStyle(tintColor: .green)
+        
+        style.sectionHeader = expectedSectonHeaderStyle
+        style.textField = expectedTextFieldStyle
+        
+        XCTAssertEqual(style.addressStyle.title, expectedSectonHeaderStyle)
+        XCTAssertEqual(style.addressStyle.textField.title, expectedTextFieldStyle.title)
+    }
+    
     func testEmptyPrefillAddress() {
         
         let addressLookupItem = FormAddressPickerItem(


### PR DESCRIPTION
## Summary
<new>
In the country/region picker for the payment form, you can now choose if the images of flags are shown.

**Components**
```
let cardConfiguration = CardComponent.Configuration()
cardConfiguration.style.addressStyle.showCountryFlags = true/false
let cardComponent = CardComponent(paymentMethod: paymentMethod,
                                  context: context,
                                  configuration: cardConfiguration)
```

**Drop-In**
```
var style = DropInComponent.Style()
style.formComponent.addressStyle.showCountryFlags = cardSettings.showsCountryFlags
let dropInConfiguration = DropInComponent.Configuration(style: style)
let dropInComponent = DropInComponent(paymentMethods: paymentMethods,
                                      context: context,
                                      configuration: dropInConfiguration)
```
</new>

### Also
- Adds a configuration to show/hide the flags in the Demo app
- Adds tests for flag visibility

| List (showing flags) | Settings (enabled) |
| --------- | --------- |
| <img src="https://github.com/Adyen/adyen-ios/assets/4838877/a7c3c398-097f-4041-adcc-838a73da4331" width="200px"> | <img src="https://github.com/Adyen/adyen-ios/assets/4838877/665e09e0-7366-429f-b583-5fcc39b8098a" width="200px"> |

| List (no flags) | Settings (disabled) |
| --------- | --------- |
| <img src="https://github.com/Adyen/adyen-ios/assets/4838877/2098ee8a-e817-4b13-b9b0-198d67cd44d0" width="200px"> | <img src="https://github.com/Adyen/adyen-ios/assets/4838877/57f0fb6c-85a8-4263-b2ec-a960f95a0c76" width="200px"> |