### PR TITLE
Provide missing localisationParameters to BCMC

### DIFF
--- a/AdyenCard/Components/BCMC/BCMCComponent.swift
+++ b/AdyenCard/Components/BCMC/BCMCComponent.swift
@@ -70,6 +70,7 @@ private extension CardComponent.Configuration {
         )
         configuration.showsSupportedCardLogos = false
         configuration.binLookupType = .bcmc
+        configuration.localizationParameters = localizationParameters
         return configuration
     }
 }

--- a/Tests/IntegrationTests/DropIn Tests/ComponentManagerTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/ComponentManagerTests.swift
@@ -133,7 +133,37 @@ class ComponentManagerTests: XCTestCase {
         XCTAssertEqual(sut.regularComponents.filter { $0 is PresentableComponent }.count, 24)
         XCTAssertEqual(sut.regularComponents.filter { $0 is FinalizableComponent }.count, 1)
     }
-    
+
+    func testCardPaymentMethod() throws {
+        let sut = ComponentManager(
+            paymentMethods: paymentMethods,
+            context: context,
+            configuration: configuration,
+            order: nil,
+            presentationDelegate: presentationDelegate
+        )
+
+        sut.configuration.localizationParameters = LocalizationParameters(tableName: "TestValue", keySeparator: nil)
+
+        let paymentComponent = try XCTUnwrap(sut.regularComponents.first { $0.paymentMethod.type.rawValue == "scheme" } as? CardComponent)
+        XCTAssertEqual(paymentComponent.configuration.localizationParameters?.tableName, "TestValue")
+    }
+
+    func testBCMCPaymentMethod() throws {
+        let sut = ComponentManager(
+            paymentMethods: paymentMethods,
+            context: context,
+            configuration: configuration,
+            order: nil,
+            presentationDelegate: presentationDelegate
+        )
+        sut.configuration.localizationParameters = LocalizationParameters(tableName: "TestValue", keySeparator: nil)
+
+        let paymentComponent = try XCTUnwrap(sut.regularComponents.first { $0.paymentMethod.type.rawValue == "bcmc" } as? BCMCComponent)
+
+        XCTAssertEqual(paymentComponent.configuration.localizationParameters?.tableName, "TestValue")
+    }
+
     func testCashAppShouldFailWithoutConfig() {
         let sut = ComponentManager(
             paymentMethods: paymentMethods,


### PR DESCRIPTION
# Summary

Address [bug](https://github.com/Adyen/adyen-react-native/issues/605) with BCMC localisation where `localizationParameters` were not propagated from `ComponenConfiguration`.

<fixed>
- For the BCMC Component: when you specify [custom localization parameters](https://github.com/Adyen/adyen-react-native/blob/develop/docs/Localization.md), the Component now correctly uses them.
</fixed>

## Ticket
<ticket>
COSDK-000
</ticket>

## Checklist
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
