### PR TITLE
Card number text field fix

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		81C5D0CE2AC4170A002E918F /* IssuerListComponentExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C5D0CC2AC4170A002E918F /* IssuerListComponentExample.swift */; };
 		81C5D0D02AC428CB002E918F /* IssuerListComponentAdvancedFlowExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C5D0CF2AC428CB002E918F /* IssuerListComponentAdvancedFlowExample.swift */; };
 		81C5D0D12AC428CB002E918F /* IssuerListComponentAdvancedFlowExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C5D0CF2AC428CB002E918F /* IssuerListComponentAdvancedFlowExample.swift */; };
+		81D7EC902CD24147005159F6 /* FormViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81D7EC8F2CD24143005159F6 /* FormViewControllerTests.swift */; };
 		81DA70812BDA5F66006CE5D5 /* PaymentMethods+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DA70802BDA5F66006CE5D5 /* PaymentMethods+Equatable.swift */; };
 		81DA70872BDA6075006CE5D5 /* Twint+Spy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DA70822BDA6075006CE5D5 /* Twint+Spy.swift */; };
 		81DA70882BDA6075006CE5D5 /* TwintSDKActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DA70832BDA6075006CE5D5 /* TwintSDKActionTests.swift */; };
@@ -1676,6 +1677,7 @@
 		81C4006F2A4347FD007EC51C /* FormErrorItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormErrorItemTests.swift; sourceTree = "<group>"; };
 		81C5D0CC2AC4170A002E918F /* IssuerListComponentExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuerListComponentExample.swift; sourceTree = "<group>"; };
 		81C5D0CF2AC428CB002E918F /* IssuerListComponentAdvancedFlowExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuerListComponentAdvancedFlowExample.swift; sourceTree = "<group>"; };
+		81D7EC8F2CD24143005159F6 /* FormViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormViewControllerTests.swift; sourceTree = "<group>"; };
 		81D8E2E82A5C06AC00BC12FD /* KeyboardObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardObserverTests.swift; sourceTree = "<group>"; };
 		81DA70802BDA5F66006CE5D5 /* PaymentMethods+Equatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PaymentMethods+Equatable.swift"; sourceTree = "<group>"; };
 		81DA70822BDA6075006CE5D5 /* Twint+Spy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Twint+Spy.swift"; sourceTree = "<group>"; };
@@ -4667,6 +4669,7 @@
 				F919DF9F24EABCC10027976E /* StoredCardComponentTests.swift */,
 				F9EDB799239664B500CFB3C9 /* StoredPaymentMethodComponentTests.swift */,
 				F919DF9824EA64680027976E /* CardPublicKeyProviderTests.swift */,
+				81D7EC8F2CD24143005159F6 /* FormViewControllerTests.swift */,
 			);
 			path = "Card Tests";
 			sourceTree = "<group>";
@@ -7186,6 +7189,7 @@
 				E773EA3A25221C4600119499 /* ThrottlerTests.swift in Sources */,
 				F97842D926C3D55200677458 /* OXXOShareableVoucherViewProviderTests.swift in Sources */,
 				F9838CCC26315E6E00963483 /* PartialPaymentDelegateMock.swift in Sources */,
+				81D7EC902CD24147005159F6 /* FormViewControllerTests.swift in Sources */,
 				A001677B2BD278410099A6AE /* BrazilSocialSecurityNumberValidatorTests.swift in Sources */,
 				C978F5EF2732CD6A00F59B3C /* FormCardSecurityCodeItemViewTests.swift in Sources */,
 				F9E4725F28CF1A2100FF9550 /* ThreeDS2PlusDACoreActionHandlerTests.swift in Sources */,

--- a/Adyen/UI/Form/Items/Text/FormTextItemView.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextItemView.swift
@@ -46,8 +46,7 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
 
         bind(item.$placeholder, to: textField, at: \.placeholder)
         observe(item.$formattedValue) { [weak self] newValue in
-            self?.textField.text = newValue
-            self?.updateValidationStatus()
+            self?.handleFormattedValueDidChange(newValue)
         }
         
         updateValidationStatus()
@@ -159,6 +158,11 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
     }
     
     // MARK: - Private
