### PR TITLE
Add validation function to SubmitCustomizable components

### DIFF
--- a/Adyen/Core/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent+Extensions.swift
+++ b/Adyen/Core/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent+Extensions.swift
@@ -15,7 +15,7 @@ extension AbstractPersonalInformationComponent: LoadingComponent {
     }
 
     internal func didSelectSubmitButton() {
-        guard formViewController.validate() else { return }
+        guard validate() else { return }
 
         button.showsActivityIndicator = true
         formViewController.view.isUserInteractionEnabled = false

--- a/Adyen/Core/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
+++ b/Adyen/Core/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
@@ -286,4 +286,8 @@ extension AbstractPersonalInformationComponent: SubmitCustomizable {
 
         didSelectSubmitButton()
     }
+
+    public func validate() -> Bool {
+        formViewController.validate()
+    }
 }

--- a/Adyen/Core/Core Protocols/SubmitCustomizable.swift
+++ b/Adyen/Core/Core Protocols/SubmitCustomizable.swift
@@ -23,7 +23,7 @@ public protocol SubmitCustomizable {
 
     /// Validates the component's form and triggers the associated validation UI.
     ///
-    /// This method checks the validity of the form linked to the payment component. It ensures that all required fields are properly 
+    /// This method checks the validity of the form linked to the payment component. It ensures that all required fields are properly
     /// filled out and conform to expected formats.
     /// Additionally, it triggers the UI to visually indicate any validation errors to the user.
     ///

--- a/Adyen/Core/Core Protocols/SubmitCustomizable.swift
+++ b/Adyen/Core/Core Protocols/SubmitCustomizable.swift
@@ -21,6 +21,15 @@ public protocol SubmitCustomizable {
     ///    - Handle stopping the loading state after the payment process is completed.
     func submit()
 
-    /// A Boolean value that indicates whether a component's form is valid.
+    /// Validates the component's form and triggers the associated validation UI.
+    ///
+    /// This method checks the validity of the form linked to the payment component. It ensures that all required fields are properly 
+    /// filled out and conform to expected formats.
+    /// Additionally, it triggers the UI to visually indicate any validation errors to the user.
+    ///
+    /// - Returns: A Boolean value indicating whether the form is valid (`true`) or not (`false`).
+    ///
+    /// - Important:
+    ///    - Make sure to call this method before initiating the payment process to ensure that the form is correctly filled out.
     func validate() -> Bool
 }

--- a/Adyen/Core/Core Protocols/SubmitCustomizable.swift
+++ b/Adyen/Core/Core Protocols/SubmitCustomizable.swift
@@ -20,4 +20,7 @@ public protocol SubmitCustomizable {
     ///    - Ensure that the payment component is properly configured before calling this method.
     ///    - Handle stopping the loading state after the payment process is completed.
     func submit()
+
+    /// A Boolean value that indicates whether a component's form is valid.
+    func validate() -> Bool
 }

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -315,4 +315,8 @@ extension CardComponent: SubmitCustomizable {
 
         didSelectSubmitButton()
     }
+
+    public func validate() -> Bool {
+        cardViewController.validate()
+    }
 }

