### PR TITLE
Fix to show cobadged brands UI only if certain brands are present in the binLookup response

### DIFF
--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -230,7 +230,7 @@ internal class CardViewController: FormViewController {
             items.coBadgedCardItem.resetItems()
         } else {
             brands = binInfo.brands ?? []
-            items.coBadgedCardItem.updateItems(brands, cardLogos: cardLogos)
+            showCoBadgedCardsUI(for: brands)
         }
         issuingCountryCode = binInfo.issuingCountryCode
         items.numberContainerItem.update(brands: brands)
@@ -243,6 +243,16 @@ internal class CardViewController: FormViewController {
         items.numberContainerItem.numberItem.selectBrand(cardBrand: selectedBrand)
 
         items.triggerInfoEvent(of: .selected, target: .dualBrandButton, brands: [selectedBrand])
+    }
+
+    private func showCoBadgedCardsUI(for brands: [CardBrand]) {
+        let allowedCoBadgedCardTypes = ["cartebancaire", "bcmc", "dankort"]
+        let coBadgedBrands = brands.filter { brand in
+            allowedCoBadgedCardTypes.contains(brand.type.rawValue)
+        }
+        if coBadgedBrands.count > 0 {
+            items.coBadgedCardItem.updateItems(brands, cardLogos: cardLogos)
+        }
     }
 }
 

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -26,6 +26,7 @@ internal class CardViewController: FormViewController {
     private let initialCountryCode: String
     private let scope: String
     private let cardLogos: [FormCardLogosItem.CardTypeLogo]
+    private let allowedCoBadgedCardTypes = Set(["cartebancaire", "bcmc", "dankort"])
     private let cardScannerAnalyticsHandler: CardScannerAnalyticsHandler
     private lazy var cardScannerController: CardScannerControlling = {
         var controller: CardScannerControlling
@@ -245,12 +246,11 @@ internal class CardViewController: FormViewController {
         items.triggerInfoEvent(of: .selected, target: .dualBrandButton, brands: [selectedBrand])
     }
 
-    private func showCoBadgedCardsUI(for brands: [CardBrand]) {
-        let allowedCoBadgedCardTypes = ["cartebancaire", "bcmc", "dankort"]
+    internal func showCoBadgedCardsUI(for brands: [CardBrand]) {
         let coBadgedBrands = brands.filter { brand in
             allowedCoBadgedCardTypes.contains(brand.type.rawValue)
         }
-        if coBadgedBrands.count > 0 {
+        if !coBadgedBrands.isEmpty { // Check if there are any co-badged brands
             items.coBadgedCardItem.updateItems(brands, cardLogos: cardLogos)
         }
     }

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -26,7 +26,7 @@ internal class CardViewController: FormViewController {
     private let initialCountryCode: String
     private let scope: String
     private let cardLogos: [FormCardLogosItem.CardTypeLogo]
-    private let allowedCoBadgedCardTypes = Set(["cartebancaire", "bcmc", "dankort"])
+    private let allowedCoBadgedCardTypes: [CardType] = [.carteBancaire, .bcmc, .dankort]
     private let cardScannerAnalyticsHandler: CardScannerAnalyticsHandler
     private lazy var cardScannerController: CardScannerControlling = {
         var controller: CardScannerControlling
@@ -248,7 +248,7 @@ internal class CardViewController: FormViewController {
 
     internal func showCoBadgedCardsUI(for brands: [CardBrand]) {
         let coBadgedBrands = brands.filter { brand in
-            allowedCoBadgedCardTypes.contains(brand.type.rawValue)
+            return allowedCoBadgedCardTypes.contains(brand.type)
         }
         if !coBadgedBrands.isEmpty { // Check if there are any co-badged brands
             items.coBadgedCardItem.updateItems(brands, cardLogos: cardLogos)

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -1402,7 +1402,7 @@ class CardComponentTests: XCTestCase {
         XCTAssertFalse(logoItemView.isHidden)
     }
 
-    func testCoBadgedCardsSelectionUIVisibility() throws {
+    func testCoBadgedCardsSelectionUIVisibilityForEU() throws {
         // Given
 
         let sut = CardComponent(
@@ -1414,12 +1414,34 @@ class CardComponentTests: XCTestCase {
         sut.viewController.loadViewIfNeeded()
 
         let newResponse = BinLookupResponse(brands: [CardBrand(type: .visa), CardBrand(type: .carteBancaire)], issuingCountryCode: "FR", isCreatedLocally: false)
-        sut.cardViewController.update(binInfo: newResponse)
+
+        sut.cardViewController.showCoBadgedCardsUI(for: newResponse.brands!)
 
         wait(for: .aMoment)
 
         // Then
         XCTAssertFalse(sut.cardViewController.items.coBadgedCardItem.isHidden.wrappedValue)
+    }
+
+    func testCoBadgedCardsSelectionUIHiddenForAU() throws {
+        // Given
+
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: CardComponent.Configuration()
+        )
+
+        sut.viewController.loadViewIfNeeded()
+
+        let newResponse = BinLookupResponse(brands: [CardBrand(type: .masterCard), CardBrand(type: .other(named: "eftpos_australia"))], issuingCountryCode: "AU", isCreatedLocally: false)
+
+        sut.cardViewController.showCoBadgedCardsUI(for: newResponse.brands!)
+
+        wait(for: .aMoment)
+
+        // Then
+        XCTAssertTrue(sut.cardViewController.items.coBadgedCardItem.isHidden.wrappedValue)
     }
 
     func testCoBadgedCardsNameOnSelectionUI() throws {


### PR DESCRIPTION
# Summary

The new cobadged brands should only be shown if the /binLookup response contains cartebancaire, bcmc, or dankort.
This PR performs the necessary check


# Demo 

![Simulator Screenshot - iPhone 12 - 2025-07-03 at 15 54 50](https://github.com/user-attachments/assets/6fad7197-b4fd-4d47-a006-c263a5d09e26)

![Simulator Screenshot - iPhone 12 - 2025-07-03 at 15 57 18](https://github.com/user-attachments/assets/52fcf4dd-9c44-4dce-8df8-d4a41dc5fe35)


<fixed>
- For cards: in the payment form, the UI to [select a card brand for a co-badged card](https://docs.adyen.com/online-payments/co-badged-cards-compliance/) now appears only if the the following brands are available: 
- Cartes Bancaires (`cartebancaire`) 
- Bancontact card (`bcmc`) 
- Dankort (`dankort`) 
</fixed>

## Ticket [Optional]
<ticket>
COSDK-531
</ticket>

## Checklist
Manually tested with dual brands that are present in the "inclusion" list and those that aren't
