### PR TITLE
Always make the initial analytics call

### DIFF
--- a/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
+++ b/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
@@ -32,7 +32,6 @@ internal final class AnalyticsProvider: AnalyticsProviderProtocol {
         static let infoLimit = 50
         static let logLimit = 5
         static let errorLimit = 5
-        static let attemptIdFetchFailed = "fetch-checkoutAttemptId-failed"
     }
 
     // MARK: - Properties
@@ -46,10 +45,6 @@ internal final class AnalyticsProvider: AnalyticsProviderProtocol {
     
     private var batchTimer: Timer?
     private let batchInterval: TimeInterval
-    
-    private var isValidAttemptId: Bool {
-        checkoutAttemptId != Constants.attemptIdFetchFailed
-    }
 
     // MARK: - Initializers
 
@@ -130,8 +125,7 @@ internal final class AnalyticsProvider: AnalyticsProviderProtocol {
     
     /// Checks the event arrays safely and creates the request with them if there is any to send.
     private func requestWithAllEvents() -> AnalyticsRequest? {
-        guard isValidAttemptId,
-              let checkoutAttemptId,
+        guard let checkoutAttemptId,
               let events = eventDataSource.allEvents() else { return nil }
         
         // as per this call's limitation, we only send up to the
@@ -152,7 +146,7 @@ internal final class AnalyticsProvider: AnalyticsProviderProtocol {
         case let .success(response):
             checkoutAttemptId = response.checkoutAttemptId
         case .failure:
-            checkoutAttemptId = Constants.attemptIdFetchFailed
+            checkoutAttemptId = nil
         }
     }
     

--- a/Tests/UnitTests/Analytics/AnalyticsEventTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsEventTests.swift
@@ -36,7 +36,7 @@ class AnalyticsEventTests: XCTestCase {
         sut.sendInitialAnalytics(with: flavor, additionalFields: nil)
     }
 
-    func testSendInitialEventGivenAnalyticsIsDisabledShouldNotSendAnyRequest() throws {
+    func testSendInitialEventGivenAnalyticsIsDisabledShouldNotSendRequest() throws {
         // Given
         var analyticsConfiguration = AnalyticsConfiguration()
         analyticsConfiguration.isEnabled = false
@@ -45,15 +45,18 @@ class AnalyticsEventTests: XCTestCase {
             configuration: analyticsConfiguration,
             eventDataSource: AnalyticsEventDataSource()
         )
-
-        let expectedRequestCalls = 0
+        
+        let checkoutAttemptIdResult: Result<Response, Error> = .success(checkoutAttemptIdResponse)
+        apiClient.mockedResults = [checkoutAttemptIdResult]
 
         // When
         sendInitialAnalytics()
 
         // Then
-        XCTAssertEqual(expectedRequestCalls, apiClient.counter, "One or more analytics requests were sent.")
-        XCTAssertEqual(sut.checkoutAttemptId, "do-not-track")
+        // Then
+        wait(for: .milliseconds(1))
+        XCTAssertEqual(apiClient.counter, 1, "One or more analytics requests were sent.")
+        XCTAssertEqual(sut.checkoutAttemptId, "cb3eef98-978e-4f6f-b299-937a4450be1f1648546838056be73d8f38ee8bcc3a65ec14e41b037a59f255dcd9e83afe8c06bd3e7abcad993")
     }
 
     func testSendInitialEventGivenEnabledAndFlavorIsComponentsShouldSendInitialRequest() throws {

--- a/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
@@ -70,28 +70,6 @@ class AnalyticsProviderTests: XCTestCase {
         sut.sendInitialAnalytics(with: .components(type: .affirm), additionalFields: nil)
         wait(until: sut, at: \.checkoutAttemptId, is: expectedCheckoutAttemptId)
     }
-    
-    func testFetchCheckoutAttemptIdFailedResult() throws {
-        // Given
-        var analyticsConfiguration = AnalyticsConfiguration()
-        analyticsConfiguration.isEnabled = true
-
-        let apiClient = APIClientMock()
-        let sut = AnalyticsProvider(
-            apiClient: apiClient,
-            configuration: analyticsConfiguration,
-            eventDataSource: eventDataSource
-        )
-
-        let failedResult: Result<Response, Error> = .failure(Dummy.error)
-        apiClient.mockedResults = [failedResult]
-
-        // When
-        sut.sendInitialAnalytics(with: .components(type: .achDirectDebit), additionalFields: nil)
-        
-        // Then
-        wait(until: sut, at: \.checkoutAttemptId, is: "fetch-checkoutAttemptId-failed")
-    }
 
     func testFetchCheckoutAttemptIdWhenRequestSucceedShouldCallCompletionWithNonNilValue() throws {
         // Given


### PR DESCRIPTION
We now always make the initial analytics call to just fetch the checkout attempt id.

<ticket>
COIOS-782 
</ticket>