### PR TITLE
Branch name validation script

### DIFF
--- a/Scripts/validate-branch-name.sh
+++ b/Scripts/validate-branch-name.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+LC_ALL=C
+
+local_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+valid_branch_regex="^(feature|fix|chore|improvement|release)\/[a-z0-9._-]+$"
+
+message="Invalid branch name. Branch names should follow this format: $valid_branch_regex. Your commit will be rejected. Rename your branch to a valid name and try again."
+
+if [[ ! $local_branch =~ $valid_branch_regex ]]
+then
+    echo "$message"
+    exit 1
+fi
+
+exit 0

--- a/Scripts/validate-branch-name.sh
+++ b/Scripts/validate-branch-name.sh
@@ -5,7 +5,7 @@ local_branch="$(git rev-parse --abbrev-ref HEAD)"
 
 valid_branch_regex="^(feature|fix|chore|improvement|release)\/[a-z0-9._-]+$"
 
-message="Invalid branch name. Branch names should follow this format: $valid_branch_regex. Your commit will be rejected. Rename your branch to a valid name and try again."
+message="Invalid branch name. Branch names should follow this format: $valid_branch_regex. Your commit will be rejected. Rename your branch to a valid name (e.g., 'feature/payto-base', 'fix/card-number-validation`, 'release/5.5.5') and try again."
 
 if [[ ! $local_branch =~ $valid_branch_regex ]]
 then


### PR DESCRIPTION
## Problem

We realized we currently only have branch rules for develop, meaning any PR targeted to any other branch than develop can be freely merged without our branch rules (e.g., 3 approvals, resolved conversations, green CI etc).


## Solution

Github allows creating rules for specific branches but that would mean we would need a new rule for every new branch which is not sustainable. Fortunately Github also allows rules for branch folders such as `feature/*` so we can create branch rules under such folders.



This would require all future branches to be created with these prefixes. This PR achieves it with a script and add it in our pre-commit hook.

Currently naming format is `{labelName}/{branchName}`

`labelName` = `feature, fix, chore, improvement, release`

`branchName` = Any name ( can be made to always include COIOS string)

# Ticket

<ticket>
COIOS-870
</ticket>
