### PR TITLE
Fix crash: duplicate items when rendering payment methods list

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -409,6 +409,7 @@
 		B62D48C52BBE8F3B001EF01A /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62D48C22BBE8ED6001EF01A /* XCTestCase+Wait.swift */; };
 		B62D48C62BBE8F45001EF01A /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62D48C22BBE8ED6001EF01A /* XCTestCase+Wait.swift */; };
 		B62D48C82BBE8F47001EF01A /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62D48C22BBE8ED6001EF01A /* XCTestCase+Wait.swift */; };
+		B6ABA1C32CA6B058003514E5 /* ListItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ABA1C22CA6B058003514E5 /* ListItemTests.swift */; };
 		B6D808032BCD140E00F3F5EB /* AssetsAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91760A62594C5DF00D653BE /* AssetsAccessTests.swift */; };
 		B6D808042BCD147600F3F5EB /* UILabelHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD40F42263150F90090E01C /* UILabelHelpersTests.swift */; };
 		B6D808052BCD147600F3F5EB /* KeyedDecodingContainerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9021E032264C55E009CF7F4 /* KeyedDecodingContainerExtensionsTests.swift */; };
@@ -1785,6 +1786,8 @@
 		B62D48AC2BBE8D79001EF01A /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B62D48C22BBE8ED6001EF01A /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		B62D48CA2BBE9059001EF01A /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
+		B6ABA1C12CA6A779003514E5 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		B6ABA1C22CA6B058003514E5 /* ListItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemTests.swift; sourceTree = "<group>"; };
 		B6EE0F432BBEBFD000B9810D /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
 		C90D26A627565750001A488F /* FormViewController+ViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormViewController+ViewProtocol.swift"; sourceTree = "<group>"; };
 		C90D26B1275900B9001A488F /* BACSInputFormViewProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BACSInputFormViewProtocolMock.swift; sourceTree = "<group>"; };
@@ -3832,6 +3835,7 @@
 		E2C0E02922097916008616F6 = {
 			isa = PBXGroup;
 			children = (
+				B6ABA1C12CA6A779003514E5 /* Config.xcconfig */,
 				F9A1B477283B689F005F3145 /* Adyen.docc */,
 				F94B870925EFB71100D270A6 /* MIGRATION.md */,
 				E27B8EAD22B79CD20075BB6A /* README.md */,
@@ -4527,6 +4531,7 @@
 				81DC5A502A73C52500DBF2D1 /* AdyenContextTests.swift */,
 				81FC2C922BB198AB007F1316 /* ImageLoaderTests.swift */,
 				81A91AB62BEBEA21001E00C8 /* OpenExternalAppDetectorTests.swift */,
+				B6ABA1C22CA6B058003514E5 /* ListItemTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -6729,6 +6734,7 @@
 				B6D808322BCD1F8900F3F5EB /* BalanceCheckerTests.swift in Sources */,
 				B6D808192BCD151F00F3F5EB /* PaymentMethodMock.swift in Sources */,
 				B6D808052BCD147600F3F5EB /* KeyedDecodingContainerExtensionsTests.swift in Sources */,
+				B6ABA1C32CA6B058003514E5 /* ListItemTests.swift in Sources */,
 				B6D808092BCD147600F3F5EB /* StringExtensionsTests.swift in Sources */,
 				B6D808152BCD151F00F3F5EB /* AppLauncherMock.swift in Sources */,
 				B62D48B52BBE8DBE001EF01A /* AnalyticsEventTests.swift in Sources */,

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -1786,7 +1786,6 @@
 		B62D48AC2BBE8D79001EF01A /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B62D48C22BBE8ED6001EF01A /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		B62D48CA2BBE9059001EF01A /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
-		B6ABA1C12CA6A779003514E5 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		B6ABA1C22CA6B058003514E5 /* ListItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemTests.swift; sourceTree = "<group>"; };
 		B6EE0F432BBEBFD000B9810D /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
 		C90D26A627565750001A488F /* FormViewController+ViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormViewController+ViewProtocol.swift"; sourceTree = "<group>"; };
@@ -3835,7 +3834,6 @@
 		E2C0E02922097916008616F6 = {
 			isa = PBXGroup;
 			children = (
-				B6ABA1C12CA6A779003514E5 /* Config.xcconfig */,
 				F9A1B477283B689F005F3145 /* Adyen.docc */,
 				F94B870925EFB71100D270A6 /* MIGRATION.md */,
 				E27B8EAD22B79CD20075BB6A /* README.md */,

--- a/Adyen/UI/List/ListItem.swift
+++ b/Adyen/UI/List/ListItem.swift
@@ -105,7 +105,7 @@ public class ListItem: FormItem {
 
     // MARK: - Private
     
-    private let listIdentifier: UUID = UUID()
+    private let listIdentifier: UUID = .init()
 }
 
 // MARK: - Hashable & Equatable

