### PR TITLE
Fix escaping chars in the branch name script

### DIFF
--- a/Scripts/validate-branch-name.sh
+++ b/Scripts/validate-branch-name.sh
@@ -5,7 +5,7 @@ local_branch="$(git rev-parse --abbrev-ref HEAD)"
 
 valid_branch_regex="^(feature|fix|chore|improvement|release)\/[a-z0-9._-]+$"
 
-message="Invalid branch name. Branch names should follow this format: $valid_branch_regex. Your commit will be rejected. Rename your branch to a valid name (e.g., 'feature/payto-base', 'fix/card-number-validation`, 'release/5.5.5') and try again."
+message="Invalid branch name. Branch names should follow this format: $valid_branch_regex. Rename your branch to a valid name (e.g., \"feature/payto-base\", \"fix/card-number-validation\", \"release/5.5.5\") and try again."
 
 if [[ ! $local_branch =~ $valid_branch_regex ]]
 then


### PR DESCRIPTION
Quotes were not properly escaped.

# Ticket

<ticket>
COIOS-870
</ticket>