+    
+    open func handleFormattedValueDidChange(_ newValue: String) {
+        textField.text = newValue
+        updateValidationStatus()
+    }
     
     @_spi(AdyenInternal)
     @objc open func textDidChange(textField: UITextField) {
@@ -272,7 +276,7 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
     
     public func notifyDelegateOfMaxLengthIfNeeded() {
         let maximumLength = item.validator?.maximumLength(for: item.value) ?? .max
-        if item.value.count >= maximumLength {
+        if item.value.count == maximumLength {
             delegate?.didReachMaximumLength(in: self)
         }
     }

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -34,6 +34,10 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
         }
     }
     
+    override public func handleFormattedValueDidChange(_ newValue: String) {
+        updateValidationStatus()
+    }
+    
     @_spi(AdyenInternal)
     override public func textDidChange(textField: UITextField) {
         // Overriding to not use the default behavior of the super class

--- a/Tests/IntegrationTests/Card Tests/FormViewControllerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/FormViewControllerTests.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2024 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+@testable @_spi(AdyenInternal) import AdyenCard
+import AdyenNetworking
+import XCTest
+
+class FormViewControllerTests: XCTestCase {
+    
+    func test_moving_firstResponders() throws {
+        
+        let style = FormComponentStyle()
+        
+        let formViewController = FormViewController(style: style, localizationParameters: nil)
+        
+        let cardNumberItem = FormCardNumberItem(cardTypeLogos: [])
+        let securityCodeItem = FormCardSecurityCodeItem(style: style.textField)
+        
+        formViewController.append(cardNumberItem)
+        formViewController.append(securityCodeItem)
+        
+        setupRootViewController(formViewController)
+        
+        let formView = try XCTUnwrap(formViewController.view.subviews.filter { $0 is FormView }.first)
+        let stackView = try XCTUnwrap(formView.subviews.filter { $0 is UIStackView }.first)
+        let cardNumberItemView = try XCTUnwrap(stackView.subviews.first as? FormCardNumberItemView)
+        let securityCodeItemView = try XCTUnwrap(stackView.subviews.last as? FormCardSecurityCodeItemView)
+        
+        cardNumberItemView.becomeFirstResponder()
+        XCTAssertTrue(cardNumberItemView.isFirstResponder)
+        
+        formViewController.didReachMaximumLength(in: cardNumberItemView)
+        
+        XCTAssertFalse(cardNumberItemView.isFirstResponder)
+        XCTAssertTrue(securityCodeItemView.isFirstResponder)
+    }
+}

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
@@ -124,28 +124,42 @@ class FormCardNumberItemViewTests: XCTestCase {
     
     func test_notifyDelegateOfMaxLengthIfNeeded() {
         
+        let panLength = 5
+        
         let cardNumberValidator = CardNumberValidator(
             isLuhnCheckEnabled: true,
             isEnteredBrandSupported: true,
-            panLength: 5
+            panLength: panLength
         )
 
         let sut = setupSut(validator: cardNumberValidator)
         
-        let expectation = expectation(description: "Handle did reach maximum length was called once")
-        
-        let delegate = FormTextItemViewDelegateMock<FormCardNumberItem, FormCardNumberItemView>()
-        delegate.handleDidReachMaximumLength = { itemView in
-            expectation.fulfill()
+        func setupDelegateExpectation() -> (delegate: FormTextItemViewDelegate, expectation: XCTestExpectation) {
+            let expectation = expectation(description: "Handle did reach maximum length was called once")
+            let delegate = FormTextItemViewDelegateMock<FormCardNumberItem, FormCardNumberItemView>()
+            delegate.handleDidReachMaximumLength = { itemView in
+                XCTAssertEqual(itemView.textField.text?.count, panLength)
+                expectation.fulfill()
+            }
+            sut.delegate = delegate
+            return (delegate, expectation)
         }
-        sut.delegate = delegate
         
+        let perCharacterSetup = setupDelegateExpectation()
+        
+        // Testing "typing" text
         "5555341244".forEach { character in
             sut.textField.text = sut.item.value + String(character)
             sut.textDidChange(textField: sut.textField)
         }
         
-        wait(for: [expectation], timeout: 0.1)
+        let pasteSetup = setupDelegateExpectation()
+        
+        // Testing setting the text with the exact panLength
+        sut.textField.text = (0..<panLength).reduce("") { $0 + "\($1)" }
+        sut.textDidChange(textField: sut.textField)
+        
+        wait(for: [perCharacterSetup.expectation, pasteSetup.expectation], timeout: 0.1)
     }
 }
 

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
@@ -229,6 +229,8 @@ class FormCardNumberItemViewTests: XCTestCase {
     }
 }
 
+// MARK: - Helpers
+
 private extension FormCardNumberItemViewTests {
     
     static let url = URL(string: "https://google.com")!
@@ -246,7 +248,8 @@ private extension FormCardNumberItemViewTests {
         return FormCardNumberItemView(item: item)
     }
     
-    func setupSingleCallDidReachMaximumLengthExpectation(
+    /// Sets up an expectation that the `handleDidReachMaximumLength` is called exactly once
+    func makeExpectation_didReachMaximumLength_once(
         for sut: FormCardNumberItemView,
         panLength: Int
     ) -> (delegate: FormTextItemViewDelegate, expectation: XCTestExpectation) {
@@ -261,7 +264,8 @@ private extension FormCardNumberItemViewTests {
         return (delegate, expectation)
     }
     
-    func setupNeverCallDidReachMaximumLengthExpectation(
+    /// Sets up an expectation that the `handleDidReachMaximumLength` is never called
+    func makeExpectation_didReachMaximumLength_never(
         for sut: FormCardNumberItemView
     ) -> FormTextItemViewDelegate {
         

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
@@ -122,7 +122,7 @@ class FormCardNumberItemViewTests: XCTestCase {
         XCTAssertEqual(expectedItemFormattedValue, sut.textField.text)
     }
     
-    func test_notifyDelegateOfMaxLengthIfNeeded() {
+    func test_pasteCardNumberWithExactlyPanLength_shouldCallNotifyDelegateOfMaxLength_Once() {
         
         let panLength = 5
         
@@ -134,38 +134,100 @@ class FormCardNumberItemViewTests: XCTestCase {
 
         let sut = setupSut(validator: cardNumberValidator)
         
-        func setupDelegateExpectation() -> (delegate: FormTextItemViewDelegate, expectation: XCTestExpectation) {
-            let expectation = expectation(description: "Handle did reach maximum length was called once")
-            let delegate = FormTextItemViewDelegateMock<FormCardNumberItem, FormCardNumberItemView>()
-            delegate.handleDidReachMaximumLength = { itemView in
-                XCTAssertEqual(itemView.textField.text?.count, panLength)
-                expectation.fulfill()
-            }
-            sut.delegate = delegate
-            return (delegate, expectation)
-        }
+        let setup = setupSingleCallDidReachMaximumLengthExpectation(
+            for: sut,
+            panLength: panLength
+        )
         
-        let perCharacterSetup = setupDelegateExpectation()
+        // Testing pasting text that's exactly the panLength
+        let cardNumberWithExactPanLength = (0..<panLength).reduce("") { $0 + "\($1)" }
+        sut.textField.text = cardNumberWithExactPanLength
+        sut.textDidChange(textField: sut.textField)
+        
+        wait(for: [setup.expectation], timeout: 0.1)
+    }
+    
+    func test_enterCardNumberLongerThanPanLength_shouldCallNotifyDelegateOfMaxLength_Once() {
+        
+        let panLength = 5
+        
+        let cardNumberValidator = CardNumberValidator(
+            isLuhnCheckEnabled: true,
+            isEnteredBrandSupported: true,
+            panLength: panLength
+        )
+
+        let sut = setupSut(validator: cardNumberValidator)
+        
+        let setup = setupSingleCallDidReachMaximumLengthExpectation(
+            for: sut,
+            panLength: panLength
+        )
         
         // Testing "typing" text
-        "5555341244".forEach { character in
+        let cardNumberLongerThanPanLength = "5555341244"
+        cardNumberLongerThanPanLength.forEach { character in
             sut.textField.text = sut.item.value + String(character)
             sut.textDidChange(textField: sut.textField)
         }
         
-        let pasteSetup = setupDelegateExpectation()
+        wait(for: [setup.expectation], timeout: 0.1)
+    }
+    
+    func test_deletingCaractersStartingFromLongerThanPanLength_shouldCallNotifyDelegateOfMaxLength_Once() {
         
-        // Testing setting the text with the exact panLength
-        sut.textField.text = (0..<panLength).reduce("") { $0 + "\($1)" }
+        let panLength = 5
+        
+        let cardNumberValidator = CardNumberValidator(
+            isLuhnCheckEnabled: true,
+            isEnteredBrandSupported: true,
+            panLength: panLength
+        )
+
+        let sut = setupSut(validator: cardNumberValidator)
+        
+        let setup = setupSingleCallDidReachMaximumLengthExpectation(
+            for: sut,
+            panLength: panLength
+        )
+        
+        // Testing "deleting" text character by character
+        let cardNumberLongerThanPanLength = "5555341244"
+        sut.item.value = cardNumberLongerThanPanLength
+        cardNumberLongerThanPanLength.forEach { character in
+            sut.textField.text = String(sut.item.value.prefix(max(0, sut.item.value.count - 1)))
+            sut.textDidChange(textField: sut.textField)
+        }
+        
+        wait(for: [setup.expectation], timeout: 0.1)
+    }
+    
+    func test_pasteCardNumberLongerThanPanLength_shouldCallNotifyDelegateOfMaxLength_Never() {
+        
+        let panLength = 5
+        
+        let cardNumberValidator = CardNumberValidator(
+            isLuhnCheckEnabled: true,
+            isEnteredBrandSupported: true,
+            panLength: panLength
+        )
+
+        let sut = setupSut(validator: cardNumberValidator)
+        
+        let setup = setupNeverCallDidReachMaximumLengthExpectation(
+            for: sut
+        )
+        
+        // Testing pasting text that's longer than the panLength
+        let cardNumberWithExactPanLength = (0..<(panLength + 2)).reduce("") { $0 + "\($1)" }
+        sut.textField.text = cardNumberWithExactPanLength
         sut.textDidChange(textField: sut.textField)
-        
-        wait(for: [perCharacterSetup.expectation, pasteSetup.expectation], timeout: 0.1)
     }
 }
 
 private extension FormCardNumberItemViewTests {
     
-    private static let url = URL(string: "https://google.com")!
+    static let url = URL(string: "https://google.com")!
     
     func setupSut(
         validator: Validator = ValidatorMock(),
@@ -178,5 +240,32 @@ private extension FormCardNumberItemViewTests {
         item.validator = validator
         item.formatter = formatter
         return FormCardNumberItemView(item: item)
+    }
+    
+    func setupSingleCallDidReachMaximumLengthExpectation(
+        for sut: FormCardNumberItemView,
+        panLength: Int
+    ) -> (delegate: FormTextItemViewDelegate, expectation: XCTestExpectation) {
+        
+        let expectation = expectation(description: "Handle did reach maximum length was called once")
+        let delegate = FormTextItemViewDelegateMock<FormCardNumberItem, FormCardNumberItemView>()
+        delegate.handleDidReachMaximumLength = { itemView in
+            XCTAssertEqual(itemView.textField.text?.count, panLength)
+            expectation.fulfill()
+        }
+        sut.delegate = delegate
+        return (delegate, expectation)
+    }
+    
+    func setupNeverCallDidReachMaximumLengthExpectation(
+        for sut: FormCardNumberItemView
+    ) -> FormTextItemViewDelegate {
+        
+        let delegate = FormTextItemViewDelegateMock<FormCardNumberItem, FormCardNumberItemView>()
+        delegate.handleDidReachMaximumLength = { itemView in
+            XCTFail("Should not have called `handleDidReachMaximumLength`")
+        }
+        sut.delegate = delegate
+        return delegate
     }
 }

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
@@ -10,12 +10,6 @@ import XCTest
 
 class FormCardNumberItemViewTests: XCTestCase {
     
-    var item: FormCardNumberItem!
-    var sut: FormCardNumberItemView!
-    var validator: ValidatorMock!
-    
-    private static let url = URL(string: "https://google.com")!
-    
     override func run() {
         AdyenDependencyValues.runTestWithValues {
             $0.imageLoader = ImageLoaderMock()
@@ -24,25 +18,8 @@ class FormCardNumberItemViewTests: XCTestCase {
         }
     }
     
-    override func setUp() {
-        item = FormCardNumberItem(cardTypeLogos: [
-            .init(url: Self.url, type: .visa),
-            .init(url: Self.url, type: .masterCard)
-        ])
-        validator = ValidatorMock()
-        
-        item.validator = validator
-        sut = FormCardNumberItemView(item: item)
-        
-    }
-    
-    override func tearDown() {
-        item = nil
-        sut = nil
-        validator = nil
-    }
-    
     func testCustomAccessoryViewWhenValueIsEmpty() {
+        let sut = setupSut()
         sut.isEditing = true
         sut.textField.delegate?.textFieldDidEndEditing?(sut.textField)
         
@@ -52,12 +29,15 @@ class FormCardNumberItemViewTests: XCTestCase {
     }
     
     func testValidationAccessoryIsInvalidWhenValueIsInvalid() {
+        let validator = ValidatorMock()
+        
         let validationExpectation = XCTestExpectation(description: "Expect validator.isValid() to be called.")
         validator.handleIsValid = { _ in
             validationExpectation.fulfill()
             return false
         }
         
+        let sut = setupSut(validator: validator)
         sut.isEditing = true
         sut.textField.text = "123456"
         sut.textField.delegate?.textFieldDidEndEditing?(sut.textField)
@@ -67,12 +47,15 @@ class FormCardNumberItemViewTests: XCTestCase {
     }
     
     func testCustomAccessoryViewWhenValueIsValid() {
+        let validator = ValidatorMock()
+        
         let validationExpectation = XCTestExpectation(description: "Expect validator.isValid() to be called.")
         validator.handleIsValid = { _ in
             validationExpectation.fulfill()
             return true
         }
         
+        let sut = setupSut(validator: validator)
         sut.isEditing = true
         sut.textField.text = "5454545454545454"
         sut.textField.delegate?.textFieldDidEndEditing?(sut.textField)
@@ -90,8 +73,11 @@ class FormCardNumberItemViewTests: XCTestCase {
             isLuhnCheckEnabled: true,
             isEnteredBrandSupported: true
         )
-        item.formatter = cardNumberFormatter
-        item.validator = cardNumberValidator
+        
+        let sut = setupSut(
+            validator: cardNumberValidator,
+            formatter: cardNumberFormatter
+        )
         
         XCTAssertEqual(sut.textField.allowsEditingActions, false)
 
@@ -117,8 +103,11 @@ class FormCardNumberItemViewTests: XCTestCase {
             isLuhnCheckEnabled: true,
             isEnteredBrandSupported: true
         )
-        item.formatter = cardNumberFormatter
-        item.validator = cardNumberValidator
+        
+        let sut = setupSut(
+            validator: cardNumberValidator,
+            formatter: cardNumberFormatter
+        )
 
         // When
         sut.textField.text = ""
@@ -130,8 +119,50 @@ class FormCardNumberItemViewTests: XCTestCase {
 
         let expectedItemFormattedValue = "5555 3412 4444 1115"
         XCTAssertEqual(expectedItemFormattedValue, sut.item.formattedValue)
+        XCTAssertEqual(expectedItemFormattedValue, sut.textField.text)
+    }
+    
+    func test_notifyDelegateOfMaxLengthIfNeeded() {
+        
+        let cardNumberValidator = CardNumberValidator(
+            isLuhnCheckEnabled: true,
+            isEnteredBrandSupported: true,
+            panLength: 5
+        )
 
-        let expectedTextFieldText = sut.item.formattedValue
-        XCTAssertEqual(expectedTextFieldText, sut.textField.text)
+        let sut = setupSut(validator: cardNumberValidator)
+        
+        let expectation = expectation(description: "Handle did reach maximum length was called once")
+        
+        let delegate = FormTextItemViewDelegateMock<FormCardNumberItem, FormCardNumberItemView>()
+        delegate.handleDidReachMaximumLength = { itemView in
+            expectation.fulfill()
+        }
+        sut.delegate = delegate
+        
+        "5555341244".forEach { character in
+            sut.textField.text = sut.item.value + String(character)
+            sut.textDidChange(textField: sut.textField)
+        }
+        
+        wait(for: [expectation], timeout: 0.1)
+    }
+}
+
+private extension FormCardNumberItemViewTests {
+    
+    private static let url = URL(string: "https://google.com")!
+    
+    func setupSut(
+        validator: Validator = ValidatorMock(),
+        formatter: Adyen.Formatter = CardNumberFormatter()
+    ) -> FormCardNumberItemView {
+        let item = FormCardNumberItem(cardTypeLogos: [
+            .init(url: Self.url, type: .visa),
+            .init(url: Self.url, type: .masterCard)
+        ])
+        item.validator = validator
+        item.formatter = formatter
+        return FormCardNumberItemView(item: item)
     }
 }

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
@@ -134,7 +134,7 @@ class FormCardNumberItemViewTests: XCTestCase {
 
         let sut = setupSut(validator: cardNumberValidator)
         
-        let setup = setupSingleCallDidReachMaximumLengthExpectation(
+        let setup = makeExpectation_didReachMaximumLength_once(
             for: sut,
             panLength: panLength
         )
@@ -159,7 +159,7 @@ class FormCardNumberItemViewTests: XCTestCase {
 
         let sut = setupSut(validator: cardNumberValidator)
         
-        let setup = setupSingleCallDidReachMaximumLengthExpectation(
+        let setup = makeExpectation_didReachMaximumLength_once(
             for: sut,
             panLength: panLength
         )
@@ -186,7 +186,7 @@ class FormCardNumberItemViewTests: XCTestCase {
 
         let sut = setupSut(validator: cardNumberValidator)
         
-        let setup = setupSingleCallDidReachMaximumLengthExpectation(
+        let setup = makeExpectation_didReachMaximumLength_once(
             for: sut,
             panLength: panLength
         )
@@ -214,7 +214,7 @@ class FormCardNumberItemViewTests: XCTestCase {
 
         let sut = setupSut(validator: cardNumberValidator)
         
-        let setup = setupNeverCallDidReachMaximumLengthExpectation(
+        let setup = makeExpectation_didReachMaximumLength_never(
             for: sut
         )
         

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
@@ -222,6 +222,10 @@ class FormCardNumberItemViewTests: XCTestCase {
         let cardNumberWithExactPanLength = (0..<(panLength + 2)).reduce("") { $0 + "\($1)" }
         sut.textField.text = cardNumberWithExactPanLength
         sut.textDidChange(textField: sut.textField)
+        
+        // We have to hold onto the setup as otherwise
+        // the delegate would be released before the end of the test
+        _ = setup
     }
 }
 

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewDelegateMock.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewDelegateMock.swift
@@ -5,18 +5,19 @@
 //
 
 @_spi(AdyenInternal) import Adyen
+@testable @_spi(AdyenInternal) import AdyenCard
 import Foundation
 
-final class FormTextItemViewDelegateMock: FormTextItemViewDelegate {
+final class FormTextItemViewDelegateMock<ItemType: FormTextItem, TextViewType: FormTextItemView<ItemType>>: FormTextItemViewDelegate {
     
-    var handleDidReachMaximumLength: ((_ itemView: FormTextItemView<FormTextInputItem>) -> Void)?
+    var handleDidReachMaximumLength: ((_ itemView: TextViewType) -> Void)?
     func didReachMaximumLength(in itemView: FormTextItemView<some FormTextItem>) {
-        handleDidReachMaximumLength?(itemView as! FormTextItemView<FormTextInputItem>)
+        handleDidReachMaximumLength?(itemView as! TextViewType)
     }
     
-    var handleDidSelectReturnKey: ((_ itemView: FormTextItemView<FormTextInputItem>) -> Void)?
+    var handleDidSelectReturnKey: ((_ itemView: TextViewType) -> Void)?
     func didSelectReturnKey(in itemView: FormTextItemView<some FormTextItem>) {
-        handleDidSelectReturnKey?(itemView as! FormTextItemView<FormTextInputItem>)
+        handleDidSelectReturnKey?(itemView as! TextViewType)
     }
     
 }

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewTests.swift
@@ -14,7 +14,7 @@ class FormTextItemViewTests: XCTestCase {
     var validator: ValidatorMock!
     var formatter: FormatterMock!
     var sut: FormTextItemView<FormTextInputItem>!
-    var delegate: FormTextItemViewDelegateMock!
+    var delegate: FormTextItemViewDelegateMock<FormTextInputItem, FormTextItemView<FormTextInputItem>>!
     
     override func setUp() {
         item = FormTextInputItem()


### PR DESCRIPTION
# Summary
- The cursor position now stays in place even when the formatting type changes

## Tests
- Enter card number (character by character) that's longer than the pan length -> should call `shouldCallNotifyDelegateOfMaxLength` **once**
- Paste card number that's exactly the the pan length -> should call `shouldCallNotifyDelegateOfMaxLength` **once**
- Deleting card number that's longer than the pan length (character by character) -> should call `shouldCallNotifyDelegateOfMaxLength` **once**
- Reaching `shouldCallNotifyDelegateOfMaxLength` should trigger the `FormViewController` to move `firstResponder` to the next field

## Background
- There is an observation on `formattedValue` which caused the text of the textField to just be replaced with that value
- This caused the cursor to jump to the end of the textfield

## Fix
- Whenever the formattedValue changes we just notify about max length on the card number field

## Also
- Reverted max length check to what it was before (Not super nice but no change in unproblematic behavior)

# Ticket

<ticket>
COIOS-000
</ticket>
