### PR TITLE
Fix crash: duplicate items when rendering payment methods list

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		A0F41EAC26CD4AA50089AD6C /* FormCardInstallmentsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F41EAB26CD4AA50089AD6C /* FormCardInstallmentsItem.swift */; };
 		A0FA143F26D65A5300627127 /* InstallmentPickerElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FA143E26D65A5300627127 /* InstallmentPickerElement.swift */; };
 		A0FA145726D65B6200627127 /* FormCardInstallmentsItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FA145626D65B6200627127 /* FormCardInstallmentsItemView.swift */; };
+		B6A5104E2CAC1A8B00D34101 /* ListItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A5104D2CAC1A8B00D34101 /* ListItemTests.swift */; };
 		C90D26A727565750001A488F /* FormViewController+ViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90D26A627565750001A488F /* FormViewController+ViewProtocol.swift */; };
 		C9126051275A3A2800C03DC4 /* BACSItemsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9126050275A3A2800C03DC4 /* BACSItemsFactoryTests.swift */; };
 		C927083827590B7500D15EA0 /* BACSInputFormViewProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C90D26B1275900B9001A488F /* BACSInputFormViewProtocolMock.swift */; };
@@ -1043,6 +1044,7 @@
 		A0F41EAB26CD4AA50089AD6C /* FormCardInstallmentsItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardInstallmentsItem.swift; sourceTree = "<group>"; };
 		A0FA143E26D65A5300627127 /* InstallmentPickerElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallmentPickerElement.swift; sourceTree = "<group>"; };
 		A0FA145626D65B6200627127 /* FormCardInstallmentsItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardInstallmentsItemView.swift; sourceTree = "<group>"; };
+		B6A5104D2CAC1A8B00D34101 /* ListItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemTests.swift; sourceTree = "<group>"; };
 		C90D26A627565750001A488F /* FormViewController+ViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormViewController+ViewProtocol.swift"; sourceTree = "<group>"; };
 		C90D26B1275900B9001A488F /* BACSInputFormViewProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BACSInputFormViewProtocolMock.swift; sourceTree = "<group>"; };
 		C90D26B32759048C001A488F /* BACSInputPresenterProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BACSInputPresenterProtocolMock.swift; sourceTree = "<group>"; };
@@ -2946,6 +2948,7 @@
 		E97B9718229D54C600505476 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				B6A5104D2CAC1A8B00D34101 /* ListItemTests.swift */,
 				E97B9719229D54D600505476 /* ActionTests.swift */,
 				E262128C22A8FE6700F2B133 /* PaymentMethodTests.swift */,
 				F9EDB79F2397BD8500CFB3C9 /* TestPaymentMethodsJson.swift */,
@@ -5125,6 +5128,7 @@
 				F9EDB79E2397AEF400CFB3C9 /* ComponentManagerTests.swift in Sources */,
 				F9EDB7922396603F00CFB3C9 /* PaymentMethodListComponentTests.swift in Sources */,
 				F92385B72757AE8B0082F7B7 /* XCTestCaseExtensions.swift in Sources */,
+				B6A5104E2CAC1A8B00D34101 /* ListItemTests.swift in Sources */,
 				F919DFA224ED599D0027976E /* AdyenActionComponentTests.swift in Sources */,
 				C927083927590B7900D15EA0 /* BACSInputPresenterProtocolMock.swift in Sources */,
 				E702BE192602525E00280682 /* AssertsTests.swift in Sources */,

--- a/Adyen/UI/List/ListItem.swift
+++ b/Adyen/UI/List/ListItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2018 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -69,6 +69,9 @@ public class ListItem: FormItem {
         builder.build(with: self)
     }
     
+    // MARK: - Private
+        
+    private let listIdentifier: UUID = .init()
 }
 
 // MARK: - Hashable & Equatable
@@ -77,13 +80,10 @@ public class ListItem: FormItem {
 extension ListItem: Hashable {
     
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(title)
-        hasher.combine(imageURL)
-        hasher.combine(trailingText)
+        hasher.combine(listIdentifier)
     }
     
     public static func == (lhs: ListItem, rhs: ListItem) -> Bool {
-        lhs.title == rhs.title && lhs.imageURL == rhs.imageURL && lhs.trailingText == rhs.trailingText
+        lhs.listIdentifier == rhs.listIdentifier
     }
-    
 }

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) 2017 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/AdyenTests/Adyen Tests/Core/ListItemTests.swift
+++ b/Tests/AdyenTests/Adyen Tests/Core/ListItemTests.swift
@@ -1,0 +1,21 @@
+//
+// Copyright (c) 2024 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import XCTest
+@testable @_spi(AdyenInternal) import Adyen
+
+final class ListItemTests: XCTestCase {
+    // Checks COIOS-797: NSInternalInconsistencyException 1008: Item identifiers are not unique
+    private let imageURL = URL(string: "https://image.url")!
+    
+    func test_listItem_isAlwaysUnique() {
+        let item1 = ListItem(title: "Test title 11", imageURL: imageURL, trailingText: "Text")
+        let item2 = ListItem(title: "Test title 11", imageURL: imageURL, trailingText: "Text")
+
+        XCTAssertNotEqual(item1, item2, "Items used for UITableView sections should be unique even if visually they are identical")
+        XCTAssertNotEqual(item1.hashValue, item2.hashValue, "Items hashValues used for UITableViewDiffableDataSource should be unique even if visually they are identical")
+    }
+}

--- a/Tests/AdyenTests/Card Tests/CardComponentTests.swift
+++ b/Tests/AdyenTests/Card Tests/CardComponentTests.swift
@@ -1350,9 +1350,9 @@ class CardComponentTests: XCTestCase {
         XCTAssertFalse(expDateItem.isValid())
         XCTAssertEqual(sut.cardViewController.card.expiryYear, "20")
         XCTAssertEqual(sut.cardViewController.card.expiryMonth, "1")
-        expDateItem.value = "0224"
+        expDateItem.value = "0226"
         XCTAssertTrue(expDateItem.isValid())
-        XCTAssertEqual(sut.cardViewController.card.expiryYear, "2024")
+        XCTAssertEqual(sut.cardViewController.card.expiryYear, "2026")
         XCTAssertEqual(sut.cardViewController.card.expiryMonth, "02")
         
         expDateItem.isOptional = brands[1].isExpiryDateOptional


### PR DESCRIPTION
# Summary
<fixed>
- On iOS 18, if the shopper has two identical stored payment methods, Drop-in/Component no longer crashes when the shopper selects a payment method that's not the default stored one.
</fixed>

Replicates https://github.com/Adyen/adyen-ios/pull/1840 for v4

<ticket>COIOS-800</ticket>
