### PR TITLE
Analytics in apple pay component

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -78,10 +78,12 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
         super.init()
 
         paymentAuthorizationViewController?.delegate = self
+        sendInitialAnalytics()
     }
 
     public var viewController: UIViewController {
-        createPaymentAuthorizationViewController()
+        sendDidLoadEvent()
+        return createPaymentAuthorizationViewController()
     }
 
     public func didFinalize(with success: Bool, completion: (() -> Void)?) {
@@ -130,6 +132,3 @@ extension ApplePayComponent {
 
 @_spi(AdyenInternal)
 extension ApplePayComponent: TrackableComponent {}
-
-@_spi(AdyenInternal)
-extension ApplePayComponent: ViewControllerDelegate {}

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -424,7 +424,7 @@ class ApplePayComponentTest: XCTestCase {
         )
 
         // When
-        sut.viewDidLoad(viewController: mockViewController)
+        setupRootViewController(sut.viewController)
 
         // Then
         XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -424,7 +424,7 @@ class ApplePayComponentTest: XCTestCase {
         )
 
         // When
-        setupRootViewController(sut.viewController)
+        sut.viewController.loadViewIfNeeded()
 
         // Then
         XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)


### PR DESCRIPTION
# Summary

Generic analytics code via the `ViewControllerDelegate` on `TrackableComponent` does not work on `ApplePayComponent` as its view controller is not a `FormViewController`. 

Call analytics explicitly here and remove redundant conformance to `ViewControllerDelegate`


# Ticket

<ticket>
COIOS-849
</ticket>
