### PR TITLE
Fixing public api change detection workflow source path

### DIFF
--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -43,11 +43,8 @@ jobs:
             LATEST_TAG=$(git describe --tags --abbrev=0)
             OLD="$LATEST_TAG~${githubRepo}"
         else
-            OLD="${source}~${githubRepo}"
+            OLD="${target}~${githubRepo}"
         fi
-        
-        echo $NEW
-        echo $OLD
         
         cd Scripts
         ./public-api-diff --new "$NEW" --old "$OLD" --output "$PROJECT_FOLDER/api_comparison.md"

--- a/.github/workflows/publish-demo-app.yml
+++ b/.github/workflows/publish-demo-app.yml
@@ -1,4 +1,4 @@
-name: Publish Demo App
+name: 🚀 Publish Demo App
 on: [workflow_dispatch]
 jobs:
 

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -1,4 +1,4 @@
-name: Validate PR labels and release notes
+name: 🏷️ Validate PR labels and release notes
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
With the last change of considering the last release when on a `release/*` branch, a small bug was introduced.
the $OLD path was targeting the current branch so the change detection broke.

### Additionally
Adding some nice emojis for other workflows
