### PR TITLE
Fixing post_release

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -12,8 +12,7 @@ jobs:
   publish-cocoapods:
     name: 🫛 Publish Cocoapods
     uses: ./.github/workflows/publish_podspec.yml
-    secrets:
-      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+    secrets: inherit
 
   deploy-docs:
     name: 📝 Deploy Docs
@@ -22,3 +21,4 @@ jobs:
   publish-app:
     name: 🚀 Publish Demo App
     uses: ./.github/workflows/publish-demo-app.yml
+    secrets: inherit

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -12,6 +12,8 @@ jobs:
   publish-cocoapods:
     name: 🫛 Publish Cocoapods
     uses: ./.github/workflows/publish_podspec.yml
+    secrets:
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
   deploy-docs:
     name: 📝 Deploy Docs

--- a/.github/workflows/publish-demo-app.yml
+++ b/.github/workflows/publish-demo-app.yml
@@ -13,25 +13,25 @@ on:
         required: true
       KEYCHAIN_PASSWORD:
         required: true
-      DEMO_APP_TEST_ENV_CLIENT_KEY
+      DEMO_APP_TEST_ENV_CLIENT_KEY:
         required: true
-      DEMO_SERVER_TEST_ENV_API_KEY
+      DEMO_SERVER_TEST_ENV_API_KEY:
         required: true
-      MERCHANT_ACCOUNT
+      MERCHANT_ACCOUNT:
         required: true
-      APPLE_DEVELOPMENT_TEAM_ID
+      APPLE_DEVELOPMENT_TEAM_ID:
         required: true
-      ENVIRONMENT
+      ENVIRONMENT:
         required: true
-      APPLE_ID_USERNAME
+      APPLE_ID_USERNAME:
         required: true
-      APPLE_APP_SPECIFIC_PASSWORD
+      APPLE_APP_SPECIFIC_PASSWORD:
         required: true
-      XCODE_AUTHENTICATION_KEY_ID
+      XCODE_AUTHENTICATION_KEY_ID:
         required: true
-      XCODE_AUTHENTICATION_KEY_ISSUER_ID
+      XCODE_AUTHENTICATION_KEY_ISSUER_ID:
         required: true
-      XCODE_AUTHENTICATION_KEY_BASE64
+      XCODE_AUTHENTICATION_KEY_BASE64:
         required: true
   
 jobs:

--- a/.github/workflows/publish-demo-app.yml
+++ b/.github/workflows/publish-demo-app.yml
@@ -2,6 +2,37 @@ name: 🚀 Publish Demo App
 on:
   workflow_dispatch:
   workflow_call:
+    secrets: # When triggered via another workflow, secrets are not automatically forwarded
+      BUILD_CERTIFICATE_BASE64:
+        required: true
+      DEVELOPMENT_CERTIFICATE_BASE64:
+        required: true
+      P12_PASSWORD:
+        required: true
+      BUILD_PROVISION_PROFILE_BASE64:
+        required: true
+      KEYCHAIN_PASSWORD:
+        required: true
+      DEMO_APP_TEST_ENV_CLIENT_KEY
+        required: true
+      DEMO_SERVER_TEST_ENV_API_KEY
+        required: true
+      MERCHANT_ACCOUNT
+        required: true
+      APPLE_DEVELOPMENT_TEAM_ID
+        required: true
+      ENVIRONMENT
+        required: true
+      APPLE_ID_USERNAME
+        required: true
+      APPLE_APP_SPECIFIC_PASSWORD
+        required: true
+      XCODE_AUTHENTICATION_KEY_ID
+        required: true
+      XCODE_AUTHENTICATION_KEY_ISSUER_ID
+        required: true
+      XCODE_AUTHENTICATION_KEY_BASE64
+        required: true
   
 jobs:
 

--- a/.github/workflows/publish_podspec.yml
+++ b/.github/workflows/publish_podspec.yml
@@ -4,7 +4,6 @@ on:
   workflow_call:
     secrets: # When triggered via another workflow, secrets are not automatically forwarded
       COCOAPODS_TRUNK_TOKEN:
-        description: 'CocoaPods Trunk token'
         required: true
   
 jobs:

--- a/.github/workflows/publish_podspec.yml
+++ b/.github/workflows/publish_podspec.yml
@@ -2,6 +2,10 @@ name: 🫛 Publish Adyen.podspec
 on:
   workflow_dispatch:
   workflow_call:
+    secrets: # When triggered via another workflow, secrets are not automatically forwarded
+      COCOAPODS_TRUNK_TOKEN:
+        description: 'CocoaPods Trunk token'
+        required: true
   
 jobs:
 

--- a/.github/workflows/verify-older-os-compatibility.yml
+++ b/.github/workflows/verify-older-os-compatibility.yml
@@ -4,8 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - develop
-    - release/**
+      - develop
+  pull_request:
+    branches:
+      - 'release/**'
     
 jobs:
   tests:

--- a/.github/workflows/verify-older-os-compatibility.yml
+++ b/.github/workflows/verify-older-os-compatibility.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - develop
   pull_request:
+    types: [opened, synchronize, reopened]
     branches:
       - 'release/**'
     

--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
@@ -553,11 +553,11 @@ private struct PayToPaymentMethodDecoder: PaymentMethodDecoder {
     func anyPaymentMethod(from paymentMethod: any PaymentMethod) -> AnyPaymentMethod? {
         switch paymentMethod {
         case let regular as PayToPaymentMethod:
-            .payTo(regular)
+            return .payTo(regular)
         case let stored as StoredPayToPaymentMethod:
-            .storedPayTo(stored)
+            return .storedPayTo(stored)
         default:
-            nil
+            return nil
         }
     }
 }


### PR DESCRIPTION
# Summary
- Forwarding secrets correctly to sub-workflows
- Running compatibility test on release PRs

## Background
Workflows triggered by a `workflow_call` don't automatically get access to the secrets like they would when being triggered manually individually. To fix that we have to forward the secrets to the workflows by passing them using the `secrets: inherit` and consuming them from the reusable workflows.

Also see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

# Ticket

<ticket>
COIOS-000
</ticket>
