### PR TITLE
Fix get release notes workflow

### DIFF
--- a/.github/workflows/get_release_notes.yml
+++ b/.github/workflows/get_release_notes.yml
@@ -48,6 +48,7 @@ jobs:
           OUTPUT=""
           # Loop through each label and find matching commits
           for LABEL in "${ALLOWED_LABELS_ARRAY[@]}"; do
+            echo "$LABEL"
             LABEL=$(echo "$LABEL" | xargs)  # Trim spaces
             
             # Finding content inside of <$LABEL> & </$LABEL> + trimming leading/trailling spaces/newlines

--- a/.github/workflows/get_release_notes.yml
+++ b/.github/workflows/get_release_notes.yml
@@ -48,11 +48,13 @@ jobs:
           OUTPUT=""
           # Loop through each label and find matching commits
           for LABEL in "${ALLOWED_LABELS_ARRAY[@]}"; do
-            echo "$LABEL"
-            LABEL=$(echo "$LABEL" | xargs)  # Trim spaces
+            LABEL=$(echo "$LABEL" | xargs) # Trim spaces
             
             # Finding content inside of <$LABEL> & </$LABEL> + trimming leading/trailling spaces/newlines
-            LABEL_OUTPUT=$(echo "$COMMITS" | awk "/<$LABEL>/,/<\/$LABEL>/" | sed "s/<$LABEL>//g; s/<\/$LABEL>//g" | xargs)
+            LABEL_OUTPUT=$(echo "$COMMITS" | awk "/<$LABEL>/,/<\/$LABEL>/" | sed "s/<$LABEL>//g; s/<\/$LABEL>//g")
+            echo $LABEL_OUTPUT
+            LABEL_OUTPUT=$(echo $LABEL_OUTPUT | xargs)
+            echo $LABEL_OUTPUT
             
             if [ -n "$LABEL_OUTPUT" ]; then
               OUTPUT="$OUTPUT

--- a/.github/workflows/get_release_notes.yml
+++ b/.github/workflows/get_release_notes.yml
@@ -51,9 +51,7 @@ jobs:
             LABEL=$(echo "$LABEL" | xargs) # Trim spaces
             
             # Finding content inside of <$LABEL> & </$LABEL> + trimming leading/trailling spaces/newlines
-            LABEL_OUTPUT=$(echo "$COMMITS" | awk "/<$LABEL>/,/<\/$LABEL>/" | sed "s/<$LABEL>//g; s/<\/$LABEL>//g")
-            echo $LABEL_OUTPUT
-            LABEL_OUTPUT=$(echo $LABEL_OUTPUT | sed 's/"/\\"/g' | sed "s/'/\\'/g" | xargs)
+            LABEL_OUTPUT=$(echo "$COMMITS" | awk "/<$LABEL>/,/<\/$LABEL>/" | sed "s/<$LABEL>//g; s/<\/$LABEL>//g" | xargs -0)
             echo $LABEL_OUTPUT
             
             if [ -n "$LABEL_OUTPUT" ]; then

--- a/.github/workflows/get_release_notes.yml
+++ b/.github/workflows/get_release_notes.yml
@@ -53,7 +53,7 @@ jobs:
             # Finding content inside of <$LABEL> & </$LABEL> + trimming leading/trailling spaces/newlines
             LABEL_OUTPUT=$(echo "$COMMITS" | awk "/<$LABEL>/,/<\/$LABEL>/" | sed "s/<$LABEL>//g; s/<\/$LABEL>//g")
             echo $LABEL_OUTPUT
-            LABEL_OUTPUT=$(echo $LABEL_OUTPUT | xargs)
+            LABEL_OUTPUT=$(echo $LABEL_OUTPUT | sed 's/"/\\"/g' | sed "s/'/\\'/g" | xargs)
             echo $LABEL_OUTPUT
             
             if [ -n "$LABEL_OUTPUT" ]; then


### PR DESCRIPTION
# Summary
- get_release_notes workflow now allows `'` and `"` usage within descriptions

# Ticket

<ticket>
COIOS-000
</ticket>
