### PR TITLE
Allow voucher document saving on iPad

### DIFF
--- a/AdyenActions/Components/Voucher/VoucherComponentExtensions.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponentExtensions.swift
@@ -85,7 +85,7 @@ extension VoucherComponent: VoucherViewDelegate, DocumentActionViewDelegate {
         ].compactMap { $0 }
     }
     
-    private func createSaveAlertAction(for action: VoucherAction, sourceView: UIView) -> UIAlertAction? {
+    private func createSaveAlertAction(for action: VoucherAction, sourceView: UIView) -> UIAlertAction {
         if let downloadable = action.anyAction as? Downloadable {
             return createDownloadPDFAlertAction(for: downloadable.downloadUrl, sourceView: sourceView)
         } else {

--- a/AdyenActions/Components/Voucher/VoucherComponentExtensions.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponentExtensions.swift
@@ -86,8 +86,6 @@ extension VoucherComponent: VoucherViewDelegate, DocumentActionViewDelegate {
     }
     
     private func createSaveAlertAction(for action: VoucherAction, sourceView: UIView) -> UIAlertAction? {
-        guard canAddPasses(action: action.anyAction) else { return nil }
-        
         if let downloadable = action.anyAction as? Downloadable {
             return createDownloadPDFAlertAction(for: downloadable.downloadUrl, sourceView: sourceView)
         } else {

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -446,13 +446,12 @@ class CardComponentTests: XCTestCase {
             configuration: configuration
         )
 
-        setupRootViewController(component.viewController)
+        presentOnRoot(component.viewController)
 
         let switchView: UISwitch = try XCTUnwrap(component.viewController.view.findView(with: "AdyenCard.CardComponent.storeDetailsItem.switch"))
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem> = try XCTUnwrap(component.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem"))
 
         wait(until: switchView, at: \.onTintColor, is: tintColor)
-
         wait(until: securityCodeItemView, at: \.titleLabel.textColor, is: titleColor)
         
         try withoutAnimation {

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -446,12 +446,13 @@ class CardComponentTests: XCTestCase {
             configuration: configuration
         )
 
-        presentOnRoot(component.viewController)
+        setupRootViewController(component.viewController)
 
         let switchView: UISwitch = try XCTUnwrap(component.viewController.view.findView(with: "AdyenCard.CardComponent.storeDetailsItem.switch"))
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem> = try XCTUnwrap(component.viewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem"))
 
         wait(until: switchView, at: \.onTintColor, is: tintColor)
+
         wait(until: securityCodeItemView, at: \.titleLabel.textColor, is: titleColor)
         
         try withoutAnimation {


### PR DESCRIPTION
# Summary
- Allows saving of a voucher (pdf or image) on iPad + Mac

# Release notes

<new> 
- Saving a voucher is not limited to iPhone anymore
</new>

# Ticket

<ticket>
COIOS-000
</ticket>
