### PR TITLE
3ds2 cancel update

### DIFF
--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -212,7 +212,6 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
     }
     
     /// Invoked to handle the error flow of a challenge handling by the 3ds2sdk.
-    /// For challenge cancelled we return the control back to the merchant immediately as an error.
     private func didReceiveErrorOnChallenge(
         error: Error?,
         challengeAction: ThreeDS2ChallengeAction,
@@ -232,18 +231,14 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
                 for: Constants.challengeEvent,
                 message: "cancelled"
             )
-            didFail(
-                with: error,
-                completionHandler: completionHandler
-            )
         default:
             sendErrorEvent(.threeDS2ChallengeHandlingFailed, for: Constants.challengeEvent)
-            didFinish(
-                threeDS2SDKError: error.base64Representation(),
-                authorizationToken: challengeAction.authorisationToken,
-                completionHandler: completionHandler
-            )
         }
+        didFinish(
+            threeDS2SDKError: error.base64Representation(),
+            authorizationToken: challengeAction.authorisationToken,
+            completionHandler: completionHandler
+        )
     }
     
     private func didFinish(


### PR DESCRIPTION
# Summary

<changed>

- For [native 3D Secure 2](https://docs.adyen.com/online-payments/3d-secure/native-3ds2/?platform=iOS&integration=Drop-in&version=5.0.0+and+later), when a shopper cancels the payment during the payment flow, the `didProvide(...`) delegate method is now triggered. What this means for your integration depends on whether you already make a `/payments/details` call to handle 3D Secure 2 errors:

   - If yes, you do not need to make any changes to your integration. 
   - If not, update your integration to make a `/payments/details` request to get the details of the canceled transaction.

</changed>

# Ticket

<ticket>
COIOS-855
</ticket>
