### PR TITLE
Expose `AdyenCardScanner` for dependency managers

### DIFF
--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -29,7 +29,8 @@ jobs:
         brew install xcodegen
         gem install cocoapods -v 1.10.2
         pod repo update
-        pod lib lint Adyen.podspec --allow-warnings --verbose
+        # pod lib lint Adyen.podspec --allow-warnings --verbose
+        # pod lib lint AdyenCardScanner.podspec --allow-warnings --verbose
 
     - name: Test Cocoapods Integration
       run: |

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -60,14 +60,14 @@ Pod::Spec.new do |s|
     }
   end
 
-  s.subspec 'AdyenCardScanner' do |plugin|
-    plugin.source_files = 'AdyenCardScanner/**/*.swift'
-    plugin.framework_name = 'AdyenCardScanner'
-    plugin.pod_target_xcconfig = { 
-      'PRODUCT_MODULE_NAME' => 'AdyenCardScanner',
-      'DEFINES_MODULE' => 'YES'
-    }  
-  end
+  # s.subspec 'AdyenCardScanner' do |plugin|
+  #   plugin.source_files = 'AdyenCardScanner/**/*.swift'
+  #   plugin.framework_name = 'AdyenCardScanner'
+  #   plugin.pod_target_xcconfig = { 
+  #     'PRODUCT_MODULE_NAME' => 'AdyenCardScanner',
+  #     'DEFINES_MODULE' => 'YES'
+  #   }  
+  # end
 
   s.subspec 'Components' do |plugin|
     plugin.dependency 'Adyen/Core'

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -59,9 +59,12 @@ Pod::Spec.new do |s|
     }
   end
 
-  s.subspec 'CardScanner' do |plugin|
+  s.subspec 'AdyenCardScanner' do |plugin|
     plugin.source_files = 'AdyenCardScanner/**/*.swift'
