### PR TITLE
Create payto specific picker subclass

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 		A0113D9B2763887800AD395C /* ActionNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0113D9A2763887800AD395C /* ActionNavigationBar.swift */; };
 		A013F98126AFF72D00602633 /* BrazilSocialSecurityNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07B2CE526A5B5440008185C /* BrazilSocialSecurityNumberFormatter.swift */; };
 		A018094826FDD345003A8DE3 /* FormCardNumberContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A018094726FDD345003A8DE3 /* FormCardNumberContainerItem.swift */; };
+		A01948342D8827FD00AA27AC /* PayToFormPickerItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01948332D8827A300AA27AC /* PayToFormPickerItemView.swift */; };
 		A01DCF0B26BD67BB00BC35B3 /* FormCardExpiryDateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01DCF0A26BD67BB00BC35B3 /* FormCardExpiryDateItem.swift */; };
 		A01DFBBF2BA887BF00205881 /* ThreadSafeAnalyticsEventDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01DFBBE2BA887BF00205881 /* ThreadSafeAnalyticsEventDataSource.swift */; };
 		A01DFBC52BB6F9FA00205881 /* ValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01DFBC42BB6F9FA00205881 /* ValidationError.swift */; };
@@ -1775,6 +1776,7 @@
 		A00F73A42B3DB67B00E9252B /* AdyenSession+StoredPaymentMethodsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdyenSession+StoredPaymentMethodsDelegate.swift"; sourceTree = "<group>"; };
 		A0113D9A2763887800AD395C /* ActionNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionNavigationBar.swift; sourceTree = "<group>"; };
 		A018094726FDD345003A8DE3 /* FormCardNumberContainerItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardNumberContainerItem.swift; sourceTree = "<group>"; };
+		A01948332D8827A300AA27AC /* PayToFormPickerItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayToFormPickerItemView.swift; sourceTree = "<group>"; };
 		A01D775529B250C10075BD70 /* CashAppPayDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashAppPayDetails.swift; sourceTree = "<group>"; };
 		A01DCF0A26BD67BB00BC35B3 /* FormCardExpiryDateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardExpiryDateItem.swift; sourceTree = "<group>"; };
 		A01DFBBE2BA887BF00205881 /* ThreadSafeAnalyticsEventDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeAnalyticsEventDataSource.swift; sourceTree = "<group>"; };
@@ -2730,6 +2732,7 @@
 		000888762D4CF5DB009C03E1 /* PayTo */ = {
 			isa = PBXGroup;
 			children = (
+				A01948332D8827A300AA27AC /* PayToFormPickerItemView.swift */,
 				000888772D4CF5F5009C03E1 /* PayToComponent.swift */,
 				A0BFBB532D6F2670003F543E /* PayToItemsProvider.swift */,
 				A0BFBB552D6F45AB003F543E /* PayToPayIdentifier.swift */,
@@ -7575,6 +7578,7 @@
 				C9D8EB9E27452D3B006D8CA1 /* BACSItemsFactory.swift in Sources */,
 				81D2186D2CC7D57700B7FC4C /* PayByBankUSComponent.swift in Sources */,
 				F9175ED32593951900D653BE /* MBWayDetails.swift in Sources */,
+				A01948342D8827FD00AA27AC /* PayToFormPickerItemView.swift in Sources */,
 				F9175EAB259394FF00D653BE /* ApplePayDetails.swift in Sources */,
 				F9175EE22593952600D653BE /* BLIKComponent.swift in Sources */,
 				C9D8EBA02745556B006D8CA1 /* BACSDirectDebitDetails.swift in Sources */,

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -2732,11 +2732,11 @@
 		000888762D4CF5DB009C03E1 /* PayTo */ = {
 			isa = PBXGroup;
 			children = (
-				A01948332D8827A300AA27AC /* PayToFormPickerItemView.swift */,
 				000888772D4CF5F5009C03E1 /* PayToComponent.swift */,
 				A0BFBB532D6F2670003F543E /* PayToItemsProvider.swift */,
 				A0BFBB552D6F45AB003F543E /* PayToPayIdentifier.swift */,
 				A0BFBB572D75FD44003F543E /* PayToDetails.swift */,
+				A01948332D8827A300AA27AC /* PayToFormPickerItemView.swift */,
 			);
 			path = PayTo;
 			sourceTree = "<group>";

--- a/Adyen/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItemView.swift
+++ b/Adyen/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItemView.swift
@@ -8,7 +8,7 @@ import UIKit
 
 /// Represents a picker item view.
 @_spi(AdyenInternal)
-public final class BaseFormPickerItemView<T: CustomStringConvertible & Equatable>:
+open class BaseFormPickerItemView<T: CustomStringConvertible & Equatable>:
     FormValueItemView<BasePickerElement<T>, FormTextItemStyle, BaseFormPickerItem<T>>,
     UIPickerViewDelegate,
     UIPickerViewDataSource {
@@ -49,7 +49,7 @@ public final class BaseFormPickerItemView<T: CustomStringConvertible & Equatable
         }
     }
 
-    override public var canBecomeFirstResponder: Bool { true }
+    override open var canBecomeFirstResponder: Bool { true }
 
     @discardableResult
     override public func becomeFirstResponder() -> Bool {

--- a/Adyen/UI/Form/Items/Value Pickers/Identifier Picker/FormStringPickerItem.swift
+++ b/Adyen/UI/Form/Items/Value Pickers/Identifier Picker/FormStringPickerItem.swift
@@ -22,7 +22,7 @@ public struct FormStringPickerElement: CustomStringConvertible, Equatable {
 
 /// A identifier picker form item
 @_spi(AdyenInternal)
-public final class FormStringPickerItem: BaseFormPickerItem<FormStringPickerElement> {
+open class FormStringPickerItem: BaseFormPickerItem<FormStringPickerElement> {
 
     public init(
         preselectedStringValue: FormStringPickerElement,
@@ -40,7 +40,7 @@ public final class FormStringPickerItem: BaseFormPickerItem<FormStringPickerElem
         )
     }
 
-    override public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    override open func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
 }

--- a/AdyenComponents/PayTo/PayToFormPickerItemView.swift
+++ b/AdyenComponents/PayTo/PayToFormPickerItemView.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) import Adyen
+import UIKit
+
+internal class PayToIdentifierItem: FormStringPickerItem {
+    
+    override internal func build(with builder: FormItemViewBuilder) -> any AnyFormItemView {
+        PayToFormPickerItemView(item: self)
+    }
+}
+
+/// Picker subclass view specific to PayTo with its own logic to prevent opening the picker at initial load.
+internal class PayToFormPickerItemView: BaseFormPickerItemView<FormStringPickerElement> {
+    
+    // To prevent this picker to become first responder initially
+    override internal var canBecomeFirstResponder: Bool { false }
+    
+}
+
+extension FormItemViewBuilder {
+    
+    internal func build(with item: PayToIdentifierItem) -> PayToFormPickerItemView {
+        PayToFormPickerItemView(item: item)
+    }
+}

--- a/AdyenComponents/PayTo/PayToItemsProvider.swift
+++ b/AdyenComponents/PayTo/PayToItemsProvider.swift
@@ -176,7 +176,7 @@ internal class PayToItemsProvider: PayToItemsProviding {
 
         AdyenAssertion.assert(message: "selectableValues should be greater than 0", condition: selectableValues.isEmpty)
 
-        let item = FormStringPickerItem(
+        let item = PayToIdentifierItem(
             preselectedStringValue: selectableValues[0],
             selectableStringValues: selectableValues,
             style: style.textField

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -101,10 +101,11 @@ class PayToComponentTests: XCTestCase {
         sut.viewController.loadViewIfNeeded()
 
         // Check by accessibility identifier
-        let identifierPickerItem: BaseFormPickerItemView<FormStringPickerElement> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.identifierPicker"))
+        let identifierPickerItem: PayToFormPickerItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.identifierPicker"))
 
         // Then
         XCTAssertNotNil(identifierPickerItem, "identifier picker should exist")
+        XCTAssertFalse(identifierPickerItem.canBecomeFirstResponder)
     }
 
     func test_firstname_textfield() throws {


### PR DESCRIPTION
# Summary

The base picker view has auto activation enabled in case it is first item on the form view to become first responder. This doesn't fit well with PayTo as it creates a jarring UX. 

Create a subclass that disables this behavior only for Payto

# Ticket

<ticket>
COIOS-882
</ticket>
