### PR TITLE
Update .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,7 @@ excluded:
   - DerivedData
   - Carthage
   - TempProject
+  - Scripts
 
 line_length:
   ignores_function_declarations: true


### PR DESCRIPTION
- Excludes `Scripts` folder from being linted