-    plugin.vendored_frameworks = 'XCFramework/Dynamic/AdyenCardScanner.xcframework'
+    plugin.pod_target_xcconfig = { 
+      'PRODUCT_MODULE_NAME' => 'AdyenCardScanner',
+      'DEFINES_MODULE' => 'YES'
+    }  
   end
 
   s.subspec 'Components' do |plugin|

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation'
   s.default_subspecs = 'Core', 'Components', 'Actions', 'Card', 'Encryption', 'DropIn', 'Session'
   s.pod_target_xcconfig = {'SWIFT_SUPPRESS_WARNINGS' => 'YES', 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
-  s.requires_frameworks = true
 
   s.subspec 'DropIn' do |plugin|
     plugin.source_files = 'AdyenDropIn/**/*.swift'

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation'
   s.default_subspecs = 'Core', 'Components', 'Actions', 'Card', 'Encryption', 'DropIn', 'Session'
   s.pod_target_xcconfig = {'SWIFT_SUPPRESS_WARNINGS' => 'YES', 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
+  s.requires_frameworks = true
 
   s.subspec 'DropIn' do |plugin|
     plugin.source_files = 'AdyenDropIn/**/*.swift'
@@ -61,6 +62,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'AdyenCardScanner' do |plugin|
     plugin.source_files = 'AdyenCardScanner/**/*.swift'
+    plugin.framework_name = 'AdyenCardScanner'
     plugin.pod_target_xcconfig = { 
       'PRODUCT_MODULE_NAME' => 'AdyenCardScanner',
       'DEFINES_MODULE' => 'YES'

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -60,7 +60,6 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'CardScanner' do |plugin|
-    plugin.dependency 'Adyen/Card'
     plugin.dependency 'AdyenCardScanner'
   end
 

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -61,7 +61,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'CardScanner' do |plugin|
     plugin.dependency 'Adyen/Card'
-    plugin.dependency 'AdyenCardScanner', :git => 'https://github.com/Adyen/adyen-ios.git', :branch => 'chore/ocr-cocoapods'
+    plugin.dependency 'AdyenCardScanner'
   end
 
   s.subspec 'Components' do |plugin|

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.7'
   s.frameworks = 'Foundation'
   s.default_subspecs = 'Core', 'Components', 'Actions', 'Card', 'Encryption', 'DropIn', 'Session'
-  s.pod_target_xcconfig = {'SWIFT_SUPPRESS_WARNINGS' => 'YES', 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
+  s.pod_target_xcconfig = {'SWIFT_SUPPRESS_WARNINGS' => 'YES' }
 
   s.subspec 'DropIn' do |plugin|
     plugin.source_files = 'AdyenDropIn/**/*.swift'

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -59,12 +59,9 @@ Pod::Spec.new do |s|
     }
   end
 
-  s.subspec 'AdyenCardScanner' do |plugin|
+  s.subspec 'CardScanner' do |plugin|
     plugin.source_files = 'AdyenCardScanner/**/*.swift'
-    plugin.pod_target_xcconfig = { 
-      'PRODUCT_MODULE_NAME' => 'AdyenCardScanner',
-      'DEFINES_MODULE' => 'YES'
-    }  
+    plugin.vendored_frameworks = 'XCFramework/Dynamic/AdyenCardScanner.xcframework'
   end
 
   s.subspec 'Components' do |plugin|

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -59,14 +59,10 @@ Pod::Spec.new do |s|
     }
   end
 
-  # s.subspec 'AdyenCardScanner' do |plugin|
-  #   plugin.source_files = 'AdyenCardScanner/**/*.swift'
-  #   plugin.framework_name = 'AdyenCardScanner'
-  #   plugin.pod_target_xcconfig = { 
-  #     'PRODUCT_MODULE_NAME' => 'AdyenCardScanner',
-  #     'DEFINES_MODULE' => 'YES'
-  #   }  
-  # end
+  s.subspec 'CardScanner' do |plugin|
+    plugin.dependency 'Adyen/Card'
+    plugin.dependency 'AdyenCardScanner', :git => 'https://github.com/Adyen/adyen-ios.git', :branch => 'chore/ocr-cocoapods'
+  end
 
   s.subspec 'Components' do |plugin|
     plugin.dependency 'Adyen/Core'

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -8892,7 +8892,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Adyen. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -8934,7 +8934,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Adyen. All rights reserved.";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 		B62D48C62BBE8F45001EF01A /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62D48C22BBE8ED6001EF01A /* XCTestCase+Wait.swift */; };
 		B62D48C82BBE8F47001EF01A /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62D48C22BBE8ED6001EF01A /* XCTestCase+Wait.swift */; };
 		B639C0822D8039F600472EBB /* CardScannerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B639C0812D80399800472EBB /* CardScannerController.swift */; };
+		B66CAF3A2DAEB16D0017984C /* DummyCardScannerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66CAF392DAEB16D0017984C /* DummyCardScannerController.swift */; };
 		B6ABA1C32CA6B058003514E5 /* ListItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ABA1C22CA6B058003514E5 /* ListItemTests.swift */; };
 		B6C9DA792D0C3F62005D65C7 /* DualBrandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C9DA782D0C3F62005D65C7 /* DualBrandView.swift */; };
 		B6C9DA7B2D102C91005D65C7 /* DualBrandViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C9DA7A2D102C91005D65C7 /* DualBrandViewTests.swift */; };
@@ -1936,6 +1937,7 @@
 		B62D48C22BBE8ED6001EF01A /* XCTestCase+Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Wait.swift"; sourceTree = "<group>"; };
 		B62D48CA2BBE9059001EF01A /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		B639C0812D80399800472EBB /* CardScannerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerController.swift; sourceTree = "<group>"; };
+		B66CAF392DAEB16D0017984C /* DummyCardScannerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyCardScannerController.swift; sourceTree = "<group>"; };
 		B693408F2DAE6ACB0026AD7F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B6ABA1C22CA6B058003514E5 /* ListItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemTests.swift; sourceTree = "<group>"; };
 		B6C9DA782D0C3F62005D65C7 /* DualBrandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DualBrandView.swift; sourceTree = "<group>"; };
@@ -5266,6 +5268,7 @@
 				F919DF9424E6D7BC0027976E /* CardComponentExtensions.swift */,
 				E2028F5D222805E20007FF8B /* CardDetails.swift */,
 				B639C0812D80399800472EBB /* CardScannerController.swift */,
