### PR TITLE
ApplePayComponent: Make sure render event is called once

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -82,8 +82,7 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     }
 
     public var viewController: UIViewController {
-        sendDidLoadEvent()
-        return createPaymentAuthorizationViewController()
+        createPaymentAuthorizationViewController()
     }
 
     public func didFinalize(with success: Bool, completion: (() -> Void)?) {

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -82,8 +82,7 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     }
 
     public var viewController: UIViewController {
-        sendDidLoadEvent()
-        return createPaymentAuthorizationViewController()
+        createPaymentAuthorizationViewController()
     }
 
     public func didFinalize(with success: Bool, completion: (() -> Void)?) {
@@ -112,6 +111,10 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
             paymentAuthorizationViewController?.delegate = self
             state = .initial
         }
+        if paymentAuthorizationViewController?.isViewLoaded == false {
+            sendDidLoadEvent()
+        }
+        
         return paymentAuthorizationViewController!
     }
 

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -78,10 +78,12 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
         super.init()
 
         paymentAuthorizationViewController?.delegate = self
+        sendInitialAnalytics()
     }
 
     public var viewController: UIViewController {
-        createPaymentAuthorizationViewController()
+        sendDidLoadEvent()
+        return createPaymentAuthorizationViewController()
     }
 
     public func didFinalize(with success: Bool, completion: (() -> Void)?) {
@@ -130,6 +132,3 @@ extension ApplePayComponent {
 
 @_spi(AdyenInternal)
 extension ApplePayComponent: TrackableComponent {}
-
-@_spi(AdyenInternal)
-extension ApplePayComponent: ViewControllerDelegate {}

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -424,7 +424,7 @@ class ApplePayComponentTest: XCTestCase {
         )
 
         // When
-        sut.viewDidLoad(viewController: mockViewController)
+        setupRootViewController(sut.viewController)
 
         // Then
         XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -424,7 +424,7 @@ class ApplePayComponentTest: XCTestCase {
         )
 
         // When
-        setupRootViewController(sut.viewController)
+        sut.viewController.loadViewIfNeeded()
 
         // Then
         XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -431,6 +431,12 @@ class ApplePayComponentTest: XCTestCase {
         XCTAssertEqual(analyticsProviderMock.infos.count, 1)
         let infoType = analyticsProviderMock.infos.first?.type
         XCTAssertEqual(infoType, .rendered)
+        
+        // access view controller again but not trigger render
+        sut.viewController.loadViewIfNeeded()
+        XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)
+        XCTAssertEqual(analyticsProviderMock.infos.count, 1)
+        
     }
     
     private func getRandomContactFieldSet() -> Set<PKContactField> {


### PR DESCRIPTION
# Summary

Small fix on apple pay analytics making sure render event is called once

# Ticket

<ticket>
COIOS-849
</ticket>
