### PR TITLE
Remove default border in pay by bank confirmation screen

### DIFF
--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent+Style.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent+Style.swift
@@ -37,7 +37,7 @@ extension PayByBankUSComponent {
         
         public var headerImage: ImageStyle = .init(
             borderColor: UIColor.Adyen.componentSeparator,
-            borderWidth: 1.0 / UIScreen.main.nativeScale,
+            borderWidth: 0,
             cornerRadius: 8.0,
             clipsToBounds: true,
             contentMode: .scaleAspectFit


### PR DESCRIPTION
# Summary
- Removes default border around icon in confirmation screen (aligned with Android)

# Ticket

<ticket>
COIOS-000
</ticket>