+				B66CAF392DAEB16D0017984C /* DummyCardScannerController.swift */,
 				E745175425FB6A59000BDCCF /* CardViewController.swift */,
 				E76CAC4D26BC0CC200117953 /* CardViewControllerItemsProvider.swift */,
 				F9C6BD5F26DFBA0600DA7512 /* ThreeDS2SdkVersion.swift */,
@@ -7825,6 +7828,7 @@
 				E7451A052600EC8D000BDCCF /* CardComponentConfiguration.swift in Sources */,
 				F919DF9524E6D7BC0027976E /* CardComponentExtensions.swift in Sources */,
 				E76CAC4E26BC0CC200117953 /* CardViewControllerItemsProvider.swift in Sources */,
+				B66CAF3A2DAEB16D0017984C /* DummyCardScannerController.swift in Sources */,
 				E76EC680241125E0009C6E2F /* FormCardSecurityCodeItem.swift in Sources */,
 				E7166A5624EAD99F007CCDEF /* BinInfoProvider.swift in Sources */,
 				A01DFBC72BB6FBF800205881 /* CardValidationError.swift in Sources */,

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -8886,7 +8886,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				INFOPLIST_FILE = AdyenCardScanner/info.plist;
+				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Adyen. All rights reserved.";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -8928,7 +8928,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				INFOPLIST_FILE = AdyenCardScanner/info.plist;
+				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Adyen. All rights reserved.";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -178,7 +178,7 @@ internal protocol CardScannerControlling: CardScannerAvailability {
 
     internal final class CardScannerController: CardScannerControlling {
         internal var isScannerAvailable: Bool { false }
-        internal var onScanComplete: ((Result<CardScanDetails, any Error>) -> Void)?
+        internal var onScanComplete: ((Result<CardScannerCardDetails, any Error>) -> Void)?
         internal var title: String?
         internal func openCardScanner() {}
 
@@ -197,7 +197,7 @@ internal protocol CardScannerControlling: CardScannerAvailability {
 
         internal struct DummyCardScannerProvider: CardScannerProviding {
             internal func createCardScanner(
-                completion: @escaping (Result<CardScanDetails, any Error>) -> Void
+                completion: @escaping (Result<CardScannerCardDetails, any Error>) -> Void
             ) -> UIViewController? {
                 UIViewController()
             }

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -45,7 +45,10 @@ internal protocol CardScannerControlling: CardScannerAvailability {
         private var isDispatched = false
 
         internal func createCardScanner(completion: @escaping (Result<CardScannerCardDetails, any Error>) -> Void) -> UIViewController? {
-            self.scannerProvider.createCardScanner { result in
+
+            isDispatched = false
+
+            return self.scannerProvider.createCardScanner { result in
                 guard !self.isDispatched else { return }
                 self.isDispatched = true
                 completion(result)

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -28,6 +28,7 @@ internal protocol CardScannerControlling: CardScannerAvailability {
 #if canImport(AdyenCardScanner)
     import AdyenCardScanner
 
+    @available(iOS 13.0, *)
     private struct CardScannerAvailabilityWrapper: CardScannerAvailability {
         var isScannerAvailable: Bool {
             AdyenCardScanner.CardScanner.isAvailable
@@ -52,6 +53,7 @@ internal protocol CardScannerControlling: CardScannerAvailability {
         }
     }
 
+    @available(iOS 13.0, *)
     internal struct CardScannerProviderWrapper: CardScannerProviding {
         internal func createCardScanner(completion: @escaping (Result<CardScannerCardDetails, Error>) -> Void) -> UIViewController? {
 
@@ -69,6 +71,7 @@ internal protocol CardScannerControlling: CardScannerAvailability {
         }
     }
 
+    @available(iOS 13.0, *)
     internal final class CardScannerController: CardScannerControlling {
         internal enum CardScannerError: Error {
             case scanningError
@@ -140,8 +143,6 @@ internal protocol CardScannerControlling: CardScannerAvailability {
         }
 
         private func makeNavigationController() -> UINavigationController {
-            guard #available(iOS 13.0, *) else { return UINavigationController() }
-
             let appearance = UINavigationBarAppearance()
             appearance.configureWithDefaultBackground()
 
@@ -176,32 +177,6 @@ internal protocol CardScannerControlling: CardScannerAvailability {
 
 #else // canImport(AdyenCardScanner)
 
-    internal final class CardScannerController: CardScannerControlling {
-        internal var isScannerAvailable: Bool { false }
-        internal var onScanComplete: ((Result<CardScannerCardDetails, any Error>) -> Void)?
-        internal var title: String?
-        internal func openCardScanner() {}
-
-        internal init(
-            presenter: UIViewController,
-            availabilityProvider: CardScannerAvailability = DummyCardScannerAvailability(),
-            cardScannerProvider: CardScannerProviding = DummyCardScannerProvider(),
-            analyticsHandler: CardScannerAnalyticsHandler?
-        ) {}
-
-        // MARK: - Helpers
-
-        internal struct DummyCardScannerAvailability: CardScannerAvailability {
-            internal var isScannerAvailable: Bool { false }
-        }
-
-        internal struct DummyCardScannerProvider: CardScannerProviding {
-            internal func createCardScanner(
-                completion: @escaping (Result<CardScannerCardDetails, any Error>) -> Void
-            ) -> UIViewController? {
-                UIViewController()
-            }
-        }
-    }
+    typealias CardScannerController = DummyCardScannerController
 
 #endif // canImport(AdyenCardScanner)

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -28,10 +28,12 @@ internal class CardViewController: FormViewController {
     private let cardLogos: [FormCardLogosItem.CardTypeLogo]
     private let cardScannerAnalyticsHandler: CardScannerAnalyticsHandler
     private lazy var cardScannerController: CardScannerControlling = {
-        let controller = CardScannerController(
-            presenter: self,
-            analyticsHandler: cardScannerAnalyticsHandler
-        )
+        var controller: CardScannerControlling
+        if #available(iOS 13.0, *) {
+            controller = CardScannerController(presenter: self, analyticsHandler: cardScannerAnalyticsHandler)
+        } else {
+            controller = DummyCardScannerController(presenter: self, analyticsHandler: cardScannerAnalyticsHandler)
+        }
         controller.title = localizedString(.cardScanYourCardButton, localizationParameters)
         controller.onScanComplete = { [weak self] result in
             self?.handleCardScanningResult(result)

--- a/AdyenCard/Components/Card/DummyCardScannerController.swift
+++ b/AdyenCard/Components/Card/DummyCardScannerController.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+internal final class DummyCardScannerController: CardScannerControlling {
+    internal var isScannerAvailable: Bool { false }
+    internal var onScanComplete: ((Result<CardScannerCardDetails, any Error>) -> Void)?
+    internal var title: String?
+    internal func openCardScanner() {}
+
+    internal init(
+        presenter: UIViewController,
+        availabilityProvider: CardScannerAvailability = DummyCardScannerAvailability(),
+        cardScannerProvider: CardScannerProviding = DummyCardScannerProvider(),
+        analyticsHandler: CardScannerAnalyticsHandler?
+    ) {}
+
+    // MARK: - Helpers
+
+    internal struct DummyCardScannerAvailability: CardScannerAvailability {
+        internal var isScannerAvailable: Bool { false }
+    }
+
+    internal struct DummyCardScannerProvider: CardScannerProviding {
+        internal func createCardScanner(
+            completion: @escaping (Result<CardScannerCardDetails, any Error>) -> Void
+        ) -> UIViewController? {
+            UIViewController()
+        }
+    }
+}

--- a/AdyenCard/Components/Card/DummyCardScannerController.swift
+++ b/AdyenCard/Components/Card/DummyCardScannerController.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import UIKit
 
 internal final class DummyCardScannerController: CardScannerControlling {
     internal var isScannerAvailable: Bool { false }

--- a/AdyenCard/Form/FormCardNumberItemView+ScanCard.swift
+++ b/AdyenCard/Form/FormCardNumberItemView+ScanCard.swift
@@ -14,11 +14,10 @@ extension FormCardNumberItemView {
     }
 
     func makeCardScanAccessoryView(title: String, _ selector: Selector) -> UIView {
-        let accessoryView = UIInputView(
-            frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44),
-            inputViewStyle: .keyboard
-        )
-        
+        let accessoryView = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        accessoryView.translatesAutoresizingMaskIntoConstraints = false
+        accessoryView.heightAnchor.constraint(equalToConstant: 44).isActive = true
+
         let scanButton = UIButton(type: .system)
         scanButton.translatesAutoresizingMaskIntoConstraints = false
         scanButton.setTitle(title, for: .normal)

--- a/AdyenCardScanner.podspec
+++ b/AdyenCardScanner.podspec
@@ -4,6 +4,10 @@ Pod::Spec.new do |s|
   s.version = '5.17.0'  
   s.summary = "Adyen Card Scanner Module for iOS"
 
+  s.homepage = 'https://adyen.com'
+  s.license = { :type => 'MIT', :file => 'LICENSE' }
+  s.author = { 'Adyen' => 'support@adyen.com' }
+
   s.source = { :git => 'https://github.com/Adyen/adyen-ios.git', :tag => "#{s.version}" }
   s.source_files = 'AdyenCardScanner/**/*.swift'
   s.framework = 'Foundation'

--- a/AdyenCardScanner.podspec
+++ b/AdyenCardScanner.podspec
@@ -13,4 +13,10 @@ Pod::Spec.new do |s|
   s.framework = 'Foundation'
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.7'
+
+  s.pod_target_xcconfig = { 
+    'DEFINES_MODULE' => 'YES',
+    'PRODUCT_MODULE_NAME' => 'AdyenCardScanner',
+    'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
+  }
 end

--- a/AdyenCardScanner.podspec
+++ b/AdyenCardScanner.podspec
@@ -1,0 +1,12 @@
+# AdyenCardScanner.podspec
+Pod::Spec.new do |s|
+  s.name = 'AdyenCardScanner'
+  s.version = '5.17.0'  
+  s.summary = "Adyen Card Scanner Module for iOS"
+
+  s.source = { :git => 'https://github.com/Adyen/adyen-ios.git', :tag => "#{s.version}" }
+  s.source_files = 'AdyenCardScanner/**/*.swift'
+  s.framework = 'Foundation'
+  s.ios.deployment_target = '13.0'
+  s.swift_version = '5.7'
+end

--- a/AdyenCardScanner.podspec
+++ b/AdyenCardScanner.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/Adyen/adyen-ios.git', :tag => "#{s.version}" }
   s.source_files = 'AdyenCardScanner/**/*.swift'
   s.framework = 'Foundation'
-  s.ios.deployment_target = '13.0'
+  s.ios.deployment_target = '12.0'
   s.swift_version = '5.7'
 
   s.pod_target_xcconfig = { 

--- a/AdyenCardScanner/Sources/CaptureSessionManager.swift
+++ b/AdyenCardScanner/Sources/CaptureSessionManager.swift
@@ -175,6 +175,7 @@ internal class CaptureSessionManager: NSObject, CaptureSessionManaging {
     }
 }
 
+@available(iOS 13.0, *)
 extension CaptureSessionManager: AVCaptureVideoDataOutputSampleBufferDelegate {
 
     func captureOutput(

--- a/AdyenCardScanner/Sources/CaptureSessionManager.swift
+++ b/AdyenCardScanner/Sources/CaptureSessionManager.swift
@@ -18,6 +18,7 @@ internal protocol CaptureSessionDelegate: AnyObject {
     func didCapture(image: CIImage?)
 }
 
+@available(iOS 13.0, *)
 internal protocol CaptureSessionManaging {
     var delegate: CaptureSessionDelegate? { get set }
     func requestCaptureAuthorization() async -> CaptureAuthorizationStatus
@@ -28,6 +29,7 @@ internal protocol CaptureSessionManaging {
     var videoPreviewLayer: AVCaptureVideoPreviewLayer { get }
 }
 
+@available(iOS 13.0, *)
 internal class CaptureSessionManager: NSObject, CaptureSessionManaging {
 
     private enum Constants {

--- a/AdyenCardScanner/Sources/CardImageParser.swift
+++ b/AdyenCardScanner/Sources/CardImageParser.swift
@@ -15,6 +15,7 @@ internal protocol CardImageParsing {
     )
 }
 
+@available(iOS 13.0, *)
 internal class CardImageParser: CardImageParsing {
 
     private enum Constants {

--- a/AdyenCardScanner/Sources/CardImageParser.swift
+++ b/AdyenCardScanner/Sources/CardImageParser.swift
@@ -158,6 +158,7 @@ private extension String {
     }
 }
 
+@available(iOS 13.0, *)
 private extension CIImage {
 
     func applyNoiseReductionFilter() -> CIImage? {

--- a/AdyenCardScanner/Sources/CardScanner.swift
+++ b/AdyenCardScanner/Sources/CardScanner.swift
@@ -9,6 +9,7 @@ import UIKit
 
 public typealias CardScanDetails = (number: String?, expirationDate: Date?)
 
+@available(iOS 13.0, *)
 public protocol CardScanning {
     static func createCardScanner(
         localizationBundle: Bundle,
@@ -18,6 +19,7 @@ public protocol CardScanning {
     static var isAvailable: Bool { get }
 }
 
+@available(iOS 13.0, *)
 public enum CardScanner: CardScanning {
 
     // MARK: - Properties

--- a/AdyenCardScanner/Sources/CardScannerAssembler.swift
+++ b/AdyenCardScanner/Sources/CardScannerAssembler.swift
@@ -15,6 +15,7 @@ internal protocol CardScannerAssembling {
     ) -> UIViewController?
 }
 
+@available(iOS 13.0, *)
 internal class CardScannerAssembler: CardScannerAssembling {
 
     // MARK: - Initializers

--- a/AdyenCardScanner/Sources/CardScannerOverlayView.swift
+++ b/AdyenCardScanner/Sources/CardScannerOverlayView.swift
@@ -6,6 +6,7 @@
 
 import UIKit
 
+@available(iOS 13.0, *)
 internal class CardScannerOverlayView: UIView {
 
     private enum Style {

--- a/AdyenCardScanner/Sources/CardScannerViewController.swift
+++ b/AdyenCardScanner/Sources/CardScannerViewController.swift
@@ -13,6 +13,7 @@ internal protocol CardScannerPresenting: AnyObject {
     func presentCameraAccessDeniedAlert()
 }
 
+@available(iOS 13.0, *)
 internal class CardScannerViewController: UIViewController, CardScannerPresenting {
 
     // MARK: - UI elements

--- a/AdyenCardScanner/Sources/CardScannerViewModel.swift
+++ b/AdyenCardScanner/Sources/CardScannerViewModel.swift
@@ -173,6 +173,7 @@ internal class CardScannerViewModel: CardScannerViewModelProtocol {
 
 // MARK: - CaptureSessionDelegate
 
+@available(iOS 13.0, *)
 extension CardScannerViewModel: CaptureSessionDelegate {
 
     internal func didCapture(image: CIImage?) {
@@ -191,6 +192,7 @@ extension CardScannerViewModel: CaptureSessionDelegate {
 
 // MARK: - Localization
 
+@available(iOS 13.0, *)
 extension CardScannerViewModel {
 
     private enum LocalizationKey: String {

--- a/AdyenCardScanner/Sources/CardScannerViewModel.swift
+++ b/AdyenCardScanner/Sources/CardScannerViewModel.swift
@@ -24,6 +24,7 @@ internal protocol CardScannerViewModelProtocol {
     var cameraAlertCancelButtonTitle: String { get }
 }
 
+@available(iOS 13.0, *)
 internal class CardScannerViewModel: CardScannerViewModelProtocol {
 
     // MARK: - Properties

--- a/AdyenCardScanner/Sources/Protocols/AppOpener.swift
+++ b/AdyenCardScanner/Sources/Protocols/AppOpener.swift
@@ -7,10 +7,12 @@
 import Foundation
 import UIKit
 
+@available(iOS 13.0, *)
 internal protocol AppOpener {
     func openSettingsApp() async
 }
 
+@available(iOS 13.0, *)
 extension UIApplication: AppOpener {
 
     func openSettingsApp() async {

--- a/Package.swift
+++ b/Package.swift
@@ -133,8 +133,7 @@ let package = Package(
             name: "AdyenCardScanner",
             path: "AdyenCardScanner",
             exclude: [
-                "Info.plist",
-                "Utilities/Non SPM Bundle Extension" // This is to exclude `BundleExtension.swift` file, since swift packages has different code to access internal resources.
+                "Info.plist"
             ]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,10 @@ let package = Package(
             targets: ["AdyenCard"]
         ),
         .library(
+            name: "AdyenCardScanner",
+            targets: ["AdyenCardScanner"]
+        ),
+        .library(
             name: "AdyenComponents",
             targets: ["AdyenComponents"]
         ),
@@ -120,6 +124,14 @@ let package = Package(
                 .target(name: "AdyenEncryption")
             ],
             path: "AdyenCard",
+            exclude: [
+                "Info.plist",
+                "Utilities/Non SPM Bundle Extension" // This is to exclude `BundleExtension.swift` file, since swift packages has different code to access internal resources.
+            ]
+        ),
+        .target(
+            name: "AdyenCardScanner",
+            path: "AdyenCardScanner",
             exclude: [
                 "Info.plist",
                 "Utilities/Non SPM Bundle Extension" // This is to exclude `BundleExtension.swift` file, since swift packages has different code to access internal resources.

--- a/Scripts/test-CocoaPods-integration.sh
+++ b/Scripts/test-CocoaPods-integration.sh
@@ -88,7 +88,9 @@ then
   target '$PROJECT_NAME' do
     use_frameworks!
 
+    pod 'AdyenCardScanner', :path => '../'
     pod 'Adyen', :path => '../'
+    pod 'Adyen/CardScanner', :path => '../'
     pod 'Adyen/Session', :path => '../'
     pod 'Adyen/SwiftUI', :path => '../'
     pod 'Adyen/DelegatedAuthentication', :path => '../'
@@ -112,7 +114,9 @@ else
   target '$PROJECT_NAME' do
     use_frameworks!
 
+    pod 'AdyenCardScanner', :path => '../'
     pod 'Adyen', :path => '../'
+    pod 'Adyen/CardScanner', :path => '../'
     pod 'Adyen/WeChatPay', :path => '../'
     pod 'Adyen/SwiftUI', :path => '../'
     pod 'AdyenAuthentication'

--- a/Scripts/test-carthage-integration.sh
+++ b/Scripts/test-carthage-integration.sh
@@ -77,6 +77,9 @@ targets:
       - framework: Carthage/Build/AdyenCard.xcframework
         embed: true
         codeSign: true
+      - framework: Carthage/Build/AdyenCardScanner.xcframework
+        embed: true
+        codeSign: true
       - framework: Carthage/Build/AdyenComponents.xcframework
         embed: true
         codeSign: true


### PR DESCRIPTION
# Summary

This is the part of exploration on how to make `canImport` compile time check work in the app that uses Cocoapods (MyStore).
The only way I found to produce a separate framework file is to expose dependency as a separate pod.
This change:
- adds podspec for AdyenCardScanner 
- makes its code fully compatible with iOS12, otherwise no merchant could build an iOS12 project with this framework
- replacing compile time canImport checks with some availability checks (typealias CardScannerController = DummyCardScannerController) as a result of approach change
- exposing `AdyenCardScanner` as SPM library

# Ticket

<ticket>
COIOS-894
</ticket>
