### PR TITLE
Fix: `cancel-duplicate-work-flows` job stuck in "in-progress" state

### DIFF
--- a/.github/workflows/cancel-duplicate-work-flows.yml
+++ b/.github/workflows/cancel-duplicate-work-flows.yml
@@ -1,5 +1,5 @@
 # .github/workflows/cancel-duplicate-work-flows.yml
-name: Cancel duplicate work flowsXX
+name: Cancel duplicate work flows
 
 on:
   pull_request:

--- a/.github/workflows/cancel-duplicate-work-flows.yml
+++ b/.github/workflows/cancel-duplicate-work-flows.yml
@@ -1,60 +1,62 @@
+# .github/workflows/cancel-duplicate-work-flows.yml
 name: Cancel duplicate work flows
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+
 jobs:
   cancel-multiple-workflow-runs:
     name: "Cancel the self CI workflow run"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    permissions:
+      actions: write
     steps:
       - name: "Cancel build"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
-          cancelMode: allDuplicates
-          cancelFutureDuplicates: true
+          workflow_id: build.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflowFileName: build.yml
+          all_but_latest: true
+
       - name: "Cancel pr scan"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
-          cancelMode: allDuplicates
-          cancelFutureDuplicates: true
+          workflow_id: pr_scan.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflowFileName: pr_scan.yml
+          all_but_latest: true
+
       - name: "Cancel spell check"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
-          cancelMode: allDuplicates
-          cancelFutureDuplicates: true
+          workflow_id: spell-check.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflowFileName: spell-check.yml
+          all_but_latest: true
+
       - name: "Cancel test_cocoapods_integration"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
-          cancelMode: allDuplicates
-          cancelFutureDuplicates: true
+          workflow_id: test_cocoapods_integration.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflowFileName: test_cocoapods_integration.yml
+          all_but_latest: true
+
       - name: "Cancel test-carthage-integration"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
-          cancelMode: allDuplicates
-          cancelFutureDuplicates: true
+          workflow_id: test-carthage-integration.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflowFileName: test-carthage-integration.yml
+          all_but_latest: true
+
       - name: "Cancel test-SPM-integration"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
-          cancelMode: allDuplicates
-          cancelFutureDuplicates: true
+          workflow_id: test-SPM-integration.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflowFileName: test-SPM-integration.yml
+          all_but_latest: true
+
       - name: "Cancel validate_pr_labels_and_release_notes"
-        uses: potiuk/cancel-workflow-runs@master
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
-          cancelMode: allDuplicates
-          cancelFutureDuplicates: true
+          workflow_id: validate_pr_labels_and_release_notes.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflowFileName: validate_pr_labels_and_release_notes.yml
+          all_but_latest: true

--- a/.github/workflows/cancel-duplicate-work-flows.yml
+++ b/.github/workflows/cancel-duplicate-work-flows.yml
@@ -1,5 +1,5 @@
 # .github/workflows/cancel-duplicate-work-flows.yml
-name: Cancel duplicate work flows
+name: Cancel duplicate work flowsXX
 
 on:
   pull_request:

--- a/.github/workflows/cancel-duplicate-work-flows.yml
+++ b/.github/workflows/cancel-duplicate-work-flows.yml
@@ -7,6 +7,7 @@ jobs:
   cancel-multiple-workflow-runs:
     name: "Cancel the self CI workflow run"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: "Cancel build"
         uses: potiuk/cancel-workflow-runs@master


### PR DESCRIPTION
# Summary [Required]

This PR resolves a visual glitch in the `cancel-duplicate-work-flows` job where it would remain in an "in-progress" state despite successfully completing.

The issue appeared to stem from the `potiuk/cancel-workflow-runs@master` action. We've replaced it with `styfle/cancel-workflow-action@0.12.1`.

The job now correctly reflects its completed status.

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
