### PR TITLE
DSP-1867: create a provider for the ThreeDSService

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -110,6 +110,8 @@
 		21C711242D6D3B2500A08111 /* ThreeDSServiceableMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C711232D6D3B2100A08111 /* ThreeDSServiceableMock.swift */; };
 		21CBEF4D2D88768700178809 /* ThreeDS2Component+FingerprintTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CBEF4C2D88766D00178809 /* ThreeDS2Component+FingerprintTokenTests.swift */; };
 		21CBEF4F2D88CA2300178809 /* ThreeDS2ComponentThreeDSConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CBEF4E2D88CA1600178809 /* ThreeDS2ComponentThreeDSConfiguration.swift */; };
+		21CBEF642D8B0A0700178809 /* ThreeDSServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CBEF632D8B0A0500178809 /* ThreeDSServiceProvider.swift */; };
+		21CBEF662D8B6B3A00178809 /* ThreeDSServiceProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CBEF652D8B6B2F00178809 /* ThreeDSServiceProviderTests.swift */; };
 		5A1315C926296B100092366D /* ProgressViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1315C826296B100092366D /* ProgressViewStyle.swift */; };
 		5A15D589264BB0BD00A8E3C7 /* BoletoComponentExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A15D588264BB0BD00A8E3C7 /* BoletoComponentExtensions.swift */; };
 		5A15D5A1264BE1E500A8E3C7 /* PrefilledShopperInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A15D5A0264BE1E500A8E3C7 /* PrefilledShopperInformation.swift */; };
@@ -1598,6 +1600,8 @@
 		21C711232D6D3B2100A08111 /* ThreeDSServiceableMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSServiceableMock.swift; sourceTree = "<group>"; };
 		21CBEF4C2D88766D00178809 /* ThreeDS2Component+FingerprintTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ThreeDS2Component+FingerprintTokenTests.swift"; sourceTree = "<group>"; };
 		21CBEF4E2D88CA1600178809 /* ThreeDS2ComponentThreeDSConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDS2ComponentThreeDSConfiguration.swift; sourceTree = "<group>"; };
+		21CBEF632D8B0A0500178809 /* ThreeDSServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSServiceProvider.swift; sourceTree = "<group>"; };
+		21CBEF652D8B6B2F00178809 /* ThreeDSServiceProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSServiceProviderTests.swift; sourceTree = "<group>"; };
 		5A1315C826296B100092366D /* ProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewStyle.swift; sourceTree = "<group>"; };
 		5A15D588264BB0BD00A8E3C7 /* BoletoComponentExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoletoComponentExtensions.swift; sourceTree = "<group>"; };
 		5A15D5A0264BE1E500A8E3C7 /* PrefilledShopperInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefilledShopperInformation.swift; sourceTree = "<group>"; };
@@ -5199,6 +5203,7 @@
 			isa = PBXGroup;
 			children = (
 				21CBEF4C2D88766D00178809 /* ThreeDS2Component+FingerprintTokenTests.swift */,
+				21CBEF652D8B6B2F00178809 /* ThreeDSServiceProviderTests.swift */,
 				21C7111B2D6D36A400A08111 /* ThreeDS2ServiceLegacyTests.swift */,
 				F957AA442552C3BB0099AD73 /* 3DS2 Fingerprint Submitter */,
 				F957AA592552D8BB0099AD73 /* ThreeDS2ComponentTests.swift */,
