### PR TITLE
Remove unused import

### DIFF
--- a/Demo/Common/IntegrationExamples/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/Components/CardComponentAdvancedFlowExample.swift
@@ -6,9 +6,6 @@
 
 import Adyen
 import AdyenActions
-#if canImport(AdyenCardScanner)
-    import AdyenCardScanner
-#endif
 import AdyenCard
 import AdyenComponents
 import AdyenDropIn


### PR DESCRIPTION
# Summary

During Carthage fixes I noticed there is an error complaining about missing AdyenCardScanner framework. To fix it, I added necessary framework to the test Carthage integration project - https://github.com/Adyen/adyen-ios/pull/2098/commits/d52f777f4daf82a0ac02078fe0bfe2b631a1f95b

Now it is clear this was the reason.

# Ticket

<ticket>
COIOS-826
</ticket>
