### PR TITLE
DSP-2591: On cancel don't prompt for passkey enrollment

### DIFF
--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -206,6 +206,8 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
         }
     }
     
+    internal func userCancelledChallenge() {}
+
     /// Invoked to handle the error flow of a challenge handling by the 3ds2sdk.
     private func didReceiveErrorOnChallenge(
         error: ThreeDSServiceChallengeError,
@@ -215,6 +217,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
         let opaqueRepresentationOfError: String
         switch error {
         case let .cancelled(errorPayload):
+            userCancelledChallenge()
             opaqueRepresentationOfError = errorPayload
             sendErrorEvent(
                 .threeDS2ChallengeHandlingFailed,

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
@@ -440,6 +440,10 @@ internal typealias VoidHandler = () -> Void
             }
         }
         
+        override internal func userCancelledChallenge() {
+            self.delegatedAuthenticationState.attemptRegistration = false
+        }
+        
         private enum RegistrationFlowError: Error {
             case registrationServiceError(underlyingError: Error)
             case userOptedOutOfRegistration

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -161,27 +161,15 @@ import XCTest
 
         func testOnChallengeFlowCancellationRegistration() throws {
             let service = ThreeDSServiceableMock()
-            service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
             service.onPerformChallenge = { params, completion in
                 completion(.failure(.cancelled(errorPayload: "")))
             }
-            service.onResetTransaction = {}
             let authenticationServiceMock = AuthenticationServiceMock()
         
             authenticationServiceMock.onRegister = { _ in
-                self.expectedSDKRegistrationOutput
+                XCTFail("Register shouldn't occur on cancellation")
+                return ""
             }
-        
-            let expectedResult = try! ThreeDSResult(
-                from: AnyChallengeResultMock(
-                    sdkTransactionIdentifier: "sdkTransactionIdentifier",
-                    transactionStatus: "Y"
-                ),
-                delegatedAuthenticationSDKOutput: expectedSDKRegistrationOutput,
-                authorizationToken: "authToken",
-                threeDS2SDKError: nil
-            )
-            
             let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
             let sut = ThreeDS2PlusDACoreActionHandler(
                 context: Dummy.context,
@@ -191,8 +179,8 @@ import XCTest
                 delegatedAuthenticationService: authenticationServiceMock,
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
             )
-            sut.threeDSRequestorAppURL = URL(string: "https://google.com")
             sut.delegatedAuthenticationState.attemptRegistration = true
+
             sut.handle(challengeAction, event: analyticsEvent) { challengeResult in
                 switch challengeResult {
                 case .success:
@@ -203,7 +191,7 @@ import XCTest
                 resultExpectation.fulfill()
             }
 
-            waitForExpectations(timeout: 2, handler: nil)
+            waitForExpectations(timeout: 1, handler: nil)
         }
         
         func testChallengeFlowSuccess() throws {

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -159,6 +159,53 @@ import XCTest
             waitForExpectations(timeout: 2, handler: nil)
         }
 
+        func testOnChallengeFlowCancellationRegistration() throws {
+            let service = ThreeDSServiceableMock()
+            service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
+            service.onPerformChallenge = { params, completion in
+                completion(.failure(.cancelled(errorPayload: "")))
+            }
+            service.onResetTransaction = {}
+            let authenticationServiceMock = AuthenticationServiceMock()
+        
+            authenticationServiceMock.onRegister = { _ in
+                self.expectedSDKRegistrationOutput
+            }
+        
+            let expectedResult = try! ThreeDSResult(
+                from: AnyChallengeResultMock(
+                    sdkTransactionIdentifier: "sdkTransactionIdentifier",
+                    transactionStatus: "Y"
+                ),
+                delegatedAuthenticationSDKOutput: expectedSDKRegistrationOutput,
+                authorizationToken: "authToken",
+                threeDS2SDKError: nil
+            )
+            
+            let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
+            let sut = ThreeDS2PlusDACoreActionHandler(
+                context: Dummy.context,
+                service: service,
+                presenter: ThreeDS2DAScreenPresenterMock(showRegistrationReturnState: .register, showApprovalScreenReturnState: .fallback),
+                delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
+                delegatedAuthenticationService: authenticationServiceMock,
+                deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
+            )
+            sut.threeDSRequestorAppURL = URL(string: "https://google.com")
+            sut.delegatedAuthenticationState.attemptRegistration = true
+            sut.handle(challengeAction, event: analyticsEvent) { challengeResult in
+                switch challengeResult {
+                case .success:
+                    XCTAssertFalse(sut.delegatedAuthenticationState.attemptRegistration)
+                case .failure:
+                    XCTFail()
+                }
+                resultExpectation.fulfill()
+            }
+
+            waitForExpectations(timeout: 2, handler: nil)
+        }
+        
         func testChallengeFlowSuccess() throws {
             
             let service = ThreeDSServiceableMock()


### PR DESCRIPTION
# Summary [Required]
On cancelling a challenge we shouldn't prompt for passkey enrollment.

<fixed> </fixed>

## Ticket [Optional]
<ticket>
DSP-2591 
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests 
- [x] Verified against acceptance criteria
