### PR TITLE
Fix Warnings

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -584,7 +584,6 @@
 		E2C0E080220B0399008616F6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C0E07F220B0399008616F6 /* AppDelegate.swift */; };
 		E2C0E087220B039B008616F6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E2C0E086220B039B008616F6 /* Assets.xcassets */; };
 		E2C0E096220B04F0008616F6 /* FormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C0E095220B04F0008616F6 /* FormViewController.swift */; };
-		E2C0E098220B0827008616F6 /* Adyen.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C0E03322097917008616F6 /* Adyen.framework */; };
 		E2C0E099220B0827008616F6 /* Adyen.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E2C0E03322097917008616F6 /* Adyen.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E2C0E0AD220B0840008616F6 /* AdyenCard.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2C0E05F220982AE008616F6 /* AdyenCard.framework */; };
 		E2C0E0AE220B0840008616F6 /* AdyenCard.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E2C0E05F220982AE008616F6 /* AdyenCard.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -2541,7 +2540,6 @@
 				8182AABD2B974E2B0087568E /* AdyenTwint.framework in Frameworks */,
 				E97B971322980CBA00505476 /* Adyen3DS2.framework in Frameworks */,
 				81B8036B2BE0E714003D037F /* AdyenWeChatPayInternal in Frameworks */,
-				81B8036B2BE0E714003D037F /* AdyenWeChatPayInternal in Frameworks */,
 				E97B970E22980C8400505476 /* AdyenDropIn.framework in Frameworks */,
 				E97B970D22980C7900505476 /* AdyenCard.framework in Frameworks */,
 				E2C0E03D22097917008616F6 /* Adyen.framework in Frameworks */,
@@ -2572,7 +2570,6 @@
 				81A91AC22BEC12A2001E00C8 /* TwintSDK.xcframework in Frameworks */,
 				F9A2D01225DBF104008944BE /* PassKit.framework in Frameworks */,
 				F973A9192791C3B0005AA753 /* AdyenActions.framework in Frameworks */,
-				E2C0E098220B0827008616F6 /* Adyen.framework in Frameworks */,
 				F92980AC27CE2B33000CA5CA /* AdyenSession.framework in Frameworks */,
 				F94D65E72B036A450095D61E /* AdyenDelegatedAuthentication.framework in Frameworks */,
 				A020EC4829E6EC4B0050B2FE /* AdyenCashAppPay.framework in Frameworks */,
