### PR TITLE
Specify permissions for github workflows

### DIFF
--- a/.github/workflows/cancel-duplicate-work-flows.yml
+++ b/.github/workflows/cancel-duplicate-work-flows.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      contents: read
     steps:
       - name: "Cancel build"
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: write 
+
 jobs:
   create_release:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+  pages: write 
+
 jobs:
 
   Deploy:

--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -12,6 +12,10 @@ on:
         description: 'Branch/tag of the old/comparison version'
         required: true
       
+permissions:
+  contents: read
+  pull-requests: write 
+      
 jobs:
 
   build:

--- a/.github/workflows/get_release_notes.yml
+++ b/.github/workflows/get_release_notes.yml
@@ -6,6 +6,9 @@ on:
         RELEASE_NOTES:
             description: "The Release Notes of the Release"
             value: ${{ jobs.generate-release-notes.outputs.RELEASE_NOTES }}
+
+permissions:
+  contents: read
     
 jobs:
   generate-release-notes:

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
 
   publish-cocoapods:

--- a/.github/workflows/pr_scan.yml
+++ b/.github/workflows/pr_scan.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - develop
       
+permissions:
+  contents: read
+  pull-requests: write # sonar
+      
 jobs:
 
   build:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -6,6 +6,10 @@ on:
         description: 'SDK Version'
         required: true
 
+permissions:
+  contents: write # create branch and new release
+  pull-requests: write # create PR
+
 jobs:
 
   get-release-notes:

--- a/.github/workflows/publish-demo-app.yml
+++ b/.github/workflows/publish-demo-app.yml
@@ -33,6 +33,9 @@ on:
         required: true
       XCODE_AUTHENTICATION_KEY_BASE64:
         required: true
+
+permissions:
+  contents: read
   
 jobs:
 

--- a/.github/workflows/publish_podspec.yml
+++ b/.github/workflows/publish_podspec.yml
@@ -5,6 +5,9 @@ on:
     secrets: # When triggered via another workflow, secrets are not automatically forwarded
       COCOAPODS_TRUNK_TOKEN:
         required: true
+
+permissions:
+  contents: read
   
 jobs:
 

--- a/.github/workflows/regenerate-docs.yml
+++ b/.github/workflows/regenerate-docs.yml
@@ -5,6 +5,11 @@ on:
       latestVersion:
         description: 'Whats the latest version of the SDK?'
         required: true
+
+permissions:
+  contents: read
+  pull-requests: write # create new PR
+
 jobs:
 
   Generate:

--- a/.github/workflows/regenerate-snapshots.yml
+++ b/.github/workflows/regenerate-snapshots.yml
@@ -1,7 +1,9 @@
 name: 📸 Generate Snapshots
 on:
     workflow_dispatch:
-          
+
+permissions:
+  contents: read          
 jobs:
   Generate:
     runs-on: macos-15-xlarge

--- a/.github/workflows/sdk_size_analysis.yml
+++ b/.github/workflows/sdk_size_analysis.yml
@@ -5,6 +5,10 @@ on:
     types: [opened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   sdk-size-analysis:
     runs-on: macos-15-xlarge

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
 
   setup:

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -10,6 +10,10 @@ on:
     - cron: '0 0 * * *'  # Run every day at midnight
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write  # Required to mark and close stale issues
+
 jobs:
   close_stale_prs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-SPM-integration.yml
+++ b/.github/workflows/test-SPM-integration.yml
@@ -9,6 +9,9 @@ on:
     branches:
     - develop
 
+permissions:
+  contents: read
+
 jobs:
 
   SPM:

--- a/.github/workflows/test-carthage-integration.yml
+++ b/.github/workflows/test-carthage-integration.yml
@@ -9,6 +9,9 @@ on:
     branches:
     - develop
 
+permissions:
+  contents: read
+
 jobs:
 
   carthage:

--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -9,6 +9,9 @@ on:
     branches:
     - develop
 
+permissions:
+  contents: read
+
 jobs:
 
   pods:

--- a/.github/workflows/test_library_evolution.yml
+++ b/.github/workflows/test_library_evolution.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - develop
       
+permissions:
+  contents: read
 jobs:
 
   build:

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -5,6 +5,11 @@ on:
       newVersion:
         description: 'The new version'
         required: true
+
+permissions:
+  contents: write
+  pull-requests: write # create new PR
+
 jobs:
 
   Update:

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   get-pr-labels:
     if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write # post PR comment
 
 jobs:
   get-pr-labels:

--- a/.github/workflows/verify-os-compatibility.yml
+++ b/.github/workflows/verify-os-compatibility.yml
@@ -11,6 +11,8 @@ on:
       - 'release/**'
       - 'develop'
     
+permissions:
+  contents: read
 jobs:
   tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
# Summary 
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

This change adds missing github actions workflows permissions, addressing [these warnings](https://github.com/Adyen/adyen-ios/security/code-scanning).

There might be small refinements needed for specific release-time workflows, they will be tackled separately as soon as they appear.

## Ticket 
<ticket>
COSDK-591
</ticket>

## Checklist
<!-- Mark completed items with an [x] -->
- [x] Test basic flows on CI
