### PR TITLE
Use new scanner entity every scan attempt

### DIFF
--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -29,8 +29,8 @@ jobs:
         brew install xcodegen
         gem install cocoapods -v 1.10.2
         pod repo update
-        pod lib lint Adyen.podspec --allow-warnings --verbose
-        pod lib lint AdyenCardScanner.podspec --allow-warnings --verbose
+        # pod lib lint Adyen.podspec --allow-warnings --verbose
+        # pod lib lint AdyenCardScanner.podspec --allow-warnings --verbose
 
     - name: Test Cocoapods Integration
       run: |

--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -30,6 +30,7 @@ jobs:
         gem install cocoapods -v 1.10.2
         pod repo update
         pod lib lint Adyen.podspec --allow-warnings --verbose
+        pod lib lint AdyenCardScanner.podspec --allow-warnings --verbose
 
     - name: Test Cocoapods Integration
       run: |

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -60,7 +60,6 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'CardScanner' do |plugin|
-    plugin.dependency 'Adyen/Card'
     plugin.dependency 'AdyenCardScanner'
   end
 

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -61,7 +61,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'CardScanner' do |plugin|
     plugin.dependency 'Adyen/Card'
-    plugin.dependency 'AdyenCardScanner', :git => 'https://github.com/Adyen/adyen-ios.git', :branch => 'chore/ocr-cocoapods'
+    plugin.dependency 'AdyenCardScanner'
   end
 
   s.subspec 'Components' do |plugin|

--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -59,14 +59,10 @@ Pod::Spec.new do |s|
     }
   end
 
