### PR TITLE
[V4] Adding support for iDeal 2.0

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -218,7 +218,6 @@ custom_categories:
   - name: Issuer List Component
     children:
       - IssuerListComponent
-      - IdealComponent
       - MOLPayComponent
       - DotpayComponent
       - EPSComponent
@@ -229,7 +228,6 @@ custom_categories:
       - EPSDetails
       - DotpayDetails
       - MOLPayDetails
-      - IdealDetails
       - IssuerListDetails
       
   - name: EContext Component

--- a/Adyen/Core/Payment Methods/IssuerListPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/IssuerListPaymentMethod.swift
@@ -1,12 +1,12 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
 import Foundation
 
-/// An issuer list payment method, such as iDEAL or Open Banking.
+/// An issuer list payment method, such as Open Banking.
 public struct IssuerListPaymentMethod: PaymentMethod {
     
     /// :nodoc:

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -8,7 +8,7 @@ import Adyen
 import Foundation
 import UIKit
 
-/// A generic component for "issuer-based" payment methods, such as iDEAL and MOLPay.
+/// A generic component for "issuer-based" payment methods, such as MOLPay.
 /// This component will provide a list in which the user can select their issuer.
 public final class IssuerListComponent: PaymentComponent, PresentableComponent, LoadingComponent {
     
@@ -83,9 +83,6 @@ public final class IssuerListComponent: PaymentComponent, PresentableComponent, 
         return listViewController
     }()
 }
-
-/// Provides an issuer selection list for iDEAL payments.
-public typealias IdealComponent = IssuerListComponent
 
 /// Provides an issuer selection list for MOLPay payments.
 public typealias MOLPayComponent = IssuerListComponent

--- a/AdyenComponents/Issuer List/IssuerListDetails.swift
+++ b/AdyenComponents/Issuer List/IssuerListDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -27,9 +27,6 @@ public struct IssuerListDetails: PaymentMethodDetails {
     }
     
 }
-
-/// Contains the details supplied by the IDEAL component.
-public typealias IdealDetails = IssuerListDetails
 
 /// Contains the details supplied by the MOLPay component.
 public typealias MOLPayDetails = IssuerListDetails

--- a/Demo/Common/Assets/payment_methods_response.json
+++ b/Demo/Common/Assets/payment_methods_response.json
@@ -76,9 +76,9 @@
           "type" : "select"
         }
       ],
-      "name" : "iDEAL",
+      "name" : "Open Banking",
       "supportsRecurring" : true,
-      "type" : "ideal"
+      "type" : "openbanking_UK"
     },
     {
       "brands" : [

--- a/Demo/Common/IntegrationExampleComponents.swift
+++ b/Demo/Common/IntegrationExampleComponents.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -19,13 +19,6 @@ extension IntegrationExample {
         let component = CardComponent(paymentMethod: paymentMethod,
                                       apiContext: apiContext)
         component.cardComponentDelegate = self
-        present(component)
-    }
-
-    internal func presentIdealComponent() {
-        guard let paymentMethod = paymentMethods?.paymentMethod(ofType: IssuerListPaymentMethod.self) else { return }
-        let component = IdealComponent(paymentMethod: paymentMethod,
-                                       apiContext: apiContext)
         present(component)
     }
 

--- a/Demo/SwiftUI/PaymentsViewModel.swift
+++ b/Demo/SwiftUI/PaymentsViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -28,10 +28,6 @@ internal final class PaymentsViewModel: ObservableObject, Identifiable, Presente
         integrationExample.presentCardComponent()
     }
 
-    internal func presentIdealComponent() {
-        integrationExample.presentIdealComponent()
-    }
-
     internal func presentSEPADirectDebitComponent() {
         integrationExample.presentSEPADirectDebitComponent()
     }
@@ -47,7 +43,6 @@ internal final class PaymentsViewModel: ObservableObject, Identifiable, Presente
             ],
             [
                 ComponentsItem(title: "Card", selectionHandler: presentCardComponent),
-                ComponentsItem(title: "iDEAL", selectionHandler: presentIdealComponent),
                 ComponentsItem(title: "SEPA Direct Debit", selectionHandler: presentSEPADirectDebitComponent),
                 ComponentsItem(title: "MB WAY", selectionHandler: presentMBWayComponent)
             ]

