### PR TITLE
CardScanner: Focus on CVC field after successful scan

### DIFF
--- a/Adyen/Core/APIClient/APIContext.swift
+++ b/Adyen/Core/APIClient/APIContext.swift
@@ -26,6 +26,7 @@ public struct APIContext: AnyAPIContext {
     public let headers: [String: String] = ["Content-Type": "application/json"]
 
     /// Environment to retrieve internal resources from.
+    /// - Note: Always use the provided `Environment` object to ensure a correct environment.
     public let environment: AnyAPIEnvironment
     
     /// The client key that corresponds to the web service user you will use for initiating the payment.
@@ -37,6 +38,7 @@ public struct APIContext: AnyAPIContext {
     ///   - environment: The environment to retrieve internal resources from.
     ///   - clientKey: The client key that corresponds to the web service user you will use for initiating the payment.
     /// - Throws: `ClientKeyError.invalidClientKey` if the client key is invalid.
+    /// - Note: Always use the provided `Environment` object to ensure a correct environment.
     public init(environment: AnyAPIEnvironment, clientKey: String) throws {
         guard ClientKeyValidator().isValid(clientKey) else {
             throw ClientKeyError.invalidClientKey

--- a/Adyen/Core/APIClient/APIContext.swift
+++ b/Adyen/Core/APIClient/APIContext.swift
@@ -26,7 +26,7 @@ public struct APIContext: AnyAPIContext {
     public let headers: [String: String] = ["Content-Type": "application/json"]
 
     /// Environment to retrieve internal resources from.
-    /// - Note: Always use the provided `Environment` object to ensure a correct environment.
+    /// - Note: Always use the provided `Environment` type to ensure a correct environment.
     public let environment: AnyAPIEnvironment
     
     /// The client key that corresponds to the web service user you will use for initiating the payment.
@@ -38,7 +38,7 @@ public struct APIContext: AnyAPIContext {
     ///   - environment: The environment to retrieve internal resources from.
     ///   - clientKey: The client key that corresponds to the web service user you will use for initiating the payment.
     /// - Throws: `ClientKeyError.invalidClientKey` if the client key is invalid.
-    /// - Note: Always use the provided `Environment` object to ensure a correct environment.
+    /// - Note: Always use the provided `Environment` type to ensure a correct environment.
     public init(environment: AnyAPIEnvironment, clientKey: String) throws {
         guard ClientKeyValidator().isValid(clientKey) else {
             throw ClientKeyError.invalidClientKey

--- a/Adyen/Core/AdyenContext/AdyenContext.swift
+++ b/Adyen/Core/AdyenContext/AdyenContext.swift
@@ -65,8 +65,13 @@ public final class AdyenContext: PaymentAware {
                 environment: analyticsEnvironment,
                 clientKey: apiContext.clientKey
             )
-        else { return nil }
-        
+        else {
+            AdyenAssertion.assertionFailure(
+                message: "AnalyticsProvider couldn't be created. Ensure the used environment is of type `Environment`"
+            )
+            return nil
+        }
+
         var eventAnalyticsProvider: AnyEventAnalyticsProvider?
         
         if analyticsConfiguration.isEnabled {

--- a/Adyen/UI/Form/FormViewController+ViewProtocol.swift
+++ b/Adyen/UI/Form/FormViewController+ViewProtocol.swift
@@ -9,7 +9,7 @@ import Foundation
 @_spi(AdyenInternal)
 public protocol FormViewProtocol {
     
-    func add<T: FormItem>(item: T?)
+    func add(item: (some FormItem)?)
     
     func displayValidation()
 }

--- a/Adyen/UI/Form/FormViewController.swift
+++ b/Adyen/UI/Form/FormViewController.swift
@@ -82,7 +82,7 @@ open class FormViewController: UIViewController, AdyenObserver, PreferredContent
         super.viewDidLoad()
         itemManager.topLevelItemViews.forEach(formView.appendItemView(_:))
         delegate?.viewDidLoad(viewController: self)
-        
+
         observe(keyboardObserver.$keyboardRect) { [weak self] _ in
             self?.didUpdatePreferredContentSize()
         }
@@ -214,11 +214,11 @@ open class FormViewController: UIViewController, AdyenObserver, PreferredContent
     public func showValidation() {
         let validatableItemViews = itemManager.flatItemViews
             .compactMap { $0 as? AnyFormValidatableValueItemView }
-        
+
         validatableItemViews.forEach { $0.showValidation() }
-        
+
         let firstInvalidItemView = validatableItemViews.first { !$0.isValid }
-        
+
         if let firstInvalidItemView {
             UIAccessibility.post(notification: .screenChanged, argument: firstInvalidItemView)
         }
@@ -237,6 +237,15 @@ open class FormViewController: UIViewController, AdyenObserver, PreferredContent
 
     public func resetForm() {
         itemManager.flatItemViews.forEach { $0.reset() }
+    }
+
+    public func focusNextInputField() {
+        let textInputItems = itemManager.flatItems.compactMap {
+            $0 as? FormTextInputItem
+        }.filter(\.isVisible)
+
+        let firstEmptyItem = textInputItems.first(where: { $0.value.isEmpty })
+        firstEmptyItem?.focus()
     }
 
     // MARK: - Private

--- a/Adyen/UI/Form/Items/Text/FormTextInputItem.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextInputItem.swift
@@ -8,13 +8,13 @@ import Foundation
 
 /// An item for plain text input
 @_spi(AdyenInternal)
-public final class FormTextInputItem: FormTextItem {
+open class FormTextInputItem: FormTextItem {
 
     @AdyenObservable(true) public var isEnabled: Bool
     
     internal var focusHandler: (() -> Void)?
     
-    override public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    override open func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
     

--- a/Adyen/UI/Form/Items/Text/FormTextInputItem.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextInputItem.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// An item for plain text input
 @_spi(AdyenInternal)
-public class FormTextInputItem: FormTextItem {
+open class FormTextInputItem: FormTextItem {
 
     @AdyenObservable(true) public var isEnabled: Bool
     

--- a/Adyen/UI/Form/Items/Text/FormTextInputItem.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextInputItem.swift
@@ -12,8 +12,8 @@ open class FormTextInputItem: FormTextItem {
 
     @AdyenObservable(true) public var isEnabled: Bool
     
-    internal var focusHandler: (() -> Void)?
-    
+    open var focusHandler: (() -> Void)?
+
     override open func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
@@ -28,7 +28,7 @@ open class FormTextInputItem: FormTextItem {
         isHidden.wrappedValue ? true : super.isValid()
     }
     
-    public func focus() {
+    open func focus() {
         AdyenAssertion.assert(message: "`focusHandler` needs to be set", condition: focusHandler == nil)
         focusHandler?()
     }

--- a/Adyen/UI/Form/Items/Text/FormTextInputItem.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextInputItem.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// An item for plain text input
 @_spi(AdyenInternal)
-open class FormTextInputItem: FormTextItem {
+public class FormTextInputItem: FormTextItem {
 
     @AdyenObservable(true) public var isEnabled: Bool
     

--- a/Adyen/UI/Form/Items/Text/FormTextInputItemView.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextInputItemView.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// A form view representing a plain text input.
 @_spi(AdyenInternal)
-public final class FormTextInputItemView: FormTextItemView<FormTextInputItem> {
+open class FormTextInputItemView: FormTextItemView<FormTextInputItem> {
 
     // MARK: - Initializers
 

--- a/Adyen/UI/Form/Items/Text/FormTextItemView.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextItemView.swift
@@ -13,12 +13,12 @@ public protocol FormTextItemViewDelegate: AnyObject {
     /// Invoked when the text entered in the item view's text field has reached the maximum length.
     ///
     /// - Parameter itemView: The item view in which the maximum length was reached.
-    func didReachMaximumLength<T: FormTextItem>(in itemView: FormTextItemView<T>)
+    func didReachMaximumLength(in itemView: FormTextItemView<some FormTextItem>)
     
     /// Invoked when the return key in the item view's text field is selected.
     ///
     /// - Parameter itemView: The item view in which the return key was selected.
-    func didSelectReturnKey<T: FormTextItem>(in itemView: FormTextItemView<T>)
+    func didSelectReturnKey(in itemView: FormTextItemView<some FormTextItem>)
     
 }
 

--- a/Adyen/UI/Form/Items/Text/FormTextItemView.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextItemView.swift
@@ -125,7 +125,7 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         
         return textField
     }()
-    
+
     // MARK: - Accessory view
     
     /// Accessory of the entry text field.

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -21,7 +21,7 @@ internal protocol CardScannerProviding {
 
 internal protocol CardScannerControlling: CardScannerAvailability {
     func openCardScanner()
-    func dismiss(_ completion: (() -> Void)?)
+    func dismiss(completion: (() -> Void)?)
     var title: String? { get set }
     var onScanComplete: ((Result<CardScannerCardDetails, Error>) -> Void)? { get set }
 }
@@ -144,7 +144,7 @@ internal protocol CardScannerControlling: CardScannerAvailability {
             sendLogEvent(.cardScannerPresented)
         }
 
-        internal func dismiss(_ completion: (() -> Void)? = nil) {
+        internal func dismiss(completion: (() -> Void)? = nil) {
             presenter?.dismiss(animated: true, completion: completion)
         }
 
@@ -172,7 +172,7 @@ internal protocol CardScannerControlling: CardScannerAvailability {
 
         internal func handleCardScanningCancelationWithCompletion(_ completion: (() -> Void)?) {
             sendLogEvent(.cardScannerCancelled)
-            dismiss(completion)
+            dismiss(completion: completion)
         }
 
         // MARK: - Analytics

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -21,6 +21,7 @@ internal protocol CardScannerProviding {
 
 internal protocol CardScannerControlling: CardScannerAvailability {
     func openCardScanner()
+    func dismiss()
     var title: String? { get set }
     var onScanComplete: ((Result<CardScannerCardDetails, Error>) -> Void)? { get set }
 }
@@ -86,6 +87,18 @@ internal protocol CardScannerControlling: CardScannerAvailability {
         internal var title: String?
         private let analyticsHandler: CardScannerAnalyticsHandler?
 
+        private let scannerNavigationController: UINavigationController = {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithDefaultBackground()
+
+            let navigationController = UINavigationController()
+            navigationController.navigationBar.standardAppearance = appearance
+            navigationController.navigationBar.compactAppearance = appearance
+            navigationController.navigationBar.scrollEdgeAppearance = appearance
+
+            return navigationController
+        }()
+
         internal var onScanComplete: ((Result<CardScannerCardDetails, Error>) -> Void)?
 
         internal init(
@@ -113,7 +126,6 @@ internal protocol CardScannerControlling: CardScannerAvailability {
         }
 
         internal func openCardScanner() {
-            let scannerNavigationController = makeNavigationController()
             guard let scannerViewController = cardScannerProvider.createCardScanner(completion: { [weak self] result in
                 guard let self else { return }
                 scannerNavigationController.dismiss(animated: true)
@@ -132,6 +144,10 @@ internal protocol CardScannerControlling: CardScannerAvailability {
             sendLogEvent(.cardScannerPresented)
         }
 
+        internal func dismiss() {
+            scannerNavigationController.dismiss(animated: true)
+        }
+
         // MARK: - Private
 
         private func map(_ result: Result<CardScannerCardDetails, Error>) -> Result<CardScannerCardDetails, Error> {
@@ -145,30 +161,14 @@ internal protocol CardScannerControlling: CardScannerAvailability {
             }
         }
 
-        private func makeNavigationController() -> UINavigationController {
-            let appearance = UINavigationBarAppearance()
-            appearance.configureWithDefaultBackground()
-
-            let navigationController = UINavigationController()
-            navigationController.navigationBar.standardAppearance = appearance
-            navigationController.navigationBar.compactAppearance = appearance
-            navigationController.navigationBar.scrollEdgeAppearance = appearance
-
-            return navigationController
-        }
-
         private func makeCancelBarButton() -> UIBarButtonItem {
             UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(handleCardScanningCancelation))
         }
 
         @objc
         private func handleCardScanningCancelation() {
-            handleCardScanningCancelationWithCompletion(nil)
-        }
-
-        internal func handleCardScanningCancelationWithCompletion(_ completion: (() -> Void)?) {
             sendLogEvent(.cardScannerCancelled)
-            presenter?.dismiss(animated: true, completion: completion)
+            scannerNavigationController.dismiss(animated: true)
         }
 
         // MARK: - Analytics

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -116,8 +116,8 @@ internal protocol CardScannerControlling: CardScannerAvailability {
             let scannerNavigationController = makeNavigationController()
             guard let scannerViewController = cardScannerProvider.createCardScanner(completion: { [weak self] result in
                 guard let self else { return }
-                self.onScanComplete?(map(result))
                 scannerNavigationController.dismiss(animated: true)
+                self.onScanComplete?(map(result))
             }) else { return }
 
             scannerViewController.navigationItem.leftBarButtonItem = makeCancelBarButton()

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -21,7 +21,7 @@ internal protocol CardScannerProviding {
 
 internal protocol CardScannerControlling: CardScannerAvailability {
     func openCardScanner()
-    func dismiss()
+    func dismiss(_ completion: (() -> Void)?)
     var title: String? { get set }
     var onScanComplete: ((Result<CardScannerCardDetails, Error>) -> Void)? { get set }
 }
@@ -144,8 +144,8 @@ internal protocol CardScannerControlling: CardScannerAvailability {
             sendLogEvent(.cardScannerPresented)
         }
 
-        internal func dismiss() {
-            scannerNavigationController.dismiss(animated: true)
+        internal func dismiss(_ completion: (() -> Void)? = nil) {
+            presenter?.dismiss(animated: true, completion: completion)
         }
 
         // MARK: - Private
@@ -167,8 +167,12 @@ internal protocol CardScannerControlling: CardScannerAvailability {
 
         @objc
         private func handleCardScanningCancelation() {
+            handleCardScanningCancelationWithCompletion(nil)
+        }
+
+        internal func handleCardScanningCancelationWithCompletion(_ completion: (() -> Void)?) {
             sendLogEvent(.cardScannerCancelled)
-            scannerNavigationController.dismiss(animated: true)
+            dismiss(completion)
         }
 
         // MARK: - Analytics

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -436,20 +436,6 @@ extension CardViewController {
             cardScannerController.dismiss(completion: nil)
         }
     }
-
-    private func focusNextInputField() {
-        let textInputItems: [FormTextInputItem] = [
-            items.expiryDateItem,
-            items.securityCodeItem,
-            items.holderNameItem,
-            items.additionalAuthCodeItem,
-            items.additionalAuthPasswordItem,
-            items.socialSecurityNumberItem
-        ].filter(\.isVisible)
-
-        let firstEmptyItem = textInputItems.first(where: { $0.value.isEmpty })
-        firstEmptyItem?.focus()
-    }
 }
 
 extension CardBrand {

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -423,14 +423,33 @@ extension CardViewController {
     private func handleCardScanningResult(_ result: Result<CardScannerCardDetails, Error>) {
         switch result {
         case let .success((number, expiryDate)):
-            items.numberContainerItem.setCardNumber(number ?? "")
+            if let number {
+                items.numberContainerItem.setCardNumber(number)
+            }
+
             if let expiryDate {
                 items.expiryDateItem.setExpiryDate(expiryDate)
             }
+
+            focusNextInputField()
         case .failure:
             // TODO: Implement error handling
             break
         }
+    }
+
+    private func focusNextInputField() {
+        let textInputItems: [FormTextInputItem] = [
+            items.expiryDateItem,
+            items.securityCodeItem,
+            items.holderNameItem,
+            items.additionalAuthCodeItem,
+            items.additionalAuthPasswordItem,
+            items.socialSecurityNumberItem
+        ].filter(\.isVisible)
+
+        let firstEmptyItem = textInputItems.first(where: { $0.value.isEmpty })
+        firstEmptyItem?.focus()
     }
 }
 

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -433,7 +433,7 @@ extension CardViewController {
 
             focusNextInputField()
         case .failure:
-            cardScannerController.dismiss(nil)
+            cardScannerController.dismiss(completion: nil)
         }
     }
 

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -433,8 +433,7 @@ extension CardViewController {
 
             focusNextInputField()
         case .failure:
-            // TODO: Implement error handling
-            break
+            cardScannerController.dismiss(nil)
         }
     }
 

--- a/AdyenCard/Components/Card/DummyCardScannerController.swift
+++ b/AdyenCard/Components/Card/DummyCardScannerController.swift
@@ -12,7 +12,7 @@ internal final class DummyCardScannerController: CardScannerControlling {
     internal var onScanComplete: ((Result<CardScannerCardDetails, any Error>) -> Void)?
     internal var title: String?
     internal func openCardScanner() { /* Empty implementation */ }
-    internal func dismiss(_ completion: (() -> Void)? = nil) { /* Empty implementation */ }
+    internal func dismiss(completion: (() -> Void)? = nil) { /* Empty implementation */ }
 
     internal init(
         presenter: UIViewController,

--- a/AdyenCard/Components/Card/DummyCardScannerController.swift
+++ b/AdyenCard/Components/Card/DummyCardScannerController.swift
@@ -12,7 +12,7 @@ internal final class DummyCardScannerController: CardScannerControlling {
     internal var onScanComplete: ((Result<CardScannerCardDetails, any Error>) -> Void)?
     internal var title: String?
     internal func openCardScanner() { /* Empty implementation */ }
-    internal func dismiss() { /* Empty implementation */ }
+    internal func dismiss(_ completion: (() -> Void)? = nil) { /* Empty implementation */ }
 
     internal init(
         presenter: UIViewController,

--- a/AdyenCard/Components/Card/DummyCardScannerController.swift
+++ b/AdyenCard/Components/Card/DummyCardScannerController.swift
@@ -11,7 +11,8 @@ internal final class DummyCardScannerController: CardScannerControlling {
     internal var isScannerAvailable: Bool { false }
     internal var onScanComplete: ((Result<CardScannerCardDetails, any Error>) -> Void)?
     internal var title: String?
-    internal func openCardScanner() {}
+    internal func openCardScanner() { /* Empty implementation */ }
+    internal func dismiss() { /* Empty implementation */ }
 
     internal init(
         presenter: UIViewController,

--- a/AdyenCard/Form/FormCardExpiryDateItem.swift
+++ b/AdyenCard/Form/FormCardExpiryDateItem.swift
@@ -8,8 +8,8 @@ import Foundation
 @_spi(AdyenInternal) import Adyen
 
 /// A form item into which card expiry date is entered, formatted and validated.
-internal final class FormCardExpiryDateItem: FormTextItem {
-    
+internal final class FormCardExpiryDateItem: FormTextInputItem {
+
     internal var localizationParameters: LocalizationParameters?
     
     /// Flag determining this forms state. Validation changes based on this.
@@ -74,7 +74,7 @@ internal final class FormCardExpiryDateItem: FormTextItem {
 }
 
 extension FormItemViewBuilder {
-    internal func build(with item: FormCardExpiryDateItem) -> FormItemView<FormCardExpiryDateItem> {
-        FormTextItemView<FormCardExpiryDateItem>(item: item)
+    internal func build(with item: FormCardExpiryDateItem) -> FormItemView<FormTextInputItem> {
+        FormTextInputItemView(item: item)
     }
 }

--- a/AdyenCard/Form/FormCardSecurityCodeItem.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItem.swift
@@ -7,7 +7,7 @@
 @_spi(AdyenInternal) import Adyen
 
 /// A form item into which a card's security code (CVC/CVV) is entered.
-internal final class FormCardSecurityCodeItem: FormTextItem {
+internal final class FormCardSecurityCodeItem: FormTextInputItem {
 
     internal enum DisplayMode {
         case required

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -29,6 +29,10 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
         }
         
         item.$selectedCard.publish(nil)
+
+        item.focusHandler = { [weak self] in
+            self?.becomeFirstResponder()
+        }
     }
     
     internal lazy var cardHintView: HintView = {

--- a/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
@@ -237,7 +237,7 @@ class BCMCComponentTests: XCTestCase {
         self.populate(textItemView: cardNumberView!, with: Dummy.bancontactCard.number!)
         
         // Enter Expiry Date
-        let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem>? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem")
+        let expiryDateItemView: FormTextInputItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem")
         XCTAssertNotNil(expiryDateItemView)
         let date = Date(timeIntervalSinceNow: 60 * 60 * 24 * 30 * 2)
         let calendar = Calendar(identifier: .gregorian)
@@ -536,8 +536,8 @@ class BCMCComponentTests: XCTestCase {
         
         // Enter Expiry Date
         let expiryDateView = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem")
-        XCTAssertNotNil(expiryDateView as? FormTextItemView<FormCardExpiryDateItem>)
-        let expiryDateItemView = expiryDateView as! FormTextItemView<FormCardExpiryDateItem>
+        XCTAssertNotNil(expiryDateView as? FormTextInputItemView)
+        let expiryDateItemView = expiryDateView as! FormTextInputItemView
         self.populate(textItemView: expiryDateItemView, with: "10/20")
         
         // Tap submit button
@@ -593,7 +593,7 @@ class BCMCComponentTests: XCTestCase {
     
     func fillCard(on view: UIView, with card: Card, simulateKeyStrokes: Bool = false) {
         let cardNumberItemView: FormCardNumberItemView? = view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
-        let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem>? = view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem")
+        let expiryDateItemView: FormTextInputItemView? = view.findView(with: "AdyenCard.BCMCComponent.expiryDateItem")
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem>? = view.findView(with: "AdyenCard.BCMCComponent.securityCodeItem")
 
         if simulateKeyStrokes {

--- a/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerControllerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerControllerTests.swift
@@ -57,6 +57,28 @@
             wait(for: [expectation], timeout: 3.0)
         }
 
+        func test_dismiss_shouldDismissPresentedNavigationController() throws {
+            // Given
+            let (sut, presenter, _) = makeSUT()
+            let window = UIWindow(frame: UIScreen.main.bounds)
+            window.rootViewController = presenter
+            window.makeKeyAndVisible()
+
+            sut.openCardScanner()
+            XCTAssertNotNil(presenter.presentedViewController)
+
+            let dismissalExpectation = XCTestExpectation(description: "Navigation controller should be dismissed")
+
+            // When
+            sut.dismiss {
+                dismissalExpectation.fulfill()
+            }
+
+            // Then
+            wait(for: [dismissalExpectation], timeout: 2)
+            XCTAssertNil(presenter.presentedViewController)
+        }
+
         func testHandleCardScanningCancelation() throws {
             let (sut, presenter, _) = makeSUT()
 

--- a/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
@@ -71,7 +71,7 @@ final class CardComponentEventTests: XCTestCase {
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = makeSUT(analyticsProviderMock: analyticsProviderMock)
 
-        let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(sut.cardViewController.view.findView(with: "AdyenCard.CardComponent.expiryDateItem"))
+        let expiryDateItemView: FormTextInputItemView = try XCTUnwrap(sut.cardViewController.view.findView(with: "AdyenCard.CardComponent.expiryDateItem"))
 
         testFocusEvents(
             for: expiryDateItemView,

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -175,7 +175,7 @@ class CardComponentTests: XCTestCase {
         let holderNameItemTitleLabel: UILabel? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.holderNameItem.titleLabel")
         let holderNameItemTextField: UITextField? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.holderNameItem.textField")
 
-        let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem>? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.expiryDateItem")
+        let expiryDateItemView: FormTextInputItemView? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.expiryDateItem")
         let expiryDateItemTitleLabel: UILabel? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.expiryDateItem.titleLabel")
         let expiryDateItemTextField: UITextField? = sut.viewController.view.findView(with: "AdyenCard.CardComponent.expiryDateItem.textField")
 
@@ -742,8 +742,8 @@ class CardComponentTests: XCTestCase {
         setupRootViewController(sut.viewController)
 
         let cardNumberItemView: FormCardNumberItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem"))
-        let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.CardComponent.expiryDateItem"))
-        
+        let expiryDateItemView: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.CardComponent.expiryDateItem"))
+
         // no focus change without panglength till max (19)
         
         var newResponse = BinLookupResponse(brands: [CardBrand(type: .americanExpress)])
@@ -797,7 +797,7 @@ class CardComponentTests: XCTestCase {
         setupRootViewController(component.viewController)
         
         let view: UIView = viewController.view
-        let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(with: "AdyenCard.CardComponent.expiryDateItem"))
+        let expiryDateItemView: FormTextInputItemView = try XCTUnwrap(view.findView(with: "AdyenCard.CardComponent.expiryDateItem"))
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem> = try XCTUnwrap(view.findView(with: "AdyenCard.CardComponent.securityCodeItem"))
         
         expiryDateItemView.becomeFirstResponder()
@@ -1871,7 +1871,7 @@ class CardComponentTests: XCTestCase {
         let view: UIView = sut.cardViewController.view
         
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
-        let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
+        let expiryDateField: FormTextInputItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
 
         let billingAddressView: FormAddressPickerItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.billingAddress))
@@ -1939,7 +1939,7 @@ class CardComponentTests: XCTestCase {
         let view: UIView = sut.cardViewController.view
         
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
-        let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
+        let expiryDateField: FormTextInputItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
         
         populate(textItemView: securityCodeField, with: "737")
@@ -1995,7 +1995,7 @@ class CardComponentTests: XCTestCase {
         let view: UIView = sut.cardViewController.view
         
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
-        let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
+        let expiryDateField: FormTextInputItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
         let postalCodeField: FormTextItemView<FormPostalCodeItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.zipCode))
         
@@ -2052,7 +2052,7 @@ class CardComponentTests: XCTestCase {
         let view: UIView = sut.cardViewController.view
         
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
-        let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
+        let expiryDateField: FormTextInputItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
         let postalCodeField: FormTextItemView<FormPostalCodeItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.zipCode))
         
@@ -2175,7 +2175,7 @@ class CardComponentTests: XCTestCase {
         let view: UIView = sut.cardViewController.view
 
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
-        let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
+        let expiryDateField: FormTextInputItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
  
         let billingAddressView: FormAddressPickerItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.billingAddress))
@@ -2231,7 +2231,7 @@ class CardComponentTests: XCTestCase {
         let view: UIView = sut.cardViewController.view
 
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
-        let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
+        let expiryDateField: FormTextInputItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
 
         let billingAddressView: FormAddressPickerItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.billingAddress))
@@ -2293,7 +2293,7 @@ class CardComponentTests: XCTestCase {
         let view: UIView = sut.cardViewController.view
 
         let securityCodeField: FormCardSecurityCodeItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.securityCode))
-        let expiryDateField: FormTextItemView<FormCardExpiryDateItem> = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
+        let expiryDateField: FormTextInputItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.expiryDate))
         let numberField: FormCardNumberItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.cardNumber))
 
         let billingAddressView: FormAddressPickerItemView = try XCTUnwrap(view.findView(by: CardViewIdentifier.billingAddress))
@@ -2446,7 +2446,7 @@ extension CardComponentTests {
 
     func fillCard(on view: UIView, with card: Card) {
         let cardNumberItemView: FormTextItemView<FormCardNumberItem>? = view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")
-        let expiryDateItemView: FormTextItemView<FormCardExpiryDateItem>? = view.findView(with: "AdyenCard.CardComponent.expiryDateItem")
+        let expiryDateItemView: FormTextInputItemView? = view.findView(with: "AdyenCard.CardComponent.expiryDateItem")
         let securityCodeItemView: FormTextItemView<FormCardSecurityCodeItem>? = view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
 
         populate(textItemView: cardNumberItemView!, with: card.number ?? "")

--- a/Tests/IntegrationTests/Card Tests/FormViewControllerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/FormViewControllerTests.swift
@@ -39,4 +39,40 @@ class FormViewControllerTests: XCTestCase {
         XCTAssertFalse(cardNumberItemView.isFirstResponder)
         XCTAssertTrue(securityCodeItemView.isFirstResponder)
     }
+
+    func test_focusNextInputField() throws {
+        // Given
+        let style = FormComponentStyle()
+
+        let sut = FormViewController(
+            scrollEnabled: true,
+            style: style,
+            localizationParameters: nil
+        )
+
+        let cardNumberItem = FormCardNumberItem(cardTypeLogos: [], scanCardHandler: nil)
+        cardNumberItem.setCardNumber("4111 1111 1111 1111")
+        let securityCodeItem = FormCardSecurityCodeItem(style: style.textField)
+        securityCodeItem.value = "737"
+        let cardHolderItem = FormTextInputItem(style: style.textField)
+
+        sut.append(cardNumberItem)
+        sut.append(securityCodeItem)
+        sut.append(cardHolderItem)
+
+        setupRootViewController(sut)
+
+        // When
+        sut.focusNextInputField()
+
+        // Then
+        let scrollView = try XCTUnwrap(
+            sut.view.subviews.filter { $0 is UIScrollView
+            }.first)
+        let formView = try XCTUnwrap(scrollView.subviews.filter { $0 is FormView }.first)
+        let stackView = try XCTUnwrap(formView.subviews.filter { $0 is UIStackView }.first)
+        let cardHolderItemView = try XCTUnwrap(stackView.subviews.last as? FormTextInputItemView)
+
+        XCTAssertTrue(cardHolderItemView.isFirstResponder)
+    }
 }

--- a/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
@@ -42,7 +42,7 @@ class GiftCardComponentTests: XCTestCase {
         sut.viewController.view.findView(with: "AdyenCard.GiftCardComponent.securityCodeItem")
     }
     
-    var expiryDateItemView: FormTextItemView<FormCardExpiryDateItem>? {
+    var expiryDateItemView: FormTextInputItemView? {
         sut.viewController.view.findView(with: "AdyenCard.GiftCardComponent.expiryDateItem")
     }
 


### PR DESCRIPTION
## Summary [Required]

Adds logic in the card component to move first responder to the next empty field after a successful scan.
On the `FormViewController`, there's a new method `focusNextInputField` that moves the first responder to the next `FormTextInputItem` with a `nil` value.

## Demo
<!-- Add screenshots or link to screen recording demonstrating the changes -->
<!-- Include both light/dark mode and different device sizes if it matters -->


https://github.com/user-attachments/assets/9398fce7-7204-4028-b223-d60e20ef0dbb



## Ticket [Optional]
<ticket>
COSDK-468
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
