### PR TITLE
Add Github workflow to ensure ticket reference is present

### DIFF
--- a/.github/workflows/validate_youtrack_ticket.yml
+++ b/.github/workflows/validate_youtrack_ticket.yml
@@ -5,11 +5,10 @@ on:
     types: [opened, synchronize, reopened, edited]
   branches:
     - develop
-  paths-ignore:
-    - 'release/*'
 jobs:
   validate-ticket:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.base.ref == 'develop' && !startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
       - name: Check ticket reference
       - env:

--- a/.github/workflows/validate_youtrack_ticket.yml
+++ b/.github/workflows/validate_youtrack_ticket.yml
@@ -1,0 +1,22 @@
+name: 🎫 Validate ticket reference
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  branches:
+    - develop
+  paths-ignore:
+    - 'release/*'
+jobs:
+  validate-ticket:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check ticket reference
+      - env:
+        PR_BODY: ${{github.event.pull_request.body}}
+        TICKET_REGEX: '<ticket>COIOS-[0-9]+</ticket>'
+      - run: |
+        if ! grep -qE "$TICKET_REGEX" <<< "$PR_BODY"; then
+            echo "::error::Pull requests must have a ticket number in the pull request body in the format '<ticket>COIOS-XXX</ticket>' where XXX is a numeric ticket number"
+            exit 1
+        fi

--- a/.github/workflows/validate_youtrack_ticket.yml
+++ b/.github/workflows/validate_youtrack_ticket.yml
@@ -3,8 +3,6 @@ name: 🎫 Validate ticket reference
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
-  branches:
-    - develop
 jobs:
   validate-ticket:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate_youtrack_ticket.yml
+++ b/.github/workflows/validate_youtrack_ticket.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.base.ref == 'develop' && !startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
+      - uses: actions/checkout@v2
       - name: Check ticket reference
       - env:
         PR_BODY: ${{github.event.pull_request.body}}

--- a/.github/workflows/validate_youtrack_ticket.yml
+++ b/.github/workflows/validate_youtrack_ticket.yml
@@ -3,17 +3,20 @@ name: 🎫 Validate ticket reference
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+
 jobs:
   validate-ticket:
     runs-on: ubuntu-latest
     if: github.event.pull_request.base.ref == 'develop' && !startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out
+        uses: actions/checkout@v2
+        
       - name: Check ticket reference
-      - env:
-        PR_BODY: ${{github.event.pull_request.body}}
-        TICKET_REGEX: '<ticket>COIOS-[0-9]+</ticket>'
-      - run: |
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          TICKET_REGEX: '<ticket>COIOS-[0-9]+</ticket>'
+        run: |
           if ! grep -qE "$TICKET_REGEX" <<< "$PR_BODY"; then
             echo "::error::Pull requests must have a ticket number in the pull request body in the format '<ticket>COIOS-XXX</ticket>' where XXX is a numeric ticket number"
             exit 1

--- a/.github/workflows/validate_youtrack_ticket.yml
+++ b/.github/workflows/validate_youtrack_ticket.yml
@@ -16,7 +16,7 @@ jobs:
         PR_BODY: ${{github.event.pull_request.body}}
         TICKET_REGEX: '<ticket>COIOS-[0-9]+</ticket>'
       - run: |
-        if ! grep -qE "$TICKET_REGEX" <<< "$PR_BODY"; then
+          if ! grep -qE "$TICKET_REGEX" <<< "$PR_BODY"; then
             echo "::error::Pull requests must have a ticket number in the pull request body in the format '<ticket>COIOS-XXX</ticket>' where XXX is a numeric ticket number"
             exit 1
-        fi
+          fi


### PR DESCRIPTION
# Summary

To make developer experience easier when investigating issues we decided to add internal tracking system ticket number as an XML tag to our pull request descriptions. 

Expected format:
`<ticket>COIOS-{number}</ticket>`

This workflow should fail the pipeline if ticket is missing.

For this PR ticket number is <ticket>COIOS-801</ticket>

# Todo
- [ ] Update internal documentation after merge