### PR TITLE
Making anchor behave like expected

### DIFF
--- a/Adyen/Helpers/UIViewConstraintsHelper.swift
+++ b/Adyen/Helpers/UIViewConstraintsHelper.swift
@@ -72,17 +72,17 @@ extension AdyenScope where Base: UIView {
         }
         if let bottom = edgeInsets.bottom {
             constraints.append(
-                base.bottomAnchor.constraint(
-                    equalTo: anchorSource.anchorSet.bottomAnchor,
-                    constant: -bottom
+                anchorSource.anchorSet.bottomAnchor.constraint(
+                    equalTo: base.bottomAnchor,
+                    constant: bottom
                 )
             )
         }
         if let right = edgeInsets.right {
             constraints.append(
-                base.trailingAnchor.constraint(
-                    equalTo: anchorSource.anchorSet.trailingAnchor,
-                    constant: -right
+                anchorSource.anchorSet.trailingAnchor.constraint(
+                    equalTo: base.trailingAnchor,
+                    constant: right
                 )
             )
         }

--- a/Adyen/Helpers/UIViewConstraintsHelper.swift
+++ b/Adyen/Helpers/UIViewConstraintsHelper.swift
@@ -12,48 +12,79 @@ import UIKit
 extension AdyenScope where Base: UIView {
 
     /// Attaches top, bottom, left and right anchors of this view to the corresponding anchors inside the specified view.
-    /// - IMPORTANT: Both views should be in the same hierarchy.
+    /// - IMPORTANT: Both views must be in the same hierarchy.
     /// - Parameter view: Container view
     /// - Parameter padding: Padding values for each edge. Default is 0 on all edges.
     @discardableResult
-    public func anchor(inside view: UIView, with padding: UIEdgeInsets = .zero) -> [NSLayoutConstraint] {
-        anchor(inside: .view(view), edgeInsets: EdgeInsets(edgeInsets: padding))
+    public func anchor(
+        inside view: UIView,
+        with padding: UIEdgeInsets = .zero
+    ) -> [NSLayoutConstraint] {
+        anchor(
+            inside: .view(view),
+            edgeInsets: EdgeInsets(edgeInsets: padding)
+        )
     }
 
     /// Attaches top, bottom, left and right anchors of this view to the corresponding anchors inside the specified layout guide.
-    /// - IMPORTANT: Both views should be in the same hierarchy.
+    /// - IMPORTANT: The view & layout guide must be in the same hierarchy.
     /// - Parameter margins: The layout guide to constraint to.
     /// - Parameter padding: Padding values for each edge. Default is 0 on all edges.
     @discardableResult
-    public func anchor(inside margins: UILayoutGuide, with padding: UIEdgeInsets = .zero) -> [NSLayoutConstraint] {
-        anchor(inside: .layoutGuide(margins), edgeInsets: EdgeInsets(edgeInsets: padding))
+    public func anchor(
+        inside margins: UILayoutGuide,
+        with padding: UIEdgeInsets = .zero
+    ) -> [NSLayoutConstraint] {
+        anchor(
+            inside: .layoutGuide(margins),
+            edgeInsets: EdgeInsets(edgeInsets: padding)
+        )
     }
     
     /// Attaches the given edges of this view to corresponding anchors inside the specified anchor source.
+    /// - IMPORTANT: The view & anchor source must be in the same hierarchy.
     /// - Parameters:
     ///   - anchorSource: The anchor source to contain this view.
     ///   - edgeInsets: Edges with inset values on which the views should be anchored. Defaults to all 4 edges with 0 inset each.
     @discardableResult
-    public func anchor(inside anchorSource: LayoutAnchorSource,
-                       edgeInsets: EdgeInsets = .zero) -> [NSLayoutConstraint] {
+    public func anchor(
+        inside anchorSource: LayoutAnchorSource,
+        edgeInsets: EdgeInsets = .zero
+    ) -> [NSLayoutConstraint] {
         base.translatesAutoresizingMaskIntoConstraints = false
         
         var constraints: [NSLayoutConstraint] = []
         if let top = edgeInsets.top {
-            constraints.append(base.topAnchor.constraint(equalTo: anchorSource.anchorSet.topAnchor,
-                                                         constant: top))
+            constraints.append(
+                base.topAnchor.constraint(
+                    equalTo: anchorSource.anchorSet.topAnchor,
+                    constant: top
+                )
+            )
         }
         if let left = edgeInsets.left {
-            constraints.append(base.leadingAnchor.constraint(equalTo: anchorSource.anchorSet.leadingAnchor,
-                                                             constant: left))
+            constraints.append(
+                base.leadingAnchor.constraint(
+                    equalTo: anchorSource.anchorSet.leadingAnchor,
+                    constant: left
+                )
+            )
         }
         if let bottom = edgeInsets.bottom {
-            constraints.append(base.bottomAnchor.constraint(equalTo: anchorSource.anchorSet.bottomAnchor,
-                                                            constant: bottom))
+            constraints.append(
+                base.bottomAnchor.constraint(
+                    equalTo: anchorSource.anchorSet.bottomAnchor,
+                    constant: -bottom
+                )
+            )
         }
         if let right = edgeInsets.right {
-            constraints.append(base.trailingAnchor.constraint(equalTo: anchorSource.anchorSet.trailingAnchor,
-                                                              constant: right))
+            constraints.append(
+                base.trailingAnchor.constraint(
+                    equalTo: anchorSource.anchorSet.trailingAnchor,
+                    constant: -right
+                )
+            )
         }
         
         NSLayoutConstraint.activate(constraints)

--- a/Adyen/UI/Form/Items/Basic Items/FormContainerItem.swift
+++ b/Adyen/UI/Form/Items/Basic Items/FormContainerItem.swift
@@ -62,14 +62,6 @@ private class FormContainerItemView: UIView, AnyFormItemView {
         addSubview(contentView)
         
         if let padding {
-            // Converting the contentInset because of the implementation of `AdyenScope.anchor`
-            let adjustedPadding = UIEdgeInsets(
-                top: padding.top,
-                left: padding.left,
-                bottom: -padding.bottom,
-                right: -padding.right
-            )
-            
             contentView.adyen.anchor(
                 inside: self,
                 with: padding

--- a/Adyen/UI/Form/Items/Button/SearchButton/FormSearchButtonItemView.swift
+++ b/Adyen/UI/Form/Items/Button/SearchButton/FormSearchButtonItemView.swift
@@ -21,7 +21,7 @@ internal final class FormSearchButtonItemView: FormItemView<FormSearchButtonItem
         preservesSuperviewLayoutMargins = true
         
         addSubview(searchBar)
-        searchBar.adyen.anchor(inside: self, with: .init(top: 0, left: 8, bottom: 0, right: -8))
+        searchBar.adyen.anchor(inside: self, with: .init(top: 0, left: 8, bottom: 0, right: 8))
         
         bind(item.$placeholder, to: searchBar, at: \.placeholder)
     }

--- a/Adyen/UI/Form/Items/Error/FormErrorItemView.swift
+++ b/Adyen/UI/Form/Items/Error/FormErrorItemView.swift
@@ -19,7 +19,7 @@ internal final class FormErrorItemView: FormItemView<FormErrorItem> {
         bind(item.$message, to: self, at: \.accessibilityLabel)
         isHidden = item.isHidden.wrappedValue
         addSubview(containerView)
-        containerView.adyen.anchor(inside: layoutMarginsGuide, with: UIEdgeInsets(top: 8, left: 0, bottom: -8, right: 0))
+        containerView.adyen.anchor(inside: layoutMarginsGuide, with: UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0))
         containerView.backgroundColor = item.style.backgroundColor
         containerView.adyen.round(using: item.style.cornerRounding)
         backgroundColor = .clear
@@ -44,7 +44,7 @@ internal final class FormErrorItemView: FormItemView<FormErrorItem> {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.preservesSuperviewLayoutMargins = true
 
-        return stackView.adyen.wrapped(with: UIEdgeInsets(top: 8, left: 16, bottom: -8, right: -16))
+        return stackView.adyen.wrapped(with: UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16))
     }()
 
     // MARK: - Message

--- a/Adyen/UI/Form/Items/Phone Number/Phone Extension Picker/FormPhoneExtensionPickerItemView.swift
+++ b/Adyen/UI/Form/Items/Phone Number/Phone Extension Picker/FormPhoneExtensionPickerItemView.swift
@@ -82,7 +82,7 @@ public final class FormPhoneExtensionPickerItemView: FormItemView<FormPhoneExten
         addSubview(button)
         
         stackView.adyen.anchor(inside: button)
-        button.adyen.anchor(inside: self, with: .init(top: 0, left: 0, bottom: -1, right: -6))
+        button.adyen.anchor(inside: self, with: .init(top: 0, left: 0, bottom: 1, right: 6))
     }
     
     internal func updateSelection() {

--- a/Adyen/UI/Form/Items/Value Pickers/Abstract/BasePickerInputControl.swift
+++ b/Adyen/UI/Form/Items/Value Pickers/Abstract/BasePickerInputControl.swift
@@ -125,7 +125,7 @@ internal class BasePickerInputControl: UIControl, PickerTextInputControl {
         stackView.isUserInteractionEnabled = false
 
         addSubview(stackView)
-        stackView.adyen.anchor(inside: self, with: .init(top: 0, left: 0, bottom: -1, right: -6))
+        stackView.adyen.anchor(inside: self, with: .init(top: 0, left: 0, bottom: 1, right: 6))
     }
 
     @objc

--- a/Adyen/UI/List/ListFooterView.swift
+++ b/Adyen/UI/List/ListFooterView.swift
@@ -52,7 +52,7 @@ internal final class ListFooterView: UIView {
     }()
 
     private lazy var titleContainerView: UIView = {
-        titleBackgroundView.adyen.wrapped(with: UIEdgeInsets(top: 6, left: 16, bottom: -12, right: -16))
+        titleBackgroundView.adyen.wrapped(with: .init(top: 6, left: 16, bottom: 12, right: 16))
     }()
 
     private lazy var titleLabel: UILabel = {
@@ -67,7 +67,7 @@ internal final class ListFooterView: UIView {
     }()
 
     private lazy var titleBackgroundView: UIView = {
-        let view = titleLabel.adyen.wrapped(with: UIEdgeInsets(top: 8, left: 16, bottom: -8, right: -16))
+        let view = titleLabel.adyen.wrapped(with: .init(top: 8, left: 16, bottom: 8, right: 16))
         view.backgroundColor = style.title.backgroundColor
         view.adyen.round(using: style.title.cornerRounding)
         return view

--- a/AdyenActions/UI/View Controllers/Document/DocumentActionView.swift
+++ b/AdyenActions/UI/View Controllers/Document/DocumentActionView.swift
@@ -97,7 +97,7 @@ internal final class DocumentActionView: UIView {
     private func configureViews() {
         backgroundColor = style.backgroundColor
         addSubview(stackView)
-        stackView.adyen.anchor(inside: .view(self), edgeInsets: .init(left: 20, right: -20))
+        stackView.adyen.anchor(inside: .view(self), edgeInsets: .init(left: 20, right: 20))
         NSLayoutConstraint.activate([stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
                                      stackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
                                      stackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -30)])

--- a/AdyenActions/UI/View Controllers/Voucher/ShareableVoucherView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/ShareableVoucherView.swift
@@ -70,7 +70,7 @@ internal class ShareableVoucherView: UIView, Localizable {
     internal func createTopView() -> UIView {
         logoView.image = model.logo
         let textLabelWrapper = textLabel.adyen.wrapped(
-            with: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: -16)
+            with: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         )
         let stackView = UIStackView(arrangedSubviews: [logoView,
                                                        textLabelWrapper,
@@ -125,7 +125,7 @@ internal class ShareableVoucherView: UIView, Localizable {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         
         let containerView = stackView.adyen.wrapped(
-            with: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: -16)
+            with: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         )
         valueLabel.widthAnchor.constraint(
             lessThanOrEqualTo: containerView.widthAnchor,

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherCardView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherCardView.swift
@@ -90,20 +90,21 @@ internal class VoucherCardView: UIView {
         buildContainerLayer()
 
         addSubview(stackView)
-        stackView.adyen.anchor(inside: self, with: innerViewsInset)
+        stackView.adyen.anchor(
+            inside: self,
+            with: .init(
+                top: containerInsets.top + 16,
+                left: containerInsets.left,
+                bottom: containerInsets.bottom + 16,
+                right: containerInsets.right
+            )
+        )
 
         separatorView.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
         separatorView.heightAnchor.constraint(equalToConstant: 20).isActive = true
 
         bottomView.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
         topView.widthAnchor.constraint(equalTo: stackView.widthAnchor).isActive = true
-    }
-
-    private var innerViewsInset: UIEdgeInsets {
-        UIEdgeInsets(top: containerInsets.top + 16,
-                     left: containerInsets.left,
-                     bottom: -containerInsets.bottom - 16,
-                     right: -containerInsets.right)
     }
 
     private func buildContainerLayer() {

--- a/AdyenCard/Form/FormCardLogosItemView.swift
+++ b/AdyenCard/Form/FormCardLogosItemView.swift
@@ -31,7 +31,7 @@ internal final class FormCardLogosItemView: FormItemView<FormCardLogosItem> {
     internal required init(item: FormCardLogosItem) {
         super.init(item: item)
         addSubview(collectionView)
-        collectionView.adyen.anchor(inside: self, with: UIEdgeInsets(top: 4, left: 16, bottom: -8, right: -16))
+        collectionView.adyen.anchor(inside: self, with: UIEdgeInsets(top: 4, left: 16, bottom: 8, right: 16))
         collectionView.register(CardLogoCell.self, forCellWithReuseIdentifier: CardLogoCell.reuseIdentifier)
         collectionView.dataSource = self
     }

--- a/Demo/UIKit/ComponentsView.swift
+++ b/Demo/UIKit/ComponentsView.swift
@@ -113,7 +113,7 @@ internal final class ComponentsView: UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(switchStackView)
         switchStackView.anchor(inside: view.layoutMarginsGuide,
-                               with: .init(top: 0, left: 20, bottom: 0, right: -20))
+                               with: .init(top: 0, left: 20, bottom: 0, right: 20))
         return view
     }()
     


### PR DESCRIPTION
## Background
The `UIViewConstraintsHelper` offer an `anchor` function to easily add constraints to a view. Because it uses auto layout it was implemented in a way that the values of `UIEdgeInset` were just forwarded as the top/bottom/leading/trailing constants, which caused passing negative numbers for bottom/trailing and positive numbers for top/leading in some places.

## Summary
- `anchor` now expects positive numbers for bottom/trailing if you want to inset from the bottom/trailing anchor