### PR TITLE
Add an event for closing the dropin

### DIFF
--- a/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
+++ b/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
@@ -59,7 +59,6 @@ internal final class AnalyticsProvider: AnalyticsProviderProtocol {
         self.uniqueAssetAPIClient = UniqueAssetAPIClient<InitialAnalyticsResponse>(apiClient: apiClient)
         self.eventDataSource = eventDataSource
         self.batchInterval = batchInterval
-        startNextTimer()
     }
     
     deinit {
@@ -145,6 +144,7 @@ internal final class AnalyticsProvider: AnalyticsProviderProtocol {
         switch result {
         case let .success(response):
             checkoutAttemptId = response.checkoutAttemptId
+            startNextTimer()
         case .failure:
             checkoutAttemptId = nil
         }
@@ -160,6 +160,8 @@ internal final class AnalyticsProvider: AnalyticsProviderProtocol {
     }
     
     private func startNextTimer() {
+        guard configuration.isEnabled else { return }
+        
         batchTimer?.invalidate()
         batchTimer = Timer.scheduledTimer(withTimeInterval: batchInterval, repeats: true) { [weak self] _ in
             self?.sendEventsIfNeeded()

--- a/Adyen/Analytics/Models/AnalyticsEventLog.swift
+++ b/Adyen/Analytics/Models/AnalyticsEventLog.swift
@@ -29,6 +29,7 @@ public struct AnalyticsEventLog: AnalyticsEvent {
         case submit = "Submit"
         case redirect = "Redirect"
         case threeDS2 = "ThreeDS2"
+        case closed = "Closed"
     }
     
     public enum LogSubType: String, Encodable {

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -279,7 +279,8 @@ public final class DropInComponent: NSObject,
         userDidCancel(component)
 
         if isRoot {
-            self.delegate?.didFail(with: ComponentError.cancelled, from: self)
+            sendExitEvent()
+            delegate?.didFail(with: ComponentError.cancelled, from: self)
         } else {
             navigationController.popViewController(animated: true)
         }
@@ -314,6 +315,11 @@ public final class DropInComponent: NSObject,
         (component as? PreApplePayComponent)?.presentationDelegate = self
 
         component._isDropIn = true
+    }
+    
+    private func sendExitEvent() {
+        let logEvent = AnalyticsEventLog(component: "dropin", type: .closed)
+        context.analyticsProvider?.add(log: logEvent)
     }
 }
 

--- a/Demo/Common/IntegrationExamples/DropIn/DropInExample.swift
+++ b/Demo/Common/IntegrationExamples/DropIn/DropInExample.swift
@@ -82,7 +82,7 @@ internal final class DropInExample: InitialDataFlowProtocol {
         let configuration = dropInConfiguration(from: paymentMethods)
         let component = DropInComponent(
             paymentMethods: paymentMethods,
-            context: generateContext(),
+            context: context,
             configuration: configuration,
             title: ConfigurationConstants.appName
         )


### PR DESCRIPTION
# Summary
Sends a new log event for when the close button of dropin is tapped.

Also updates the timer logic to start after the first analytics call rather than instantly starting and doing nothing.

# Ticket

<ticket>
COIOS-663
</ticket>