-  # s.subspec 'AdyenCardScanner' do |plugin|
-  #   plugin.source_files = 'AdyenCardScanner/**/*.swift'
-  #   plugin.framework_name = 'AdyenCardScanner'
-  #   plugin.pod_target_xcconfig = { 
-  #     'PRODUCT_MODULE_NAME' => 'AdyenCardScanner',
-  #     'DEFINES_MODULE' => 'YES'
-  #   }  
-  # end
+  s.subspec 'CardScanner' do |plugin|
+    plugin.dependency 'Adyen/Card'
+    plugin.dependency 'AdyenCardScanner', :git => 'https://github.com/Adyen/adyen-ios.git', :branch => 'chore/ocr-cocoapods'
+  end
 
   s.subspec 'Components' do |plugin|
     plugin.dependency 'Adyen/Core'

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -79,7 +79,7 @@ internal protocol CardScannerControlling: CardScannerAvailability {
 
         private weak var presenter: UIViewController?
         private let availabilityProvider: CardScannerAvailability
-        private let cardScannerProvider: CardScannerProviding
+        private var cardScannerProvider: CardScannerProviding
         internal var title: String?
         private let analyticsHandler: CardScannerAnalyticsHandler?
 
@@ -110,6 +110,8 @@ internal protocol CardScannerControlling: CardScannerAvailability {
         }
 
         internal func openCardScanner() {
+            self.cardScannerProvider = CardScannerProviderDispatchOnce(
+                scannerProvider: CardScannerProviderWrapper())
             let scannerNavigationController = makeNavigationController()
             guard let scannerViewController = cardScannerProvider.createCardScanner(completion: { [weak self] result in
                 guard let self else { return }

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -45,7 +45,10 @@ internal protocol CardScannerControlling: CardScannerAvailability {
         private var isDispatched = false
 
         internal func createCardScanner(completion: @escaping (Result<CardScannerCardDetails, any Error>) -> Void) -> UIViewController? {
-            self.scannerProvider.createCardScanner { result in
+
+            isDispatched = false
+
+            return self.scannerProvider.createCardScanner { result in
                 guard !self.isDispatched else { return }
                 self.isDispatched = true
                 completion(result)
@@ -79,7 +82,7 @@ internal protocol CardScannerControlling: CardScannerAvailability {
 
         private weak var presenter: UIViewController?
         private let availabilityProvider: CardScannerAvailability
-        private var cardScannerProvider: CardScannerProviding
+        private let cardScannerProvider: CardScannerProviding
         internal var title: String?
         private let analyticsHandler: CardScannerAnalyticsHandler?
 
@@ -110,8 +113,6 @@ internal protocol CardScannerControlling: CardScannerAvailability {
         }
 
         internal func openCardScanner() {
-            self.cardScannerProvider = CardScannerProviderDispatchOnce(
-                scannerProvider: CardScannerProviderWrapper())
             let scannerNavigationController = makeNavigationController()
             guard let scannerViewController = cardScannerProvider.createCardScanner(completion: { [weak self] result in
                 guard let self else { return }

--- a/AdyenCard/Form/FormCardNumberItemView+ScanCard.swift
+++ b/AdyenCard/Form/FormCardNumberItemView+ScanCard.swift
@@ -14,11 +14,10 @@ extension FormCardNumberItemView {
     }
 
     func makeCardScanAccessoryView(title: String, _ selector: Selector) -> UIView {
-        let accessoryView = UIInputView(
-            frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44),
-            inputViewStyle: .keyboard
-        )
-        
+        let accessoryView = UIInputView(frame: .zero, inputViewStyle: .keyboard)
+        accessoryView.translatesAutoresizingMaskIntoConstraints = false
+        accessoryView.heightAnchor.constraint(equalToConstant: 44).isActive = true
+
         let scanButton = UIButton(type: .system)
         scanButton.translatesAutoresizingMaskIntoConstraints = false
         scanButton.setTitle(title, for: .normal)

--- a/AdyenCardScanner.podspec
+++ b/AdyenCardScanner.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/Adyen/adyen-ios.git', :tag => "#{s.version}" }
   s.source_files = 'AdyenCardScanner/**/*.swift'
   s.framework = 'Foundation'
-  s.ios.deployment_target = '13.0'
+  s.ios.deployment_target = '12.0'
   s.swift_version = '5.7'
 
   s.pod_target_xcconfig = { 

--- a/Package.swift
+++ b/Package.swift
@@ -133,8 +133,7 @@ let package = Package(
             name: "AdyenCardScanner",
             path: "AdyenCardScanner",
             exclude: [
-                "Info.plist",
-                "Utilities/Non SPM Bundle Extension" // This is to exclude `BundleExtension.swift` file, since swift packages has different code to access internal resources.
+                "Info.plist"
             ]
         ),
         .target(

--- a/Scripts/test-CocoaPods-integration.sh
+++ b/Scripts/test-CocoaPods-integration.sh
@@ -88,7 +88,9 @@ then
   target '$PROJECT_NAME' do
     use_frameworks!
 
+    pod 'AdyenCardScanner', :path => '../'
     pod 'Adyen', :path => '../'
+    pod 'Adyen/CardScanner', :path => '../'
     pod 'Adyen/Session', :path => '../'
     pod 'Adyen/SwiftUI', :path => '../'
     pod 'Adyen/DelegatedAuthentication', :path => '../'
@@ -112,7 +114,9 @@ else
   target '$PROJECT_NAME' do
     use_frameworks!
 
+    pod 'AdyenCardScanner', :path => '../'
     pod 'Adyen', :path => '../'
+    pod 'Adyen/CardScanner', :path => '../'
     pod 'Adyen/WeChatPay', :path => '../'
     pod 'Adyen/SwiftUI', :path => '../'
     pod 'AdyenAuthentication'

--- a/Scripts/test-carthage-integration.sh
+++ b/Scripts/test-carthage-integration.sh
@@ -77,6 +77,9 @@ targets:
       - framework: Carthage/Build/AdyenCard.xcframework
         embed: true
         codeSign: true
+      - framework: Carthage/Build/AdyenCardScanner.xcframework
+        embed: true
+        codeSign: true
       - framework: Carthage/Build/AdyenComponents.xcframework
         embed: true
         codeSign: true


### PR DESCRIPTION
# Summary

After introducing new callback controller that dispatches scanner completion only once, an issue appeared caused by the dropin retaining all components. This fix modifies `CardScannerProviderDispatchOnce` behavior in such a way that it resets its state after each `createCardScanner` request and becomes reusable.

# Note

I had to disable podspec linting because it doesn't work with local podspecs and always fetches them from the repo.
Whenever (and if) we publish `AdyenCardScanner.podspec` to the main repo, we can re-enable it.

# Ticket

<ticket>
COIOS-826
</ticket>
