### PR TITLE
Make UISwitch form element accessible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ Package.resolved
 # CI temp files
 TempProject/
 .build
+.vscode

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,7 @@ opt_in_rules:
 
 excluded:
   - Build
+  - .build
   - Tests
   - Internal
   - Docs
@@ -26,7 +27,7 @@ line_length:
 file_length:
   warning: 500
   
-variable_name:
+identifier_name:
   min_length:
     warning: 2
   max_length:

--- a/Adyen/UI/Form/Items/Toggle/FormToggleItemView.swift
+++ b/Adyen/UI/Form/Items/Toggle/FormToggleItemView.swift
@@ -36,7 +36,7 @@ public final class FormToggleItemView: FormItemView<FormToggleItem> {
         switchControl.translatesAutoresizingMaskIntoConstraints = false
         switchControl.isOn = item.value
         switchControl.onTintColor = item.style.tintColor
-        switchControl.isAccessibilityElement = false
+        switchControl.isAccessibilityElement = true
         switchControl.setContentHuggingPriority(.required, for: .horizontal)
         switchControl.setContentCompressionResistancePriority(.required, for: .horizontal)
         switchControl.addTarget(self, action: #selector(switchControlValueChanged), for: .valueChanged)


### PR DESCRIPTION
# Summary

This change aims to address [this issue](https://github.com/Adyen/adyen-react-native/issues/532) enabling UISwitch elements to be accessible. They do have their own accessibility identifiers defined.

# Release notes

<new>
- Switch elements are now accessible for external testing with tools like Appium.
</new>

# Ticket

<ticket>
COIOS-808
</ticket>
