### PR TITLE
New public api diff

### DIFF
--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -47,7 +47,7 @@ jobs:
         fi
         
         cd Scripts
-        ./public-api-diff --new "$NEW" --old "$OLD" --output "$PROJECT_FOLDER/api_comparison.md" --log-output "$PROJECT_FOLDER/logs.txt"
+        ./public-api-diff project --new "$NEW" --old "$OLD" --output "$PROJECT_FOLDER/api_comparison.md" --log-output "$PROJECT_FOLDER/logs.txt"
         cat "$PROJECT_FOLDER/logs.txt"
         cat "$PROJECT_FOLDER/api_comparison.md" >> $GITHUB_STEP_SUMMARY
       env:

--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -47,7 +47,8 @@ jobs:
         fi
         
         cd Scripts
-        ./public-api-diff --new "$NEW" --old "$OLD" --output "$PROJECT_FOLDER/api_comparison.md"
+        ./public-api-diff --new "$NEW" --old "$OLD" --output "$PROJECT_FOLDER/api_comparison.md" --log-output "$PROJECT_FOLDER/logs.txt"
+        cat "$PROJECT_FOLDER/logs.txt"
         cat "$PROJECT_FOLDER/api_comparison.md" >> $GITHUB_STEP_SUMMARY
       env:
         source: '${{ github.event.inputs.new || github.head_ref }}'

--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -58,8 +58,8 @@ jobs:
        
     - if: ${{ github.event.pull_request.base.ref != '' }}
       name: 📝 Comment on PR
-      uses: thollander/actions-comment-pull-request@v2
+      uses: thollander/actions-comment-pull-request@v3
       with:
-        filePath: "${{ github.workspace }}/api_comparison.md"
-        comment_tag: api_changes
+        file-path: "${{ github.workspace }}/api_comparison.md"
+        comment-tag: api_changes
         mode: recreate


### PR DESCRIPTION
# Summary
Instead of a sdk-dump we are now using `.swiftinterface` files to create a diff.
These files automatically get created when archiving a swift project/package with library evolution enabled.

You can either provide 2 versions of your project/package `public-api-diff project --new ... --old ...` or your already generated `.swiftinterface` files for both versions you want to compare `public-api-diff swift-interface --new ... --old ...`

# Ticket

<ticket>
COIOS-791
</ticket>
