### PR TITLE
Exclude SPM packages from Swiftlint run

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -20,7 +20,6 @@ jobs:
           any-of-labels: 'awaiting feedback'
           stale-issue-message: 'This issue is now stale because it has been open for 14 days with no activity. Please provide the requested information or the issue will be closed automatically.'
           close-issue-message: 'This issue is now closed because it has been stalled for 14 days with no activity.'
-          days-before-issue-stale: 0
-          days-before-issue-close: 0
           days-before-issue-stale: 14
           days-before-issue-close: 14
+          stale-issue-label: 'stale'

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -22,3 +22,5 @@ jobs:
           close-issue-message: 'This issue is now closed because it has been stalled for 14 days with no activity.'
           days-before-issue-stale: 0
           days-before-issue-close: 0
+          days-before-issue-stale: 14
+          days-before-issue-close: 14

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -22,4 +22,3 @@ jobs:
           close-issue-message: 'This issue is now closed because it has been stalled for 14 days with no activity.'
           days-before-issue-stale: 0
           days-before-issue-close: 0
-          debug-only: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,7 @@ opt_in_rules:
 
 excluded:
   - Build
+  - .build
   - Tests
   - Internal
   - Docs
@@ -26,7 +27,7 @@ line_length:
 file_length:
   warning: 500
   
-variable_name:
+identifier_name:
   min_length:
     warning: 2
   max_length:


### PR DESCRIPTION
# Summary

Local Swiftlint picks up wrong configuration files from underlying SPM packages that typically live inside the .build folder. This change adds .build folder to exemptions list.

# Ticket

<ticket>
COIOS-000
</ticket>