@@ -6276,7 +6273,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1520;
-				LastUpgradeCheck = 1420;
+				LastUpgradeCheck = 1610;
 				ORGANIZATIONNAME = Adyen;
 				TargetAttributes = {
 					00E5D6502AF4E99A00CDE118 = {
@@ -8405,7 +8402,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = "";
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -8465,7 +8462,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = "";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/Adyen.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/Adyen.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenActions.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenActions.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenCard.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenCard.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenComponents.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenComponents.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenDelegatedAuthentication.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenDelegatedAuthentication.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1500"
+   LastUpgradeVersion = "1610"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenDropIn.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenDropIn.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenEncryption.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenEncryption.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenSession.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenSession.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenSwiftUI.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenSwiftUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenSwiftUIHost.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenSwiftUIHost.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenUIHost.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenUIHost.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenWeChatPay.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/AdyenWeChatPay.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/GenerateSnapshots.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/GenerateSnapshots.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1520"
+   LastUpgradeVersion = "1610"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/IntegrationUIKitTests.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/IntegrationUIKitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -79,6 +79,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E2C0E07C220B0399008616F6"
+            BuildableName = "AdyenUIHost.app"
+            BlueprintName = "AdyenUIHost"
+            ReferencedContainer = "container:Adyen.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/SnapshotTests.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/SnapshotTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1610"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -72,6 +72,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F9CCA3B4296ECB3E00AD643D"
+            BuildableName = "SnapshotsTests.xctest"
+            BlueprintName = "SnapshotsTests"
+            ReferencedContainer = "container:Adyen.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Adyen.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/Adyen.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1520"
+   LastUpgradeVersion = "1610"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/AdyenCard/Utilities/CardType/CardTypeDetector.swift
+++ b/AdyenCard/Utilities/CardType/CardTypeDetector.swift
@@ -8,8 +8,13 @@
 import Foundation
 
 /// So that any `Array` instance will inherit the `adyen` scope.
+#if compiler(>=6)
 @_spi(AdyenInternal)
 extension Array: @retroactive AdyenCompatible {}
+#else
+@_spi(AdyenInternal)
+extension Array: AdyenCompatible {}
+#endif
 
 /// Adds helper functionality to any `[CardType]` instance through the `adyen` property.
 @_spi(AdyenInternal)

--- a/AdyenCard/Utilities/CardType/CardTypeDetector.swift
+++ b/AdyenCard/Utilities/CardType/CardTypeDetector.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// So that any `Array` instance will inherit the `adyen` scope.
 @_spi(AdyenInternal)
-extension Array: AdyenCompatible {}
+extension Array: @retroactive AdyenCompatible {}
 
 /// Adds helper functionality to any `[CardType]` instance through the `adyen` property.
 @_spi(AdyenInternal)

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -135,7 +135,7 @@ extension ApplePayComponent {
                 // Even though there is a deprecation warning and `.available` looks to be available since iOS 15,
                 // it does not compile when using older versions of Xcode - so we have to ignore this warning for now
                 
-                #if compiler(>=5.7)
+                #if compiler(>=6)
                     paymentRequest.shippingContactEditingMode = allowShippingContactEditing ? .available : .storePickup
                 #else
                     paymentRequest.shippingContactEditingMode = allowShippingContactEditing ? .enabled : .storePickup

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -136,9 +136,9 @@ extension ApplePayComponent {
                 // it does not compile when using older versions of Xcode - so we have to ignore this warning for now
                 
                 #if compiler(>=5.7)
-                paymentRequest.shippingContactEditingMode = allowShippingContactEditing ? .available : .storePickup
+                    paymentRequest.shippingContactEditingMode = allowShippingContactEditing ? .available : .storePickup
                 #else
-                paymentRequest.shippingContactEditingMode = allowShippingContactEditing ? .enabled : .storePickup
+                    paymentRequest.shippingContactEditingMode = allowShippingContactEditing ? .enabled : .storePickup
                 #endif
             }
             

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -134,7 +134,12 @@ extension ApplePayComponent {
                 
                 // Even though there is a deprecation warning and `.available` looks to be available since iOS 15,
                 // it does not compile when using older versions of Xcode - so we have to ignore this warning for now
+                
+                #if compiler(>=5.7)
+                paymentRequest.shippingContactEditingMode = allowShippingContactEditing ? .available : .storePickup
+                #else
                 paymentRequest.shippingContactEditingMode = allowShippingContactEditing ? .enabled : .storePickup
+                #endif
             }
             
             return paymentRequest

--- a/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
@@ -44,7 +44,7 @@ struct AwaitActionHandlerProviderMock: AnyPollingHandlerProvider {
     }
 }
 
-extension AwaitAction: Equatable {
+extension AwaitAction: @retroactive Equatable {
     public static func == (lhs: AwaitAction, rhs: AwaitAction) -> Bool {
         lhs.paymentData == rhs.paymentData && lhs.paymentMethodType == rhs.paymentMethodType
     }
@@ -112,8 +112,7 @@ class AwaitComponentTests: XCTestCase {
 
         let presentationDelegate = PresentationDelegateMock()
         let waitExpectation = expectation(description: "Wait for the presentationDelegate to be called.")
-        presentationDelegate.doPresent = { [weak self] component in
-            guard let self else { return }
+        presentationDelegate.doPresent = { component in
             
             XCTAssertNotNil(component.viewController as? AwaitViewController)
             let viewController = component.viewController as! AwaitViewController

--- a/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
@@ -44,7 +44,13 @@ struct AwaitActionHandlerProviderMock: AnyPollingHandlerProvider {
     }
 }
 
-extension AwaitAction: @retroactive Equatable {
+#if compiler(>=6)
+extension AwaitAction: @retroactive Equatable {}
+#else
+extension AwaitAction: Equatable {}
+#endif
+
+extension AwaitAction {
     public static func == (lhs: AwaitAction, rhs: AwaitAction) -> Bool {
         lhs.paymentData == rhs.paymentData && lhs.paymentMethodType == rhs.paymentMethodType
     }

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -252,8 +252,6 @@ import XCTest
         }
 
         func testChallengeFlowMissingTransaction() throws {
-            let service = AnyADYServiceMock()
-        
             let authenticationServiceMock = AuthenticationServiceMock()
             let sut = ThreeDS2PlusDACoreActionHandler(
                 context: Dummy.context,

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -411,7 +411,6 @@ class ApplePayComponentTest: XCTestCase {
         // Given
         let analyticsProviderMock = AnalyticsProviderMock()
         let context = Dummy.context(with: analyticsProviderMock)
-        let mockViewController = UIViewController()
 
         let configuration = ApplePayComponent.Configuration(
             payment: Dummy.createTestApplePayPayment(),

--- a/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
@@ -158,8 +158,6 @@ class BLIKComponentTests: XCTestCase {
 
         setupRootViewController(sut.viewController)
 
-        let didSubmitExpectation = XCTestExpectation(description: "Expect delegate.didSubmit() to be called.")
-
         let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
         let expectedResult = formViewController.validate()
 

--- a/Tests/IntegrationTests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
@@ -95,7 +95,6 @@ class QiwiWalletComponentTests: XCTestCase {
         let phoneNumberViewTitleLabel: UILabel? = sut.viewController.view.findView(with: "AdyenComponents.QiwiWalletComponent.phoneNumberItem.titleLabel")
         let phoneNumberViewTextField: UITextField? = sut.viewController.view.findView(with: "AdyenComponents.QiwiWalletComponent.phoneNumberItem.textField")
         
-        let phoneExtensionView: FormPhoneExtensionPickerItemView? = sut.viewController.view.findView(with: "Adyen.FormPhoneNumberItem.phoneExtensionPickerItem")
         let phoneExtensionViewLabel: UILabel? = sut.viewController.view.findView(with: "Adyen.FormPhoneNumberItem.phoneExtensionPickerItem.label")
         
         let payButtonItemViewButton: UIControl? = sut.viewController.view.findView(with: "AdyenComponents.QiwiWalletComponent.payButtonItem.button")

--- a/Tests/IntegrationTests/Helpers/UIViewController+Search.swift
+++ b/Tests/IntegrationTests/Helpers/UIViewController+Search.swift
@@ -37,7 +37,13 @@ public extension UIViewController {
     }
 }
 
-extension UIViewController: @retroactive PresentationDelegate {
+#if compiler(>=6)
+extension UIViewController: @retroactive PresentationDelegate {}
+#else
+extension UIViewController: PresentationDelegate {}
+#endif
+
+extension UIViewController {
     public func present(component: PresentableComponent) {
         self.present(component.viewController, animated: false, completion: nil)
     }

--- a/Tests/IntegrationTests/Helpers/UIViewController+Search.swift
+++ b/Tests/IntegrationTests/Helpers/UIViewController+Search.swift
@@ -37,7 +37,7 @@ public extension UIViewController {
     }
 }
 
-extension UIViewController: PresentationDelegate {
+extension UIViewController: @retroactive PresentationDelegate {
     public func present(component: PresentableComponent) {
         self.present(component.viewController, animated: false, completion: nil)
     }

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -681,7 +681,6 @@ class SessionTests: XCTestCase {
     func testRemoveStoredPaymentMethodSuccess() throws {
         let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
-        let paymentMethod = expectedPaymentMethods.regular.last as! MBWayPaymentMethod
         
         let apiClient = APIClientMock()
         sut.apiClient = apiClient
@@ -709,7 +708,6 @@ class SessionTests: XCTestCase {
     func testRemoveStoredPaymentMethodFailure() throws {
         let expectedPaymentMethods = try AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
         let sut = try initializeSession(expectedPaymentMethods: expectedPaymentMethods)
-        let paymentMethod = expectedPaymentMethods.regular.last as! MBWayPaymentMethod
         
         let apiClient = APIClientMock()
         sut.apiClient = apiClient

--- a/Tests/UnitTests/Helpers/PaymentMethods+Equatable.swift
+++ b/Tests/UnitTests/Helpers/PaymentMethods+Equatable.swift
@@ -6,7 +6,13 @@
 
 import Adyen
 
-extension PaymentMethods: @retroactive Equatable {
+#if compiler(>=6)
+extension PaymentMethods: @retroactive Equatable {}
+#else
+extension PaymentMethods: Equatable {}
+#endif
+
+extension PaymentMethods {
     public static func == (lhs: PaymentMethods, rhs: PaymentMethods) -> Bool {
         guard lhs.regular.count == rhs.regular.count else { return false }
         guard lhs.stored.count == rhs.stored.count else { return false }

--- a/Tests/UnitTests/Helpers/PaymentMethods+Equatable.swift
+++ b/Tests/UnitTests/Helpers/PaymentMethods+Equatable.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 
-extension PaymentMethods: Equatable {
+extension PaymentMethods: @retroactive Equatable {
     public static func == (lhs: PaymentMethods, rhs: PaymentMethods) -> Bool {
         guard lhs.regular.count == rhs.regular.count else { return false }
         guard lhs.stored.count == rhs.stored.count else { return false }


### PR DESCRIPTION
# Summary
- Checking if the compiler knows about the backported apple pay enum case
- Updating Project settings
- Adding [@retroactive](https://forums.swift.org/t/supressing-retroactive-conformance-warning-while-supporting-both-swift-5-10-and-6-0/73784) for extensions of foundational types

## Background regarding #if compiler(>=6)

Xcode started complaining:
```
Extension declares a conformance of imported type 'Array' to imported protocol 'AdyenCompatible'; 
this will not behave correctly if the owners of 'Swift' introduce this conformance in the future
```

## Issue

When adding the @retroactive tag it silences the warning but it will start failing if you build with a compiler that doesn’t know about this label. Which is the case on our CI because we need older Xcodes (with older toolchain) to get access to older Simulators to be able to test older iOS versions.

## Solution
You can check for the swift or compiler version that is used to compile your project via a compiler directive.

e.g.
```
#if swift(>=6) // Checks for the minimum swift version
#if compiler(>=6) // Checks for the minimum compiler version
```

So wrapping the code in an `#if compiler(>=6)` block and providing the old code in the `#else` block silences the warnings AND allows you to build the code with older toolchains

# Ticket

<ticket>
COIOS-000
</ticket>
