### PR TITLE
chore: set special attemptId in payments object on fetch fail

### DIFF
--- a/Adyen/Analytics/Models/AnalyticsConstants.swift
+++ b/Adyen/Analytics/Models/AnalyticsConstants.swift
@@ -9,6 +9,9 @@ import Foundation
 @_spi(AdyenInternal)
 public enum AnalyticsConstants {
     
+    /// A constant to pass into the payment data object in the case where fetching the checkout attempt Id fails.
+    public static let fetchCheckoutAttemptIdFailed = "fetch-checkoutAttemptId-failed"
+    
     public enum ValidationErrorCodes {
         
         public static let cardNumberEmpty = 900

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -33,8 +33,8 @@ extension PaymentComponent {
         sendSubmitEvent()
         
         let component = component ?? self
-        
-        let updatedData = data.replacing(checkoutAttemptId: component.context.analyticsProvider?.checkoutAttemptId)
+        let checkoutAttemptId = component.context.analyticsProvider?.checkoutAttemptId ?? AnalyticsConstants.fetchCheckoutAttemptIdFailed
+        let updatedData = data.replacing(checkoutAttemptId: checkoutAttemptId)
 
         guard updatedData.browserInfo == nil else {
             delegate?.didSubmit(updatedData, from: component)


### PR DESCRIPTION
## Summary
In the event that fetching the checkout attempt id fails, we are passing a specific constant in the payments object for the value of `checkoutAttemptId`


<ticket>COIOS-789</ticket>
