### PR TITLE
Fixing debug build crash on device

### DIFF
--- a/AdyenActions/UI/UI Style/ActionComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/ActionComponentStyle.swift
@@ -24,9 +24,6 @@ public struct ActionComponentStyle {
     
     /// Indicates the UI configuration of the document action component.
     public var documentActionComponentStyle: DocumentComponentStyle
-    
-    /// Indicates the UI configuration of the delegated authentication screens.
-    public var delegatedAuthenticationComponentStyle: DelegatedAuthenticationComponentStyle
 
     /// Initializes the
     /// - Parameters:
@@ -41,14 +38,12 @@ public struct ActionComponentStyle {
         awaitComponentStyle: AwaitComponentStyle = AwaitComponentStyle(),
         voucherComponentStyle: VoucherComponentStyle = VoucherComponentStyle(),
         qrCodeComponentStyle: QRCodeComponentStyle = QRCodeComponentStyle(),
-        documentActionComponentStyle: DocumentComponentStyle = DocumentComponentStyle(),
-        delegatedAuthenticationComponentStyle: DelegatedAuthenticationComponentStyle = DelegatedAuthenticationComponentStyle()
+        documentActionComponentStyle: DocumentComponentStyle = DocumentComponentStyle()
     ) {
         self.redirectComponentStyle = redirectComponentStyle
         self.awaitComponentStyle = awaitComponentStyle
         self.voucherComponentStyle = voucherComponentStyle
         self.qrCodeComponentStyle = qrCodeComponentStyle
         self.documentActionComponentStyle = documentActionComponentStyle
-        self.delegatedAuthenticationComponentStyle = delegatedAuthenticationComponentStyle
     }
 }

--- a/AdyenActions/UI/UI Style/ActionComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/ActionComponentStyle.swift
@@ -32,7 +32,6 @@ public struct ActionComponentStyle {
     ///   - voucherComponentStyle: The UI configuration of the voucher component.
     ///   - qrCodeComponentStyle: The UI configuration of the QR code component.
     ///   - documentActionComponentStyle: The UI configuration of the document action component.
-    ///   - delegatedAuthenticationComponentStyle: The UI configuration of the delegated authentication component.
     public init(
         redirectComponentStyle: RedirectComponentStyle = RedirectComponentStyle(),
         awaitComponentStyle: AwaitComponentStyle = AwaitComponentStyle(),


### PR DESCRIPTION
## Summary
- Remove delegated authentication style property from action component style as it lead to a crash on a physical device when running in debug mode. Probably due to increased size of the style object.
