### PR TITLE
Adding `maxIssuerNumber` to the Twint configuration

### DIFF
--- a/AdyenActions/Components/SDK/Twint+Injectable.swift
+++ b/AdyenActions/Components/SDK/Twint+Injectable.swift
@@ -11,8 +11,11 @@ import Foundation
 
 #if canImport(TwintSDK)
     extension Twint {
-        @objc func fetchInstalledAppConfigurations(completion: @escaping ([TWAppConfiguration]) -> Void) {
-            Twint.fetchInstalledAppConfigurations(withMaxIssuerNumber: .max) { configurations in
+        @objc func fetchInstalledAppConfigurations(
+            maxIssuerNumber: Int,
+            completion: @escaping ([TWAppConfiguration]) -> Void
+        ) {
+            Twint.fetchInstalledAppConfigurations(withMaxIssuerNumber: maxIssuerNumber) { configurations in
                 completion(configurations ?? [])
             }
         }

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/Twint+Spy.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/Twint+Spy.swift
@@ -14,7 +14,7 @@ import Foundation
 
     internal class TwintSpy: Twint {
     
-        internal typealias HandleFetchBlock = (@escaping ([TWAppConfiguration]) -> Void) -> Void
+        internal typealias HandleFetchBlock = (Int, @escaping ([TWAppConfiguration]) -> Void) -> Void
     
         internal typealias HandlePayBlock = (
             _ code: String,
@@ -62,9 +62,10 @@ import Foundation
         }
     
         @objc override internal func fetchInstalledAppConfigurations(
+            maxIssuerNumber: Int,
             completion: @escaping ([TWAppConfiguration]) -> Void
         ) {
-            handleFetchInstalledAppConfigurations(completion)
+            handleFetchInstalledAppConfigurations(maxIssuerNumber, completion)
         }
 
         @objc override internal func pay(

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Convenience.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Convenience.swift
@@ -26,6 +26,10 @@ import XCTest
         static var dummy: Self {
             .init(callbackAppScheme: "ui-host")
         }
+        
+        static func dummy(maxIssuerNumber: Int) -> Self {
+            .init(callbackAppScheme: "ui-host", maxIssuerNumber: maxIssuerNumber)
+        }
     }
 
     extension TwintSDKAction {
@@ -45,6 +49,7 @@ import XCTest
     
         static func actionComponent(
             with twintSpy: TwintSpy,
+            configuration: TwintSDKActionComponent.Configuration = .dummy,
             presentationDelegate: PresentationDelegate?,
             delegate: ActionComponentDelegate?,
             shouldFailPolling: Bool = false
@@ -60,7 +65,7 @@ import XCTest
         
             let component = TwintSDKActionComponent(
                 context: Dummy.context,
-                configuration: .dummy,
+                configuration: configuration,
                 twint: twintSpy,
                 pollingComponentBuilder: pollingBuilder
             )

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Flows.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Flows.swift
@@ -103,7 +103,8 @@ import XCTest
         
             var twintResponseHandler: ((Error?) -> Void)?
         
-            let twintSpy = TwintSpy { configurationsBlock in
+            let twintSpy = TwintSpy { maxIssuerNumber, configurationsBlock in
+                XCTAssertEqual(maxIssuerNumber, .max)
                 fetchBlockExpectation.fulfill()
                 configurationsBlock([.dummy])
             } handlePay: { code, appConfiguration, callbackAppScheme, completionHandler in

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests.swift
@@ -28,7 +28,8 @@ import XCTest
 
             let expectedAlertMessage = "No or an outdated version of TWINT is installed on this device. Please update or install the TWINT app."
 
-            let twintSpy = TwintSpy { configurationsBlock in
+            let twintSpy = TwintSpy { maxIssuerNumber, configurationsBlock in
+                XCTAssertEqual(maxIssuerNumber, .max)
                 fetchBlockExpectation.fulfill()
                 configurationsBlock([])
             } handlePay: { code, appConfiguration, callbackAppScheme, completionHandler in
@@ -80,10 +81,12 @@ import XCTest
 
         func testSingleAppFound() throws {
 
+            let expectedMaxIssuerNumber = 5
             let fetchBlockExpectation = expectation(description: "Fetch was called")
             let payBlockExpectation = expectation(description: "Pay was called")
 
-            let twintSpy = TwintSpy { configurationsBlock in
+            let twintSpy = TwintSpy { maxIssuerNumber, configurationsBlock in
+                XCTAssertEqual(maxIssuerNumber, expectedMaxIssuerNumber)
                 fetchBlockExpectation.fulfill()
                 configurationsBlock([.dummy])
             } handlePay: { code, appConfiguration, callbackAppScheme, completionHandler in
@@ -108,6 +111,7 @@ import XCTest
 
             let twintActionComponent = Self.actionComponent(
                 with: twintSpy,
+                configuration: .dummy(maxIssuerNumber: expectedMaxIssuerNumber),
                 presentationDelegate: presentationDelegate,
                 delegate: nil
             )
@@ -136,7 +140,8 @@ import XCTest
             var appSelectionHandler: ((TWAppConfiguration?) -> Void)? = nil
             var appCancelHandler: (() -> Void)? = nil
 
-            let twintSpy = TwintSpy { configurationsBlock in
+            let twintSpy = TwintSpy { maxIssuerNumber, configurationsBlock in
+                XCTAssertEqual(maxIssuerNumber, .max)
                 fetchBlockExpectation.fulfill()
                 configurationsBlock(expectedAppConfigurations)
             } handlePay: { code, appConfiguration, callbackAppScheme, completionHandler in
@@ -219,7 +224,8 @@ import XCTest
 
             let expectedAlertMessage = "Error Message"
 
-            let twintSpy = TwintSpy { configurationsBlock in
+            let twintSpy = TwintSpy { maxIssuerNumber, configurationsBlock in
+                XCTAssertEqual(maxIssuerNumber, .max)
                 fetchBlockExpectation.fulfill()
                 configurationsBlock([.dummy])
             } handlePay: { code, appConfiguration, callbackAppScheme, completionHandler in
@@ -268,7 +274,8 @@ import XCTest
             let fetchBlockExpectation = expectation(description: "Fetch was called")
             let registerForUFO = expectation(description: "registerForUFO was called")
 
-            let twintSpy = TwintSpy { configurationsBlock in
+            let twintSpy = TwintSpy { maxIssuerNumber, configurationsBlock in
+                XCTAssertEqual(maxIssuerNumber, .max)
                 fetchBlockExpectation.fulfill()
                 configurationsBlock([.dummy])
             } handlePay: { _, _, _, completionHandler in
@@ -325,7 +332,8 @@ import XCTest
             var appSelectionHandler: ((TWAppConfiguration?) -> Void)? = nil
             var appCancelHandler: (() -> Void)? = nil
 
-            let twintSpy = TwintSpy { configurationsBlock in
+            let twintSpy = TwintSpy { maxIssuerNumber, configurationsBlock in
+                XCTAssertEqual(maxIssuerNumber, .max)
                 fetchBlockExpectation.fulfill()
                 configurationsBlock(expectedAppConfigurations)
             } handlePay: { _, _, _, completionHandler in


### PR DESCRIPTION
# Summary
- Adds `maxIssuerNumber` to Twint configuration which allows to reduce the amount of `LSApplicationQueriesSchemes` needed.

# Release notes

<new>
- For Twint, you can now reduce the required number of `LSApplicationQueriesSchemes` values. In `TwintActionComponent.Configuration`, set the new `maxIssuerNumber` property.

</new>

# Ticket

<ticket>
COIOS-796
</ticket>
