### PR TITLE
UPI Only handle main txvariant

### DIFF
--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
@@ -43,6 +43,9 @@ internal enum AnyPaymentMethodDecoder {
         .androidPay: UnsupportedPaymentMethodDecoder(),
         .amazonPay: UnsupportedPaymentMethodDecoder(),
         .bizum: UnsupportedPaymentMethodDecoder(),
+        .upiQr: UnsupportedPaymentMethodDecoder(),
+        .upiIntent: UnsupportedPaymentMethodDecoder(),
+        .upiCollect: UnsupportedPaymentMethodDecoder(),
 
         // Supported payment methods
         .card: CardPaymentMethodDecoder(),
@@ -119,7 +122,7 @@ internal enum AnyPaymentMethodDecoder {
             if isStored, brand == "bcmc", type == .scheme {
                 return try decoders[.bcmc, default: defaultDecoder].decode(from: decoder, isStored: true)
             }
-
+            
             let paymentDecoder = type.map { decoders[$0, default: defaultDecoder] } ?? defaultDecoder
             return try paymentDecoder.decode(from: decoder, isStored: isStored)
         } catch {

--- a/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
+++ b/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
@@ -23,19 +23,11 @@ public enum PaymentMethodType: RawRepresentable, Hashable, Codable {
     case applePay
     case payPal
     case bcmc
-    case bcmcMobileQR
     case bcmcMobile
-    case weChatMiniProgram
-    case weChatQR
     case qiwiWallet
-    case weChatPayWeb
     case weChatPaySDK
     case mbWay
     case blik
-    case googlePay
-    case afterpay
-    case androidPay
-    case amazonPay
     case dokuWallet
     case dokuAlfamart
     case dokuIndomaret
@@ -59,9 +51,22 @@ public enum PaymentMethodType: RawRepresentable, Hashable, Codable {
     case mealVoucherSodexo
     case upi
     case cashAppPay
-    case bizum
     case twint
     case other(String)
+    
+    // Unsupported
+    case bcmcMobileQR
+    case weChatMiniProgram
+    case weChatQR
+    case weChatPayWeb
+    case googlePay
+    case afterpay
+    case androidPay
+    case amazonPay
+    case upiCollect
+    case upiIntent
+    case upiQr
+    case bizum
     
     // swiftlint:disable cyclomatic_complexity function_body_length
     
@@ -118,6 +123,9 @@ public enum PaymentMethodType: RawRepresentable, Hashable, Codable {
         case "mealVoucher_FR_natixis": self = .mealVoucherNatixis
         case "mealVoucher_FR_sodexo": self = .mealVoucherSodexo
         case "upi": self = .upi
+        case "upi_collect": self = .upiCollect
+        case "upi_intent": self = .upiIntent
+        case "upi_qr": self = .upiQr
         case "cashapp": self = .cashAppPay
         case "bizum": self = .bizum
         case "twint": self = .twint
@@ -178,6 +186,9 @@ public enum PaymentMethodType: RawRepresentable, Hashable, Codable {
         case .mealVoucherNatixis: return "mealVoucher_FR_natixis"
         case .mealVoucherSodexo: return "mealVoucher_FR_sodexo"
         case .upi: return "upi"
+        case .upiQr: return "upi_qr"
+        case .upiIntent: return "upi_intent"
+        case .upiCollect: return "upi_collect"
         case .cashAppPay: return "cashapp"
         case .bizum: return "bizum"
         case .twint: return "twint"
@@ -245,6 +256,9 @@ extension PaymentMethodType {
         case .mealVoucherNatixis: return "meal voucher natixis"
         case .mealVoucherSodexo: return "meal voucher sodexo"
         case .upi: return "UPI"
+        case .upiQr: return "UPI QR"
+        case .upiIntent: return "UPI Intent"
+        case .upiCollect: return "UPI Collect"
         case .cashAppPay: return "cash app"
         case .bizum: return "bizum"
         case .twint: return "twint"

--- a/AdyenComponents/UPI/UPIComponent.swift
+++ b/AdyenComponents/UPI/UPIComponent.swift
@@ -34,6 +34,7 @@ public final class UPIComponent: PaymentComponent,
         static let upiQRCode = "upi_qr"
         static let upiIntent = "upi_intent"
         static let vpaFlowIdentifier = "UPI/VPA"
+        static let noAppsVpaSegmentTitle = "VPA"
         
         static let qrCodeIcon = "qrcode"
     }
@@ -104,10 +105,7 @@ public final class UPIComponent: PaymentComponent,
     internal lazy var upiFlowSelectionItem: FormSegmentedControlItem = {
         let item = FormSegmentedControlItem(
             items: [
-                localizedString(
-                    .UPIFirstTabTitle,
-                    configuration.localizationParameters
-                ),
+                firstSegmentTitle,
                 localizedString(
                     .UPISecondTabTitle,
                     configuration.localizationParameters
@@ -287,6 +285,17 @@ extension UPIComponent {
 // MARK: - Private
 
 private extension UPIComponent {
+    
+    var firstSegmentTitle: String {
+        guard let apps = upiPaymentMethod.apps, !apps.isEmpty else {
+            return Constants.noAppsVpaSegmentTitle
+        }
+        
+        return localizedString(
+            .UPIFirstTabTitle,
+            configuration.localizationParameters
+        )
+    }
     
     func updateSelection() {
         upiAppsList.forEach { $0.isSelected = false }


### PR DESCRIPTION
## Summary
- all upi txvariants (`upi_qr`, `upi_collect` & `upi_intent`) except for the main `upi` are ignored by drop-in
- using `VPA` as title when no apps are provided