### PR TITLE
Update ApplePay amount in paymentRequest.paymentSummaryItems

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -751,6 +751,7 @@
 		E795A27626404E9400321C48 /* AddressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E795A27526404E9400321C48 /* AddressViewModel.swift */; };
 		E7975F982880421600A12C40 /* XCTestCase+Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04E60D227E0E6280051C72C /* XCTestCase+Result.swift */; };
 		E79A64812490D98F00368E9F /* CardComponentDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E79A64802490D98F00368E9F /* CardComponentDelegateMock.swift */; };
+		E7AEDBEC2E1E742900377AB2 /* ApplePayPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7AEDBEB2E1E742900377AB2 /* ApplePayPaymentTests.swift */; };
 		E7B3DE9F25A61B9200CA4D2B /* UIViewConstraintsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B3DE9E25A61B9200CA4D2B /* UIViewConstraintsHelper.swift */; };
 		E7B627FD24ED32CC000CEC6E /* BinLookupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B627FC24ED32CC000CEC6E /* BinLookupService.swift */; };
 		E7CC63D2287EFFC00034108B /* DummyHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CC63D1287EFFC00034108B /* DummyHelper.swift */; };
@@ -2224,6 +2225,7 @@
 		E788A5062658045D00089448 /* Amount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Amount.swift; sourceTree = "<group>"; };
 		E795A27526404E9400321C48 /* AddressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressViewModel.swift; sourceTree = "<group>"; };
 		E79A64802490D98F00368E9F /* CardComponentDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardComponentDelegateMock.swift; sourceTree = "<group>"; };
+		E7AEDBEB2E1E742900377AB2 /* ApplePayPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayPaymentTests.swift; sourceTree = "<group>"; };
 		E7B3DE9E25A61B9200CA4D2B /* UIViewConstraintsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewConstraintsHelper.swift; sourceTree = "<group>"; };
 		E7B627FC24ED32CC000CEC6E /* BinLookupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinLookupService.swift; sourceTree = "<group>"; };
 		E7CC63D1287EFFC00034108B /* DummyHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyHelper.swift; sourceTree = "<group>"; };
@@ -5602,6 +5604,7 @@
 		F960FB06237181DC00AEF74B /* Apple Pay */ = {
 			isa = PBXGroup;
 			children = (
+				E7AEDBEB2E1E742900377AB2 /* ApplePayPaymentTests.swift */,
 				F960FB082371823A00AEF74B /* ApplePayComponentTests.swift */,
 				F96A25462372C39F007DBF0B /* ApplePayDetailsTest.swift */,
 				5A238C9E263BDEA200758FEF /* PreApplePayComponentTests.swift */,
@@ -7717,6 +7720,7 @@
 				5A56E15326B6DB9C00744CA0 /* VoucherViewTests.swift in Sources */,
 				81DC5A592A79287400DBF2D1 /* AddressInputFormViewControllerTests.swift in Sources */,
 				81A2E3BE2A5C453200CF5F9C /* LinkTextViewTests.swift in Sources */,
+				E7AEDBEC2E1E742900377AB2 /* ApplePayPaymentTests.swift in Sources */,
 				81825CC42AC59C6C00F91912 /* XCTestCase+Wait+UIKit.swift in Sources */,
 				E9E3DAC2221ECE1000697074 /* CardSecurityCodeFormatterTests.swift in Sources */,
 				F9A6C453265640E000D8CD3E /* InstantPaymentComponentTests.swift in Sources */,

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -163,6 +163,9 @@ extension ApplePayComponent {
         public func replacing(amount: Amount) -> Self {
             var newConfig = self
             newConfig.applePayPayment.update(amount: amount)
+            if let paymentRequest {
+                paymentRequest.paymentSummaryItems = newConfig.applePayPayment.summaryItems
+            }
             return newConfig
         }
 

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -92,7 +92,8 @@ extension ApplePayComponent {
         ///   - allowOnboarding: Flag to allow shoppers to add new cards for Apple Pay  if there is none. Default is `false`.
         /// - Important: When created via this init, rest of the properties of this configuration
         /// are ignored since the request should already be populated.
-        ///  - Use this initializer to support any new additions to the `PKPaymentRequest` object,
+        /// - Warning: The instance of `paymentRequest` may be mutated.
+        /// - Note: Use this initializer to support any new additions to the `PKPaymentRequest` object,
         ///  such as recurring payments via its `recurringPaymentRequest` property.
         /// - Throws: An error object describing whether any required field in the request is missing.
         public init(

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -200,57 +200,6 @@ class ApplePayComponentTest: XCTestCase {
 
         waitForExpectations(timeout: 10)
     }
-
-    func testInvalidCurrencyCode() {
-        let amount = Amount(value: 2, unsafeCurrencyCode: "ZZZ")
-        let payment = Payment(amount: amount, countryCode: getRandomCountryCode())
-        XCTAssertThrowsError(try ApplePayPayment(payment: payment, brand: "TEST")) { error in
-            XCTAssertTrue(error is ApplePayComponent.Error)
-            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidCurrencyCode)
-            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The currency code is invalid.")
-        }
-    }
-    
-    func testInvalidCountryCode() {
-        let payment = Payment(amount: amount, unsafeCountryCode: "ZZ")
-        XCTAssertThrowsError(try ApplePayPayment(payment: payment, brand: "TEST")) { error in
-            XCTAssertTrue(error is ApplePayComponent.Error)
-            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidCountryCode)
-            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The country code is invalid.")
-        }
-    }
-    
-    func testEmptySummaryItems() {
-        XCTAssertThrowsError(try ApplePayPayment(countryCode: "US", currencyCode: "USD", summaryItems: [])) { error in
-            XCTAssertTrue(error is ApplePayComponent.Error)
-            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.emptySummaryItems)
-            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The summaryItems array is empty.")
-        }
-    }
-    
-    func testGrandTotalIsNegative() {
-        XCTAssertThrowsError(try ApplePayPayment(
-            countryCode: "US",
-            currencyCode: "USD",
-            summaryItems: createInvalidGrandTotalTestSummaryItems()
-        )) { error in
-            XCTAssertTrue(error is ApplePayComponent.Error)
-            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.negativeGrandTotal)
-            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The grand total summary item should be greater than or equal to zero.")
-        }
-    }
-    
-    func testOneItemWithZeroAmount() {
-        XCTAssertThrowsError(try ApplePayPayment(
-            countryCode: "US",
-            currencyCode: "USD",
-            summaryItems: createTestSummaryItemsWithZeroAmount()
-        )) { error in
-            XCTAssertTrue(error is ApplePayComponent.Error)
-            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidSummaryItem)
-            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "At least one of the summary items has an invalid amount.")
-        }
-    }
     
     func testRequiresModalPresentation() {
         XCTAssertEqual(sut?.requiresModalPresentation, false)
@@ -400,6 +349,70 @@ class ApplePayComponentTest: XCTestCase {
         XCTAssertThrowsError(try ApplePayComponent.Configuration(paymentRequest: request))
     }
 
+    func testReplacingSummaryItemsUSD() throws {
+        // Given
+        let request = PKPaymentRequest()
+        request.merchantIdentifier = "test_id"
+        request.currencyCode = "USD"
+        request.countryCode = "US"
+        request.paymentSummaryItems = [
+            PKPaymentSummaryItem(label: "New Item 1", amount: 1111),
+            PKPaymentSummaryItem(label: "New Item 2", amount: 2222)
+        ]
+        let testAmount = Amount(value: 1000, currencyCode: "USD")
+        let config = try ApplePayComponent.Configuration(paymentRequest: request)
+
+        // When
+        let sut = config.replacing(amount: testAmount)
+
+        // Then
+        XCTAssertEqual(sut.applePayPayment.amount, testAmount)
+        XCTAssertNotNil(sut.paymentRequest?.paymentSummaryItems)
+        XCTAssertEqual(sut.paymentRequest?.paymentSummaryItems.count, 2)
+        let summaryItem = sut.paymentRequest?.paymentSummaryItems.last
+        XCTAssertNotNil(summaryItem)
+        XCTAssertEqual(summaryItem?.amount, 10)
+    }
+
+    func testReplacingSummaryItemsJPY() throws {
+        // Given
+        let request = PKPaymentRequest()
+        request.merchantIdentifier = "test_id"
+        request.currencyCode = "JPY"
+        request.countryCode = "JP"
+        request.paymentSummaryItems = [
+            PKPaymentSummaryItem(label: "New Item 1", amount: 1111),
+            PKPaymentSummaryItem(label: "New Item 2", amount: 2222)
+        ]
+        let testAmount = Amount(value: 1000, currencyCode: "JPY")
+        let config = try ApplePayComponent.Configuration(paymentRequest: request)
+
+        // When
+        let sut = config.replacing(amount: testAmount)
+
+        // Then
+        XCTAssertEqual(sut.applePayPayment.amount, testAmount)
+        XCTAssertNotNil(sut.paymentRequest?.paymentSummaryItems)
+        XCTAssertEqual(sut.paymentRequest?.paymentSummaryItems.count, 2)
+        let summaryItem = sut.paymentRequest?.paymentSummaryItems.last
+        XCTAssertNotNil(summaryItem)
+        XCTAssertEqual(summaryItem?.amount, 1000)
+    }
+
+    func testReplacingAmountWithPayemtn() throws {
+        // Given
+        let payment = try ApplePayPayment(payment: Payment(amount: Amount(value: 1050, currencyCode: "USD"), countryCode: "US"), brand: "My Label")
+        let config = ApplePayComponent.Configuration(payment: payment, merchantIdentifier: "")
+        let testAmount = Amount(value: 1000, currencyCode: "USD")
+
+        // When
+        let sut = config.replacing(amount: testAmount)
+
+        // Then
+        XCTAssertEqual(sut.applePayPayment.amount, testAmount)
+        XCTAssertNil(sut.paymentRequest?.paymentSummaryItems)
+    }
+
     func testBrandsFiltering() {
         let paymentMethod = ApplePayPaymentMethod(type: .applePay, name: "test_name", brands: ["mc", "elo", "unknown_network"])
         let supportedNetworks = paymentMethod.supportedNetworks
@@ -442,25 +455,6 @@ class ApplePayComponentTest: XCTestCase {
     private func getRandomContactFieldSet() -> Set<PKContactField> {
         let contactFieldsPool: [PKContactField] = [.emailAddress, .name, .phoneNumber, .postalAddress, .phoneticName]
         return contactFieldsPool.randomElement().map { [$0] } ?? []
-    }
-    
-    private func createInvalidGrandTotalTestSummaryItems() -> [PKPaymentSummaryItem] {
-        var amounts = (0...3).map { _ in
-            NSDecimalNumber(mantissa: UInt64.random(in: 1...20), exponent: 1, isNegative: Bool.random())
-        }
-        // Negative Grand total
-        amounts.append(NSDecimalNumber(mantissa: 20, exponent: 1, isNegative: true))
-        return amounts.enumerated().map {
-            PKPaymentSummaryItem(label: "summary_\($0)", amount: $1)
-        }
-    }
-    
-    private func createTestSummaryItemsWithZeroAmount() -> [PKPaymentSummaryItem] {
-        var items = Dummy.createTestSummaryItems()
-        let amount = NSDecimalNumber(mantissa: 0, exponent: 1, isNegative: true)
-        let item = PKPaymentSummaryItem(label: "summary_zero_value", amount: amount)
-        items.insert(item, at: 0)
-        return items
     }
     
 }

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -359,7 +359,9 @@ class ApplePayComponentTest: XCTestCase {
             PKPaymentSummaryItem(label: "New Item 1", amount: 1111),
             PKPaymentSummaryItem(label: "New Item 2", amount: 2222)
         ]
-        let testAmount = Amount(value: 1000, currencyCode: "USD")
+        let minorUnits = 1234
+        let decimalAmount: NSDecimalNumber = 12.34 // USD decimals is 2
+        let testAmount = Amount(value: minorUnits, currencyCode: "USD")
         let config = try ApplePayComponent.Configuration(paymentRequest: request)
 
         // When
@@ -371,7 +373,7 @@ class ApplePayComponentTest: XCTestCase {
         XCTAssertEqual(sut.paymentRequest?.paymentSummaryItems.count, 2)
         let summaryItem = sut.paymentRequest?.paymentSummaryItems.last
         XCTAssertNotNil(summaryItem)
-        XCTAssertEqual(summaryItem?.amount, 10)
+        XCTAssertEqual(summaryItem?.amount, decimalAmount)
     }
 
     func testReplacingSummaryItemsJPY() throws {
@@ -384,7 +386,9 @@ class ApplePayComponentTest: XCTestCase {
             PKPaymentSummaryItem(label: "New Item 1", amount: 1111),
             PKPaymentSummaryItem(label: "New Item 2", amount: 2222)
         ]
-        let testAmount = Amount(value: 1000, currencyCode: "JPY")
+        let minorUnits = 1234
+        let decimalAmount: NSDecimalNumber = 1234.0 // JPY decimals is 0
+        let testAmount = Amount(value: minorUnits, currencyCode: "JPY")
         let config = try ApplePayComponent.Configuration(paymentRequest: request)
 
         // When
@@ -396,10 +400,10 @@ class ApplePayComponentTest: XCTestCase {
         XCTAssertEqual(sut.paymentRequest?.paymentSummaryItems.count, 2)
         let summaryItem = sut.paymentRequest?.paymentSummaryItems.last
         XCTAssertNotNil(summaryItem)
-        XCTAssertEqual(summaryItem?.amount, 1000)
+        XCTAssertEqual(summaryItem?.amount, decimalAmount)
     }
 
-    func testReplacingAmountWithPayemtn() throws {
+    func testReplacingAmountWithPayment() throws {
         // Given
         let payment = try ApplePayPayment(payment: Payment(amount: Amount(value: 1050, currencyCode: "USD"), countryCode: "US"), brand: "My Label")
         let config = ApplePayComponent.Configuration(payment: payment, merchantIdentifier: "")

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayPaymentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayPaymentTests.swift
@@ -11,82 +11,111 @@ import XCTest
 
 class ApplePayPaymentTest: XCTestCase {
 
-    func testCreateApplePayPaymentWithSummeryItems() throws {
-        _ = try ApplePayPayment(countryCode: "US", currencyCode: "USD", summaryItems: [.init(label: "My Label", amount: 10.5)])
+    func test_initWithSummaryItems_shouldNotThrow() throws {
+        XCTAssertNoThrow(try ApplePayPayment(countryCode: "US", currencyCode: "USD", summaryItems: [.init(label: "My Label", amount: 10.5)]))
     }
 
-    func testCreateApplePayPaymentWithPayemtn() throws {
-        _ = try ApplePayPayment(payment: Payment(amount: Amount(value: 1050, currencyCode: "USD"), countryCode: "US"), brand: "My Label")
+    func test_initWithPayment_shouldNotThrow() throws {
+        XCTAssertNoThrow(try ApplePayPayment(payment: Payment(amount: Amount(value: 1050, currencyCode: "USD"), countryCode: "US"), brand: "My Label"))
     }
 
-    func testInvalidCurrencyCode() {
+    func test_initWithPayment_whenInvalidCurrencyCode_throwsInvalidCurrencyCodeError() {
         // Given
-        let amount = Amount(value: 2, unsafeCurrencyCode: "ZZZ")
+        let invalidCurrencyCode = "ZZZ"
 
         // When
-        let payment = Payment(amount: amount, countryCode: getRandomCountryCode())
+        let payment = Payment(amount: Amount(value: 2, unsafeCurrencyCode: invalidCurrencyCode), countryCode: "US")
 
         // Then
         XCTAssertThrowsError(try ApplePayPayment(payment: payment, brand: "TEST")) { error in
             XCTAssertTrue(error is ApplePayComponent.Error)
-            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidCurrencyCode)
-            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The currency code is invalid.")
+            let applePayError = try? XCTUnwrap(error as? ApplePayComponent.Error)
+            XCTAssertEqual(applePayError, .invalidCurrencyCode)
         }
-
-        XCTAssertThrowsError(try ApplePayPayment(
-            countryCode: "US",
-            currencyCode: "ZZZ",
-            summaryItems: [.init(label: "My Label", amount: 10.5)]
-        ))
     }
 
-    func testInvalidCountryCode() {
+    func test_initWithSummaryItems_whenInvalidCurrencyCode_throwsInvalidCurrencyCodeError() {
+        // Given
+        let invalidCurrencyCode = "ZZZ"
+
+        // Then
+        XCTAssertThrowsError(try ApplePayPayment(
+            countryCode: "US",
+            currencyCode: invalidCurrencyCode,
+            summaryItems: [.init(label: "My Label", amount: 10.5)]
+        )) { error in
+            let applePayError = try? XCTUnwrap(error as? ApplePayComponent.Error)
+            XCTAssertEqual(applePayError, .invalidCurrencyCode)
+        }
+    }
+
+    func test_initWithPayment_whenInvalidCountryCode_throwsInvalidCountryCodeError() {
+        // Given
+        let invalidCountryCode = "ZZ"
+
         // When
-        let payment = Payment(amount: Amount(value: 1050, currencyCode: "USD"), unsafeCountryCode: "ZZ")
+        let payment = Payment(amount: Amount(value: 1050, currencyCode: "USD"), unsafeCountryCode: invalidCountryCode)
 
         // Then
         XCTAssertThrowsError(try ApplePayPayment(payment: payment, brand: "TEST")) { error in
-            XCTAssertTrue(error is ApplePayComponent.Error)
-            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidCountryCode)
-            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The country code is invalid.")
+            let applePayError = try? XCTUnwrap(error as? ApplePayComponent.Error)
+            XCTAssertEqual(applePayError, .invalidCountryCode)
         }
+    }
 
+    func test_initWithSummaryItems_whenInvalidCountryCode_throwsInvalidCountryCodeError() {
+        // Given
+        let invalidCountryCode = "ZZ"
+
+        // Then
         XCTAssertThrowsError(try ApplePayPayment(
-            countryCode: "ZZ",
+            countryCode: invalidCountryCode,
             currencyCode: "USD",
             summaryItems: [.init(label: "My Label", amount: 10.5)]
-        ))
-    }
-
-    func testEmptySummaryItems() {
-        XCTAssertThrowsError(try ApplePayPayment(countryCode: "US", currencyCode: "USD", summaryItems: [])) { error in
-            XCTAssertTrue(error is ApplePayComponent.Error)
-            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.emptySummaryItems)
-            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The summaryItems array is empty.")
+        )) { error in
+            let applePayError = try? XCTUnwrap(error as? ApplePayComponent.Error)
+            XCTAssertEqual(applePayError, .invalidCountryCode)
         }
     }
 
-    func testGrandTotalIsNegative() {
-        XCTAssertThrowsError(try ApplePayPayment(
-            countryCode: "US",
-            currencyCode: "USD",
-            summaryItems: createInvalidGrandTotalTestSummaryItems()
-        )) { error in
-            XCTAssertTrue(error is ApplePayComponent.Error)
-            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.negativeGrandTotal)
-            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The grand total summary item should be greater than or equal to zero.")
+    func test_init_withEmptySummaryItems_throwsEmptySummaryItemsError() {
+        // Given
+        let invalidSummeryItems: [PKPaymentSummaryItem] = []
+
+        // Then
+        XCTAssertThrowsError(try ApplePayPayment(countryCode: "US", currencyCode: "USD", summaryItems: invalidSummeryItems)) { error in
+            let applePayError = try? XCTUnwrap(error as? ApplePayComponent.Error)
+            XCTAssertEqual(applePayError, .emptySummaryItems)
         }
     }
 
-    func testOneItemWithZeroAmount() {
+    func test_init_withNegativeGrandTotal_throwsNegativeGrandTotalError() {
+        // Given
+        let invalidSummeryItems = createInvalidGrandTotalTestSummaryItems()
+
+        // Then
         XCTAssertThrowsError(try ApplePayPayment(
             countryCode: "US",
             currencyCode: "USD",
-            summaryItems: createTestSummaryItemsWithZeroAmount()
+            summaryItems: invalidSummeryItems
         )) { error in
-            XCTAssertTrue(error is ApplePayComponent.Error)
-            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidSummaryItem)
-            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "At least one of the summary items has an invalid amount.")
+            let applePayError = try? XCTUnwrap(error as? ApplePayComponent.Error)
+            XCTAssertEqual(applePayError, .negativeGrandTotal)
+        }
+    }
+
+    func test_init_withZeroAmountSummaryItem_throwsInvalidSummaryItemError() {
+        // Given
+        let invalidSummeryItems = createTestSummaryItemsWithZeroAmount()
+
+        // Then
+        XCTAssertThrowsError(try ApplePayPayment(
+            countryCode: "US",
+            currencyCode: "USD",
+            summaryItems: invalidSummeryItems
+        )) { error in
+            let applePayError = try? XCTUnwrap(error as? ApplePayComponent.Error)
+            XCTAssertEqual(applePayError, .invalidSummaryItem)
         }
     }
 
@@ -94,7 +123,6 @@ class ApplePayPaymentTest: XCTestCase {
         var amounts = (0...3).map { _ in
             NSDecimalNumber(mantissa: UInt64.random(in: 1...20), exponent: 1, isNegative: Bool.random())
         }
-        // Negative Grand total
         amounts.append(NSDecimalNumber(mantissa: 20, exponent: 1, isNegative: true))
         return amounts.enumerated().map {
             PKPaymentSummaryItem(label: "summary_\($0)", amount: $1)

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayPaymentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayPaymentTests.swift
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+@_spi(AdyenInternal) @testable import AdyenComponents
+import PassKit
+import XCTest
+
+class ApplePayPaymentTest: XCTestCase {
+
+    func testCreateApplePayPaymentWithSummeryItems() throws {
+        _ = try ApplePayPayment(countryCode: "US", currencyCode: "USD", summaryItems: [.init(label: "My Label", amount: 10.5)])
+    }
+
+    func testCreateApplePayPaymentWithPayemtn() throws {
+        _ = try ApplePayPayment(payment: Payment(amount: Amount(value: 1050, currencyCode: "USD"), countryCode: "US"), brand: "My Label")
+    }
+
+    func testInvalidCurrencyCode() {
+        // Given
+        let amount = Amount(value: 2, unsafeCurrencyCode: "ZZZ")
+
+        // When
+        let payment = Payment(amount: amount, countryCode: getRandomCountryCode())
+
+        // Then
+        XCTAssertThrowsError(try ApplePayPayment(payment: payment, brand: "TEST")) { error in
+            XCTAssertTrue(error is ApplePayComponent.Error)
+            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidCurrencyCode)
+            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The currency code is invalid.")
+        }
+
+        XCTAssertThrowsError(try ApplePayPayment(
+            countryCode: "US",
+            currencyCode: "ZZZ",
+            summaryItems: [.init(label: "My Label", amount: 10.5)]
+        ))
+    }
+
+    func testInvalidCountryCode() {
+        // When
+        let payment = Payment(amount: Amount(value: 1050, currencyCode: "USD"), unsafeCountryCode: "ZZ")
+
+        // Then
+        XCTAssertThrowsError(try ApplePayPayment(payment: payment, brand: "TEST")) { error in
+            XCTAssertTrue(error is ApplePayComponent.Error)
+            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidCountryCode)
+            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The country code is invalid.")
+        }
+
+        XCTAssertThrowsError(try ApplePayPayment(
+            countryCode: "ZZ",
+            currencyCode: "USD",
+            summaryItems: [.init(label: "My Label", amount: 10.5)]
+        ))
+    }
+
+    func testEmptySummaryItems() {
+        XCTAssertThrowsError(try ApplePayPayment(countryCode: "US", currencyCode: "USD", summaryItems: [])) { error in
+            XCTAssertTrue(error is ApplePayComponent.Error)
+            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.emptySummaryItems)
+            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The summaryItems array is empty.")
+        }
+    }
+
+    func testGrandTotalIsNegative() {
+        XCTAssertThrowsError(try ApplePayPayment(
+            countryCode: "US",
+            currencyCode: "USD",
+            summaryItems: createInvalidGrandTotalTestSummaryItems()
+        )) { error in
+            XCTAssertTrue(error is ApplePayComponent.Error)
+            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.negativeGrandTotal)
+            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "The grand total summary item should be greater than or equal to zero.")
+        }
+    }
+
+    func testOneItemWithZeroAmount() {
+        XCTAssertThrowsError(try ApplePayPayment(
+            countryCode: "US",
+            currencyCode: "USD",
+            summaryItems: createTestSummaryItemsWithZeroAmount()
+        )) { error in
+            XCTAssertTrue(error is ApplePayComponent.Error)
+            XCTAssertEqual(error as! ApplePayComponent.Error, ApplePayComponent.Error.invalidSummaryItem)
+            XCTAssertEqual((error as! ApplePayComponent.Error).localizedDescription, "At least one of the summary items has an invalid amount.")
+        }
+    }
+
+    private func createInvalidGrandTotalTestSummaryItems() -> [PKPaymentSummaryItem] {
+        var amounts = (0...3).map { _ in
+            NSDecimalNumber(mantissa: UInt64.random(in: 1...20), exponent: 1, isNegative: Bool.random())
+        }
+        // Negative Grand total
+        amounts.append(NSDecimalNumber(mantissa: 20, exponent: 1, isNegative: true))
+        return amounts.enumerated().map {
+            PKPaymentSummaryItem(label: "summary_\($0)", amount: $1)
+        }
+    }
+
+    private func createTestSummaryItemsWithZeroAmount() -> [PKPaymentSummaryItem] {
+        var items = Dummy.createTestSummaryItems()
+        let amount = NSDecimalNumber(mantissa: 0, exponent: 1, isNegative: true)
+        let item = PKPaymentSummaryItem(label: "summary_zero_value", amount: amount)
+        items.insert(item, at: 0)
+        return items
+    }
+}


### PR DESCRIPTION
# Summary

This PR fixes an issue where the Apple Pay payment sheet would display an outdated (original) amount after a partial payment. This occurred when the component configuration initiated with a `PKPaymentRequest`, which is now correctly updated to reflect the new total.

## Release Notes

<fixed>
- The amount displayed on the Apple Pay payment sheet is now correctly updated after a partial payment.
</fixed>

## Testing Instructions

- Change Demo/Configuration.swift so ApplePayComponent.Configuration use PKPaymentRequest:

```diff
-        var config = ApplePayComponent.Configuration(
-            payment: applePayPayment,
-            merchantIdentifier:
-            ConfigurationConstants.current.applePaySettings.merchantIdentifier
-        )
+        let paymentRequest = PKPaymentRequest()
+        paymentRequest.merchantIdentifier = ConfigurationConstants.current.applePaySettings.merchantIdentifier
+        paymentRequest.countryCode = payment.countryCode
+        paymentRequest.currencyCode = payment.amount.currencyCode
+        paymentRequest.merchantCapabilities = [.capability3DS]
+        let decimal = AmountFormatter.decimalAmount(
+            amount.value,
+            currencyCode: amount.currencyCode,
+            localeIdentifier: amount.localeIdentifier
+        )
+        paymentRequest.paymentSummaryItems = [.init(label: "My app", amount: decimal)]
+        var config = try ApplePayComponent.Configuration(paymentRequest: paymentRequest)
```

- Open DropIn. Observe Amount **X**
- Open Giftcard payment (ex Givex, 6036280000000000000, PIN 100)
- Press "Pay" and observe total amount to change to **Y**
- Open ApplePay. Observe Amount **Y** in Pre-ApplePay view.
- Press "ApplePayButton" and observe amount **X** on ApplePay sheet.

## Ticket
<ticket>
COSDK-540
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
