### PR TITLE
Disabling deprecated compatibility builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,30 +36,33 @@ jobs:
           runtime: 'iOS-16-4'
           device: 'iPhone 14'
           displayname: 'iPhone-14'
-          os: 'macos-13-xl'
+          os: 'macos-13'
           xcode_version: '14.3'
           needs_custom_sim: false # Takes the shipped simulator that comes with Xcode 14
         
-        - version: '15.0'
-          runtime: 'iOS-15-0'
-          device: 'iPhone 13'
-          displayname: 'iPhone-13'
-          os: 'macos-12-xl'
-          needs_custom_sim: true
-        
-        - version: '14.2'
-          device: 'iPhone 12'
-          displayname: 'iPhone-12'
-          runtime: 'iOS-14-2'
-          os: 'macos-12-xl'
-          needs_custom_sim: true
-          
-        - version: '13.7'
-          runtime: 'iOS-13-7'
-          device: 'iPhone 11'
-          displayname: 'iPhone-11'
-          os: 'macos-12-xl'
-          needs_custom_sim: true
+      # Github deprecated macos-12 runners
+      # so we have to find another solution to test on older iOS versions
+      #
+      # - version: '15.0'
+      #   runtime: 'iOS-15-0'
+      #   device: 'iPhone 13'
+      #   displayname: 'iPhone-13'
+      #   os: 'macos-12-xl'
+      #   needs_custom_sim: true
+      #
+      # - version: '14.2'
+      #   device: 'iPhone 12'
+      #   displayname: 'iPhone-12'
+      #   runtime: 'iOS-14-2'
+      #   os: 'macos-12-xl'
+      #   needs_custom_sim: true
+      #
+      # - version: '13.7'
+      #   runtime: 'iOS-13-7'
+      #   device: 'iPhone 11'
+      #   displayname: 'iPhone-11'
+      #   os: 'macos-12-xl'
+      #   needs_custom_sim: true
           
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
# Summary
- Temporarily disabling tests that use macos-12 runners ([deprecated by github](https://github.com/actions/runner-images/issues/10721))
  - Disables tests for iOS 15, 14 & 13 unfortunately
- Switching from macos-13-xl to macos-13 (for some reason there is no xl runner anymore for macos-13)

# Ticket

<ticket>
COIOS-000
</ticket>

---

<img width="296" alt="Screenshot 2025-01-08 at 11 52 33" src="https://github.com/user-attachments/assets/0c03302e-1757-4c7a-b7aa-24955d783343" />