@@ -5596,6 +5601,7 @@
 		F9A7AC592554062400012EBC /* 3DS2 SDK Adapters */ = {
 			isa = PBXGroup;
 			children = (
+				21CBEF632D8B0A0500178809 /* ThreeDSServiceProvider.swift */,
 				21C7110D2D67F86700A08111 /* ThreeDSServiceable.swift */,
 				21C7111A2D67FEFF00A08111 /* LegacySDK */,
 				21C711142D67FE9A00A08111 /* FingerprintServiceParameters.swift */,
@@ -7317,6 +7323,7 @@
 				F97C83F725BF0C2800D7F85C /* DokuComponentTests.swift in Sources */,
 				81F177AE2B4C49B9009CAD96 /* PresenterMock.swift in Sources */,
 				F924C072246BEEF0006DDAB8 /* CardDetailsTests.swift in Sources */,
+				21CBEF662D8B6B3A00178809 /* ThreeDSServiceProviderTests.swift in Sources */,
 				F9FE39E32679E09200F02A9B /* LoadingViewTests.swift in Sources */,
 				B6EE0F3D2BBEBF5100B9810D /* AnalyticsProviderMock.swift in Sources */,
 				A0290DF82C413056005BE269 /* StoredPaymentMethodDelegateMock.swift in Sources */,
@@ -7625,6 +7632,7 @@
 				F9976BB326D903F400D2D7CE /* MultibancoVoucherAction.swift in Sources */,
 				F9175FFA259499D500D653BE /* AwaitViewController.swift in Sources */,
 				21C711112D67FE6B00A08111 /* ThreeDSServiceChallengeError.swift in Sources */,
+				21CBEF642D8B0A0700178809 /* ThreeDSServiceProvider.swift in Sources */,
 				F96757C327CF909900A16FB6 /* AnyWeChatPaySDKActionComponent.swift in Sources */,
 				F9175FD22594999600D653BE /* RedirectComponent.swift in Sources */,
 				00165FE02C05DA8600347399 /* RedireactableAwaitAction.swift in Sources */,

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ThreeDSServiceLegacy.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ThreeDSServiceLegacy.swift
@@ -63,9 +63,7 @@ internal final class ThreeDSServiceLegacy: ThreeDSServiceable {
         )
         
         guard let transaction else {
-            return completionHandler(.failure(.transactionNotInitialized(
-                errorPayload: opaqueErrorObject(error: ThreeDSServiceChallengeError.transactionNotInitialized(errorPayload: ""))
-            )))
+            return completionHandler(.failure(.transactionNotInitialized))
         }
         
         transaction.performChallenge(

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceChallengeError.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceChallengeError.swift
@@ -7,9 +7,9 @@
 import Foundation
 
 /// Errors that could happen during a challenge
-internal enum ThreeDSServiceChallengeError: Error {
+internal enum ThreeDSServiceChallengeError: Error, Equatable {
     /// The transaction was not initialized during fingerprinting.
-    case transactionNotInitialized(errorPayload: String)
+    case transactionNotInitialized
     /// Edge case which should never occur.
     case errorAndResultAreNil(errorPayload: String)
     /// The challenge has been cancelled.

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceProvider.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceProvider.swift
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+@_spi(AdyenInternal) import Adyen
+
+internal protocol ThreeDSConfigurable {
+    var configuration: ThreeDSFeatureChecker? { get set }
+}
+
+internal protocol ThreeDSFeatureChecker {
+    func isFeatureEnabled(_ name: String) -> Bool
+}
+
+/// This type creates a ThreeDSServiceable implementation and consumes ThreeDSConfigurable.
+internal final class ThreeDSServiceProvider: ThreeDSServiceable, ThreeDSConfigurable {
+    
+    /// An optional configuration that can be provided to the service provider.
+    internal var configuration: ThreeDSFeatureChecker?
+    
+    private var service: ThreeDSServiceable?
+    private let serviceCreationHandler: (ThreeDSFeatureChecker?) -> ThreeDSServiceable
+
+    internal init(
+        serviceCreationHandler: @escaping (ThreeDSFeatureChecker?) -> ThreeDSServiceable = createService
+    ) {
+        self.serviceCreationHandler = serviceCreationHandler
+    }
+    
+    internal func performFingerprint(
+        parameters: FingerprintServiceParameters,
+        completionHandler: @escaping (Result<any AnyAuthenticationRequestParameters, ThreeDSServiceFingerprintError>) -> Void
+    ) {
+        self.resetTransaction()
+        let service = serviceCreationHandler(configuration)
+        self.service = service
+        service.performFingerprint(
+            parameters: parameters,
+            completionHandler: completionHandler
+        )
+    }
+    
+    internal func performChallenge(
+        with parameters: ChallengeParameters,
+        completionHandler: @escaping (Result<any AnyChallengeResult, ThreeDSServiceChallengeError>) -> Void
+    ) {
+        // The service needs to be already created during the fingerprint step.
+        // There is no way a challenge action should happen without a fingerprint action.
+        guard let service = self.service else {
+            completionHandler(.failure(.transactionNotInitialized))
+            return
+        }
+        service.performChallenge(with: parameters) { result in
+            self.resetTransaction()
+            completionHandler(result)
+        }
+    }
+    
+    internal func resetTransaction() {
+        service?.resetTransaction()
+        service = nil
+    }
+    
+    internal static func createService(
+        configuration: ThreeDSFeatureChecker?
+    ) -> ThreeDSServiceable {
+        ThreeDSServiceLegacy()
+    }
+}

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -11,8 +11,6 @@ import Foundation
 internal protocol AnyThreeDS2CoreActionHandler: Component {
     var threeDSRequestorAppURL: URL? { get set }
     
-    var service: ThreeDSServiceable { get set }
-
     var presentationDelegate: PresentationDelegate? { get set }
     
     func handle(
@@ -28,6 +26,8 @@ internal protocol AnyThreeDS2CoreActionHandler: Component {
     )
 }
 
+internal typealias ThreeDSService = ThreeDSConfigurable & ThreeDSServiceable
+
 /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
 internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
     private enum Constants {
@@ -40,8 +40,8 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
 
     /// The appearance configuration of the 3D Secure 2 challenge UI.
     internal let appearanceConfiguration: ADYAppearanceConfiguration
-
-    internal lazy var service: ThreeDSServiceable = ThreeDSServiceLegacy()
+    
+    private var service: ThreeDSService
     
     internal weak var presentationDelegate: PresentationDelegate?
     
@@ -55,7 +55,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
     /// - Parameter appearanceConfiguration: The appearance configuration of the 3D Secure 2 challenge UI.
     internal init(
         context: AdyenContext,
-        service: ThreeDSServiceable = ThreeDSServiceLegacy(),
+        service: ThreeDSService,
         appearanceConfiguration: ADYAppearanceConfiguration = ADYAppearanceConfiguration()
     ) {
         self.context = context
@@ -88,7 +88,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
                 appearanceConfiguration: appearanceConfiguration,
                 threeDSMessageVersion: token.threeDSMessageVersion
             )
-            
+            service.configuration = token.configuration
             service.performFingerprint(
                 parameters: serviceParameters
             ) { result in
@@ -222,8 +222,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
                 message: "cancelled"
             )
 
-        case let .transactionNotInitialized(errorPayload):
-            opaqueRepresentationOfError = errorPayload
+        case .transactionNotInitialized:
             sendErrorEvent(
                 .threeDS2TransactionMissing,
                 for: Constants.challengeEvent
@@ -246,7 +245,6 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
                 threeDS2SDKError: opaqueRepresentationOfError,
                 transStatus: Constants.transStatusWhenError
             )
-            self.service.resetTransaction()
             completionHandler(.success(threeDSResult))
         } catch {
             didFail(with: error, completionHandler: completionHandler)
@@ -265,7 +263,6 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
                 authorizationToken: authorizationToken,
                 threeDS2SDKError: nil
             )
-            self.service.resetTransaction()
             completionHandler(.success(threeDSResult))
         } catch {
             didFail(with: error, completionHandler: completionHandler)
@@ -276,7 +273,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
         with error: Error,
         completionHandler: @escaping (Result<R, Error>) -> Void
     ) {
-        self.service.resetTransaction()
+        service.resetTransaction()
         completionHandler(.failure(error))
     }
 

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
@@ -42,11 +42,13 @@ internal typealias VoidHandler = () -> Void
         /// - Parameter presentationDelegate: The presentation delegate
         internal convenience init(
             context: AdyenContext,
+            service: ThreeDSService,
             appearanceConfiguration: ADYAppearanceConfiguration,
             delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication
         ) {
             self.init(
                 context: context,
+                service: service,
                 presenter: ThreeDS2PlusDAScreenPresenter(
                     style: delegatedAuthenticationConfiguration.delegatedAuthenticationComponentStyle,
                     localizedParameters: delegatedAuthenticationConfiguration.localizationParameters,
@@ -69,7 +71,7 @@ internal typealias VoidHandler = () -> Void
         /// - Parameter delegatedAuthenticationService: The Delegated Authentication service.
         internal init(
             context: AdyenContext,
-            service: ThreeDSServiceable = ThreeDSServiceLegacy(),
+            service: ThreeDSService,
             presenter: ThreeDS2PlusDAScreenPresenterProtocol,
             appearanceConfiguration: ADYAppearanceConfiguration = .init(),
             style: DelegatedAuthenticationComponentStyle = .init(),

--- a/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -50,6 +50,7 @@ extension ComponentWrapper {
 
 internal func createDefaultThreeDS2CoreActionHandler(
     context: AdyenContext,
+    service: ThreeDSService,
     appearanceConfiguration: ADYAppearanceConfiguration,
     delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication?
 ) -> AnyThreeDS2CoreActionHandler {
@@ -57,18 +58,21 @@ internal func createDefaultThreeDS2CoreActionHandler(
         if #available(iOS 16.0, *), let delegatedAuthenticationConfiguration {
             return ThreeDS2PlusDACoreActionHandler(
                 context: context,
+                service: service,
                 appearanceConfiguration: appearanceConfiguration,
                 delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
             )
         } else {
             return ThreeDS2CoreActionHandler(
                 context: context,
+                service: service,
                 appearanceConfiguration: appearanceConfiguration
             )
         }
     #else
         return ThreeDS2CoreActionHandler(
             context: context,
+            service: service,
             appearanceConfiguration: appearanceConfiguration
         )
     #endif

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler+Initializers.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler+Initializers.swift
@@ -16,17 +16,20 @@ extension ThreeDS2ClassicActionHandler {
     /// Initializes the 3D Secure 2 action handler.
     internal convenience init(
         context: AdyenContext,
+        service: ThreeDSService,
         appearanceConfiguration: ADYAppearanceConfiguration,
         delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication?
     ) {
         let defaultHandler = createDefaultThreeDS2CoreActionHandler(
             context: context,
+            service: service,
             appearanceConfiguration: appearanceConfiguration,
             delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
         )
         self.init(
             context: context,
             appearanceConfiguration: appearanceConfiguration,
+            service: service,
             coreActionHandler: defaultHandler,
             delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
         )

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
@@ -36,18 +36,18 @@ internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, Component
     
     internal init(
         context: AdyenContext,
-        service: ThreeDSServiceable = ThreeDSServiceLegacy(),
-        appearanceConfiguration: ADYAppearanceConfiguration = ADYAppearanceConfiguration(),
+        appearanceConfiguration: ADYAppearanceConfiguration,
+        service: ThreeDSService,
         coreActionHandler: AnyThreeDS2CoreActionHandler? = nil,
         delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication? = nil
     ) {
         self.coreActionHandler = coreActionHandler ?? createDefaultThreeDS2CoreActionHandler(
             context: context,
+            service: service,
             appearanceConfiguration: appearanceConfiguration,
             delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
         )
         self.context = context
-        self.coreActionHandler.service = service
     }
 
     // MARK: - Fingerprint

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler+Initializers.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler+Initializers.swift
@@ -16,6 +16,7 @@ extension ThreeDS2CompactActionHandler {
     /// Initializes the 3D Secure 2 action handler.
     internal convenience init(
         context: AdyenContext,
+        service: ThreeDSService,
         appearanceConfiguration: ADYAppearanceConfiguration,
         delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication?
     ) {
@@ -25,8 +26,10 @@ extension ThreeDS2CompactActionHandler {
             context: context,
             fingerprintSubmitter: fingerprintSubmitter,
             appearanceConfiguration: appearanceConfiguration,
+            service: service,
             coreActionHandler: createDefaultThreeDS2CoreActionHandler(
                 context: context,
+                service: service,
                 appearanceConfiguration: appearanceConfiguration,
                 delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
             ),

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
@@ -52,19 +52,19 @@ internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, Com
     internal init(
         context: AdyenContext,
         fingerprintSubmitter: AnyThreeDS2FingerprintSubmitter? = nil,
-        service: ThreeDSServiceable = ThreeDSServiceLegacy(),
-        appearanceConfiguration: ADYAppearanceConfiguration = ADYAppearanceConfiguration(),
+        appearanceConfiguration: ADYAppearanceConfiguration,
+        service: ThreeDSService,
         coreActionHandler: AnyThreeDS2CoreActionHandler? = nil,
         delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication? = nil
     ) {
         self.context = context
         self.coreActionHandler = coreActionHandler ?? createDefaultThreeDS2CoreActionHandler(
             context: context,
+            service: service,
             appearanceConfiguration: appearanceConfiguration,
             delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
         )
         self.fingerprintSubmitter = fingerprintSubmitter ?? ThreeDS2FingerprintSubmitter(context: context)
-        self.coreActionHandler.service = service
     }
 
     // MARK: - Fingerprint

--- a/AdyenActions/Components/3DS2/ThreeDS2Component.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2Component.swift
@@ -229,6 +229,7 @@ public final class ThreeDS2Component: ActionComponent {
     internal lazy var threeDS2CompactFlowHandler: AnyThreeDS2ActionHandler = {
         let handler = ThreeDS2CompactActionHandler(
             context: context,
+            service: ThreeDSServiceProvider(),
             appearanceConfiguration: configuration.appearanceConfiguration,
             delegatedAuthenticationConfiguration: configuration.delegateAuthentication
         )
@@ -242,6 +243,7 @@ public final class ThreeDS2Component: ActionComponent {
     internal lazy var threeDS2ClassicFlowHandler: AnyThreeDS2ActionHandler = {
         let handler = ThreeDS2ClassicActionHandler(
             context: context,
+            service: ThreeDSServiceProvider(),
             appearanceConfiguration: configuration.appearanceConfiguration,
             delegatedAuthenticationConfiguration: configuration.delegateAuthentication
         )

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentThreeDSConfiguration.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentThreeDSConfiguration.swift
@@ -5,7 +5,7 @@
 //
 
 internal extension ThreeDS2Component {
-    struct ThreeDSConfiguration: Decodable {
+    struct ThreeDSConfiguration: Decodable, ThreeDSFeatureChecker {
         private let version: String
         internal let featureFlags: [String: Bool]?
         

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
@@ -44,13 +44,13 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
     }
     
     func testSettingThreeDSRequestorAppURL() {
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration())
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: ThreeDSServiceableMock())
         sut.threeDSRequestorAppURL = URL(string: "https://google.com")
         XCTAssertEqual(sut.coreActionHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
     }
 
     func testWrappedComponent() {
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration())
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: ThreeDSServiceableMock())
         XCTAssertEqual(sut.wrappedComponent.context.apiContext.clientKey, Dummy.apiContext.clientKey)
         
         XCTAssertEqual(sut.wrappedComponent.context.apiContext.environment.baseURL, Dummy.apiContext.environment.baseURL)
@@ -65,6 +65,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
     func testFingerprintFlowSuccess() throws {
         
         let service = ThreeDSServiceableMock()
+        service.onResetTransaction = {}
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
 
         let fingerprint = try ThreeDS2Component.Fingerprint(
@@ -79,6 +80,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2ClassicActionHandler(
             context: Dummy.context(with: analyticsProviderMock),
+            appearanceConfiguration: ADYAppearanceConfiguration(),
             service: service
         )
         sut.handle(fingerprintAction) { fingerprintResult in
@@ -120,6 +122,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
         submitter.mockedResult = .success(.details(mockedDetails))
 
         let service = ThreeDSServiceableMock()
+        service.onResetTransaction = {}
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
 
         let fingerprintAction = ThreeDS2FingerprintAction(
@@ -129,7 +132,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
         )
 
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, service: service)
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: service)
         sut.handle(fingerprintAction) { result in
             switch result {
             case .success:
@@ -150,6 +153,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
 
     func testChallengeFlowSuccess() throws {
         let service = ThreeDSServiceableMock()
+        service.onResetTransaction = {}
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
         service.onPerformChallenge = { params, completion in
             XCTAssertEqual(params.threeDSRequestorAppURL, URL(string: "https://google.com"))
@@ -159,6 +163,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2ClassicActionHandler(
             context: Dummy.context(with: analyticsProviderMock),
+            appearanceConfiguration: ADYAppearanceConfiguration(),
             service: service
         )
         sut.threeDSRequestorAppURL = URL(string: "https://google.com")
@@ -204,8 +209,8 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
         let service = ThreeDSServiceableMock()
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
         service.onPerformChallenge = { $1(.failure(.challengeError(errorPayload: ""))) }
-
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, service: service)
+        service.onResetTransaction = {}
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: service)
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
 
         sut.handle(challengeAction) { result in
@@ -238,8 +243,9 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
 
     func testChallengeFlowMissingTransaction() throws {
         let service = ThreeDSServiceableMock()
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, service: service)
-        service.onPerformChallenge = { $1(.failure(.transactionNotInitialized(errorPayload: ""))) }
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: service)
+        service.onPerformChallenge = { $1(.failure(.transactionNotInitialized)) }
+        service.onResetTransaction = {}
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
         sut.handle(challengeAction) { result in
             switch result {
@@ -261,11 +267,12 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
 
     func testInvalidChallengeToken() throws {
         let service = ThreeDSServiceableMock()
+        service.onResetTransaction = {}
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
         service.onPerformChallenge = { parameters, completion in
             XCTFail()
         }
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, service: service)
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: service)
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
 
         let challengeAction = ThreeDS2ChallengeAction(challengeToken: "Invalid-token", authorisationToken: "AuthToken", paymentData: "paymentData")

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
@@ -44,13 +44,13 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
     }
     
     func testSettingThreeDSRequestorAppURL() {
-        let sut = ThreeDS2CompactActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), delegatedAuthenticationConfiguration: nil)
+        let sut = ThreeDS2CompactActionHandler(context: Dummy.context, service: ThreeDSServiceableMock(), appearanceConfiguration: ADYAppearanceConfiguration(), delegatedAuthenticationConfiguration: nil)
         sut.threeDSRequestorAppURL = URL(string: "https://google.com")
         XCTAssertEqual(sut.coreActionHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
     }
 
     func testWrappedComponent() {
-        let sut = ThreeDS2CompactActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), delegatedAuthenticationConfiguration: nil)
+        let sut = ThreeDS2CompactActionHandler(context: Dummy.context, service: ThreeDSServiceableMock(), appearanceConfiguration: ADYAppearanceConfiguration(), delegatedAuthenticationConfiguration: nil)
         XCTAssertEqual(sut.wrappedComponent.context.apiContext.clientKey, Dummy.apiContext.clientKey)
         XCTAssertEqual(sut.wrappedComponent.context.apiContext.environment.baseURL, Dummy.apiContext.environment.baseURL)
 
@@ -69,7 +69,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
 
         let service = ThreeDSServiceableMock()
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
-
+        service.onResetTransaction = {}
         let fingerprintAction = ThreeDS2FingerprintAction(
             fingerprintToken: "Invalid-token",
             authorisationToken: "AuthToken",
@@ -81,6 +81,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(with: analyticsProviderMock),
             fingerprintSubmitter: submitter,
+            appearanceConfiguration: ADYAppearanceConfiguration(),
             service: service
         )
         sut.handle(fingerprintAction) { result in
@@ -116,11 +117,12 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
             XCTAssertEqual(params.threeDSRequestorAppURL, URL(string: "https://google.com"))
             completion(.success(AnyChallengeResultMock(sdkTransactionIdentifier: "sdkTxId", transactionStatus: "Y")))
         }
-
+        service.onResetTransaction = {}
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(with: analyticsProviderMock),
+            appearanceConfiguration: ADYAppearanceConfiguration(),
             service: service
         )
         sut.threeDSRequestorAppURL = URL(string: "https://google.com")
@@ -167,11 +169,12 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let service = ThreeDSServiceableMock()
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
         service.onPerformChallenge = { $1(.failure(.challengeError(errorPayload: ""))) }
-
+        service.onResetTransaction = {}
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(with: analyticsProviderMock),
             fingerprintSubmitter: submitter,
+            appearanceConfiguration: ADYAppearanceConfiguration(),
             service: service
         )
 
@@ -221,11 +224,12 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         service.onPerformChallenge = { parameters, completion in
             completion(.failure(.challengeError(errorPayload: "")))
         }
-
+        service.onResetTransaction = {}
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(with: analyticsProviderMock),
             fingerprintSubmitter: submitter,
+            appearanceConfiguration: ADYAppearanceConfiguration(),
             service: service
         )
 
@@ -262,10 +266,11 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(with: analyticsProviderMock),
             fingerprintSubmitter: submitter,
+            appearanceConfiguration: ADYAppearanceConfiguration(),
             service: service
         )
-        service.onPerformChallenge = { $1(.failure(.transactionNotInitialized(errorPayload: ""))) }
-
+        service.onPerformChallenge = { $1(.failure(.transactionNotInitialized)) }
+        service.onResetTransaction = {}
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
         sut.handle(challengeAction) { result in
             switch result {
@@ -312,13 +317,14 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
                 ))
             )
         }
-
+        service.onResetTransaction = {}
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
         
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(with: analyticsProviderMock),
             fingerprintSubmitter: submitter,
+            appearanceConfiguration: ADYAppearanceConfiguration(),
             service: service
         )
         sut.handle(fingerprintAction) { result in
@@ -355,7 +361,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
 
         let service = ThreeDSServiceableMock()
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
-
+        service.onResetTransaction = {}
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2CompactActionHandler(
@@ -363,6 +369,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
                 with: analyticsProviderMock
             ),
             fingerprintSubmitter: submitter,
+            appearanceConfiguration: ADYAppearanceConfiguration(),
             service: service
         )
         sut.handle(fingerprintAction) { result in
@@ -405,9 +412,14 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
 
         let service = ThreeDSServiceableMock()
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
-
+        service.onResetTransaction = {}
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
-        let sut = ThreeDS2CompactActionHandler(context: Dummy.context, fingerprintSubmitter: submitter, service: service)
+        let sut = ThreeDS2CompactActionHandler(
+            context: Dummy.context,
+            fingerprintSubmitter: submitter,
+            appearanceConfiguration: ADYAppearanceConfiguration(),
+            service: service
+        )
         sut.handle(fingerprintAction) { result in
             switch result {
             case let .success(result):
@@ -438,9 +450,14 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
 
         let service = ThreeDSServiceableMock()
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
-
+        service.onResetTransaction = {}
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
-        let sut = ThreeDS2CompactActionHandler(context: Dummy.context, fingerprintSubmitter: submitter, service: service)
+        let sut = ThreeDS2CompactActionHandler(
+            context: Dummy.context,
+            fingerprintSubmitter: submitter,
+            appearanceConfiguration: ADYAppearanceConfiguration(),
+            service: service
+        )
         sut.handle(fingerprintAction) { result in
             switch result {
             case .success:
@@ -469,7 +486,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         
         let service = ThreeDSServiceableMock()
         service.onPerformFingerprint = { $1(.failure(.fingerprintingError(errorPayload: errorPayload))) }
-
+        service.onResetTransaction = {}
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2CompactActionHandler(
@@ -477,6 +494,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
                 with: analyticsProviderMock
             ),
             fingerprintSubmitter: submitter,
+            appearanceConfiguration: ADYAppearanceConfiguration(),
             service: service
         )
         sut.handle(fingerprintAction) { result in

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
@@ -8,6 +8,7 @@
 @testable @_spi(AdyenInternal) import AdyenCard
 import XCTest
 @_spi(AdyenInternal) import Adyen
+import Adyen3DS2
 
 @available(iOS 16.0, *)
 class ThreeDS2ComponentTests: XCTestCase {
@@ -462,6 +463,7 @@ class ThreeDS2ComponentTests: XCTestCase {
         
             // A mock for the 3ds2 sdk
             let mockService = ThreeDSServiceableMock()
+            mockService.onResetTransaction = {}
             mockService.onPerformFingerprint = { parameters, completion in
                 completion(
                     .success(
@@ -490,7 +492,12 @@ class ThreeDS2ComponentTests: XCTestCase {
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
             )
                 
-            let classicActionHandler = ThreeDS2ClassicActionHandler(context: Dummy.context, service: mockService, coreActionHandler: threeDS2ActionHandler)
+            let classicActionHandler = ThreeDS2ClassicActionHandler(
+                context: Dummy.context,
+                appearanceConfiguration: ADYAppearanceConfiguration(),
+                service: mockService,
+                coreActionHandler: threeDS2ActionHandler
+            )
         
             let sut = ThreeDS2Component(
                 context: Dummy.context,
@@ -567,6 +574,7 @@ class ThreeDS2ComponentTests: XCTestCase {
         
             // A mock for the 3ds2 sdk
             let mockService = ThreeDSServiceableMock()
+            mockService.onResetTransaction = {}
             mockService.onPerformFingerprint = {
                 $1(
                     .success(
@@ -595,7 +603,12 @@ class ThreeDS2ComponentTests: XCTestCase {
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
             )
                 
-            let classicActionHandler = ThreeDS2ClassicActionHandler(context: Dummy.context, service: mockService, coreActionHandler: threeDS2ActionHandler)
+            let classicActionHandler = ThreeDS2ClassicActionHandler(
+                context: Dummy.context,
+                appearanceConfiguration: ADYAppearanceConfiguration(),
+                service: mockService,
+                coreActionHandler: threeDS2ActionHandler
+            )
         
             let sut = ThreeDS2Component(
                 context: Dummy.context,
@@ -695,6 +708,7 @@ class ThreeDS2ComponentTests: XCTestCase {
         
             // A mock for the 3ds2 sdk, which would successfully complete a challenge.
             let mockService = ThreeDSServiceableMock()
+            mockService.onResetTransaction = {}
             let authenticationRequestParameters = AuthenticationRequestParametersMock(
                 deviceInformation: "device_info",
                 sdkApplicationIdentifier: "sdkApplicationIdentifier",
@@ -718,7 +732,12 @@ class ThreeDS2ComponentTests: XCTestCase {
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
             )
             threeDS2ActionHandler.delegatedAuthenticationState.attemptRegistration = true
-            let classicActionHandler = ThreeDS2ClassicActionHandler(context: Dummy.context, service: mockService, coreActionHandler: threeDS2ActionHandler)
+            let classicActionHandler = ThreeDS2ClassicActionHandler(
+                context: Dummy.context,
+                appearanceConfiguration: ADYAppearanceConfiguration(),
+                service: mockService,
+                coreActionHandler: threeDS2ActionHandler
+            )
             mockService.onPerformChallenge = { $1(.success(AnyChallengeResultMock(sdkTransactionIdentifier: "sdkTxId", transactionStatus: "Y"))) }
             let sut = ThreeDS2Component(
                 context: Dummy.context,
@@ -794,6 +813,7 @@ class ThreeDS2ComponentTests: XCTestCase {
     
             // A mock for the 3ds2 sdk, which would successfully complete a challenge.
             let mockService = ThreeDSServiceableMock()
+            mockService.onResetTransaction = {}
             let authenticationRequestParameters = AuthenticationRequestParametersMock(
                 deviceInformation: "device_info",
                 sdkApplicationIdentifier: "sdkApplicationIdentifier",
@@ -817,7 +837,12 @@ class ThreeDS2ComponentTests: XCTestCase {
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
             )
             threeDS2ActionHandler.delegatedAuthenticationState.attemptRegistration = true
-            let classicActionHandler = ThreeDS2ClassicActionHandler(context: Dummy.context, service: mockService, coreActionHandler: threeDS2ActionHandler)
+            let classicActionHandler = ThreeDS2ClassicActionHandler(
+                context: Dummy.context,
+                appearanceConfiguration: ADYAppearanceConfiguration(),
+                service: mockService,
+                coreActionHandler: threeDS2ActionHandler
+            )
             mockService.onPerformChallenge = { $1(.success(AnyChallengeResultMock(sdkTransactionIdentifier: "sdkTxId", transactionStatus: "Y"))) }
             let sut = ThreeDS2Component(
                 context: Dummy.context,

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -58,6 +58,7 @@ import XCTest
         func testSettingThreeDSRequestorAppURL() throws {
             let sut = ThreeDS2PlusDACoreActionHandler(
                 context: Dummy.context,
+                service: ThreeDSServiceableMock(),
                 appearanceConfiguration: ADYAppearanceConfiguration(),
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations
             )
@@ -68,6 +69,7 @@ import XCTest
         func testWrappedComponent() throws {
             let sut = ThreeDS2PlusDACoreActionHandler(
                 context: Dummy.context,
+                service: ThreeDSServiceableMock(),
                 appearanceConfiguration: ADYAppearanceConfiguration(),
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations
             )
@@ -119,7 +121,7 @@ import XCTest
         func testInvalidFingerprintToken() throws {
             let service = ThreeDSServiceableMock()
             service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
-
+            service.onResetTransaction = {}
             let authenticationServiceMock = AuthenticationServiceMock()
 
             let fingerprintAction = ThreeDS2FingerprintAction(
@@ -165,6 +167,7 @@ import XCTest
                 XCTAssertEqual(params.threeDSRequestorAppURL, URL(string: "https://google.com"))
                 completion(.success(AnyChallengeResultMock(sdkTransactionIdentifier: "sdkTxId", transactionStatus: "Y")))
             }
+            service.onResetTransaction = {}
             let authenticationServiceMock = AuthenticationServiceMock()
         
             authenticationServiceMock.onRegister = { _ in
@@ -209,6 +212,7 @@ import XCTest
             let service = ThreeDSServiceableMock()
             service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
             service.onPerformChallenge = { $1(.failure(.challengeError(errorPayload: ""))) }
+            service.onResetTransaction = {}
             let authenticationServiceMock = AuthenticationServiceMock()
         
             let sut = ThreeDS2PlusDACoreActionHandler(
@@ -244,6 +248,7 @@ import XCTest
             let authenticationServiceMock = AuthenticationServiceMock()
             let sut = ThreeDS2PlusDACoreActionHandler(
                 context: Dummy.context,
+                service: ThreeDSServiceProvider(),
                 presenter: ThreeDS2DAScreenPresenterMock(showRegistrationReturnState: .fallback, showApprovalScreenReturnState: .fallback),
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
@@ -274,11 +279,12 @@ import XCTest
             service.onPerformChallenge = { parameters, completion in
                 XCTFail()
             }
-
+            service.onResetTransaction = {}
             let authenticationServiceMock = AuthenticationServiceMock()
 
             let sut = ThreeDS2PlusDACoreActionHandler(
                 context: Dummy.context,
+                service: service,
                 presenter: ThreeDS2DAScreenPresenterMock(showRegistrationReturnState: .fallback, showApprovalScreenReturnState: .fallback),
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
@@ -318,7 +324,7 @@ import XCTest
 
             let service = ThreeDSServiceableMock()
             service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
-                
+            service.onResetTransaction = {}
             let authenticationServiceMock = AuthenticationServiceMock()
             authenticationServiceMock.onAuthenticate = { input in
                 "OnAuthenticate"
@@ -376,7 +382,7 @@ import XCTest
 
             let service = ThreeDSServiceableMock()
             service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
-                
+            service.onResetTransaction = {}
             let authenticationServiceMock = AuthenticationServiceMock()
             authenticationServiceMock.onAuthenticate = { input in
                 throw NSError(domain: "Error during Authentication", code: 123)
@@ -423,7 +429,7 @@ import XCTest
 
             let service = ThreeDSServiceableMock()
             service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
-                
+            service.onResetTransaction = {}
             let authenticationServiceMock = AuthenticationServiceMock()
             authenticationServiceMock.onAuthenticate = { input in
                 "OnAuthenticate"
@@ -470,7 +476,7 @@ import XCTest
 
             let service = ThreeDSServiceableMock()
             service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
-                
+            service.onResetTransaction = {}
             let onAuthenticateExpectation = expectation(description: "Expect onReset to be called")
             let authenticationServiceMock = AuthenticationServiceMock()
             authenticationServiceMock.onAuthenticate = { input in
@@ -521,6 +527,7 @@ import XCTest
             service.onPerformChallenge = { params, completion in
                 completion(.success(AnyChallengeResultMock(sdkTransactionIdentifier: "sdkTxId", transactionStatus: "Y")))
             }
+            service.onResetTransaction = {}
             let authenticationServiceMock = AuthenticationServiceMock()
         
             authenticationServiceMock.onRegister = { _ in
@@ -569,6 +576,7 @@ import XCTest
                 XCTAssertEqual(params.threeDSRequestorAppURL, URL(string: "https://google.com"))
                 completion(.success(AnyChallengeResultMock(sdkTransactionIdentifier: "sdkTxId", transactionStatus: "Y")))
             }
+            service.onResetTransaction = {}
             let authenticationServiceMock = AuthenticationServiceMock()
         
             authenticationServiceMock.onRegister = { _ in

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceProviderTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceProviderTests.swift
@@ -1,0 +1,157 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen3DS2
+@_spi(AdyenInternal) @testable import AdyenActions
+@testable @_spi(AdyenInternal) import AdyenCard
+import XCTest
+@_spi(AdyenInternal) import Adyen
+
+@available(iOS 16.0, *)
+final class ThreeDSServiceProviderTests: XCTestCase {
+    private let authenticationRequestParameters = AuthenticationRequestParametersMock(
+        deviceInformation: "device_info",
+        sdkApplicationIdentifier: "sdkApplicationIdentifier",
+        sdkTransactionIdentifier: "sdkTransactionIdentifier",
+        sdkReferenceNumber: "sdkReferenceNumber",
+        sdkEphemeralPublicKey: "{\"y\":\"zv0kz1SKfNvT3ql75L217de6ZszxfLA8LUKOIKe5Zf4\",\"x\":\"3b3mPfWhuOxwOWydLejS3DJEUPiMVFxtzGCV6906rfc\",\"kty\":\"EC\",\"crv\":\"P-256\"}",
+        messageVersion: "messageVersion"
+    )
+
+    // Expect during fingerprint that
+    // Service is created and fingerprint performed.
+    func testPerformFingerprint() {
+        let serviceMock = ThreeDSServiceableMock()
+        serviceMock.onResetTransaction = {}
+        let expectationFingerprintCreated = expectation(description: "fingeprint")
+
+        serviceMock.onPerformFingerprint = {
+            expectationFingerprintCreated.fulfill()
+            $1(.success(self.authenticationRequestParameters))
+        }
+        let expectationServiceCreated = expectation(description: "service created")
+        let sut = ThreeDSServiceProvider { _ in
+            expectationServiceCreated.fulfill()
+            return serviceMock
+        }
+        sut.performFingerprint(
+            parameters: FingerprintServiceParameters.mock
+        ) { result in
+            switch result {
+            case .success:
+                break
+            case .failure:
+                XCTFail("Shouldn't fail")
+            }
+        }
+        
+        wait(
+            for: [
+                expectationServiceCreated,
+                expectationFingerprintCreated
+            ],
+            timeout: 0.1,
+            enforceOrder: true
+        )
+    }
+    
+    func testChallenge() {
+        let serviceMock = ThreeDSServiceableMock()
+        let expectationFingerprintCreated = expectation(description: "fingeprint")
+
+        serviceMock.onPerformFingerprint = {
+            expectationFingerprintCreated.fulfill()
+            $1(.success(self.authenticationRequestParameters))
+        }
+        
+        let expectationChallengeExecuted = expectation(description: "fingeprint")
+        serviceMock.onPerformChallenge = {
+            expectationChallengeExecuted.fulfill()
+            $1(.success(AnyChallengeResultMock(sdkTransactionIdentifier: "", transactionStatus: "Y")))
+        }
+
+        let expectationResetTransaction = expectation(description: "Reset transaction")
+        serviceMock.onResetTransaction = {
+            expectationResetTransaction.fulfill()
+        }
+        
+        let expectationServiceCreated = expectation(description: "service created")
+        let sut = ThreeDSServiceProvider { _ in
+            expectationServiceCreated.fulfill()
+            return serviceMock
+        }
+        sut.performFingerprint(
+            parameters: FingerprintServiceParameters.mock
+        ) { result in
+            switch result {
+            case .success:
+                sut.performChallenge(with: .mock) { result in
+                    switch result {
+                    case .success:
+                        break
+                    case .failure:
+                        XCTFail("Should not fail")
+                    }
+                }
+            case .failure:
+                XCTFail("Shouldn't fail")
+            }
+        }
+        
+        wait(
+            for: [
+                expectationServiceCreated,
+                expectationFingerprintCreated,
+                expectationChallengeExecuted,
+                expectationResetTransaction
+            ],
+            timeout: 0.1,
+            enforceOrder: true
+        )
+    }
+    
+    func testPerformChallengeWithoutFingerprint() {
+        let sut = ThreeDSServiceProvider { _ in
+            ThreeDSServiceableMock()
+        }
+        sut.performChallenge(
+            with: ChallengeParameters.mock
+        ) { result in
+            switch result {
+            case .success:
+                XCTFail("Shouldn't pass challenge")
+            case let .failure(failure):
+                XCTAssertEqual(failure, .transactionNotInitialized)
+            }
+        }
+    }
+}
+
+private extension FingerprintServiceParameters {
+    static let mock = FingerprintServiceParameters(
+        directoryServerIdentifier: "",
+        directoryServerPublicKey: "",
+        directoryServerRootCertificates: "",
+        deviceExcludedParameters: nil,
+        appearanceConfiguration: ADYAppearanceConfiguration(),
+        threeDSMessageVersion: ""
+    )
+}
+
+private extension ChallengeParameters {
+    static let mock = ChallengeParameters(
+        challengeToken: ThreeDS2Component.ChallengeToken(
+            acsReferenceNumber: "",
+            acsSignedContent: "",
+            acsTransactionIdentifier: "",
+            serverTransactionIdentifier: "",
+            threeDSRequestorAppURL: nil,
+            delegatedAuthenticationSDKInput: "",
+            paymentInfo: nil
+        ),
+        threeDSRequestorAppURL: nil
+    )
+}

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceableMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceableMock.swift
@@ -8,8 +8,16 @@ import Adyen3DS2
 @_spi(AdyenInternal) @testable import AdyenActions
 import Foundation
 
-final class ThreeDSServiceableMock: ThreeDSServiceable {
-    func resetTransaction() {}
+final class ThreeDSServiceableMock: ThreeDSService {
+    var configuration: ThreeDSFeatureChecker?
+    
+    var onResetTransaction: (() -> Void)?
+    func resetTransaction() {
+        guard let onResetTransaction else {
+            fatalError("Need to provide a mock data if you are using this mock.")
+        }
+        onResetTransaction()
+    }
     
     typealias FingerprintResult = Result<any AnyAuthenticationRequestParameters, ThreeDSServiceFingerprintError>
     var onPerformFingerprint: ((FingerprintServiceParameters, (FingerprintResult) -> Void) -> Void)?


### PR DESCRIPTION
# Summary
Created a type `ThreeDSServiceProvider` which handles creating the ThreeDSService.
This type would consume the configuration and create a service implementation.

<ticket>
DSP-1867
</ticket>
