### PR TITLE
Update prepare_release.yml with PAT

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -70,4 +70,4 @@ jobs:
         commit-message: "chore: prepare '${{ github.event.inputs.sdk-version }}' release"
         title: "[Release] ${{ github.event.inputs.sdk-version }}"
         body-path: "${{ github.workspace }}/.tmp/release_notes.md"
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PAT_FOR_PR_CREATION }}


### PR DESCRIPTION
# Summary [Required]
Use PAT (Personal Access Token) to create PR on release job.
**This is a temporary solution until a Github App linked to our project is created with a permanent PAT not linked to any contributor.**