--- a/Demo/UIKit/ComponentsViewController.swift
+++ b/Demo/UIKit/ComponentsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2024 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -33,7 +33,6 @@ internal final class ComponentsViewController: UIViewController, Presenter {
             ],
             [
                 ComponentsItem(title: "Card", selectionHandler: presentCardComponent),
-                ComponentsItem(title: "iDEAL", selectionHandler: presentIdealComponent),
                 ComponentsItem(title: "SEPA Direct Debit", selectionHandler: presentSEPADirectDebitComponent),
                 ComponentsItem(title: "BACS Direct Debit", selectionHandler: presentBACSDirectDebitComponent),
                 ComponentsItem(title: "MB WAY", selectionHandler: presentMBWayComponent),
@@ -59,10 +58,6 @@ internal final class ComponentsViewController: UIViewController, Presenter {
 
     internal func presentCardComponent() {
         integrationExample.presentCardComponent()
-    }
-
-    internal func presentIdealComponent() {
-        integrationExample.presentIdealComponent()
     }
 
     internal func presentSEPADirectDebitComponent() {

--- a/Demo/UIKit/PaymentMethods.json
+++ b/Demo/UIKit/PaymentMethods.json
@@ -72,9 +72,9 @@
           "type" : "select"
         }
       ],
-      "name" : "iDEAL",
+      "name" : "Open Banking",
       "supportsRecurring" : true,
-      "type" : "ideal"
+      "type" : "openbanking_UK"
     },
     {
       "brands" : [

--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ In order to have more flexibility over the checkout flow, you can use our Compon
 - [3D Secure 2 Component][reference.threeDS2Component]
 - [Apple Pay Component][reference.applePayComponent]
 - [BCMC Component][reference.bcmcComponent]
-- [iDEAL Component][reference.issuerListComponent]
 - [SEPA Direct Debit Component][reference.sepaDirectDebitComponent]
 - [MOLPay Component][reference.issuerListComponent]
 - [Dotpay Component][reference.issuerListComponent]

--- a/Tests/AdyenTests/Adyen Tests/Core/PaymentMethodTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Core/PaymentMethodTests.swift
@@ -61,7 +61,8 @@ class PaymentMethodTests: XCTestCase {
                 econtextATM,
                 econtextStores,
                 econtextOnline,
-                oxxo
+                oxxo,
+                ideal
             ]
         ]
         
@@ -116,7 +117,7 @@ class PaymentMethodTests: XCTestCase {
         
         // Regular payment methods
         
-        XCTAssertEqual(paymentMethods.regular.count, 21)
+        XCTAssertEqual(paymentMethods.regular.count, 22)
         XCTAssertTrue(paymentMethods.regular[0] is CardPaymentMethod)
         XCTAssertEqual((paymentMethods.regular[0] as! CardPaymentMethod).fundingSource!, .credit)
         
@@ -210,6 +211,10 @@ class PaymentMethodTests: XCTestCase {
         XCTAssertTrue(paymentMethods.regular[20] is OXXOPaymentMethod)
         XCTAssertEqual(paymentMethods.regular[20].name, "OXXO")
         XCTAssertEqual(paymentMethods.regular[20].type, "oxxo")
+        
+        XCTAssertTrue(paymentMethods.regular[21] is RedirectPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[21].name, "iDeal")
+        XCTAssertEqual(paymentMethods.regular[21].type, "ideal")
 
     }
     
@@ -355,8 +360,8 @@ class PaymentMethodTests: XCTestCase {
     
     func testDecodingIssuerListPaymentMethod() throws {
         let paymentMethod = try Coder.decode(issuerListDictionary) as IssuerListPaymentMethod
-        XCTAssertEqual(paymentMethod.type, "ideal")
-        XCTAssertEqual(paymentMethod.name, "iDEAL")
+        XCTAssertEqual(paymentMethod.type, "openbanking_UK")
+        XCTAssertEqual(paymentMethod.name, "Open Banking")
         
         XCTAssertEqual(paymentMethod.issuers.count, 3)
         XCTAssertEqual(paymentMethod.issuers[0].identifier, "1121")
@@ -369,8 +374,8 @@ class PaymentMethodTests: XCTestCase {
 
     func testDecodingIssuerListPaymentMethodWithoutDetailsObject() throws {
         let paymentMethod = try Coder.decode(issuerListDictionaryWithoutDetailsObject) as IssuerListPaymentMethod
-        XCTAssertEqual(paymentMethod.type, "ideal_100")
-        XCTAssertEqual(paymentMethod.name, "iDEAL_100")
+        XCTAssertEqual(paymentMethod.type, "openbanking_UK_100")
+        XCTAssertEqual(paymentMethod.name, "Open_Banking_100")
 
         XCTAssertEqual(paymentMethod.issuers.count, 3)
         XCTAssertEqual(paymentMethod.issuers[0].identifier, "1121")

--- a/Tests/AdyenTests/Adyen Tests/Core/PaymentMethodTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Core/PaymentMethodTests.swift
@@ -122,6 +122,9 @@ class PaymentMethodTests: XCTestCase {
         XCTAssertEqual((paymentMethods.regular[0] as! CardPaymentMethod).fundingSource!, .credit)
         
         XCTAssertTrue(paymentMethods.regular[1] is IssuerListPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[1].type, "openbanking_UK")
+        XCTAssertEqual(paymentMethods.regular[1].name, "Open Banking")
+        
         XCTAssertTrue(paymentMethods.regular[2] is SEPADirectDebitPaymentMethod)
         XCTAssertTrue(paymentMethods.regular[3] is RedirectPaymentMethod)
         

--- a/Tests/AdyenTests/Adyen Tests/Core/TestPaymentMethodsJson.swift
+++ b/Tests/AdyenTests/Adyen Tests/Core/TestPaymentMethodsJson.swift
@@ -96,8 +96,8 @@ let storedBcmcDictionary = [
 ] as [String: Any]
 
 let issuerListDictionary = [
-    "type": "ideal",
-    "name": "iDEAL",
+    "type": "openbanking_UK",
+    "name": "Open Banking",
     "details": [
         [
             "items": [
@@ -144,8 +144,8 @@ let sevenElevenDictionary = [
 ] as [String: Any]
 
 let issuerListDictionaryWithoutDetailsObject = [
-    "type": "ideal_100",
-    "name": "iDEAL_100",
+    "type": "openbanking_UK_100",
+    "name": "Open_Banking_100",
     "issuers": [
         [
             "id": "1121",
@@ -224,6 +224,11 @@ let econtextOnline = [
 let oxxo = [
     "name": "OXXO",
     "type": "oxxo"
+] as [String: Any]
+
+let ideal = [
+    "name": "iDeal",
+    "type": "ideal"
 ] as [String: Any]
 
 let multibanco = [

--- a/Tests/AdyenTests/Adyen Tests/DropIn/DropInTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/DropIn/DropInTests.swift
@@ -41,9 +41,9 @@ class DropInTests: XCTestCase {
                   "type" : "select"
                 }
               ],
-              "name" : "iDEAL",
+              "name" : "Open Banking",
               "supportsRecurring" : true,
-              "type" : "ideal"
+              "type" : "openbanking_UK"
             },
             {
               "brands" : [ "mc", "visa" ],


### PR DESCRIPTION
## Summary
- Changed iDeal to be an InstantPaymentMethod (ignoring the issuers)

## Release Notes
<new>
The new iDEAL payment flow where the shopper is redirected to the iDEAL payment page to select their bank and authorize the payment.
</new>