### PR TITLE
Docs: move list of available components to the page bottom

### DIFF
--- a/Adyen.docc/Components.md
+++ b/Adyen.docc/Components.md
@@ -2,36 +2,6 @@
 
 In order to have more flexibility over the checkout flow, you can use our Components to present each payment method individually. Implementation details of our Components can be found in our Components API Reference.
 
-## Available Components
-
-- ``CardComponent``
-- ``ThreeDS2Component``
-- ``ApplePayComponent``
-- ``BCMCComponent``
-- ``IssuerListComponent``
-- ``MOLPayComponent``
-- ``DotpayComponent``
-- ``EPSComponent``
-- ``EntercashComponent``
-- ``OpenBankingComponent``
-- ``SEPADirectDebitComponent``
-- ``WeChatPaySDKActionComponent``
-- ``QiwiWalletComponent``
-- ``RedirectComponent``
-- ``MBWayComponent``
-- ``BLIKComponent``
-- ``DokuComponent``
-- ``BoletoComponent``
-- ``ACHDirectDebitComponent``
-- ``AffirmComponent``
-- ``AtomeComponent``
-- ``BACSDirectDebitComponent``
-- ``OnlineBankingComponent``
-- ``UPIComponent``
-- ``QRCodeActionComponent``
-- ``CashAppPayComponent``
-
-
 ## Setting up the Component
 
 All Components need an ``AdyenContext``. An instance of ``AdyenContext`` wraps your client key, environment, payment, analytics configuration and so on.
@@ -187,3 +157,32 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpe
     return true
 }
 ```
+
+## Available Components
+
+- ``CardComponent``
+- ``ThreeDS2Component``
+- ``ApplePayComponent``
+- ``BCMCComponent``
+- ``IssuerListComponent``
+- ``MOLPayComponent``
+- ``DotpayComponent``
+- ``EPSComponent``
+- ``EntercashComponent``
+- ``OpenBankingComponent``
+- ``SEPADirectDebitComponent``
+- ``WeChatPaySDKActionComponent``
+- ``QiwiWalletComponent``
+- ``RedirectComponent``
+- ``MBWayComponent``
+- ``BLIKComponent``
+- ``DokuComponent``
+- ``BoletoComponent``
+- ``ACHDirectDebitComponent``
+- ``AffirmComponent``
+- ``AtomeComponent``
+- ``BACSDirectDebitComponent``
+- ``OnlineBankingComponent``
+- ``UPIComponent``
+- ``QRCodeActionComponent``
+- ``CashAppPayComponent``


### PR DESCRIPTION
This change aims to improve consistency of our documentation and decrease time to find a solution for new developers not familiar with the SDK.

I noticed we offer DropIn integration example right away on the main GitHub page. However, when it comes to Components, we direct developers to the docs pages and the main one starts with endless list of components that make little sense to someone who is looking for a quick example of how to start using our SDK.

Moving this list to the bottom of the page increases code samples visibility and hopefully will reduce search time for new developers.