--- a/Adyen/UI/List/ListItem.swift
+++ b/Adyen/UI/List/ListItem.swift
@@ -102,6 +102,10 @@ public class ListItem: FormItem {
         
         loadingHandler(isLoading, self)
     }
+
+    // MARK: - Private
+    
+    internal var listIdentifier: UUID = UUID()
 }
 
 // MARK: - Hashable & Equatable
@@ -110,12 +114,10 @@ public class ListItem: FormItem {
 extension ListItem: Hashable {
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(title)
-        hasher.combine(icon)
-        hasher.combine(trailingText)
+        hasher.combine(listIdentifier)
     }
     
     public static func == (lhs: ListItem, rhs: ListItem) -> Bool {
-        lhs.title == rhs.title && lhs.icon == rhs.icon && lhs.trailingText == rhs.trailingText
+        lhs.listIdentifier == rhs.listIdentifier && lhs.title == rhs.title
     }
 }

--- a/Adyen/UI/List/ListItem.swift
+++ b/Adyen/UI/List/ListItem.swift
@@ -105,7 +105,7 @@ public class ListItem: FormItem {
 
     // MARK: - Private
     
-    internal var listIdentifier: UUID = UUID()
+    private let listIdentifier: UUID = UUID()
 }
 
 // MARK: - Hashable & Equatable
@@ -118,6 +118,6 @@ extension ListItem: Hashable {
     }
     
     public static func == (lhs: ListItem, rhs: ListItem) -> Bool {
-        lhs.listIdentifier == rhs.listIdentifier && lhs.title == rhs.title
+        lhs.listIdentifier == rhs.listIdentifier
     }
 }

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -457,4 +457,3 @@ extension GiftCardComponent: PartialPaymentComponent {}
 
 @_spi(AdyenInternal)
 extension GiftCardComponent: PublicKeyConsumer {}
-

--- a/Tests/UnitTests/Core/ListItemTests.swift
+++ b/Tests/UnitTests/Core/ListItemTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable @_spi(AdyenInternal) import Adyen
 
 final class ListItemTests: XCTestCase {
-    // Checks COIOS-797 fix
+    // Checks COIOS-797: NSInternalInconsistencyException 1008: Item identifiers are not unique
     func test_listItem_isAlwaysUnique() {
         let item1 = ListItem(title: "Test title 11", icon: .dummy(), trailingText: "Text")
         let item2 = ListItem(title: "Test title 11", icon: .dummy(), trailingText: "Text")

--- a/Tests/UnitTests/Core/ListItemTests.swift
+++ b/Tests/UnitTests/Core/ListItemTests.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2024 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import XCTest
+@testable @_spi(AdyenInternal) import Adyen
+
+final class ListItemTests: XCTestCase {
+    // Checks COIOS-797 fix
+    func test_listItem_isAlwaysUnique() {
+        let item1 = ListItem(title: "Test title 11", icon: .dummy(), trailingText: "Text")
+        let item2 = ListItem(title: "Test title 11", icon: .dummy(), trailingText: "Text")
+
+        XCTAssertNotEqual(item1, item2, "Items used for UITableView sections should be unique even if visually they are identical")
+        XCTAssertNotEqual(item1.hashValue, item2.hashValue, "Items hashValues used for UITableViewDiffableDataSource should be unique even if visually they are identical")
+    }
+}
+
+private extension ListItem.Icon {
+    static func dummy() -> ListItem.Icon {
+        .init(image: UIImage.checkmark)
+    }
+}


### PR DESCRIPTION
# Summary
<fixed>
- On iOS 18, if the shopper has two identical stored payment methods, Drop-in/Component no longer crashes when the shopper selects a payment method that's not the default stored one.
</fixed>

# Details 
iOS18 release introduced new crash which didn't happen before.

When rendering payments list, in rare occasions we could have multiple payment methods having same title and description.
Providing ListItem that is used to render the list uses title as part of it's `Hashable` and `Equatable` conformance, resulting in having two identical entries.
This list typically has few sections: stored payment methods and generic payment methods. While any stored payment method always has an unique identifier coming from the backend, the rest of the sections do not.

That's why this fix does not use any backend-provided identifiers and relies purely on `UUID` that is created upon `ListItem` instantiation and doesn't get exposed anywhere else.
It can be improved by providing a parameter in the init so it could be injected from the outside.

## Note:
`ListItem` has `identifier` property that can be mistreated easily and abused. We use it so set an identifier that is later used as `accessibilityIdentifier` for UI elements. This is misleading as for such a case when we have two identical stored payment methods this could be a potential accessibility problem that will make second duped element on the list inaccessible.

## Screenshot 
![image](https://github.com/user-attachments/assets/15f62807-30e7-46a7-b786-fcb11e2f1a0b)

<youtrack>COIOS-797</youtrack>
