### PR TITLE
Remove deprecated property on ApplePay Configuration

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -125,7 +125,7 @@ extension ApplePayComponent {
             if #available(iOS 15.0, *) {
                 paymentRequest.couponCode = couponCode
                 paymentRequest.supportsCouponCode = supportsCouponCode
-                paymentRequest.shippingContactEditingMode = allowShippingContactEditing ? .enabled : .storePickup
+                paymentRequest.shippingContactEditingMode = allowShippingContactEditing ? .available : .storePickup
             }
             
             return paymentRequest


### PR DESCRIPTION
# Open PR

## Changes

* remove deprecated [PKShippingContactEditingMode.enabled](https://developer.apple.com/documentation/passkit_apple_pay_and_wallet/pkshippingcontacteditingmode/3747099-enabled), use [PKShippingContactEditingMode.available](https://developer.apple.com/documentation/passkit_apple_pay_and_wallet/pkshippingcontacteditingmode/available) instead.