### PR TITLE
Use `github.event.pull_request.user.login` to detect renovate bot

### DIFF
--- a/.github/workflows/validate_ticket.yml
+++ b/.github/workflows/validate_ticket.yml
@@ -10,7 +10,7 @@ jobs:
     if: |
       github.event.pull_request.base.ref == 'develop' && 
       !startsWith(github.event.pull_request.head.ref, 'release/') && 
-      !contains(github.actor, 'renovate') &&
+      !contains(github.event.pull_request.user.login, 'renovate') &&
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Check out


### PR DESCRIPTION
# Summary

This is a proper way to check for renovate bot and skip ticket number validation flow.

# Ticket

<ticket>
COIOS-000
</ticket>
