### PR TITLE
Exclude bot PRs from ticket checks

### DIFF
--- a/.github/workflows/validate_ticket.yml
+++ b/.github/workflows/validate_ticket.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Check ticket reference
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-          TICKET_REGEX: '<ticket>COIOS-[0-9]+</ticket>'
+          TICKET_REGEX: '<ticket>\s*COIOS-[0-9]+\s*</ticket>'
         run: |
-          if ! grep -qE "$TICKET_REGEX" <<< "$PR_BODY"; then
+          if ! grep -zqP "$TICKET_REGEX" <<< "$PR_BODY"; then
             echo "::error::Pull requests must have a ticket number in the pull request body in the format '<ticket>COIOS-XXX</ticket>' where XXX is a numeric ticket number"
             exit 1
           fi

--- a/.github/workflows/validate_ticket.yml
+++ b/.github/workflows/validate_ticket.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   validate-ticket:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.base.ref == 'develop' && !startsWith(github.event.pull_request.head.ref, 'release/')
+    if: github.event.pull_request.base.ref == 'develop' && !startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.actor, 'renovate')
     steps:
       - name: Check out
         uses: actions/checkout@v2


### PR DESCRIPTION
# Summary 

- We don't need to have tickets for automatic dependency updates so this excludes PS authored by renovatebot from checks
- Regex now is quite strict and doesn't pass when tags and content are separated with newline, this PR relaxes the check

<ticket>COIOS-801</ticket>