--- a/AdyenCard/Components/Card/CardComponentExtensions.swift
+++ b/AdyenCard/Components/Card/CardComponentExtensions.swift
@@ -16,7 +16,7 @@ import UIKit
 extension CardComponent {
     
     internal func didSelectSubmitButton() {
-        guard cardViewController.validate() else {
+        guard validate() else {
             return
         }
         

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -446,4 +446,8 @@ extension GiftCardComponent: SubmitCustomizable {
 
         didSelectSubmitButton()
     }
+
+    public func validate() -> Bool {
+        formViewController.validate()
+    }
 }

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -261,7 +261,7 @@ extension GiftCardComponent {
     
     internal func didSelectSubmitButton() {
         hideError()
-        guard formViewController.validate() else {
+        guard validate() else {
             return
         }
 

--- a/AdyenCashAppPay/CashAppPayComponent.swift
+++ b/AdyenCashAppPay/CashAppPayComponent.swift
@@ -121,7 +121,7 @@ public final class CashAppPayComponent: PaymentComponent,
     }
 
     private func didSelectSubmitButton() {
-        guard formViewController.validate() else { return }
+        guard validate() else { return }
     
         startLoading()
         startCashAppPayFlow()

--- a/AdyenCashAppPay/CashAppPayComponent.swift
+++ b/AdyenCashAppPay/CashAppPayComponent.swift
@@ -271,4 +271,8 @@ extension CashAppPayComponent: SubmitCustomizable {
 
         didSelectSubmitButton()
     }
+
+    public func validate() -> Bool {
+        formViewController.validate()
+    }
 }

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -394,4 +394,8 @@ extension ACHDirectDebitComponent: SubmitCustomizable {
 
         didSelectSubmitButton()
     }
+
+    public func validate() -> Bool {
+        formViewController.validate()
+    }
 }

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -98,7 +98,7 @@ public final class ACHDirectDebitComponent: PaymentComponent,
     }
 
     private func didSelectSubmitButton() {
-        guard formViewController.validate() else { return }
+        guard validate() else { return }
         
         startLoading()
         

--- a/AdyenComponents/BLIK/BLIKComponent.swift
+++ b/AdyenComponents/BLIK/BLIKComponent.swift
@@ -109,7 +109,7 @@ public final class BLIKComponent: PaymentComponent, PresentableComponent, Paymen
     // MARK: - Private
 
     private func didSelectSubmitButton() {
-        guard formViewController.validate() else { return }
+        guard validate() else { return }
 
         let details = BLIKDetails(paymentMethod: paymentMethod,
                                   blikCode: codeItem.value)

--- a/AdyenComponents/BLIK/BLIKComponent.swift
+++ b/AdyenComponents/BLIK/BLIKComponent.swift
@@ -138,4 +138,8 @@ extension BLIKComponent: SubmitCustomizable {
 
         didSelectSubmitButton()
     }
+
+    public func validate() -> Bool {
+        formViewController.validate()
+    }
 }

--- a/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
+++ b/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
@@ -161,4 +161,8 @@ extension OnlineBankingComponent: SubmitCustomizable {
 
         didSelectContinueButton()
     }
+
+    public func validate() -> Bool {
+        formViewController.validate()
+    }
 }

--- a/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
+++ b/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
@@ -113,7 +113,7 @@ public final class OnlineBankingComponent: PaymentComponent,
     // MARK: - Private
 
     private func didSelectContinueButton() {
-        guard formViewController.validate() else { return }
+        guard validate() else { return }
 
         let details = OnlineBankingDetails(paymentMethod: paymentMethod,
                                            issuer: issuerListPickerItem.value.identifier)

--- a/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
+++ b/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
@@ -158,4 +158,8 @@ extension SEPADirectDebitComponent: SubmitCustomizable {
 
         didSelectSubmitButton()
     }
+
+    public func validate() -> Bool {
+        formViewController.validate()
+    }
 }

--- a/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
+++ b/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
@@ -80,7 +80,7 @@ public final class SEPADirectDebitComponent: PaymentComponent, PaymentAware, Pre
     // MARK: - Private
     
     private func didSelectSubmitButton() {
-        guard formViewController.validate() else {
+        guard validate() else {
             return
         }
         

--- a/AdyenComponents/UPI/UPIComponent.swift
+++ b/AdyenComponents/UPI/UPIComponent.swift
@@ -444,4 +444,8 @@ extension UPIComponent: SubmitCustomizable {
 
         didSelectContinueButton()
     }
+
+    public func validate() -> Bool {
+        formViewController.validate()
+    }
 }

--- a/AdyenComponents/UPI/UPIComponent.swift
+++ b/AdyenComponents/UPI/UPIComponent.swift
@@ -301,7 +301,7 @@ extension UPIComponent {
     }
     
     private func didSelectContinueButton() {
-        guard formViewController.validate() else { return }
+        guard validate() else { return }
 
         guard canSubmit() else {
             showError()

--- a/Demo/UIKit/ComponentsViewController.swift
+++ b/Demo/UIKit/ComponentsViewController.swift
@@ -173,6 +173,7 @@ internal final class ComponentsViewController: UIViewController {
         let assembler = CustomComponentAssembler()
         let customComponentView = assembler.resolveCustomComponentView()
         let navigationController = UINavigationController(rootViewController: customComponentView)
+        navigationController.modalPresentationStyle = .fullScreen
         present(viewController: navigationController, completion: nil)
     }
 

--- a/Demo/UIKit/ComponentsViewController.swift
+++ b/Demo/UIKit/ComponentsViewController.swift
@@ -173,7 +173,6 @@ internal final class ComponentsViewController: UIViewController {
         let assembler = CustomComponentAssembler()
         let customComponentView = assembler.resolveCustomComponentView()
         let navigationController = UINavigationController(rootViewController: customComponentView)
-        navigationController.modalPresentationStyle = .fullScreen
         present(viewController: navigationController, completion: nil)
     }
 

--- a/Demo/UIKit/CustomComponent/CustomComponentPresenter.swift
+++ b/Demo/UIKit/CustomComponent/CustomComponentPresenter.swift
@@ -72,7 +72,7 @@ class CustomComponentPresenter: CustomComponentPresenterProtocol {
 
     private func performPayment(with data: PaymentComponentData,
                                 from component: PaymentComponent) {
-        guard cardComponent?.validate() ?? false else {
+        guard let cardComponent = cardComponent, cardComponent.validate() else {
             return
         }
         view?.startActivityIndicator()

--- a/Demo/UIKit/CustomComponent/CustomComponentPresenter.swift
+++ b/Demo/UIKit/CustomComponent/CustomComponentPresenter.swift
@@ -13,6 +13,7 @@ import AdyenSession
 
 protocol CustomComponentPresenterProtocol {
     var cardViewController: UIViewController { get }
+    func performValidation()
     func performPayment()
     func viewDidLoad()
 }
@@ -50,6 +51,11 @@ class CustomComponentPresenter: CustomComponentPresenterProtocol {
 
     func viewDidLoad() {}
 
+    func performValidation() {
+        let isValid = cardComponent?.validate() ?? false
+        print("CARD COMPONENT VALIDITY: \(isValid)")
+    }
+
     func performPayment() {
         cardComponent?.submit()
     }
@@ -66,6 +72,9 @@ class CustomComponentPresenter: CustomComponentPresenterProtocol {
 
     private func performPayment(with data: PaymentComponentData,
                                 from component: PaymentComponent) {
+        guard cardComponent?.validate() ?? false else {
+            return
+        }
         view?.startActivityIndicator()
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 6) {

--- a/Demo/UIKit/CustomComponent/CustomComponentViewController.swift
+++ b/Demo/UIKit/CustomComponent/CustomComponentViewController.swift
@@ -20,6 +20,7 @@ class CustomComponentViewController: UIViewController, CustomComponentViewProtoc
     private enum Content {
         static let title = "Checkout"
         static let submitButtonTitle = "Buy now"
+        static let validationButtonTitle = "Validate"
     }
 
     // MARK: - View components
@@ -65,6 +66,20 @@ class CustomComponentViewController: UIViewController, CustomComponentViewProtoc
 
         button.layer.cornerRadius = 8
         button.addTarget(self, action: #selector(performPayment), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var validityButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.setTitle(Content.validationButtonTitle, for: .normal)
+
+        let coralColor = UIColor(red: 255 / 255, green: 127 / 255, blue: 80 / 255, alpha: 1.0)
+        button.backgroundColor = coralColor
+        button.titleLabel?.textColor = .white
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
+
+        button.layer.cornerRadius = 8
+        button.addTarget(self, action: #selector(performValidation), for: .touchUpInside)
         return button
     }()
 
@@ -144,10 +159,13 @@ class CustomComponentViewController: UIViewController, CustomComponentViewProtoc
         scrollView.addSubview(stackView)
         stackView.addSubview(activityIndicator)
 
-        [topPlaceholderView,
-         cardComponentView,
-         payButton,
-         bottomPlaceholderView].forEach { subView in
+        [
+            topPlaceholderView,
+            cardComponentView,
+            payButton,
+            validityButton,
+            bottomPlaceholderView
+        ].forEach { subView in
             subView.translatesAutoresizingMaskIntoConstraints = false
             stackView.addArrangedSubview(subView)
         }
@@ -169,9 +187,12 @@ class CustomComponentViewController: UIViewController, CustomComponentViewProtoc
             payButton.widthAnchor.constraint(equalTo: stackView.widthAnchor),
             payButton.heightAnchor.constraint(equalToConstant: 48),
 
+            validityButton.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+            validityButton.heightAnchor.constraint(equalToConstant: 48),
+
             topPlaceholderView.heightAnchor.constraint(equalToConstant: 450),
             topPlaceholderView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
-            bottomPlaceholderView.heightAnchor.constraint(equalToConstant: 450),
+            bottomPlaceholderView.heightAnchor.constraint(equalToConstant: 700),
             bottomPlaceholderView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
 
             activityIndicator.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
@@ -191,6 +212,11 @@ class CustomComponentViewController: UIViewController, CustomComponentViewProtoc
     private func setupNavigationBar() {
         navigationItem.title = Content.title
         navigationItem.largeTitleDisplayMode = .always
+    }
+
+    @objc
+    private func performValidation() {
+        presenter.performValidation()
     }
 
     @objc

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -2210,6 +2210,54 @@ class CardComponentTests: XCTestCase {
         wait(until: expiryDateItem, at: \.expiryMonth, is: "03")
     }
 
+    func testValidateGivenValidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        var configuration = CardComponent.Configuration()
+        configuration.billingAddress.mode = .none
+        let sut = CardComponent(paymentMethod: method,
+                                context: Dummy.context(with: nil),
+                                configuration: configuration,
+                                publicKeyProvider: PublicKeyProviderMock(),
+                                binProvider: BinInfoProviderMock())
+
+        setupRootViewController(sut.viewController)
+
+        fillCard(on: sut.viewController.view, with: Dummy.visaCard)
+
+        let cardViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<CardViewController>)?.childViewController)
+        let expectedResult = cardViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertTrue(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
+
+    func testValidateGivenInvalidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        var configuration = CardComponent.Configuration()
+        configuration.billingAddress.mode = .none
+        let sut = CardComponent(paymentMethod: method,
+                                context: Dummy.context(with: nil),
+                                configuration: configuration,
+                                publicKeyProvider: PublicKeyProviderMock(),
+                                binProvider: BinInfoProviderMock())
+
+        setupRootViewController(sut.viewController)
+
+        let cardViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<CardViewController>)?.childViewController)
+        let expectedResult = cardViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertFalse(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
+
     // MARK: - Private
 
     private func focus(textItemView: some FormTextItemView<some FormTextItem>) {

--- a/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -364,4 +364,58 @@ class ACHDirectDebitComponentTests: XCTestCase {
         // Then
         XCTAssertEqual(delegateMock.didSubmitCallsCount, 0)
     }
+
+    func testValidateWithValidInputSubmitShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let paymentMethod = ACHDirectDebitPaymentMethod(type: .achDirectDebit, name: "Test name")
+        let configuration = ACHDirectDebitComponent.Configuration(showsSubmitButton: false,
+                                                                  showsBillingAddress: false)
+        let sut = ACHDirectDebitComponent(paymentMethod: paymentMethod,
+                                          context: context,
+                                          configuration: configuration,
+                                          publicKeyProvider: PublicKeyProviderMock())
+
+        setupRootViewController(sut.viewController)
+
+        let nameItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.holderNameItem"))
+        let accountNumberItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankAccountNumberItem"))
+        let routingNumberItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankRoutingNumberItem"))
+
+        self.populate(textItemView: nameItemView, with: "test")
+        self.populate(textItemView: accountNumberItemView, with: "123456789")
+        self.populate(textItemView: routingNumberItemView, with: "121000358")
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertTrue(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
+
+    func testValidateWithInvalidInputSubmitShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let paymentMethod = ACHDirectDebitPaymentMethod(type: .achDirectDebit, name: "Test name")
+        let configuration = ACHDirectDebitComponent.Configuration(showsSubmitButton: false,
+                                                                  showsBillingAddress: false)
+        let sut = ACHDirectDebitComponent(paymentMethod: paymentMethod,
+                                          context: context,
+                                          configuration: configuration,
+                                          publicKeyProvider: PublicKeyProviderMock())
+
+        setupRootViewController(sut.viewController)
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertFalse(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
 }

--- a/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
@@ -141,4 +141,38 @@ class BLIKComponentTests: XCTestCase {
         // Then
         XCTAssertEqual(paymentDelegateMock.didSubmitCallsCount, 0)
     }
+
+    func testValidateGivenValidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let configuration = BLIKComponent.Configuration(showsSubmitButton: false)
+        let sut = BLIKComponent(
+            paymentMethod: paymentMethod,
+            context: context,
+            configuration: configuration
+        )
+
+        setupRootViewController(sut.viewController)
+
+        let didSubmitExpectation = XCTestExpectation(description: "Expect delegate.didSubmit() to be called.")
+
+        let paymentDelegateMock = PaymentComponentDelegateMock()
+        sut.delegate = paymentDelegateMock
+
+        paymentDelegateMock.onDidSubmit = { _, _ in
+            didSubmitExpectation.fulfill()
+        }
+
+        let codeItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.BLIKComponent.blikCodeItem"))
+
+        self.populate(textItemView: codeItemView, with: "123456")
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertEqual(expectedResult, validationResult)
+    }
 }

--- a/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
@@ -153,15 +153,6 @@ class BLIKComponentTests: XCTestCase {
 
         setupRootViewController(sut.viewController)
 
-        let didSubmitExpectation = XCTestExpectation(description: "Expect delegate.didSubmit() to be called.")
-
-        let paymentDelegateMock = PaymentComponentDelegateMock()
-        sut.delegate = paymentDelegateMock
-
-        paymentDelegateMock.onDidSubmit = { _, _ in
-            didSubmitExpectation.fulfill()
-        }
-
         let codeItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.BLIKComponent.blikCodeItem"))
 
         self.populate(textItemView: codeItemView, with: "123456")
@@ -189,13 +180,6 @@ class BLIKComponentTests: XCTestCase {
         setupRootViewController(sut.viewController)
 
         let didSubmitExpectation = XCTestExpectation(description: "Expect delegate.didSubmit() to be called.")
-
-        let paymentDelegateMock = PaymentComponentDelegateMock()
-        sut.delegate = paymentDelegateMock
-
-        paymentDelegateMock.onDidSubmit = { _, _ in
-            didSubmitExpectation.fulfill()
-        }
 
         let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
         let expectedResult = formViewController.validate()

--- a/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
@@ -173,6 +173,38 @@ class BLIKComponentTests: XCTestCase {
         let validationResult = sut.validate()
 
         // Then
+        XCTAssertTrue(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
+
+    func testValidateGivenInvalidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let configuration = BLIKComponent.Configuration(showsSubmitButton: false)
+        let sut = BLIKComponent(
+            paymentMethod: paymentMethod,
+            context: context,
+            configuration: configuration
+        )
+
+        setupRootViewController(sut.viewController)
+
+        let didSubmitExpectation = XCTestExpectation(description: "Expect delegate.didSubmit() to be called.")
+
+        let paymentDelegateMock = PaymentComponentDelegateMock()
+        sut.delegate = paymentDelegateMock
+
+        paymentDelegateMock.onDidSubmit = { _, _ in
+            didSubmitExpectation.fulfill()
+        }
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertFalse(validationResult)
         XCTAssertEqual(expectedResult, validationResult)
     }
 }

--- a/Tests/IntegrationTests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
@@ -292,5 +292,26 @@ import XCTest
             // Then
             XCTAssertEqual(paymentDelegateMock.didSubmitCallsCount, 0)
         }
+
+        func testValidateShouldReturnFormViewControllerValidateResult() throws {
+            // Given
+            let configuration = CashAppPayConfiguration(redirectURL: URL(string: "test")!, showsSubmitButton: false)
+            let sut = CashAppPayComponent(
+                paymentMethod: paymentMethod,
+                context: context,
+                configuration: configuration
+            )
+            setupRootViewController(sut.viewController)
+
+            let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+            let expectedResult = formViewController.validate()
+
+            // When
+            let validationResult = sut.validate()
+
+            // Then
+            XCTAssertTrue(validationResult)
+            XCTAssertEqual(expectedResult, validationResult)
+        }
     }
 #endif

--- a/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
@@ -37,11 +37,11 @@ class GiftCardComponentTests: XCTestCase {
     var securityCodeItemTitleLabel: UILabel? {
         sut.viewController.view.findView(with: "AdyenCard.GiftCardComponent.securityCodeItem.titleLabel")
     }
-    
+
     var securityCodeItemView: FormTextInputItemView? {
         sut.viewController.view.findView(with: "AdyenCard.GiftCardComponent.securityCodeItem")
     }
-    
+
     var expiryDateItemView: FormItemView<FormCardExpiryDateItem>? {
         sut.viewController.view.findView(with: "AdyenCard.GiftCardComponent.expiryDateItem")
     }
@@ -78,39 +78,39 @@ class GiftCardComponentTests: XCTestCase {
         sut = nil
         try super.tearDownWithError()
     }
-    
+
     func testGiftCardUI() {
-        
+
         // Given
         let paymentMethod = GiftCardPaymentMethod(type: .giftcard, name: "testName", brand: "testBrand")
         sut = GiftCardComponent(partialPaymentMethodType: .giftCard(paymentMethod),
                                 context: context,
                                 amount: amountToPay,
                                 publicKeyProvider: publicKeyProvider)
-        
+
         // When
         setupRootViewController(sut.viewController)
         wait(for: .milliseconds(300))
-        
+
         // Then
         XCTAssertNil(expiryDateItemView, "should not have expiry date field for gift card")
         XCTAssertNotNil(securityCodeItemView, "security code should be shown by default")
         XCTAssertEqual(securityCodeItemTitleLabel?.text, "Pin", "cvc title changes based on payment method")
     }
-    
+
     func testMealVoucherUI() {
-        
+
         // Given
         let paymentMethod = MealVoucherPaymentMethod(type: .mealVoucherSodexo, name: "Sodexo")
         sut = GiftCardComponent(partialPaymentMethodType: .mealVoucher(paymentMethod),
                                 context: context,
                                 amount: amountToPay,
                                 publicKeyProvider: publicKeyProvider)
-        
+
         // When
         setupRootViewController(sut.viewController)
         wait(for: .milliseconds(300))
-        
+
         // Then
         XCTAssertNotNil(expiryDateItemView, "should have expiry date field for meal voucher")
         XCTAssertNotNil(securityCodeItemView, "security code should be shown by default")
@@ -578,9 +578,9 @@ class GiftCardComponentTests: XCTestCase {
         let infoType = analyticsProviderMock.infos.first?.type
         XCTAssertEqual(infoType, .rendered)
     }
-    
+
     func testGiftCardHidingSecurityCodeItemView() throws {
-        
+
         // Given
         sut = GiftCardComponent(partialPaymentMethodType: .giftCard(giftCardPaymentMethod),
                                 context: context,
@@ -596,9 +596,9 @@ class GiftCardComponentTests: XCTestCase {
         XCTAssertNotNil(numberItemView)
         XCTAssertNil(securityCodeItemView)
     }
-    
+
     func testMealVoucherHidingSecurityCodeItemView() {
-        
+
         // Given
         let paymentMethod = MealVoucherPaymentMethod(type: .mealVoucherSodexo, name: "Sodexo")
         sut = GiftCardComponent(partialPaymentMethodType: .mealVoucher(paymentMethod),
@@ -606,38 +606,38 @@ class GiftCardComponentTests: XCTestCase {
                                 amount: amountToPay,
                                 showsSecurityCodeField: false,
                                 publicKeyProvider: publicKeyProvider)
-        
+
         // When
         let mockViewController = UIViewController()
         sut.viewWillAppear(viewController: mockViewController)
-        
+
         // Then
         XCTAssertNotNil(numberItemView)
         XCTAssertNotNil(expiryDateItemView, "expiry date should still be shown when security code item is hidden")
         XCTAssertNil(securityCodeItemView)
     }
-    
+
     func testPartialConfirmationPaymentMethod() {
-        
+
         let giftCard = GiftCardPaymentMethod(type: .giftcard, name: "Giftcard", brand: "giftcard")
-        
+
         let paymentMethod = PartialConfirmationPaymentMethod(
             paymentMethod: giftCard,
             lastFour: "1234",
             remainingAmount: .init(value: 1000, currencyCode: "USD")
         )
-        
+
         XCTAssertEqual(paymentMethod.type, giftCard.type)
-        
+
         let displayInformation = paymentMethod.defaultDisplayInformation(using: nil)
-        
+
         XCTAssertEqual(displayInformation.title, "•••• 1234")
         XCTAssertEqual(displayInformation.logoName, giftCard.brand)
         XCTAssertEqual(displayInformation.accessibilityLabel, "Giftcard, Last 4 digits: 1, 2, 3, 4, Remaining balance will be $10.00")
     }
-    
+
     func testPartialPaymentOrder() throws {
-        
+
         let order = PartialPaymentOrder(
             pspReference: "psp-reference",
             orderData: "order-data",
@@ -646,10 +646,10 @@ class GiftCardComponentTests: XCTestCase {
             remainingAmount: .init(value: 500, currencyCode: "USD"),
             expiresAt: Date()
         )
-        
+
         let encodedOrder = try JSONEncoder().encode(order)
         let decodedOrder = try JSONDecoder().decode(PartialPaymentOrder.self, from: encodedOrder)
-        
+
         XCTAssertEqual(order.pspReference, decodedOrder.pspReference)
         XCTAssertEqual(order.orderData, decodedOrder.orderData)
         XCTAssertEqual(order.reference, decodedOrder.reference)
@@ -658,10 +658,47 @@ class GiftCardComponentTests: XCTestCase {
         XCTAssertNil(decodedOrder.expiresAt)
         XCTAssertEqual(order.compactOrder, decodedOrder.compactOrder)
     }
+
+    func testValidateGivenValidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        sut = GiftCardComponent(partialPaymentMethodType: .giftCard(giftCardPaymentMethod),
+                                context: context,
+                                amount: amountToPay,
+                                publicKeyProvider: publicKeyProvider)
+        populate(cardNumber: "60643650100000000000", pin: "73737")
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertTrue(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
+
+    func testValidateGivenInvalidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        sut = GiftCardComponent(partialPaymentMethodType: .giftCard(giftCardPaymentMethod),
+                                context: context,
+                                amount: amountToPay,
+                                publicKeyProvider: publicKeyProvider)
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertFalse(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
 }
 
 private extension GiftCardComponentTests {
-    
+
     func populate(cardNumber: String, pin: String) {
         populate(textItemView: numberItemView!, with: cardNumber)
         populate(textItemView: securityCodeItemView!, with: pin)

--- a/Tests/IntegrationTests/Components Tests/Online Banking/OnlineBankingComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Online Banking/OnlineBankingComponentTests.swift
@@ -111,4 +111,24 @@ class OnlineBankingComponentTests: XCTestCase {
         // Then
         XCTAssertEqual(paymentDelegateMock.didSubmitCallsCount, 0)
     }
+
+    func testValidateShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let configuration = OnlineBankingComponent.Configuration(showsSubmitButton: false)
+        let sut = OnlineBankingComponent(
+            paymentMethod: paymentMethod,
+            context: context,
+            configuration: configuration
+        )
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertTrue(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
 }

--- a/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
@@ -311,4 +311,56 @@ class SEPADirectDebitComponentTests: XCTestCase {
         // Then
         XCTAssertEqual(delegateMock.didSubmitCallsCount, 0)
     }
+
+    func testValidateGivenValidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let paymentMethod = SEPADirectDebitPaymentMethod(type: .sepaDirectDebit, name: "Test name")
+        let configuration = SEPADirectDebitComponent.Configuration(showsSubmitButton: false)
+        let sut = SEPADirectDebitComponent(
+            paymentMethod: paymentMethod,
+            context: context,
+            configuration: configuration
+        )
+
+        setupRootViewController(sut.viewController)
+
+        let ibanItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.SEPADirectDebitComponent.ibanItem"))
+        let nameItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.SEPADirectDebitComponent.nameItem"))
+
+        self.populate(textItemView: ibanItemView, with: "NL13TEST0123456789")
+        self.populate(textItemView: nameItemView, with: "A. Klaassen")
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertTrue(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
+
+    func testValidateGivenInvalidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let paymentMethod = SEPADirectDebitPaymentMethod(type: .sepaDirectDebit, name: "Test name")
+        let configuration = SEPADirectDebitComponent.Configuration(showsSubmitButton: false)
+        let sut = SEPADirectDebitComponent(
+            paymentMethod: paymentMethod,
+            context: context,
+            configuration: configuration
+        )
+
+        setupRootViewController(sut.viewController)
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertFalse(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
 }

--- a/Tests/IntegrationTests/Components Tests/UPIComponent/UPIComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/UPIComponent/UPIComponentTests.swift
@@ -107,4 +107,50 @@ class UPIComponentTests: XCTestCase {
         // Then
         XCTAssertEqual(delegateMock.didSubmitCallsCount, 0)
     }
+
+    func testValidateGivenValidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let paymentMethod: UPIPaymentMethod = try AdyenCoder.decode(upi)
+        let configuration = UPIComponent.Configuration(showsSubmitButton: false)
+        let sut = UPIComponent(
+            paymentMethod: paymentMethod,
+            context: Dummy.context,
+            configuration: configuration
+        )
+
+        let vpaInputItem: FormTextItemView<FormTextInputItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.UPIComponent.virtualPaymentAddressInputItem"))
+        self.populate(textItemView: vpaInputItem, with: "testvpa@icici")
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertTrue(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
+
+    func testValidateGivenInvalidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let paymentMethod: UPIPaymentMethod = try AdyenCoder.decode(upi)
+        let configuration = UPIComponent.Configuration(showsSubmitButton: false)
+        let sut = UPIComponent(
+            paymentMethod: paymentMethod,
+            context: Dummy.context,
+            configuration: configuration
+        )
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertFalse(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
+
 }

--- a/Tests/SnapshotTests/Components/DokuComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/DokuComponentUITests.swift
@@ -155,6 +155,67 @@ final class DokuComponentUITests: XCTestCase {
         // Then
         XCTAssertEqual(paymentDelegateMock.didSubmitCallsCount, 0)
     }
+    
+    func testValidateWitValidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let configuration = AbstractPersonalInformationComponent.Configuration(showsSubmitButton: false)
+        let sut = DokuComponent(
+            paymentMethod: paymentMethod,
+            context: context,
+            configuration: configuration
+        )
+
+        let paymentDelegateMock = PaymentComponentDelegateMock()
+        sut.delegate = paymentDelegateMock
+
+        let firstNameView: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: DokuViewIdentifier.firstName))
+        self.populate(textItemView: firstNameView, with: "Katrina")
+
+        let lastNameView: FormTextInputItemView! = try XCTUnwrap(sut.viewController.view.findView(with: DokuViewIdentifier.lastName))
+        self.populate(textItemView: lastNameView, with: "Del Mar")
+
+        let emailView: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: DokuViewIdentifier.email))
+        self.populate(textItemView: emailView, with: "katrina.mar@mail.com")
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertTrue(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
+
+    func testValidateWitInvalidInputShouldReturnFormViewControllerValidateResult() throws {
+        // Given
+        let configuration = AbstractPersonalInformationComponent.Configuration(showsSubmitButton: false)
+        let sut = DokuComponent(
+            paymentMethod: paymentMethod,
+            context: context,
+            configuration: configuration
+        )
+
+        let paymentDelegateMock = PaymentComponentDelegateMock()
+        sut.delegate = paymentDelegateMock
+
+        let firstNameView: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: DokuViewIdentifier.firstName))
+        self.populate(textItemView: firstNameView, with: "Katrina")
+
+        let lastNameView: FormTextInputItemView! = try XCTUnwrap(sut.viewController.view.findView(with: DokuViewIdentifier.lastName))
+        self.populate(textItemView: lastNameView, with: "Del Mar")
+
+        let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
+        let expectedResult = formViewController.validate()
+
+        // When
+        let validationResult = sut.validate()
+
+        // Then
+        XCTAssertFalse(validationResult)
+        XCTAssertEqual(expectedResult, validationResult)
+    }
 
     private enum DokuViewIdentifier {
         static let firstName = "AdyenComponents.DokuComponent.firstNameItem"


### PR DESCRIPTION
## Summary

This PR introduces a validation function to each customizable submit button component, as part of the ongoing submit button customization project. The purpose of this function is to enable merchants to check the validation status of a component before initiating a payment. The function returns a Boolean indicating the component's validation status and also triggers the corresponding validation UI.

## Motivation

To provide merchants with the ability to verify the validation status of a component prior to starting the payment process.

## Changelog

<new>

- [Added] Implemented `func validate() -> Bool` to retrieve the validation status of the component. Impacted components:
  - `AbstractPersonalInformationComponent`
  - `GiftCardComponent`
  - `CardComponent`
  - `ACHDirectDebitComponent`
  - `OnlineBankingComponent`
  - `UPIComponent`
  - `BLIKComponent`
  - `SEPADirectDebitComponent`
  - `CashAppPayComponent`

</new>