### PR TITLE
switching to Void? for AssociatedKeys

### DIFF
--- a/Adyen/Core/Components/Base/Component.swift
+++ b/Adyen/Core/Components/Base/Component.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2019 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -78,9 +78,9 @@ public extension Component {
 }
 
 private enum AssociatedKeys {
-    internal static var isDropIn = "isDropInObject"
+    internal static var isDropIn: Void?
 
-    internal static var environment = "environmentObject"
+    internal static var environment: Void?
 
-    internal static var clientKey = "clientKeyObject"
+    internal static var clientKey: Void?
 }

--- a/Adyen/Core/Components/Base/PaymentComponent.swift
+++ b/Adyen/Core/Components/Base/PaymentComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2019 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -96,7 +96,7 @@ extension PaymentAwareComponent {
 
 private enum AssociatedKeys {
 
-    internal static var payment = "paymentObject"
+    internal static var payment: Void?
 
-    internal static var order = "orderObject"
+    internal static var order: Void?
 }

--- a/Adyen/Helpers/UIViewAnimation.swift
+++ b/Adyen/Helpers/UIViewAnimation.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 private enum AssociatedKeys {
-    internal static var animations = "animations"
+    internal static var animations: Void?
 }
 
 /// :nodoc:

--- a/Adyen/UI/Form/Items/Address/AddressViewModel.swift
+++ b/Adyen/UI/Form/Items/Address/AddressViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) 2021 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -49,7 +49,7 @@ public struct AddressViewModel {
     /// :nodoc:
     public private(set) var schema: [FormScheme]
 
-    // swiftlint:disable function_body_length explicit_acl
+    // swiftlint:disable function_body_length
     internal static subscript(context: AddressViewModelBuilderContext) -> AddressViewModel {
         var viewModel = AddressViewModel(labels: [.city: .cityFieldTitle,
                                                   .houseNumberOrName: .houseNumberFieldTitle,

--- a/Adyen/Utilities/Observable/Observer.swift
+++ b/Adyen/Utilities/Observable/Observer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) 2019 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -161,6 +161,6 @@ public extension Observer {
 private enum AssociatedKeys {
     
     /// The observation manager associated with the object.
-    public static var observationManager = "observationManager"
+    public static var observationManager: Void?
     
 }

--- a/Demo/Common/Helpers/APIClientHelper.swift
+++ b/Demo/Common/Helpers/APIClientHelper.swift
@@ -48,5 +48,5 @@ extension APIClientAware {
 }
 
 private enum AssociatedKeys {
-    internal static var apiClient = "apiClient"
+    internal static var apiClient: Void?
 }


### PR DESCRIPTION
# Summary
- Switching to `Void?` for `AssociatedKey`s as described [here](https://github.com/atrick/swift-evolution/blob/diagnose-implicit-raw-bitwise/proposals/nnnn-implicit-raw-bitwise-conversion.md#workarounds-for-common-cases)
- Removing superfluous `swiftlint:disable`

# Ticket

<ticket>
COIOS-000
</ticket>
