### PR TITLE
Add accessibility identifier for "close" button to enable DropIn Card component e2e testing 

### DIFF
--- a/Adyen/Core/ToolBar/ModalToolbar.swift
+++ b/Adyen/Core/ToolBar/ModalToolbar.swift
@@ -85,6 +85,9 @@ public class ModalToolbar: UIView, AnyNavigationBar {
             addSubview(stackView)
             stackView.adyen.anchor(inside: self)
         }
+        
+        self.accessibilityIdentifier = "adyen.ModalToolbar"
+        cancelButton.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "closeButton")
 
         setupStyle()
     }


### PR DESCRIPTION
In order to make e2e tests more robust and future-proof, this adds missing accessibility id for the close button in the DropIn card component.

<img width="352" alt="image" src="https://github.com/user-attachments/assets/fce396dd-3a8c-475e-9f44-391c355d3891">
