### PR TITLE
Add accessibility identifier to Apple Pay pre-page root view

### DIFF
--- a/AdyenDropIn/Views/PreApplePayView.swift
+++ b/AdyenDropIn/Views/PreApplePayView.swift
@@ -52,6 +52,8 @@ internal final class PreApplePayView: UIView, Localizable {
     }
     
     private func buildUI() {
+        accessibilityIdentifier = "adyen.preApplePay"
+        
         addButton()
         addHintLabel()
     }


### PR DESCRIPTION
# Summary

Our current system to build accessibility identifier in runtime doesn't really work nicely when root view
doesn't have an identifier.

`PreApplePayView` is an "orphan" view that is presented using abstract `ADYViewController` and doesn't have and shouldn't have any accessibility logic. It's up to a child view to decide and while we don't have many such cases, it seems to be one of them.

## Before
`<Adyen.PreApplePayView: 0x103374f00; frame = (0 0; 0 0); layer = <CALayer: 0x60000036b900>>.applePayButton`
## After
`adyen.preApplePay.applePayButton`

# Ticket

<ticket>
COIOS-000
</ticket>
