### PR TITLE
[DO NOT MERGE] PoC | Opt-out strategy for `Adyen3DS2`

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -169,7 +169,6 @@
 		8128977C2CCA660A00275487 /* StoredPayByBankUSPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812897752CC8FEC100275487 /* StoredPayByBankUSPaymentMethod.swift */; };
 		8128977E2CCA6FE900275487 /* SupportedPaymentMethodLogosViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128977D2CCA6FE400275487 /* SupportedPaymentMethodLogosViewTests.swift */; };
 		812B24872CDE56D90074A5D9 /* PayByBankUSComponent+ConfirmationViewController+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812B24862CDE56D90074A5D9 /* PayByBankUSComponent+ConfirmationViewController+Model.swift */; };
-		8136619E2BE0F6F7009AA0CD /* Adyen3DS2 in Frameworks */ = {isa = PBXBuildFile; productRef = 8136619D2BE0F6F7009AA0CD /* Adyen3DS2 */; };
 		813BF1122B2365400096940E /* XCTestCase+FirstResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 813BF1102B2364E00096940E /* XCTestCase+FirstResponder.swift */; };
 		813BF1132B2365400096940E /* XCTestCase+FirstResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 813BF1102B2364E00096940E /* XCTestCase+FirstResponder.swift */; };
 		813EF9DE2A5DA0BC00C65D15 /* FormPickerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 813EF9DD2A5DA0BC00C65D15 /* FormPickerItem.swift */; };
@@ -276,7 +275,6 @@
 		81DA70902BDA60F6006CE5D5 /* TwintComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DA708E2BDA60F6006CE5D5 /* TwintComponentTests.swift */; };
 		81DA70912BDA6120006CE5D5 /* PaymentMethods+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DA70802BDA5F66006CE5D5 /* PaymentMethods+Equatable.swift */; };
 		81DC4D772BDBE8820048B9EF /* TwintSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00E5D6602AF527C200CDE118 /* TwintSDK.xcframework */; };
-		81DC5A552A77ED0400DBF2D1 /* Adyen3DS2 in Frameworks */ = {isa = PBXBuildFile; productRef = 81DC5A542A77ED0400DBF2D1 /* Adyen3DS2 */; };
 		81DC5A592A79287400DBF2D1 /* AddressInputFormViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DC5A582A79287400DBF2D1 /* AddressInputFormViewControllerTests.swift */; };
 		81DC5A5D2A7BADB200DBF2D1 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DC5A5C2A7BADB200DBF2D1 /* EmptyStateView.swift */; };
 		81DF940A2BAAD8EB0001DCBC /* MBWayComponentUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00220957299E5B1D00B2BACD /* MBWayComponentUITests.swift */; };
@@ -921,7 +919,6 @@
 		F92327DF25A47561002C5BC4 /* AdyenEncryption.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F92326AC25A3669E002C5BC4 /* AdyenEncryption.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F92329D225AD0240002C5BC4 /* CardBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92329D125AD0240002C5BC4 /* CardBrand.swift */; };
 		F92329DD25AD049E002C5BC4 /* FallbackCardBrandProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92329DC25AD049E002C5BC4 /* FallbackCardBrandProvider.swift */; };
-		F9237D3428CA1E7C004F9929 /* Adyen3DS2 in Frameworks */ = {isa = PBXBuildFile; productRef = F9237D3328CA1E7C004F9929 /* Adyen3DS2 */; };
 		F9237D3B28CB467D004F9929 /* ThreeDS2CompactActionHandler+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9237D3A28CB467D004F9929 /* ThreeDS2CompactActionHandler+Initializers.swift */; };
 		F9237D3D28CB470E004F9929 /* ThreeDS2ClassicActionHandler+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9237D3C28CB470E004F9929 /* ThreeDS2ClassicActionHandler+Initializers.swift */; };
 		F924C072246BEEF0006DDAB8 /* CardDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F924C071246BEEF0006DDAB8 /* CardDetailsTests.swift */; };
@@ -2787,7 +2784,6 @@
 			files = (
 				E72375DD27AABF450020DCF9 /* AdyenWeChatPayInternal in Frameworks */,
 				E72375D827AABF400020DCF9 /* AdyenWeChatPay.framework in Frameworks */,
-				F9237D3428CA1E7C004F9929 /* Adyen3DS2 in Frameworks */,
 				8169B9EC2A0506CC00AAC9F8 /* Adyen.framework in Frameworks */,
 				81088A1F2BDBACB7007FCDB9 /* AdyenTwint.framework in Frameworks */,
 				F9175EEE2593955C00D653BE /* AdyenComponents.framework in Frameworks */,
@@ -2829,7 +2825,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8136619E2BE0F6F7009AA0CD /* Adyen3DS2 in Frameworks */,
 				F9175F9E259498C300D653BE /* Adyen.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2880,7 +2875,6 @@
 				0042EBCD2B9081A5001B1F6C /* AdyenTwint.framework in Frameworks */,
 				F95B6DC62527565E002C9062 /* AdyenCard.framework in Frameworks */,
 				E74E41D22C492C1600354C76 /* AdyenWeChatPay.framework in Frameworks */,
-				81DC5A552A77ED0400DBF2D1 /* Adyen3DS2 in Frameworks */,
 				81BDD6D92B21CF2C0022250E /* AdyenDelegatedAuthentication.framework in Frameworks */,
 				81BDD6CF2B21CF100022250E /* Adyen.framework in Frameworks */,
 				F95B6DC82527565F002C9062 /* AdyenDropIn.framework in Frameworks */,
@@ -6567,7 +6561,6 @@
 			name = AdyenUIHost;
 			packageProductDependencies = (
 				E72375DC27AABF450020DCF9 /* AdyenWeChatPayInternal */,
-				F9237D3328CA1E7C004F9929 /* Adyen3DS2 */,
 				81BDD6CD2B21CE6C0022250E /* AdyenAuthentication */,
 			);
 			productName = AdyenUIHost;
@@ -6630,7 +6623,6 @@
 			);
 			name = AdyenActions;
 			packageProductDependencies = (
-				8136619D2BE0F6F7009AA0CD /* Adyen3DS2 */,
 			);
 			productName = AdyenActions;
 			productReference = F9175F8C2594986900D653BE /* AdyenActions.framework */;
@@ -6742,7 +6734,6 @@
 			);
 			name = AdyenSwiftUIHost;
 			packageProductDependencies = (
-				81DC5A542A77ED0400DBF2D1 /* Adyen3DS2 */,
 				81BDD6D32B21CF1B0022250E /* AdyenAuthentication */,
 				81BDD6E22B21CF5C0022250E /* AdyenWeChatPayInternal */,
 			);
@@ -6910,7 +6901,6 @@
 			packageReferences = (
 				F913B3EB26B7FAA8008F6CD2 /* XCRemoteSwiftPackageReference "adyen-networking-ios" */,
 				E72375CC27AAB7760020DCF9 /* XCRemoteSwiftPackageReference "adyen-wechatpay-ios" */,
-				F9237D3228CA1E7C004F9929 /* XCRemoteSwiftPackageReference "adyen-3ds2-ios" */,
 				F9CCA3D8296ECDF900AD643D /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 				A03B7C9329B21C3D00FDDDFC /* XCRemoteSwiftPackageReference "cash-app-pay-ios-sdk" */,
 				F94D65E42B0365C30095D61E /* XCRemoteSwiftPackageReference "adyen-authentication-ios" */,
@@ -10351,14 +10341,6 @@
 				version = 3.0.1;
 			};
 		};
-		F9237D3228CA1E7C004F9929 /* XCRemoteSwiftPackageReference "adyen-3ds2-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Adyen/adyen-3ds2-ios";
-			requirement = {
-				kind = exactVersion;
-				version = 2.4.3;
-			};
-		};
 		F94D65E42B0365C30095D61E /* XCRemoteSwiftPackageReference "adyen-authentication-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Adyen/adyen-authentication-ios";
@@ -10378,11 +10360,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		8136619D2BE0F6F7009AA0CD /* Adyen3DS2 */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F9237D3228CA1E7C004F9929 /* XCRemoteSwiftPackageReference "adyen-3ds2-ios" */;
-			productName = Adyen3DS2;
-		};
 		81B8036A2BE0E714003D037F /* AdyenWeChatPayInternal */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E72375CC27AAB7760020DCF9 /* XCRemoteSwiftPackageReference "adyen-wechatpay-ios" */;
@@ -10402,11 +10379,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = E72375CC27AAB7760020DCF9 /* XCRemoteSwiftPackageReference "adyen-wechatpay-ios" */;
 			productName = AdyenWeChatPayInternal;
-		};
-		81DC5A542A77ED0400DBF2D1 /* Adyen3DS2 */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F9237D3228CA1E7C004F9929 /* XCRemoteSwiftPackageReference "adyen-3ds2-ios" */;
-			productName = Adyen3DS2;
 		};
 		81DF94072BAAD8EB0001DCBC /* SnapshotTesting */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -10432,11 +10404,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F913B3EB26B7FAA8008F6CD2 /* XCRemoteSwiftPackageReference "adyen-networking-ios" */;
 			productName = AdyenNetworking;
-		};
-		F9237D3328CA1E7C004F9929 /* Adyen3DS2 */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F9237D3228CA1E7C004F9929 /* XCRemoteSwiftPackageReference "adyen-3ds2-ios" */;
-			productName = Adyen3DS2;
 		};
 		F94D65E52B0365C30095D61E /* AdyenAuthentication */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/AdyenActions/Actions/Action.swift
+++ b/AdyenActions/Actions/Action.swift
@@ -11,26 +11,28 @@ public enum Action: Decodable {
     
     /// Indicates the user should be redirected to a URL.
     case redirect(RedirectAction)
-
+    
     /// Indicates the user should be redirected to an SDK.
     case sdk(SDKAction)
     
-    /// Indicates a 3D Secure device fingerprint should be taken.
-    case threeDS2Fingerprint(ThreeDS2FingerprintAction)
+    #if canImport(Adyen3DS2)
+        /// Indicates a 3D Secure device fingerprint should be taken.
+        case threeDS2Fingerprint(ThreeDS2FingerprintAction)
     
-    /// Indicates a 3D Secure challenge should be presented.
-    case threeDS2Challenge(ThreeDS2ChallengeAction)
-
-    /// Indicates a full 3D Secure 2 flow should be executed including fingerprint collection,
-    /// and potentially a challenge or a fallback to 3DS1.
-    case threeDS2(ThreeDS2Action)
+        /// Indicates a 3D Secure challenge should be presented.
+        case threeDS2Challenge(ThreeDS2ChallengeAction)
+    
+        /// Indicates a full 3D Secure 2 flow should be executed including fingerprint collection,
+        /// and potentially a challenge or a fallback to 3DS1.
+        case threeDS2(ThreeDS2Action)
+    #endif
     
     /// Indicate that the SDK should wait for user action.
     case await (AwaitAction)
-
+    
     /// Indicate that the SDK should wait for user action while redirecting.
     case redirectableAwait(RedirectableAwaitAction)
-
+    
     /// Indicates that a voucher is presented to the shopper.
     case voucher(VoucherAction)
     
@@ -50,11 +52,23 @@ public enum Action: Decodable {
         case .redirect, .nativeRedirect:
             self = try .redirect(RedirectAction(from: decoder))
         case .threeDS2Fingerprint:
-            self = try .threeDS2Fingerprint(ThreeDS2FingerprintAction(from: decoder))
+            #if canImport(Adyen3DS2)
+                self = try .threeDS2Fingerprint(ThreeDS2FingerprintAction(from: decoder))
+            #else
+                throw NSError(domain: "", code: 1)
+            #endif
         case .threeDS2Challenge:
-            self = try .threeDS2Challenge(ThreeDS2ChallengeAction(from: decoder))
+            #if canImport(Adyen3DS2)
+                self = try .threeDS2Challenge(ThreeDS2ChallengeAction(from: decoder))
+            #else
+                throw NSError(domain: "", code: 1)
+            #endif
         case .threeDS2:
-            self = try .threeDS2(ThreeDS2Action(from: decoder))
+            #if canImport(Adyen3DS2)
+                self = try .threeDS2(ThreeDS2Action(from: decoder))
+            #else
+                throw NSError(domain: "", code: 1)
+            #endif
         case .sdk:
             self = try .sdk(SDKAction(from: decoder))
         case .await:
@@ -84,7 +98,7 @@ public enum Action: Decodable {
             return try .voucher(VoucherAction(from: decoder))
         }
     }
-
+    
     private static func handleAwaitType(from decoder: Decoder) throws -> Action {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         if (try? container.decode(URL.self, forKey: .redirectUrl)) != nil {
@@ -93,7 +107,7 @@ public enum Action: Decodable {
             return try .await(AwaitAction(from: decoder))
         }
     }
-
+    
     private enum ActionType: String, Decodable {
         case redirect
         case nativeRedirect
@@ -105,7 +119,7 @@ public enum Action: Decodable {
         case `await`
         case voucher
     }
-
+    
     private enum CodingKeys: String, CodingKey {
         case type
         case paymentMethodType

--- a/AdyenActions/AdyenActionComponent.swift
+++ b/AdyenActions/AdyenActionComponent.swift
@@ -5,7 +5,9 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
+#if canImport(Adyen3DS2)
+    import Adyen3DS2
+#endif
 import Foundation
 import UIKit
 
@@ -39,33 +41,35 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
         /// The UI style configurations.
         public var style: ActionComponentStyle = .init()
         
-        /// Three DS configurations
-        public var threeDS: ThreeDS = .init()
+        #if canImport(Adyen3DS2)
+            /// Three DS configurations
+            public var threeDS: ThreeDS = .init()
         
-        /// Three DS configurations
-        public struct ThreeDS {
-            /// `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
-            public var requestorAppURL: URL?
+            /// Three DS configurations
+            public struct ThreeDS {
+                /// `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
+                public var requestorAppURL: URL?
             
-            /// The configuration for Delegated Authentication.
-            public var delegateAuthentication: ThreeDS2Component.Configuration.DelegatedAuthentication?
+                /// The configuration for Delegated Authentication.
+                public var delegateAuthentication: ThreeDS2Component.Configuration.DelegatedAuthentication?
             
-            /// ThreeDS2Component UI configuration.
-            public var appearanceConfiguration: ADYAppearanceConfiguration
+                /// ThreeDS2Component UI configuration.
+                public var appearanceConfiguration: ADYAppearanceConfiguration
             
-            /// Initializes a new instance
-            ///
-            /// - Parameter requestorAppURL: `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
-            public init(
-                requestorAppURL: URL? = nil,
-                delegateAuthentication: ThreeDS2Component.Configuration.DelegatedAuthentication? = nil,
-                appearanceConfiguration: ADYAppearanceConfiguration = .init()
-            ) {
-                self.requestorAppURL = requestorAppURL
-                self.delegateAuthentication = delegateAuthentication
-                self.appearanceConfiguration = appearanceConfiguration
+                /// Initializes a new instance
+                ///
+                /// - Parameter requestorAppURL: `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
+                public init(
+                    requestorAppURL: URL? = nil,
+                    delegateAuthentication: ThreeDS2Component.Configuration.DelegatedAuthentication? = nil,
+                    appearanceConfiguration: ADYAppearanceConfiguration = .init()
+                ) {
+                    self.requestorAppURL = requestorAppURL
+                    self.delegateAuthentication = delegateAuthentication
+                    self.appearanceConfiguration = appearanceConfiguration
+                }
             }
-        }
+        #endif
         
         public var twint: Twint?
         
@@ -117,24 +121,47 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
             }
         }
         
-        /// Initializes a new instance
-        ///
-        /// - Parameters:
-        ///   - localizationParameters: Localization parameters.
-        ///   - style: The UI style configurations.
-        ///   - threeDS: Three DS configurations
-        ///   - twint: Twint configurations
-        public init(
-            localizationParameters: LocalizationParameters? = nil,
-            style: ActionComponentStyle = .init(),
-            threeDS: AdyenActionComponent.Configuration.ThreeDS = .init(),
-            twint: Twint? = nil
-        ) {
-            self.localizationParameters = localizationParameters
-            self.style = style
-            self.threeDS = threeDS
-            self.twint = twint
-        }
+        #if canImport(Adyen3DS2)
+        
+            /// Initializes a new instance
+            ///
+            /// - Parameters:
+            ///   - localizationParameters: Localization parameters.
+            ///   - style: The UI style configurations.
+            ///   - threeDS: Three DS configurations
+            ///   - twint: Twint configurations
+            public init(
+                localizationParameters: LocalizationParameters? = nil,
+                style: ActionComponentStyle = .init(),
+                threeDS: AdyenActionComponent.Configuration.ThreeDS = .init(),
+                twint: Twint? = nil
+            ) {
+                self.localizationParameters = localizationParameters
+                self.style = style
+                self.threeDS = threeDS
+                self.twint = twint
+            }
+        
+        #else
+        
+            /// Initializes a new instance
+            ///
+            /// - Parameters:
+            ///   - localizationParameters: Localization parameters.
+            ///   - style: The UI style configurations.
+            ///   - threeDS: Three DS configurations
+            ///   - twint: Twint configurations
+            public init(
+                localizationParameters: LocalizationParameters? = nil,
+                style: ActionComponentStyle = .init(),
+                twint: Twint? = nil
+            ) {
+                self.localizationParameters = localizationParameters
+                self.style = style
+                self.twint = twint
+            }
+        
+        #endif
     }
     
     internal var currentActionComponent: Component?
@@ -219,6 +246,8 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
         component.handle(action)
     }
     
+    #if canImport(Adyen3DS2)
+    
     private func createThreeDS2Component() -> ThreeDS2Component {
         let threeDS2Configuration = ThreeDS2Component.Configuration(
             redirectComponentStyle: configuration.style.redirectComponentStyle,
@@ -246,6 +275,8 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
         }
         threeDS2Component.handle(action)
     }
+    
+    #endif
     
     private func handle(_ sdkAction: SDKAction) {
         switch sdkAction {

--- a/AdyenActions/AdyenActionComponent.swift
+++ b/AdyenActions/AdyenActionComponent.swift
@@ -193,12 +193,14 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
         switch action {
         case let .redirect(redirectAction):
             handle(redirectAction)
-        case let .threeDS2Fingerprint(fingerprintAction):
-            handle(fingerprintAction)
-        case let .threeDS2Challenge(challengeAction):
-            handle(challengeAction)
-        case let .threeDS2(threeDS2Action):
-            handle(threeDS2Action)
+        #if canImport(Adyen3DS2)
+            case let .threeDS2Fingerprint(fingerprintAction):
+                handle(fingerprintAction)
+            case let .threeDS2Challenge(challengeAction):
+                handle(challengeAction)
+            case let .threeDS2(threeDS2Action):
+                handle(threeDS2Action)
+        #endif
         case let .sdk(sdkAction):
             handle(sdkAction)
         case let .await(awaitAction):
@@ -232,50 +234,48 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
         component.handle(action)
     }
     
-    private func handle(_ action: ThreeDS2Action) {
-        let component = createThreeDS2Component()
-        currentActionComponent = component
-        
-        component.handle(action)
-    }
-    
-    private func handle(_ action: ThreeDS2FingerprintAction) {
-        let component = createThreeDS2Component()
-        currentActionComponent = component
-        
-        component.handle(action)
-    }
-    
     #if canImport(Adyen3DS2)
-    
-    private func createThreeDS2Component() -> ThreeDS2Component {
-        let threeDS2Configuration = ThreeDS2Component.Configuration(
-            redirectComponentStyle: configuration.style.redirectComponentStyle,
-            appearanceConfiguration: configuration.threeDS.appearanceConfiguration,
-            requestorAppURL: configuration.threeDS.requestorAppURL,
-            delegateAuthentication: configuration.threeDS.delegateAuthentication
-        )
-        let component = ThreeDS2Component(
-            context: context,
-            configuration: threeDS2Configuration
-        )
-        component._isDropIn = _isDropIn
-        component.delegate = delegate
-        component.presentationDelegate = presentationDelegate
+        private func handle(_ action: ThreeDS2Action) {
+            let component = createThreeDS2Component()
+            currentActionComponent = component
         
-        return component
-    }
-    
-    private func handle(_ action: ThreeDS2ChallengeAction) {
-        guard let threeDS2Component = currentActionComponent as? ThreeDS2Component else {
-            AdyenAssertion.assertionFailure( // swiftlint:disable:next line_length
-                message: "ThreeDS2Component is nil. There must be a ThreeDS2FingerprintAction action preceding a ThreeDS2ChallengeAction action"
-            )
-            return
+            component.handle(action)
         }
-        threeDS2Component.handle(action)
-    }
     
+        private func handle(_ action: ThreeDS2FingerprintAction) {
+            let component = createThreeDS2Component()
+            currentActionComponent = component
+        
+            component.handle(action)
+        }
+        
+        private func createThreeDS2Component() -> ThreeDS2Component {
+            let threeDS2Configuration = ThreeDS2Component.Configuration(
+                redirectComponentStyle: configuration.style.redirectComponentStyle,
+                appearanceConfiguration: configuration.threeDS.appearanceConfiguration,
+                requestorAppURL: configuration.threeDS.requestorAppURL,
+                delegateAuthentication: configuration.threeDS.delegateAuthentication
+            )
+            let component = ThreeDS2Component(
+                context: context,
+                configuration: threeDS2Configuration
+            )
+            component._isDropIn = _isDropIn
+            component.delegate = delegate
+            component.presentationDelegate = presentationDelegate
+        
+            return component
+        }
+    
+        private func handle(_ action: ThreeDS2ChallengeAction) {
+            guard let threeDS2Component = currentActionComponent as? ThreeDS2Component else {
+                AdyenAssertion.assertionFailure( // swiftlint:disable:next line_length
+                    message: "ThreeDS2Component is nil. There must be a ThreeDS2FingerprintAction action preceding a ThreeDS2ChallengeAction action"
+                )
+                return
+            }
+            threeDS2Component.handle(action)
+        }
     #endif
     
     private func handle(_ sdkAction: SDKAction) {
@@ -398,12 +398,14 @@ private extension Action {
             return "redirect"
         case .sdk:
             return "sdk"
-        case .threeDS2Fingerprint:
-            return "threeDS2Fingerprint"
-        case .threeDS2Challenge:
-            return "threeDS2Challenge"
-        case .threeDS2:
-            return "threeDS2"
+        #if canImport(Adyen3DS2)
+            case .threeDS2Fingerprint:
+                return "threeDS2Fingerprint"
+            case .threeDS2Challenge:
+                return "threeDS2Challenge"
+            case .threeDS2:
+                return "threeDS2"
+        #endif
         case .await, .redirectableAwait:
             return "await"
         case .voucher, .document:

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ChallengeParameters.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ChallengeParameters.swift
@@ -4,9 +4,13 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+#if canImport(Adyen3DS2)
+
 import Foundation
 
 internal struct ChallengeParameters {
     internal let challengeToken: ThreeDS2Component.ChallengeToken
     internal let threeDSRequestorAppURL: URL?
 }
+
+#endif

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ChallengeParameters.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ChallengeParameters.swift
@@ -6,11 +6,11 @@
 
 #if canImport(Adyen3DS2)
 
-import Foundation
+    import Foundation
 
-internal struct ChallengeParameters {
-    internal let challengeToken: ThreeDS2Component.ChallengeToken
-    internal let threeDSRequestorAppURL: URL?
-}
+    internal struct ChallengeParameters {
+        internal let challengeToken: ThreeDS2Component.ChallengeToken
+        internal let threeDSRequestorAppURL: URL?
+    }
 
 #endif

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/FingerprintServiceParameters.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/FingerprintServiceParameters.swift
@@ -6,16 +6,16 @@
 
 #if canImport(Adyen3DS2)
 
-import class Adyen3DS2.ADYAppearanceConfiguration
-import Foundation
+    import class Adyen3DS2.ADYAppearanceConfiguration
+    import Foundation
 
-internal struct FingerprintServiceParameters {
-    internal let directoryServerIdentifier: String
-    internal let directoryServerPublicKey: String
-    internal let directoryServerRootCertificates: String
-    internal let deviceExcludedParameters: [String: Any]?
-    internal let appearanceConfiguration: Adyen3DS2.ADYAppearanceConfiguration
-    internal let threeDSMessageVersion: String
-}
+    internal struct FingerprintServiceParameters {
+        internal let directoryServerIdentifier: String
+        internal let directoryServerPublicKey: String
+        internal let directoryServerRootCertificates: String
+        internal let deviceExcludedParameters: [String: Any]?
+        internal let appearanceConfiguration: Adyen3DS2.ADYAppearanceConfiguration
+        internal let threeDSMessageVersion: String
+    }
 
 #endif

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/FingerprintServiceParameters.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/FingerprintServiceParameters.swift
@@ -4,6 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+#if canImport(Adyen3DS2)
+
 import class Adyen3DS2.ADYAppearanceConfiguration
 import Foundation
 
@@ -15,3 +17,5 @@ internal struct FingerprintServiceParameters {
     internal let appearanceConfiguration: Adyen3DS2.ADYAppearanceConfiguration
     internal let threeDSMessageVersion: String
 }
+
+#endif

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ADYServiceAdapter.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ADYServiceAdapter.swift
@@ -4,41 +4,45 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen3DS2
-import Foundation
-@_spi(AdyenInternal) import Adyen
+#if canImport(Adyen3DS2)
 
-internal protocol AnyADYService {
-    func service(
-        with parameters: ADYServiceParameters,
-        appearanceConfiguration: ADYAppearanceConfiguration,
-        completionHandler: @escaping (_ service: AnyADYService) -> Void
-    )
+    import Adyen3DS2
+    import Foundation
+    @_spi(AdyenInternal) import Adyen
 
-    func transaction(withMessageVersion: String) throws -> AnyADYTransaction
-}
+    internal protocol AnyADYService {
+        func service(
+            with parameters: ADYServiceParameters,
+            appearanceConfiguration: ADYAppearanceConfiguration,
+            completionHandler: @escaping (_ service: AnyADYService) -> Void
+        )
 
-internal final class ADYServiceAdapter: AnyADYService {
-
-    private var service: ADYService?
-
-    internal func service(
-        with parameters: ADYServiceParameters,
-        appearanceConfiguration: ADYAppearanceConfiguration,
-        completionHandler: @escaping (AnyADYService) -> Void
-    ) {
-        ADYService.service(with: parameters, appearanceConfiguration: appearanceConfiguration) { [weak self] service in
-            guard let self else { return }
-            self.service = service
-            completionHandler(self)
-        }
+        func transaction(withMessageVersion: String) throws -> AnyADYTransaction
     }
 
-    internal func transaction(withMessageVersion: String) throws -> AnyADYTransaction {
-        guard let service else {
-            throw UnknownError.serviceIsNil
+    internal final class ADYServiceAdapter: AnyADYService {
+
+        private var service: ADYService?
+
+        internal func service(
+            with parameters: ADYServiceParameters,
+            appearanceConfiguration: ADYAppearanceConfiguration,
+            completionHandler: @escaping (AnyADYService) -> Void
+        ) {
+            ADYService.service(with: parameters, appearanceConfiguration: appearanceConfiguration) { [weak self] service in
+                guard let self else { return }
+                self.service = service
+                completionHandler(self)
+            }
         }
-        return try service.transaction(withMessageVersion: withMessageVersion)
-    }
+
+        internal func transaction(withMessageVersion: String) throws -> AnyADYTransaction {
+            guard let service else {
+                throw UnknownError.serviceIsNil
+            }
+            return try service.transaction(withMessageVersion: withMessageVersion)
+        }
     
-}
+    }
+
+#endif

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/AnyADYTransaction.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/AnyADYTransaction.swift
@@ -4,29 +4,33 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen3DS2
-import Foundation
+#if canImport(Adyen3DS2)
 
-internal protocol AnyADYTransaction {
+    import Adyen3DS2
+    import Foundation
 
-    var authenticationParameters: AnyAuthenticationRequestParameters { get }
+    internal protocol AnyADYTransaction {
 
-    func performChallenge(with parameters: ADYChallengeParameters, completionHandler: @escaping (AnyChallengeResult?, Error?) -> Void)
-}
+        var authenticationParameters: AnyAuthenticationRequestParameters { get }
 
-extension ADYTransaction: AnyADYTransaction {
-
-    internal var authenticationParameters: AnyAuthenticationRequestParameters { authenticationRequestParameters }
-
-    internal func performChallenge(
-        with parameters: ADYChallengeParameters,
-        completionHandler: @escaping (AnyChallengeResult?, Error?) -> Void
-    ) {
-        performChallenge(
-            with: parameters,
-            completionHandler: { (result: ADYChallengeResult?, error: Error?) in
-                completionHandler(result, error)
-            }
-        )
+        func performChallenge(with parameters: ADYChallengeParameters, completionHandler: @escaping (AnyChallengeResult?, Error?) -> Void)
     }
-}
+
+    extension ADYTransaction: AnyADYTransaction {
+
+        internal var authenticationParameters: AnyAuthenticationRequestParameters { authenticationRequestParameters }
+
+        internal func performChallenge(
+            with parameters: ADYChallengeParameters,
+            completionHandler: @escaping (AnyChallengeResult?, Error?) -> Void
+        ) {
+            performChallenge(
+                with: parameters,
+                completionHandler: { (result: ADYChallengeResult?, error: Error?) in
+                    completionHandler(result, error)
+                }
+            )
+        }
+    }
+
+#endif

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ThreeDSServiceLegacy.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ThreeDSServiceLegacy.swift
@@ -4,108 +4,112 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen3DS2
-import Foundation
-@_spi(AdyenInternal) import Adyen
+#if canImport(Adyen3DS2)
 
-/// This is a wrapper class for the Objective C 3ds2 sdk.
-/// This translates simple non specific sdk bound types such as
-/// `FingerprintServiceParameters` & `ChallengeParameters` to sdk specific types and performs actions.
-internal final class ThreeDSServiceLegacy: ThreeDSServiceable {
-    private var service: AnyADYService
-    private var transaction: AnyADYTransaction?
+    import Adyen3DS2
+    import Foundation
+    @_spi(AdyenInternal) import Adyen
+
+    /// This is a wrapper class for the Objective C 3ds2 sdk.
+    /// This translates simple non specific sdk bound types such as
+    /// `FingerprintServiceParameters` & `ChallengeParameters` to sdk specific types and performs actions.
+    internal final class ThreeDSServiceLegacy: ThreeDSServiceable {
+        private var service: AnyADYService
+        private var transaction: AnyADYTransaction?
     
-    internal init(
-        service: AnyADYService = ADYServiceAdapter()
-    ) {
-        self.service = service
-    }
+        internal init(
+            service: AnyADYService = ADYServiceAdapter()
+        ) {
+            self.service = service
+        }
     
-    internal func performFingerprint(
-        parameters: FingerprintServiceParameters,
-        completionHandler: @escaping (Result<AnyAuthenticationRequestParameters, ThreeDSServiceFingerprintError>) -> Void
-    ) {
-        let serviceParameters = ADYServiceParameters(
-            directoryServerIdentifier: parameters.directoryServerIdentifier,
-            directoryServerPublicKey: parameters.directoryServerPublicKey,
-            directoryServerRootCertificates: parameters.directoryServerRootCertificates
-        )
-        service.service(
-            with: serviceParameters,
-            appearanceConfiguration: parameters.appearanceConfiguration
-        ) { [weak self] service in
-            guard let self else { return }
-            do {
-                let transaction = try service.transaction(withMessageVersion: parameters.threeDSMessageVersion)
-                self.transaction = transaction
-                completionHandler(.success(transaction.authenticationParameters))
+        internal func performFingerprint(
+            parameters: FingerprintServiceParameters,
+            completionHandler: @escaping (Result<AnyAuthenticationRequestParameters, ThreeDSServiceFingerprintError>) -> Void
+        ) {
+            let serviceParameters = ADYServiceParameters(
+                directoryServerIdentifier: parameters.directoryServerIdentifier,
+                directoryServerPublicKey: parameters.directoryServerPublicKey,
+                directoryServerRootCertificates: parameters.directoryServerRootCertificates
+            )
+            service.service(
+                with: serviceParameters,
+                appearanceConfiguration: parameters.appearanceConfiguration
+            ) { [weak self] service in
+                guard let self else { return }
+                do {
+                    let transaction = try service.transaction(withMessageVersion: parameters.threeDSMessageVersion)
+                    self.transaction = transaction
+                    completionHandler(.success(transaction.authenticationParameters))
                 
-            } catch {
-                completionHandler(
-                    .failure(.fingerprintingError(
-                        errorPayload: self.opaqueErrorObject(error: error)
-                    ))
-                )
+                } catch {
+                    completionHandler(
+                        .failure(.fingerprintingError(
+                            errorPayload: self.opaqueErrorObject(error: error)
+                        ))
+                    )
+                }
             }
         }
-    }
     
-    internal func performChallenge(
-        with parameters: ChallengeParameters,
-        completionHandler: @escaping (Result<AnyChallengeResult, ThreeDSServiceChallengeError>) -> Void
-    ) {
-        let challengeParameters = ADYChallengeParameters(
-            serverTransactionIdentifier: parameters.challengeToken.serverTransactionIdentifier,
-            threeDSRequestorAppURL: parameters.threeDSRequestorAppURL,
-            acsTransactionIdentifier: parameters.challengeToken.acsTransactionIdentifier,
-            acsReferenceNumber: parameters.challengeToken.acsReferenceNumber,
-            acsSignedContent: parameters.challengeToken.acsSignedContent
-        )
+        internal func performChallenge(
+            with parameters: ChallengeParameters,
+            completionHandler: @escaping (Result<AnyChallengeResult, ThreeDSServiceChallengeError>) -> Void
+        ) {
+            let challengeParameters = ADYChallengeParameters(
+                serverTransactionIdentifier: parameters.challengeToken.serverTransactionIdentifier,
+                threeDSRequestorAppURL: parameters.threeDSRequestorAppURL,
+                acsTransactionIdentifier: parameters.challengeToken.acsTransactionIdentifier,
+                acsReferenceNumber: parameters.challengeToken.acsReferenceNumber,
+                acsSignedContent: parameters.challengeToken.acsSignedContent
+            )
         
-        guard let transaction else {
-            return completionHandler(.failure(.transactionNotInitialized))
-        }
+            guard let transaction else {
+                return completionHandler(.failure(.transactionNotInitialized))
+            }
         
-        transaction.performChallenge(
-            with: challengeParameters
-        ) { [weak self] challengeResult, error in
-            guard let self else { return }
+            transaction.performChallenge(
+                with: challengeParameters
+            ) { [weak self] challengeResult, error in
+                guard let self else { return }
             
-            guard let result = challengeResult else {
-                guard let error else {
-                    completionHandler(.failure(.errorAndResultAreNil(
-                        errorPayload: opaqueErrorObject(error: UnknownError.resultAndErrorAreNil)
-                    )))
-                    return
-                }
+                guard let result = challengeResult else {
+                    guard let error else {
+                        completionHandler(.failure(.errorAndResultAreNil(
+                            errorPayload: opaqueErrorObject(error: UnknownError.resultAndErrorAreNil)
+                        )))
+                        return
+                    }
                 
-                if isCancelled(error: error) {
-                    return completionHandler(.failure(.cancelled(
-                        errorPayload: opaqueErrorObject(error: error)
-                    )))
-                } else {
-                    return completionHandler(.failure(.challengeError(
-                        errorPayload: opaqueErrorObject(error: error)
-                    )))
+                    if isCancelled(error: error) {
+                        return completionHandler(.failure(.cancelled(
+                            errorPayload: opaqueErrorObject(error: error)
+                        )))
+                    } else {
+                        return completionHandler(.failure(.challengeError(
+                            errorPayload: opaqueErrorObject(error: error)
+                        )))
+                    }
                 }
+                completionHandler(.success(result))
             }
-            completionHandler(.success(result))
+        }
+    
+        private func isCancelled(error: Error) -> Bool {
+            let error: NSError = error as NSError
+            return (error.code == Int(ADYRuntimeErrorCode.challengeCancelled.rawValue)) && (error.domain == ADYRuntimeErrorDomain)
+        }
+    
+        internal func opaqueErrorObject(error: any Error) -> String {
+            (error as NSError).base64Representation()
+        }
+
+        internal func resetTransaction() {
+            self.transaction = nil
         }
     }
-    
-    private func isCancelled(error: Error) -> Bool {
-        let error: NSError = error as NSError
-        return (error.code == Int(ADYRuntimeErrorCode.challengeCancelled.rawValue)) && (error.domain == ADYRuntimeErrorDomain)
-    }
-    
-    internal func opaqueErrorObject(error: any Error) -> String {
-        (error as NSError).base64Representation()
-    }
 
-    internal func resetTransaction() {
-        self.transaction = nil
-    }
-}
+    extension Adyen3DS2.ADYAuthenticationRequestParameters: AnyAuthenticationRequestParameters {}
+    extension Adyen3DS2.ADYChallengeResult: AnyChallengeResult {}
 
-extension Adyen3DS2.ADYAuthenticationRequestParameters: AnyAuthenticationRequestParameters {}
-extension Adyen3DS2.ADYChallengeResult: AnyChallengeResult {}
+#endif

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceProvider.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceProvider.swift
@@ -6,71 +6,71 @@
 
 #if canImport(Adyen3DS2)
 
-import Foundation
-@_spi(AdyenInternal) import Adyen
+    import Foundation
+    @_spi(AdyenInternal) import Adyen
 
-internal protocol ThreeDSConfigurable {
-    var configuration: ThreeDSFeatureChecker? { get set }
-}
-
-internal protocol ThreeDSFeatureChecker {
-    func isFeatureEnabled(_ name: String) -> Bool
-}
-
-/// This type creates a ThreeDSServiceable implementation and consumes ThreeDSConfigurable.
-internal final class ThreeDSServiceProvider: ThreeDSServiceable, ThreeDSConfigurable {
-    
-    /// An optional configuration that can be provided to the service provider.
-    internal var configuration: ThreeDSFeatureChecker?
-    
-    private var service: ThreeDSServiceable?
-    private let serviceCreationHandler: (ThreeDSFeatureChecker?) -> ThreeDSServiceable
-
-    internal init(
-        serviceCreationHandler: @escaping (ThreeDSFeatureChecker?) -> ThreeDSServiceable = createService
-    ) {
-        self.serviceCreationHandler = serviceCreationHandler
+    internal protocol ThreeDSConfigurable {
+        var configuration: ThreeDSFeatureChecker? { get set }
     }
-    
-    internal func performFingerprint(
-        parameters: FingerprintServiceParameters,
-        completionHandler: @escaping (Result<any AnyAuthenticationRequestParameters, ThreeDSServiceFingerprintError>) -> Void
-    ) {
-        self.resetTransaction()
-        let service = serviceCreationHandler(configuration)
-        self.service = service
-        service.performFingerprint(
-            parameters: parameters,
-            completionHandler: completionHandler
-        )
+
+    internal protocol ThreeDSFeatureChecker {
+        func isFeatureEnabled(_ name: String) -> Bool
     }
+
+    /// This type creates a ThreeDSServiceable implementation and consumes ThreeDSConfigurable.
+    internal final class ThreeDSServiceProvider: ThreeDSServiceable, ThreeDSConfigurable {
     
-    internal func performChallenge(
-        with parameters: ChallengeParameters,
-        completionHandler: @escaping (Result<any AnyChallengeResult, ThreeDSServiceChallengeError>) -> Void
-    ) {
-        // The service needs to be already created during the fingerprint step.
-        // There is no way a challenge action should happen without a fingerprint action.
-        guard let service = self.service else {
-            completionHandler(.failure(.transactionNotInitialized))
-            return
+        /// An optional configuration that can be provided to the service provider.
+        internal var configuration: ThreeDSFeatureChecker?
+    
+        private var service: ThreeDSServiceable?
+        private let serviceCreationHandler: (ThreeDSFeatureChecker?) -> ThreeDSServiceable
+
+        internal init(
+            serviceCreationHandler: @escaping (ThreeDSFeatureChecker?) -> ThreeDSServiceable = createService
+        ) {
+            self.serviceCreationHandler = serviceCreationHandler
         }
-        service.performChallenge(with: parameters) { result in
+    
+        internal func performFingerprint(
+            parameters: FingerprintServiceParameters,
+            completionHandler: @escaping (Result<any AnyAuthenticationRequestParameters, ThreeDSServiceFingerprintError>) -> Void
+        ) {
             self.resetTransaction()
-            completionHandler(result)
+            let service = serviceCreationHandler(configuration)
+            self.service = service
+            service.performFingerprint(
+                parameters: parameters,
+                completionHandler: completionHandler
+            )
+        }
+    
+        internal func performChallenge(
+            with parameters: ChallengeParameters,
+            completionHandler: @escaping (Result<any AnyChallengeResult, ThreeDSServiceChallengeError>) -> Void
+        ) {
+            // The service needs to be already created during the fingerprint step.
+            // There is no way a challenge action should happen without a fingerprint action.
+            guard let service = self.service else {
+                completionHandler(.failure(.transactionNotInitialized))
+                return
+            }
+            service.performChallenge(with: parameters) { result in
+                self.resetTransaction()
+                completionHandler(result)
+            }
+        }
+    
+        internal func resetTransaction() {
+            service?.resetTransaction()
+            service = nil
+        }
+    
+        internal static func createService(
+            configuration: ThreeDSFeatureChecker?
+        ) -> ThreeDSServiceable {
+            ThreeDSServiceLegacy()
         }
     }
-    
-    internal func resetTransaction() {
-        service?.resetTransaction()
-        service = nil
-    }
-    
-    internal static func createService(
-        configuration: ThreeDSFeatureChecker?
-    ) -> ThreeDSServiceable {
-        ThreeDSServiceLegacy()
-    }
-}
 
 #endif

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceProvider.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceProvider.swift
@@ -4,6 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+#if canImport(Adyen3DS2)
+
 import Foundation
 @_spi(AdyenInternal) import Adyen
 
@@ -70,3 +72,5 @@ internal final class ThreeDSServiceProvider: ThreeDSServiceable, ThreeDSConfigur
         ThreeDSServiceLegacy()
     }
 }
+
+#endif

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceable.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceable.swift
@@ -4,6 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+#if canImport(Adyen3DS2)
+
 import Foundation
 @_spi(AdyenInternal) import Adyen
 
@@ -21,3 +23,5 @@ internal protocol ThreeDSServiceable {
     )
     func resetTransaction()
 }
+
+#endif

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceable.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceable.swift
@@ -6,22 +6,22 @@
 
 #if canImport(Adyen3DS2)
 
-import Foundation
-@_spi(AdyenInternal) import Adyen
+    import Foundation
+    @_spi(AdyenInternal) import Adyen
 
-/// This protocol abstracts the SDK logic away.
-/// The 3DS2 SDK performs 2 tasks - fingerprint & challenge.
-/// Additionally we provide a way to reset the transaction.
-internal protocol ThreeDSServiceable {
-    func performFingerprint(
-        parameters: FingerprintServiceParameters,
-        completionHandler: @escaping (Result<AnyAuthenticationRequestParameters, ThreeDSServiceFingerprintError>) -> Void
-    )
-    func performChallenge(
-        with parameters: ChallengeParameters,
-        completionHandler: @escaping (Result<AnyChallengeResult, ThreeDSServiceChallengeError>) -> Void
-    )
-    func resetTransaction()
-}
+    /// This protocol abstracts the SDK logic away.
+    /// The 3DS2 SDK performs 2 tasks - fingerprint & challenge.
+    /// Additionally we provide a way to reset the transaction.
+    internal protocol ThreeDSServiceable {
+        func performFingerprint(
+            parameters: FingerprintServiceParameters,
+            completionHandler: @escaping (Result<AnyAuthenticationRequestParameters, ThreeDSServiceFingerprintError>) -> Void
+        )
+        func performChallenge(
+            with parameters: ChallengeParameters,
+            completionHandler: @escaping (Result<AnyChallengeResult, ThreeDSServiceChallengeError>) -> Void
+        )
+        func resetTransaction()
+    }
 
 #endif

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -4,304 +4,308 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
-import Adyen3DS2
-import Foundation
+#if canImport(Adyen3DS2)
 
-internal protocol AnyThreeDS2CoreActionHandler: Component {
-    var threeDSRequestorAppURL: URL? { get set }
-    
-    var presentationDelegate: PresentationDelegate? { get set }
-    
-    func handle(
-        _ fingerprintAction: ThreeDS2FingerprintAction,
-        event: Analytics.Event,
-        completionHandler: @escaping (Result<String, Error>) -> Void
-    )
-    
-    func handle(
-        _ challengeAction: ThreeDS2ChallengeAction,
-        event: Analytics.Event,
-        completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void
-    )
-}
+    @_spi(AdyenInternal) import Adyen
+    import Adyen3DS2
+    import Foundation
 
-internal typealias ThreeDSService = ThreeDSConfigurable & ThreeDSServiceable
-
-/// Handles the 3D Secure 2 fingerprint and challenge actions separately.
-internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
-    private enum Constants {
-        static let transStatusWhenError = "U"
-        static let fingerprintEvent = "threeDS2Fingerprint"
-        static let challengeEvent = "threeDS2Challenge"
-    }
+    internal protocol AnyThreeDS2CoreActionHandler: Component {
+        var threeDSRequestorAppURL: URL? { get set }
     
-    internal let context: AdyenContext
-
-    /// The appearance configuration of the 3D Secure 2 challenge UI.
-    internal let appearanceConfiguration: ADYAppearanceConfiguration
+        var presentationDelegate: PresentationDelegate? { get set }
     
-    private var service: ThreeDSService
+        func handle(
+            _ fingerprintAction: ThreeDS2FingerprintAction,
+            event: Analytics.Event,
+            completionHandler: @escaping (Result<String, Error>) -> Void
+        )
     
-    internal weak var presentationDelegate: PresentationDelegate?
-    
-    /// `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
-    internal var threeDSRequestorAppURL: URL?
-
-    /// Initializes the 3D Secure 2 action handler.
-    ///
-    /// - Parameter context: The context object for this component.
-    /// - Parameter service: The 3DS2 Service.
-    /// - Parameter appearanceConfiguration: The appearance configuration of the 3D Secure 2 challenge UI.
-    internal init(
-        context: AdyenContext,
-        service: ThreeDSService,
-        appearanceConfiguration: ADYAppearanceConfiguration = ADYAppearanceConfiguration()
-    ) {
-        self.context = context
-        self.appearanceConfiguration = appearanceConfiguration
-        self.service = service
+        func handle(
+            _ challengeAction: ThreeDS2ChallengeAction,
+            event: Analytics.Event,
+            completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void
+        )
     }
 
-    // MARK: - Fingerprint
+    internal typealias ThreeDSService = ThreeDSConfigurable & ThreeDSServiceable
 
-    /// Handles the 3D Secure 2 fingerprint action.
-    ///
-    /// - Parameter fingerprintAction: The fingerprint action as received from the Checkout API.
-    /// - Parameter event: The Analytics event.
-    /// - Parameter completionHandler: The completion closure.
-    internal func handle(
-        _ fingerprintAction: ThreeDS2FingerprintAction,
-        event: Analytics.Event,
-        completionHandler: @escaping (Result<String, Error>) -> Void
-    ) {
-        Analytics.sendEvent(event)
-        sendLogEvent(.fingerprintSent, for: Constants.fingerprintEvent)
+    /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
+    internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
+        private enum Constants {
+            static let transStatusWhenError = "U"
+            static let fingerprintEvent = "threeDS2Fingerprint"
+            static let challengeEvent = "threeDS2Challenge"
+        }
+    
+        internal let context: AdyenContext
+
+        /// The appearance configuration of the 3D Secure 2 challenge UI.
+        internal let appearanceConfiguration: ADYAppearanceConfiguration
+    
+        private var service: ThreeDSService
+    
+        internal weak var presentationDelegate: PresentationDelegate?
+    
+        /// `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
+        internal var threeDSRequestorAppURL: URL?
+
+        /// Initializes the 3D Secure 2 action handler.
+        ///
+        /// - Parameter context: The context object for this component.
+        /// - Parameter service: The 3DS2 Service.
+        /// - Parameter appearanceConfiguration: The appearance configuration of the 3D Secure 2 challenge UI.
+        internal init(
+            context: AdyenContext,
+            service: ThreeDSService,
+            appearanceConfiguration: ADYAppearanceConfiguration = ADYAppearanceConfiguration()
+        ) {
+            self.context = context
+            self.appearanceConfiguration = appearanceConfiguration
+            self.service = service
+        }
+
+        // MARK: - Fingerprint
+
+        /// Handles the 3D Secure 2 fingerprint action.
+        ///
+        /// - Parameter fingerprintAction: The fingerprint action as received from the Checkout API.
+        /// - Parameter event: The Analytics event.
+        /// - Parameter completionHandler: The completion closure.
+        internal func handle(
+            _ fingerprintAction: ThreeDS2FingerprintAction,
+            event: Analytics.Event,
+            completionHandler: @escaping (Result<String, Error>) -> Void
+        ) {
+            Analytics.sendEvent(event)
+            sendLogEvent(.fingerprintSent, for: Constants.fingerprintEvent)
         
-        do {
-            let token = try AdyenCoder.decodeBase64(fingerprintAction.fingerprintToken) as ThreeDS2Component.FingerprintToken
-            let serviceParameters = FingerprintServiceParameters(
-                directoryServerIdentifier: token.directoryServerIdentifier,
-                directoryServerPublicKey: token.directoryServerPublicKey,
-                directoryServerRootCertificates: token.directoryServerRootCertificates,
-                deviceExcludedParameters: nil,
-                appearanceConfiguration: appearanceConfiguration,
-                threeDSMessageVersion: token.threeDSMessageVersion
+            do {
+                let token = try AdyenCoder.decodeBase64(fingerprintAction.fingerprintToken) as ThreeDS2Component.FingerprintToken
+                let serviceParameters = FingerprintServiceParameters(
+                    directoryServerIdentifier: token.directoryServerIdentifier,
+                    directoryServerPublicKey: token.directoryServerPublicKey,
+                    directoryServerRootCertificates: token.directoryServerRootCertificates,
+                    deviceExcludedParameters: nil,
+                    appearanceConfiguration: appearanceConfiguration,
+                    threeDSMessageVersion: token.threeDSMessageVersion
+                )
+                service.configuration = token.configuration
+                service.performFingerprint(
+                    parameters: serviceParameters
+                ) { result in
+                    self.sendLogEvent(.fingerprintComplete, for: Constants.fingerprintEvent)
+                    switch result {
+                    case let .success(authenticationRequestParameters):
+                        self.didFinishFingerprintSuccessfully(
+                            authenticationRequestParameters: authenticationRequestParameters,
+                            completionHandler: completionHandler
+                        )
+                    case let .failure(error):
+                        self.didReceiveErrorOnFingerprint(
+                            error: error,
+                            completionHandler: completionHandler
+                        )
+                    }
+                }
+            
+            } catch {
+                sendErrorEvent(.threeDS2DecodingFailed, for: Constants.fingerprintEvent)
+                didFail(with: error, completionHandler: completionHandler)
+            }
+        }
+        
+        private func didReceiveErrorOnFingerprint(
+            error: ThreeDSServiceFingerprintError,
+            completionHandler: @escaping (Result<String, Error>) -> Void
+        ) {
+            let errorPayload: String = {
+                switch error {
+                case let .fingerprintingError(errorPayload: errorPayload):
+                    errorPayload
+                }
+            }()
+        
+            do {
+                let encodedError = try AdyenCoder.encodeBase64(
+                    ThreeDS2Component.Fingerprint(
+                        threeDS2SDKError: errorPayload
+                    )
+                )
+                completionHandler(.success(encodedError))
+            } catch {
+                sendErrorEvent(.threeDS2FingerprintHandlingFailed, for: Constants.fingerprintEvent)
+                didFail(with: error, completionHandler: completionHandler)
+            }
+        }
+
+        private func didFinishFingerprintSuccessfully(
+            authenticationRequestParameters: AnyAuthenticationRequestParameters,
+            completionHandler: @escaping (Result<String, Error>) -> Void
+        ) {
+            do {
+                let encodedFingerprint = try AdyenCoder.encodeBase64(ThreeDS2Component.Fingerprint(
+                    authenticationRequestParameters: authenticationRequestParameters,
+                    delegatedAuthenticationSDKOutput: nil,
+                    deleteDelegatedAuthenticationCredential: nil
+                ))
+                completionHandler(.success(encodedFingerprint))
+            } catch {
+                sendErrorEvent(.threeDS2FingerprintCreationFailed, for: Constants.fingerprintEvent)
+                didFail(with: error, completionHandler: completionHandler)
+            }
+        }
+    
+        // MARK: - Challenge
+
+        /// Handles the 3D Secure 2 challenge action.
+        ///
+        /// - Parameter challengeAction: The challenge action as received from the Checkout API.
+        /// - Parameter event: The Analytics event.
+        /// - Parameter completionHandler: The completion closure.
+        internal func handle(
+            _ challengeAction: ThreeDS2ChallengeAction,
+            event: Analytics.Event,
+            completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void
+        ) {
+            Analytics.sendEvent(event)
+        
+            sendLogEvent(.challengeDataSent, for: Constants.challengeEvent)
+
+            let token: ThreeDS2Component.ChallengeToken
+            do {
+                token = try AdyenCoder.decodeBase64(challengeAction.challengeToken) as ThreeDS2Component.ChallengeToken
+            } catch {
+                sendErrorEvent(.threeDS2DecodingFailed, for: Constants.challengeEvent)
+                return didFail(with: error, completionHandler: completionHandler)
+            }
+            let challengeParameters = ChallengeParameters(
+                challengeToken: token,
+                threeDSRequestorAppURL: threeDSRequestorAppURL ?? token.threeDSRequestorAppURL
             )
-            service.configuration = token.configuration
-            service.performFingerprint(
-                parameters: serviceParameters
-            ) { result in
-                self.sendLogEvent(.fingerprintComplete, for: Constants.fingerprintEvent)
+        
+            sendLogEvent(.challengeDisplayed, for: Constants.challengeEvent)
+
+            service.performChallenge(
+                with: challengeParameters
+            ) { [weak self] result in
+                guard let self else { return }
+                self.sendLogEvent(.challengeComplete, for: Constants.challengeEvent)
                 switch result {
-                case let .success(authenticationRequestParameters):
-                    self.didFinishFingerprintSuccessfully(
-                        authenticationRequestParameters: authenticationRequestParameters,
+                case let .success(success):
+                    self.didFinishChallengeSuccessfully(
+                        with: success,
+                        authorizationToken: challengeAction.authorisationToken,
                         completionHandler: completionHandler
                     )
                 case let .failure(error):
-                    self.didReceiveErrorOnFingerprint(
+                    self.didReceiveErrorOnChallenge(
                         error: error,
+                        challengeAction: challengeAction,
                         completionHandler: completionHandler
                     )
                 }
             }
-            
-        } catch {
-            sendErrorEvent(.threeDS2DecodingFailed, for: Constants.fingerprintEvent)
-            didFail(with: error, completionHandler: completionHandler)
         }
-    }
-        
-    private func didReceiveErrorOnFingerprint(
-        error: ThreeDSServiceFingerprintError,
-        completionHandler: @escaping (Result<String, Error>) -> Void
-    ) {
-        let errorPayload: String = {
+    
+        internal func userCancelledChallenge() {}
+
+        /// Invoked to handle the error flow of a challenge handling by the 3ds2sdk.
+        private func didReceiveErrorOnChallenge(
+            error: ThreeDSServiceChallengeError,
+            challengeAction: ThreeDS2ChallengeAction,
+            completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void
+        ) {
+            let opaqueRepresentationOfError: String
             switch error {
-            case let .fingerprintingError(errorPayload: errorPayload):
-                errorPayload
-            }
-        }()
-        
-        do {
-            let encodedError = try AdyenCoder.encodeBase64(
-                ThreeDS2Component.Fingerprint(
-                    threeDS2SDKError: errorPayload
+            case let .cancelled(errorPayload):
+                userCancelledChallenge()
+                opaqueRepresentationOfError = errorPayload
+                sendErrorEvent(
+                    .threeDS2ChallengeHandlingFailed,
+                    for: Constants.challengeEvent,
+                    message: "cancelled"
                 )
-            )
-            completionHandler(.success(encodedError))
-        } catch {
-            sendErrorEvent(.threeDS2FingerprintHandlingFailed, for: Constants.fingerprintEvent)
-            didFail(with: error, completionHandler: completionHandler)
-        }
-    }
 
-    private func didFinishFingerprintSuccessfully(
-        authenticationRequestParameters: AnyAuthenticationRequestParameters,
-        completionHandler: @escaping (Result<String, Error>) -> Void
-    ) {
-        do {
-            let encodedFingerprint = try AdyenCoder.encodeBase64(ThreeDS2Component.Fingerprint(
-                authenticationRequestParameters: authenticationRequestParameters,
-                delegatedAuthenticationSDKOutput: nil,
-                deleteDelegatedAuthenticationCredential: nil
-            ))
-            completionHandler(.success(encodedFingerprint))
-        } catch {
-            sendErrorEvent(.threeDS2FingerprintCreationFailed, for: Constants.fingerprintEvent)
-            didFail(with: error, completionHandler: completionHandler)
-        }
-    }
-    
-    // MARK: - Challenge
+            case .transactionNotInitialized:
+                sendErrorEvent(
+                    .threeDS2TransactionMissing,
+                    for: Constants.challengeEvent
+                )
+                return didFail(with: ThreeDS2Component.Error.missingTransaction, completionHandler: completionHandler)
 
-    /// Handles the 3D Secure 2 challenge action.
-    ///
-    /// - Parameter challengeAction: The challenge action as received from the Checkout API.
-    /// - Parameter event: The Analytics event.
-    /// - Parameter completionHandler: The completion closure.
-    internal func handle(
-        _ challengeAction: ThreeDS2ChallengeAction,
-        event: Analytics.Event,
-        completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void
-    ) {
-        Analytics.sendEvent(event)
+            case let .challengeError(errorPayload),
+                 let .errorAndResultAreNil(errorPayload):
+                opaqueRepresentationOfError = errorPayload
+                sendErrorEvent(
+                    .threeDS2ChallengeHandlingFailed,
+                    for: Constants.challengeEvent
+                )
+            }
         
-        sendLogEvent(.challengeDataSent, for: Constants.challengeEvent)
-
-        let token: ThreeDS2Component.ChallengeToken
-        do {
-            token = try AdyenCoder.decodeBase64(challengeAction.challengeToken) as ThreeDS2Component.ChallengeToken
-        } catch {
-            sendErrorEvent(.threeDS2DecodingFailed, for: Constants.challengeEvent)
-            return didFail(with: error, completionHandler: completionHandler)
-        }
-        let challengeParameters = ChallengeParameters(
-            challengeToken: token,
-            threeDSRequestorAppURL: threeDSRequestorAppURL ?? token.threeDSRequestorAppURL
-        )
-        
-        sendLogEvent(.challengeDisplayed, for: Constants.challengeEvent)
-
-        service.performChallenge(
-            with: challengeParameters
-        ) { [weak self] result in
-            guard let self else { return }
-            self.sendLogEvent(.challengeComplete, for: Constants.challengeEvent)
-            switch result {
-            case let .success(success):
-                self.didFinishChallengeSuccessfully(
-                    with: success,
+            do {
+                // When we get an error we need to send transStatus as "U" along with the threeDS2SDKError field.
+                let threeDSResult = try ThreeDSResult(
                     authorizationToken: challengeAction.authorisationToken,
-                    completionHandler: completionHandler
+                    threeDS2SDKError: opaqueRepresentationOfError,
+                    transStatus: Constants.transStatusWhenError
                 )
-            case let .failure(error):
-                self.didReceiveErrorOnChallenge(
-                    error: error,
-                    challengeAction: challengeAction,
-                    completionHandler: completionHandler
-                )
+                completionHandler(.success(threeDSResult))
+            } catch {
+                didFail(with: error, completionHandler: completionHandler)
             }
         }
-    }
     
-    internal func userCancelledChallenge() {}
-
-    /// Invoked to handle the error flow of a challenge handling by the 3ds2sdk.
-    private func didReceiveErrorOnChallenge(
-        error: ThreeDSServiceChallengeError,
-        challengeAction: ThreeDS2ChallengeAction,
-        completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void
-    ) {
-        let opaqueRepresentationOfError: String
-        switch error {
-        case let .cancelled(errorPayload):
-            userCancelledChallenge()
-            opaqueRepresentationOfError = errorPayload
-            sendErrorEvent(
-                .threeDS2ChallengeHandlingFailed,
-                for: Constants.challengeEvent,
-                message: "cancelled"
-            )
-
-        case .transactionNotInitialized:
-            sendErrorEvent(
-                .threeDS2TransactionMissing,
-                for: Constants.challengeEvent
-            )
-            return didFail(with: ThreeDS2Component.Error.missingTransaction, completionHandler: completionHandler)
-
-        case let .challengeError(errorPayload),
-             let .errorAndResultAreNil(errorPayload):
-            opaqueRepresentationOfError = errorPayload
-            sendErrorEvent(
-                .threeDS2ChallengeHandlingFailed,
-                for: Constants.challengeEvent
-            )
+        private func didFinishChallengeSuccessfully(
+            with challengeResult: AnyChallengeResult,
+            authorizationToken: String?,
+            completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void
+        ) {
+            do {
+                let threeDSResult = try ThreeDSResult(
+                    from: challengeResult,
+                    delegatedAuthenticationSDKOutput: nil,
+                    authorizationToken: authorizationToken,
+                    threeDS2SDKError: nil
+                )
+                completionHandler(.success(threeDSResult))
+            } catch {
+                didFail(with: error, completionHandler: completionHandler)
+            }
         }
-        
-        do {
-            // When we get an error we need to send transStatus as "U" along with the threeDS2SDKError field.
-            let threeDSResult = try ThreeDSResult(
-                authorizationToken: challengeAction.authorisationToken,
-                threeDS2SDKError: opaqueRepresentationOfError,
-                transStatus: Constants.transStatusWhenError
+    
+        private func didFail<R>(
+            with error: Error,
+            completionHandler: @escaping (Result<R, Error>) -> Void
+        ) {
+            service.resetTransaction()
+            completionHandler(.failure(error))
+        }
+
+        // MARK: - Events {
+    
+        private func sendLogEvent(_ subtype: AnalyticsEventLog.LogSubType, for component: String) {
+            let logEvent = AnalyticsEventLog(
+                component: component,
+                type: .threeDS2,
+                subType: subtype
             )
-            completionHandler(.success(threeDSResult))
-        } catch {
-            didFail(with: error, completionHandler: completionHandler)
+            context.analyticsProvider?.add(log: logEvent)
+        }
+    
+        private func sendErrorEvent(_ code: AnalyticsConstants.ErrorCode, for component: String, message: String? = nil) {
+            var errorEvent = AnalyticsEventError(component: component, type: .threeDS2)
+            errorEvent.code = code.stringValue
+            errorEvent.message = message
+            context.analyticsProvider?.add(error: errorEvent)
         }
     }
-    
-    private func didFinishChallengeSuccessfully(
-        with challengeResult: AnyChallengeResult,
-        authorizationToken: String?,
-        completionHandler: @escaping (Result<ThreeDSResult, Error>) -> Void
-    ) {
-        do {
-            let threeDSResult = try ThreeDSResult(
-                from: challengeResult,
-                delegatedAuthenticationSDKOutput: nil,
-                authorizationToken: authorizationToken,
-                threeDS2SDKError: nil
-            )
-            completionHandler(.success(threeDSResult))
-        } catch {
-            didFail(with: error, completionHandler: completionHandler)
+
+    extension ThreeDS2CoreActionHandler: PresentationDelegate {
+        func present(component: any PresentableComponent) {
+            AdyenAssertion.assert(message: "presentationDelegate should not be nil", condition: presentationDelegate == nil)
+            presentationDelegate?.present(component: component)
         }
     }
-    
-    private func didFail<R>(
-        with error: Error,
-        completionHandler: @escaping (Result<R, Error>) -> Void
-    ) {
-        service.resetTransaction()
-        completionHandler(.failure(error))
-    }
 
-    // MARK: - Events {
-    
-    private func sendLogEvent(_ subtype: AnalyticsEventLog.LogSubType, for component: String) {
-        let logEvent = AnalyticsEventLog(
-            component: component,
-            type: .threeDS2,
-            subType: subtype
-        )
-        context.analyticsProvider?.add(log: logEvent)
-    }
-    
-    private func sendErrorEvent(_ code: AnalyticsConstants.ErrorCode, for component: String, message: String? = nil) {
-        var errorEvent = AnalyticsEventError(component: component, type: .threeDS2)
-        errorEvent.code = code.stringValue
-        errorEvent.message = message
-        context.analyticsProvider?.add(error: errorEvent)
-    }
-}
-
-extension ThreeDS2CoreActionHandler: PresentationDelegate {
-    func present(component: any PresentableComponent) {
-        AdyenAssertion.assert(message: "presentationDelegate should not be nil", condition: presentationDelegate == nil)
-        presentationDelegate?.present(component: component)
-    }
-}
+#endif

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
@@ -8,7 +8,7 @@ internal typealias VoidHandler = () -> Void
 
 // swiftlint:disable file_length
 
-#if canImport(AdyenAuthentication)
+#if canImport(AdyenAuthentication) && canImport(Adyen3DS2)
     @_spi(AdyenInternal) import Adyen
     import Adyen3DS2
     import AdyenAuthentication

--- a/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -4,76 +4,80 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
-import Adyen3DS2
-import Foundation
+#if canImport(Adyen3DS2)
 
-internal protocol AnyThreeDS2ActionHandler {
+    @_spi(AdyenInternal) import Adyen
+    import Adyen3DS2
+    import Foundation
 
-    func handle(
-        _ fingerprintAction: ThreeDS2FingerprintAction,
-        completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
-    )
+    internal protocol AnyThreeDS2ActionHandler {
 
-    func handle(
-        _ challengeAction: ThreeDS2ChallengeAction,
-        completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
-    )
+        func handle(
+            _ fingerprintAction: ThreeDS2FingerprintAction,
+            completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
+        )
+
+        func handle(
+            _ challengeAction: ThreeDS2ChallengeAction,
+            completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
+        )
     
-    var threeDSRequestorAppURL: URL? { get set }
+        var threeDSRequestorAppURL: URL? { get set }
     
-    var presentationDelegate: PresentationDelegate? { get set }
-}
+        var presentationDelegate: PresentationDelegate? { get set }
+    }
 
-internal protocol ComponentWrapper: Component {
+    internal protocol ComponentWrapper: Component {
 
-    var wrappedComponent: Component { get }
+        var wrappedComponent: Component { get }
     
-}
+    }
 
-extension ComponentWrapper {
+    extension ComponentWrapper {
 
-    internal var apiContext: APIContext { wrappedComponent.context.apiContext }
+        internal var apiContext: APIContext { wrappedComponent.context.apiContext }
 
-    internal var context: AdyenContext { wrappedComponent.context }
+        internal var context: AdyenContext { wrappedComponent.context }
 
-    internal var _isDropIn: Bool { // swiftlint:disable:this identifier_name
-        get {
-            wrappedComponent._isDropIn
-        }
+        internal var _isDropIn: Bool { // swiftlint:disable:this identifier_name
+            get {
+                wrappedComponent._isDropIn
+            }
 
-        set {
-            wrappedComponent._isDropIn = newValue
+            set {
+                wrappedComponent._isDropIn = newValue
+            }
         }
     }
-}
 
-internal func createDefaultThreeDS2CoreActionHandler(
-    context: AdyenContext,
-    service: ThreeDSService,
-    appearanceConfiguration: ADYAppearanceConfiguration,
-    delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication?
-) -> AnyThreeDS2CoreActionHandler {
-    #if canImport(AdyenAuthentication)
-        if #available(iOS 16.0, *), let delegatedAuthenticationConfiguration {
-            return ThreeDS2PlusDACoreActionHandler(
-                context: context,
-                service: service,
-                appearanceConfiguration: appearanceConfiguration,
-                delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
-            )
-        } else {
+    internal func createDefaultThreeDS2CoreActionHandler(
+        context: AdyenContext,
+        service: ThreeDSService,
+        appearanceConfiguration: ADYAppearanceConfiguration,
+        delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication?
+    ) -> AnyThreeDS2CoreActionHandler {
+        #if canImport(AdyenAuthentication)
+            if #available(iOS 16.0, *), let delegatedAuthenticationConfiguration {
+                return ThreeDS2PlusDACoreActionHandler(
+                    context: context,
+                    service: service,
+                    appearanceConfiguration: appearanceConfiguration,
+                    delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
+                )
+            } else {
+                return ThreeDS2CoreActionHandler(
+                    context: context,
+                    service: service,
+                    appearanceConfiguration: appearanceConfiguration
+                )
+            }
+        #else
             return ThreeDS2CoreActionHandler(
                 context: context,
                 service: service,
                 appearanceConfiguration: appearanceConfiguration
             )
-        }
-    #else
-        return ThreeDS2CoreActionHandler(
-            context: context,
-            service: service,
-            appearanceConfiguration: appearanceConfiguration
-        )
-    #endif
-}
+        #endif
+    }
+
+#endif

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler+Initializers.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler+Initializers.swift
@@ -4,34 +4,38 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
-import Adyen3DS2
-import Foundation
-#if canImport(AdyenAuthentication)
-    import AdyenAuthentication
-#endif
+#if canImport(Adyen3DS2)
 
-extension ThreeDS2ClassicActionHandler {
+    @_spi(AdyenInternal) import Adyen
+    import Adyen3DS2
+    import Foundation
+    #if canImport(AdyenAuthentication)
+        import AdyenAuthentication
+    #endif
+
+    extension ThreeDS2ClassicActionHandler {
     
-    /// Initializes the 3D Secure 2 action handler.
-    internal convenience init(
-        context: AdyenContext,
-        service: ThreeDSService,
-        appearanceConfiguration: ADYAppearanceConfiguration,
-        delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication?
-    ) {
-        let defaultHandler = createDefaultThreeDS2CoreActionHandler(
-            context: context,
-            service: service,
-            appearanceConfiguration: appearanceConfiguration,
-            delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
-        )
-        self.init(
-            context: context,
-            appearanceConfiguration: appearanceConfiguration,
-            service: service,
-            coreActionHandler: defaultHandler,
-            delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
-        )
+        /// Initializes the 3D Secure 2 action handler.
+        internal convenience init(
+            context: AdyenContext,
+            service: ThreeDSService,
+            appearanceConfiguration: ADYAppearanceConfiguration,
+            delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication?
+        ) {
+            let defaultHandler = createDefaultThreeDS2CoreActionHandler(
+                context: context,
+                service: service,
+                appearanceConfiguration: appearanceConfiguration,
+                delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
+            )
+            self.init(
+                context: context,
+                appearanceConfiguration: appearanceConfiguration,
+                service: service,
+                coreActionHandler: defaultHandler,
+                delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
+            )
+        }
     }
-}
+
+#endif

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
@@ -4,115 +4,119 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
-import Adyen3DS2
-import Foundation
+#if canImport(Adyen3DS2)
 
-/// Handles the 3D Secure 2 fingerprint and challenge actions separately.
-internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, ComponentWrapper {
+    @_spi(AdyenInternal) import Adyen
+    import Adyen3DS2
+    import Foundation
+
+    /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
+    internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, ComponentWrapper {
     
-    internal let context: AdyenContext
+        internal let context: AdyenContext
 
-    internal var wrappedComponent: Component { coreActionHandler }
+        internal var wrappedComponent: Component { coreActionHandler }
 
-    internal let coreActionHandler: AnyThreeDS2CoreActionHandler
+        internal let coreActionHandler: AnyThreeDS2CoreActionHandler
     
-    internal weak var presentationDelegate: Adyen.PresentationDelegate? {
-        didSet {
-            coreActionHandler.presentationDelegate = presentationDelegate
+        internal weak var presentationDelegate: Adyen.PresentationDelegate? {
+            didSet {
+                coreActionHandler.presentationDelegate = presentationDelegate
+            }
         }
-    }
 
-    /// `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
-    internal var threeDSRequestorAppURL: URL? {
-        get {
-            coreActionHandler.threeDSRequestorAppURL
-        }
+        /// `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
+        internal var threeDSRequestorAppURL: URL? {
+            get {
+                coreActionHandler.threeDSRequestorAppURL
+            }
         
-        set {
-            coreActionHandler.threeDSRequestorAppURL = newValue
+            set {
+                coreActionHandler.threeDSRequestorAppURL = newValue
+            }
         }
-    }
     
-    internal init(
-        context: AdyenContext,
-        appearanceConfiguration: ADYAppearanceConfiguration,
-        service: ThreeDSService,
-        coreActionHandler: AnyThreeDS2CoreActionHandler? = nil,
-        delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication? = nil
-    ) {
-        self.coreActionHandler = coreActionHandler ?? createDefaultThreeDS2CoreActionHandler(
-            context: context,
-            service: service,
-            appearanceConfiguration: appearanceConfiguration,
-            delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
-        )
-        self.context = context
+        internal init(
+            context: AdyenContext,
+            appearanceConfiguration: ADYAppearanceConfiguration,
+            service: ThreeDSService,
+            coreActionHandler: AnyThreeDS2CoreActionHandler? = nil,
+            delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication? = nil
+        ) {
+            self.coreActionHandler = coreActionHandler ?? createDefaultThreeDS2CoreActionHandler(
+                context: context,
+                service: service,
+                appearanceConfiguration: appearanceConfiguration,
+                delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
+            )
+            self.context = context
+        }
+
+        // MARK: - Fingerprint
+
+        /// Handles the 3D Secure 2 fingerprint action.
+        ///
+        /// - Parameter fingerprintAction: The fingerprint action as received from the Checkout API.
+        /// - Parameter completionHandler: The completion closure.
+        internal func handle(
+            _ fingerprintAction: ThreeDS2FingerprintAction,
+            completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
+        ) {
+            let event = Analytics.Event(
+                component: fingerprintEventName,
+                flavor: _isDropIn ? .dropin : .components,
+                environment: context.apiContext.environment
+            )
+            coreActionHandler.handle(fingerprintAction, event: event) { result in
+                switch result {
+                case let .success(encodedFingerprint):
+                    let additionalDetails = ThreeDS2Details.fingerprint(encodedFingerprint)
+                    let result = ThreeDSActionHandlerResult.details(additionalDetails)
+                    completionHandler(.success(result))
+                case let .failure(error):
+                    completionHandler(.failure(error))
+                }
+            }
+        }
+
+        // MARK: - Challenge
+
+        /// Handles the 3D Secure 2 challenge action.
+        ///
+        /// - Parameter challengeAction: The challenge action as received from the Checkout API.
+        /// - Parameter completionHandler: The completion closure.
+        internal func handle(
+            _ challengeAction: ThreeDS2ChallengeAction,
+            completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
+        ) {
+            let event = Analytics.Event(
+                component: challengeEventName,
+                flavor: _isDropIn ? .dropin : .components,
+                environment: context.apiContext.environment
+            )
+            coreActionHandler.handle(challengeAction, event: event) { result in
+                switch result {
+                case let .success(result):
+                    let additionalDetails = ThreeDS2Details.challengeResult(result)
+                    completionHandler(.success(.details(additionalDetails)))
+                case let .failure(error):
+                    completionHandler(.failure(error))
+                }
+            }
+        }
+
+        // MARK: - Private
+
+        private let fingerprintEventName = "3ds2fingerprint"
+
+        private let challengeEventName = "3ds2challenge"
+
     }
 
-    // MARK: - Fingerprint
-
-    /// Handles the 3D Secure 2 fingerprint action.
-    ///
-    /// - Parameter fingerprintAction: The fingerprint action as received from the Checkout API.
-    /// - Parameter completionHandler: The completion closure.
-    internal func handle(
-        _ fingerprintAction: ThreeDS2FingerprintAction,
-        completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
-    ) {
-        let event = Analytics.Event(
-            component: fingerprintEventName,
-            flavor: _isDropIn ? .dropin : .components,
-            environment: context.apiContext.environment
-        )
-        coreActionHandler.handle(fingerprintAction, event: event) { result in
-            switch result {
-            case let .success(encodedFingerprint):
-                let additionalDetails = ThreeDS2Details.fingerprint(encodedFingerprint)
-                let result = ThreeDSActionHandlerResult.details(additionalDetails)
-                completionHandler(.success(result))
-            case let .failure(error):
-                completionHandler(.failure(error))
-            }
+    extension ThreeDS2ClassicActionHandler: PresentationDelegate {
+        func present(component: any Adyen.PresentableComponent) {
+            presentationDelegate?.present(component: component)
         }
     }
 
-    // MARK: - Challenge
-
-    /// Handles the 3D Secure 2 challenge action.
-    ///
-    /// - Parameter challengeAction: The challenge action as received from the Checkout API.
-    /// - Parameter completionHandler: The completion closure.
-    internal func handle(
-        _ challengeAction: ThreeDS2ChallengeAction,
-        completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
-    ) {
-        let event = Analytics.Event(
-            component: challengeEventName,
-            flavor: _isDropIn ? .dropin : .components,
-            environment: context.apiContext.environment
-        )
-        coreActionHandler.handle(challengeAction, event: event) { result in
-            switch result {
-            case let .success(result):
-                let additionalDetails = ThreeDS2Details.challengeResult(result)
-                completionHandler(.success(.details(additionalDetails)))
-            case let .failure(error):
-                completionHandler(.failure(error))
-            }
-        }
-    }
-
-    // MARK: - Private
-
-    private let fingerprintEventName = "3ds2fingerprint"
-
-    private let challengeEventName = "3ds2challenge"
-
-}
-
-extension ThreeDS2ClassicActionHandler: PresentationDelegate {
-    func present(component: any Adyen.PresentableComponent) {
-        presentationDelegate?.present(component: component)
-    }
-}
+#endif

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler+Initializers.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler+Initializers.swift
@@ -4,36 +4,40 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
-import Adyen3DS2
-import Foundation
-#if canImport(AdyenAuthentication)
-    import AdyenAuthentication
-#endif
+#if canImport(Adyen3DS2)
 
-extension ThreeDS2CompactActionHandler {
+    @_spi(AdyenInternal) import Adyen
+    import Adyen3DS2
+    import Foundation
+    #if canImport(AdyenAuthentication)
+        import AdyenAuthentication
+    #endif
+
+    extension ThreeDS2CompactActionHandler {
     
-    /// Initializes the 3D Secure 2 action handler.
-    internal convenience init(
-        context: AdyenContext,
-        service: ThreeDSService,
-        appearanceConfiguration: ADYAppearanceConfiguration,
-        delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication?
-    ) {
+        /// Initializes the 3D Secure 2 action handler.
+        internal convenience init(
+            context: AdyenContext,
+            service: ThreeDSService,
+            appearanceConfiguration: ADYAppearanceConfiguration,
+            delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication?
+        ) {
         
-        let fingerprintSubmitter = ThreeDS2FingerprintSubmitter(context: context)
-        self.init(
-            context: context,
-            fingerprintSubmitter: fingerprintSubmitter,
-            appearanceConfiguration: appearanceConfiguration,
-            service: service,
-            coreActionHandler: createDefaultThreeDS2CoreActionHandler(
+            let fingerprintSubmitter = ThreeDS2FingerprintSubmitter(context: context)
+            self.init(
                 context: context,
-                service: service,
+                fingerprintSubmitter: fingerprintSubmitter,
                 appearanceConfiguration: appearanceConfiguration,
+                service: service,
+                coreActionHandler: createDefaultThreeDS2CoreActionHandler(
+                    context: context,
+                    service: service,
+                    appearanceConfiguration: appearanceConfiguration,
+                    delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
+                ),
                 delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
-            ),
-            delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
-        )
+            )
+        }
     }
-}
+
+#endif

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
@@ -4,121 +4,125 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
-import Adyen3DS2
-import Foundation
+#if canImport(Adyen3DS2)
 
-/// Handles the 3D Secure 2 fingerprint and challenge in one call using a `fingerprintSubmitter`.
-internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, ComponentWrapper {
-    
-    // MARK: - Private
+    @_spi(AdyenInternal) import Adyen
+    import Adyen3DS2
+    import Foundation
 
-    private let fingerprintSubmitter: AnyThreeDS2FingerprintSubmitter
+    /// Handles the 3D Secure 2 fingerprint and challenge in one call using a `fingerprintSubmitter`.
+    internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, ComponentWrapper {
+    
+        // MARK: - Private
 
-    private let threeDS2EventName = "3ds2"
+        private let fingerprintSubmitter: AnyThreeDS2FingerprintSubmitter
+
+        private let threeDS2EventName = "3ds2"
     
-    // MARK: - Internal
+        // MARK: - Internal
     
-    internal weak var presentationDelegate: Adyen.PresentationDelegate? {
-        didSet {
-            coreActionHandler.presentationDelegate = presentationDelegate
+        internal weak var presentationDelegate: Adyen.PresentationDelegate? {
+            didSet {
+                coreActionHandler.presentationDelegate = presentationDelegate
+            }
         }
-    }
 
-    internal var wrappedComponent: Component { coreActionHandler }
+        internal var wrappedComponent: Component { coreActionHandler }
 
-    internal let coreActionHandler: AnyThreeDS2CoreActionHandler
+        internal let coreActionHandler: AnyThreeDS2CoreActionHandler
     
-    /// `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
-    internal var threeDSRequestorAppURL: URL? {
-        get {
-            coreActionHandler.threeDSRequestorAppURL
-        }
+        /// `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
+        internal var threeDSRequestorAppURL: URL? {
+            get {
+                coreActionHandler.threeDSRequestorAppURL
+            }
         
-        set {
-            coreActionHandler.threeDSRequestorAppURL = newValue
+            set {
+                coreActionHandler.threeDSRequestorAppURL = newValue
+            }
         }
-    }
     
-    internal var context: AdyenContext
+        internal var context: AdyenContext
     
-    /// Initializes the 3D Secure 2 action handler.
-    ///
-    /// - Parameter context: The context object for this component.
-    /// - Parameter fingerprintSubmitter: The fingerprint submitter.
-    /// - Parameter service: The 3DS2 Service.
-    /// - Parameter appearanceConfiguration: The appearance configuration of the 3D Secure 2 challenge UI.
-    /// - Parameter delegatedAuthenticationConfiguration: The delegated authentication configuration.
-    internal init(
-        context: AdyenContext,
-        fingerprintSubmitter: AnyThreeDS2FingerprintSubmitter? = nil,
-        appearanceConfiguration: ADYAppearanceConfiguration,
-        service: ThreeDSService,
-        coreActionHandler: AnyThreeDS2CoreActionHandler? = nil,
-        delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication? = nil
-    ) {
-        self.context = context
-        self.coreActionHandler = coreActionHandler ?? createDefaultThreeDS2CoreActionHandler(
-            context: context,
-            service: service,
-            appearanceConfiguration: appearanceConfiguration,
-            delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
-        )
-        self.fingerprintSubmitter = fingerprintSubmitter ?? ThreeDS2FingerprintSubmitter(context: context)
-    }
+        /// Initializes the 3D Secure 2 action handler.
+        ///
+        /// - Parameter context: The context object for this component.
+        /// - Parameter fingerprintSubmitter: The fingerprint submitter.
+        /// - Parameter service: The 3DS2 Service.
+        /// - Parameter appearanceConfiguration: The appearance configuration of the 3D Secure 2 challenge UI.
+        /// - Parameter delegatedAuthenticationConfiguration: The delegated authentication configuration.
+        internal init(
+            context: AdyenContext,
+            fingerprintSubmitter: AnyThreeDS2FingerprintSubmitter? = nil,
+            appearanceConfiguration: ADYAppearanceConfiguration,
+            service: ThreeDSService,
+            coreActionHandler: AnyThreeDS2CoreActionHandler? = nil,
+            delegatedAuthenticationConfiguration: ThreeDS2Component.Configuration.DelegatedAuthentication? = nil
+        ) {
+            self.context = context
+            self.coreActionHandler = coreActionHandler ?? createDefaultThreeDS2CoreActionHandler(
+                context: context,
+                service: service,
+                appearanceConfiguration: appearanceConfiguration,
+                delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
+            )
+            self.fingerprintSubmitter = fingerprintSubmitter ?? ThreeDS2FingerprintSubmitter(context: context)
+        }
 
-    // MARK: - Fingerprint
+        // MARK: - Fingerprint
 
-    /// Handles the 3D Secure 2 fingerprint action using full flow.
-    ///
-    /// - Parameter fingerprintAction: The fingerprint action as received from the Checkout API.
-    /// - Parameter completionHandler: The completion closure.
-    internal func handle(
-        _ fingerprintAction: ThreeDS2FingerprintAction,
-        completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
-    ) {
-        let event = Analytics.Event(
-            component: "\(threeDS2EventName).fingerprint",
-            flavor: _isDropIn ? .dropin : .components,
-            environment: context.apiContext.environment
-        )
-        coreActionHandler.handle(fingerprintAction, event: event) { [weak self] result in
-            switch result {
-            case let .success(encodedFingerprint):
-                self?.fingerprintSubmitter.submit(
-                    fingerprint: encodedFingerprint,
-                    paymentData: fingerprintAction.paymentData,
-                    completionHandler: completionHandler
-                )
-            case let .failure(error):
-                completionHandler(.failure(error))
+        /// Handles the 3D Secure 2 fingerprint action using full flow.
+        ///
+        /// - Parameter fingerprintAction: The fingerprint action as received from the Checkout API.
+        /// - Parameter completionHandler: The completion closure.
+        internal func handle(
+            _ fingerprintAction: ThreeDS2FingerprintAction,
+            completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
+        ) {
+            let event = Analytics.Event(
+                component: "\(threeDS2EventName).fingerprint",
+                flavor: _isDropIn ? .dropin : .components,
+                environment: context.apiContext.environment
+            )
+            coreActionHandler.handle(fingerprintAction, event: event) { [weak self] result in
+                switch result {
+                case let .success(encodedFingerprint):
+                    self?.fingerprintSubmitter.submit(
+                        fingerprint: encodedFingerprint,
+                        paymentData: fingerprintAction.paymentData,
+                        completionHandler: completionHandler
+                    )
+                case let .failure(error):
+                    completionHandler(.failure(error))
+                }
+            }
+        }
+
+        // MARK: - Challenge
+
+        /// Handles the 3D Secure 2 challenge action.
+        ///
+        /// - Parameter challengeAction: The challenge action as received from the Checkout API.
+        /// - Parameter completionHandler: The completion closure.
+        internal func handle(
+            _ challengeAction: ThreeDS2ChallengeAction,
+            completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
+        ) {
+            let event = Analytics.Event(
+                component: "\(threeDS2EventName).challenge",
+                flavor: _isDropIn ? .dropin : .components,
+                environment: context.apiContext.environment
+            )
+            coreActionHandler.handle(challengeAction, event: event) { result in
+                switch result {
+                case let .success(result):
+                    let additionalDetails = ThreeDS2Details.completed(result)
+                    completionHandler(.success(.details(additionalDetails)))
+                case let .failure(error):
+                    completionHandler(.failure(error))
+                }
             }
         }
     }
 
-    // MARK: - Challenge
-
-    /// Handles the 3D Secure 2 challenge action.
-    ///
-    /// - Parameter challengeAction: The challenge action as received from the Checkout API.
-    /// - Parameter completionHandler: The completion closure.
-    internal func handle(
-        _ challengeAction: ThreeDS2ChallengeAction,
-        completionHandler: @escaping (Result<ThreeDSActionHandlerResult, Error>) -> Void
-    ) {
-        let event = Analytics.Event(
-            component: "\(threeDS2EventName).challenge",
-            flavor: _isDropIn ? .dropin : .components,
-            environment: context.apiContext.environment
-        )
-        coreActionHandler.handle(challengeAction, event: event) { result in
-            switch result {
-            case let .success(result):
-                let additionalDetails = ThreeDS2Details.completed(result)
-                completionHandler(.success(.details(additionalDetails)))
-            case let .failure(error):
-                completionHandler(.failure(error))
-            }
-        }
-    }
-}
+#endif

--- a/AdyenActions/Components/3DS2/ThreeDS2Component.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2Component.swift
@@ -5,300 +5,305 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
 import Foundation
 
 internal protocol AnyRedirectComponent: ActionComponent {
     func handle(_ action: RedirectAction)
 }
 
-/// Handles the 3D Secure 2 fingerprint and challenge.
-public final class ThreeDS2Component: ActionComponent {
-    
-    /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
-    /// The delegate of the component.
-    public weak var delegate: ActionComponentDelegate?
+#if canImport(Adyen3DS2)
 
-    /// Delegates `PresentableComponent`'s presentation.  This property must be set if you wish to use delegated authentication.
-    public weak var presentationDelegate: PresentationDelegate? {
-        didSet {
-            threeDS2ClassicFlowHandler.presentationDelegate = presentationDelegate
-            threeDS2CompactFlowHandler.presentationDelegate = presentationDelegate
-        }
-    }
+    import Adyen3DS2
+
+    /// Handles the 3D Secure 2 fingerprint and challenge.
+    public final class ThreeDS2Component: ActionComponent {
     
-    /// Three DS2 component configurations.
-    public var configuration: Configuration {
-        didSet {
-            updateConfiguration()
-        }
-    }
+        /// The context object for this component.
+        @_spi(AdyenInternal)
+        public let context: AdyenContext
     
-    /// Three DS2 component configurations.
-    public struct Configuration {
-        
-        /// ``RedirectComponent`` style
-        public var redirectComponentStyle: RedirectComponentStyle?
-        
-        /// The appearance configuration of the 3D Secure 2 challenge UI.
-        public var appearanceConfiguration = ADYAppearanceConfiguration()
-        
-        /// `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
-        public var requestorAppURL: URL?
-        
-        /// The configuration for Delegated Authentication.
-        public let delegateAuthentication: DelegatedAuthentication?
-        
-        /// The configuration for Delegated Authentication.
-        public struct DelegatedAuthentication {
-            // The relying party identifier that is used for PassKeys.
-            // See: https://developer.apple.com/documentation/xcode/supporting-associated-domains
-            // See: https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication/supporting_passkeys
-            public let relyingPartyIdentifier: String
+        /// The delegate of the component.
+        public weak var delegate: ActionComponentDelegate?
 
-            /// The configuration for Delegated Authentication Component style
-            public let delegatedAuthenticationComponentStyle: DelegatedAuthenticationComponentStyle
-
-            /// The localization parameters, leave it nil to use the default parameters.
-            public let localizationParameters: LocalizationParameters?
-
-            /// Initializes a new instance.
-            ///
-            /// - Parameter relyingPartyIdentifier: The relying party identifier that is used for PassKeys
-            /// - Parameter delegatedAuthenticationComponentStyle: The delegated authentication component style.
-            /// - Parameter localizationParameters: The localization parameters, leave it nil to use the default parameters.
-            public init(
-                relyingPartyIdentifier: String,
-                delegatedAuthenticationComponentStyle: DelegatedAuthenticationComponentStyle = .init(),
-                localizationParameters: LocalizationParameters? = nil
-            ) {
-                self.relyingPartyIdentifier = relyingPartyIdentifier
-                self.delegatedAuthenticationComponentStyle = delegatedAuthenticationComponentStyle
-                self.localizationParameters = localizationParameters
+        /// Delegates `PresentableComponent`'s presentation.  This property must be set if you wish to use delegated authentication.
+        public weak var presentationDelegate: PresentationDelegate? {
+            didSet {
+                threeDS2ClassicFlowHandler.presentationDelegate = presentationDelegate
+                threeDS2CompactFlowHandler.presentationDelegate = presentationDelegate
             }
         }
+    
+        /// Three DS2 component configurations.
+        public var configuration: Configuration {
+            didSet {
+                updateConfiguration()
+            }
+        }
+    
+        /// Three DS2 component configurations.
+        public struct Configuration {
         
-        /// Initializes a new instance
+            /// ``RedirectComponent`` style
+            public var redirectComponentStyle: RedirectComponentStyle?
+        
+            /// The appearance configuration of the 3D Secure 2 challenge UI.
+            public var appearanceConfiguration = ADYAppearanceConfiguration()
+        
+            /// `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
+            public var requestorAppURL: URL?
+        
+            /// The configuration for Delegated Authentication.
+            public let delegateAuthentication: DelegatedAuthentication?
+        
+            /// The configuration for Delegated Authentication.
+            public struct DelegatedAuthentication {
+                // The relying party identifier that is used for PassKeys.
+                // See: https://developer.apple.com/documentation/xcode/supporting-associated-domains
+                // See: https://developer.apple.com/documentation/authenticationservices/public-private_key_authentication/supporting_passkeys
+                public let relyingPartyIdentifier: String
+
+                /// The configuration for Delegated Authentication Component style
+                public let delegatedAuthenticationComponentStyle: DelegatedAuthenticationComponentStyle
+
+                /// The localization parameters, leave it nil to use the default parameters.
+                public let localizationParameters: LocalizationParameters?
+
+                /// Initializes a new instance.
+                ///
+                /// - Parameter relyingPartyIdentifier: The relying party identifier that is used for PassKeys
+                /// - Parameter delegatedAuthenticationComponentStyle: The delegated authentication component style.
+                /// - Parameter localizationParameters: The localization parameters, leave it nil to use the default parameters.
+                public init(
+                    relyingPartyIdentifier: String,
+                    delegatedAuthenticationComponentStyle: DelegatedAuthenticationComponentStyle = .init(),
+                    localizationParameters: LocalizationParameters? = nil
+                ) {
+                    self.relyingPartyIdentifier = relyingPartyIdentifier
+                    self.delegatedAuthenticationComponentStyle = delegatedAuthenticationComponentStyle
+                    self.localizationParameters = localizationParameters
+                }
+            }
+        
+            /// Initializes a new instance
+            ///
+            /// - Parameters:
+            ///   - redirectComponentStyle: `RedirectComponent` style
+            ///   - appearanceConfiguration: The appearance configuration of the 3D Secure 2 challenge UI.
+            ///   - requestorAppURL: `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
+            ///   - delegateAuthentication: The configuration for delegate authentication
+            public init(
+                redirectComponentStyle: RedirectComponentStyle? = nil,
+                appearanceConfiguration: ADYAppearanceConfiguration = ADYAppearanceConfiguration(),
+                requestorAppURL: URL? = nil,
+                delegateAuthentication: DelegatedAuthentication? = nil
+            ) {
+                self.redirectComponentStyle = redirectComponentStyle
+                self.appearanceConfiguration = appearanceConfiguration
+                self.requestorAppURL = requestorAppURL
+                self.delegateAuthentication = delegateAuthentication
+            }
+        }
+    
+        /// Initializes the 3D Secure 2 component.
+        ///
+        /// - Parameter context: The context object for this component.
+        /// - Parameter configuration: The component's configuration.
+        public init(
+            context: AdyenContext,
+            configuration: Configuration = Configuration()
+        ) {
+            self.context = context
+            self.configuration = configuration
+
+            self.updateConfiguration()
+        }
+    
+        /// Initializes the 3D Secure 2 component.
         ///
         /// - Parameters:
-        ///   - redirectComponentStyle: `RedirectComponent` style
-        ///   - appearanceConfiguration: The appearance configuration of the 3D Secure 2 challenge UI.
-        ///   - requestorAppURL: `threeDSRequestorAppURL` for protocol version 2.2.0 OOB challenges
-        ///   - delegateAuthentication: The configuration for delegate authentication
-        public init(
-            redirectComponentStyle: RedirectComponentStyle? = nil,
-            appearanceConfiguration: ADYAppearanceConfiguration = ADYAppearanceConfiguration(),
-            requestorAppURL: URL? = nil,
-            delegateAuthentication: DelegatedAuthentication? = nil
+        ///   - context: The  Adyen context.
+        ///   - threeDS2CompactFlowHandler: The internal `AnyThreeDS2ActionHandler` for the compact flow.
+        ///   - threeDS2ClassicFlowHandler: The internal `AnyThreeDS2ActionHandler` for the classic flow.
+        ///   - redirectComponent: The redirect component.
+        ///   - redirectComponentStyle: `RedirectComponent` style.
+        internal convenience init(
+            context: AdyenContext,
+            threeDS2CompactFlowHandler: AnyThreeDS2ActionHandler,
+            threeDS2ClassicFlowHandler: AnyThreeDS2ActionHandler,
+            redirectComponent: AnyRedirectComponent,
+            configuration: Configuration = Configuration()
         ) {
-            self.redirectComponentStyle = redirectComponentStyle
-            self.appearanceConfiguration = appearanceConfiguration
-            self.requestorAppURL = requestorAppURL
-            self.delegateAuthentication = delegateAuthentication
+            self.init(
+                context: context,
+                configuration: configuration
+            )
+            self.threeDS2CompactFlowHandler = threeDS2CompactFlowHandler
+            self.threeDS2ClassicFlowHandler = threeDS2ClassicFlowHandler
+            self.redirectComponent = redirectComponent
+            self.updateConfiguration()
         }
-    }
     
-    /// Initializes the 3D Secure 2 component.
-    ///
-    /// - Parameter context: The context object for this component.
-    /// - Parameter configuration: The component's configuration.
-    public init(
-        context: AdyenContext,
-        configuration: Configuration = Configuration()
-    ) {
-        self.context = context
-        self.configuration = configuration
+        private func updateConfiguration() {
+            let threeDSRequestorAppURL = configuration.requestorAppURL
+            threeDS2ClassicFlowHandler.threeDSRequestorAppURL = threeDSRequestorAppURL
+            threeDS2CompactFlowHandler.threeDSRequestorAppURL = threeDSRequestorAppURL
+        }
 
-        self.updateConfiguration()
-    }
+        // MARK: - 3D Secure 2 action
     
-    /// Initializes the 3D Secure 2 component.
-    ///
-    /// - Parameters:
-    ///   - context: The  Adyen context.
-    ///   - threeDS2CompactFlowHandler: The internal `AnyThreeDS2ActionHandler` for the compact flow.
-    ///   - threeDS2ClassicFlowHandler: The internal `AnyThreeDS2ActionHandler` for the classic flow.
-    ///   - redirectComponent: The redirect component.
-    ///   - redirectComponentStyle: `RedirectComponent` style.
-    internal convenience init(
-        context: AdyenContext,
-        threeDS2CompactFlowHandler: AnyThreeDS2ActionHandler,
-        threeDS2ClassicFlowHandler: AnyThreeDS2ActionHandler,
-        redirectComponent: AnyRedirectComponent,
-        configuration: Configuration = Configuration()
-    ) {
-        self.init(
-            context: context,
-            configuration: configuration
-        )
-        self.threeDS2CompactFlowHandler = threeDS2CompactFlowHandler
-        self.threeDS2ClassicFlowHandler = threeDS2ClassicFlowHandler
-        self.redirectComponent = redirectComponent
-        self.updateConfiguration()
-    }
-    
-    private func updateConfiguration() {
-        let threeDSRequestorAppURL = configuration.requestorAppURL
-        threeDS2ClassicFlowHandler.threeDSRequestorAppURL = threeDSRequestorAppURL
-        threeDS2CompactFlowHandler.threeDSRequestorAppURL = threeDSRequestorAppURL
-    }
-
-    // MARK: - 3D Secure 2 action
-    
-    /// Handles the 3D Secure 2 action.
-    ///
-    /// - Parameter threeDS2Action: The 3D Secure 2 action as received from the Checkout API.
-    public func handle(_ threeDS2Action: ThreeDS2Action) {
-        switch threeDS2Action {
-        case let .fingerprint(fingerprintAction):
-            threeDS2CompactFlowHandler.handle(fingerprintAction) { [weak self] result in
-                self?.didReceive(result, paymentData: nil)
-            }
-        case let .challenge(challengeAction):
-            threeDS2CompactFlowHandler.handle(challengeAction) { [weak self] result in
-                self?.didReceive(result, paymentData: nil)
+        /// Handles the 3D Secure 2 action.
+        ///
+        /// - Parameter threeDS2Action: The 3D Secure 2 action as received from the Checkout API.
+        public func handle(_ threeDS2Action: ThreeDS2Action) {
+            switch threeDS2Action {
+            case let .fingerprint(fingerprintAction):
+                threeDS2CompactFlowHandler.handle(fingerprintAction) { [weak self] result in
+                    self?.didReceive(result, paymentData: nil)
+                }
+            case let .challenge(challengeAction):
+                threeDS2CompactFlowHandler.handle(challengeAction) { [weak self] result in
+                    self?.didReceive(result, paymentData: nil)
+                }
             }
         }
-    }
 
-    // MARK: - Fingerprint
+        // MARK: - Fingerprint
 
-    /// Handles the 3D Secure 2 fingerprint action.
-    ///
-    /// - Parameter fingerprintAction: The fingerprint action as received from the Checkout API.
-    public func handle(_ fingerprintAction: ThreeDS2FingerprintAction) {
-        threeDS2ClassicFlowHandler.handle(fingerprintAction) { [weak self] result in
-            self?.didReceive(result, paymentData: fingerprintAction.paymentData)
+        /// Handles the 3D Secure 2 fingerprint action.
+        ///
+        /// - Parameter fingerprintAction: The fingerprint action as received from the Checkout API.
+        public func handle(_ fingerprintAction: ThreeDS2FingerprintAction) {
+            threeDS2ClassicFlowHandler.handle(fingerprintAction) { [weak self] result in
+                self?.didReceive(result, paymentData: fingerprintAction.paymentData)
+            }
         }
-    }
     
-    // MARK: - Challenge
+        // MARK: - Challenge
     
-    /// Handles the 3D Secure 2 challenge action.
-    ///
-    /// - Parameter challengeAction: The challenge action as received from the Checkout API.
-    public func handle(_ challengeAction: ThreeDS2ChallengeAction) {
-        threeDS2ClassicFlowHandler.handle(challengeAction) { [weak self] result in
-            self?.didReceive(result, paymentData: challengeAction.paymentData)
+        /// Handles the 3D Secure 2 challenge action.
+        ///
+        /// - Parameter challengeAction: The challenge action as received from the Checkout API.
+        public func handle(_ challengeAction: ThreeDS2ChallengeAction) {
+            threeDS2ClassicFlowHandler.handle(challengeAction) { [weak self] result in
+                self?.didReceive(result, paymentData: challengeAction.paymentData)
+            }
         }
-    }
     
-    // MARK: - Private
+        // MARK: - Private
 
-    private func didReceive(_ result: Result<ThreeDSActionHandlerResult, Swift.Error>, paymentData: String?) {
-        switch result {
-        case let .success(result):
-            didReceive(result, paymentData: paymentData)
-        case let .failure(error):
-            didFail(with: error)
+        private func didReceive(_ result: Result<ThreeDSActionHandlerResult, Swift.Error>, paymentData: String?) {
+            switch result {
+            case let .success(result):
+                didReceive(result, paymentData: paymentData)
+            case let .failure(error):
+                didFail(with: error)
+            }
         }
-    }
 
-    private func didReceive(_ result: ThreeDSActionHandlerResult, paymentData: String?) {
-        switch result {
-        case let .action(action):
-            didReceive(action)
-        case let .details(details):
-            let data = ActionComponentData(details: details, paymentData: paymentData)
-            didFinish(data: data)
+        private func didReceive(_ result: ThreeDSActionHandlerResult, paymentData: String?) {
+            switch result {
+            case let .action(action):
+                didReceive(action)
+            case let .details(details):
+                let data = ActionComponentData(details: details, paymentData: paymentData)
+                didFinish(data: data)
+            }
         }
-    }
 
-    private func didReceive(_ action: Action) {
-        switch action {
-        case let .redirect(redirectAction):
-            redirectComponent.handle(redirectAction)
-        case let .threeDS2(threeDS2Action):
-            handle(threeDS2Action)
-        default:
-            didFail(with: Error.unexpectedAction)
+        private func didReceive(_ action: Action) {
+            switch action {
+            case let .redirect(redirectAction):
+                redirectComponent.handle(redirectAction)
+            case let .threeDS2(threeDS2Action):
+                handle(threeDS2Action)
+            default:
+                didFail(with: Error.unexpectedAction)
+            }
         }
+
+        private func didFinish(data: ActionComponentData) {
+            delegate?.didProvide(data, from: self)
+        }
+
+        private func didFail(with error: Swift.Error) {
+            delegate?.didFail(with: error, from: self)
+        }
+
+        internal lazy var threeDS2CompactFlowHandler: AnyThreeDS2ActionHandler = {
+            let handler = ThreeDS2CompactActionHandler(
+                context: context,
+                service: ThreeDSServiceProvider(),
+                appearanceConfiguration: configuration.appearanceConfiguration,
+                delegatedAuthenticationConfiguration: configuration.delegateAuthentication
+            )
+            handler.presentationDelegate = presentationDelegate
+            handler._isDropIn = _isDropIn
+            handler.threeDSRequestorAppURL = configuration.requestorAppURL
+
+            return handler
+        }()
+
+        internal lazy var threeDS2ClassicFlowHandler: AnyThreeDS2ActionHandler = {
+            let handler = ThreeDS2ClassicActionHandler(
+                context: context,
+                service: ThreeDSServiceProvider(),
+                appearanceConfiguration: configuration.appearanceConfiguration,
+                delegatedAuthenticationConfiguration: configuration.delegateAuthentication
+            )
+            handler.presentationDelegate = presentationDelegate
+            handler._isDropIn = _isDropIn
+            handler.threeDSRequestorAppURL = configuration.requestorAppURL
+            return handler
+        }()
+
+        private lazy var redirectComponent: AnyRedirectComponent = {
+            let component = RedirectComponent(context: context)
+            component.configuration.style = configuration.redirectComponentStyle
+
+            component.delegate = self
+            component._isDropIn = _isDropIn
+            component.presentationDelegate = presentationDelegate
+
+            return component
+        }()
     }
 
-    private func didFinish(data: ActionComponentData) {
-        delegate?.didProvide(data, from: self)
-    }
+    // This is for the RedirectComponent inside the ThreeDS2Component
+    extension ThreeDS2Component: ActionComponentDelegate {
 
-    private func didFail(with error: Swift.Error) {
-        delegate?.didFail(with: error, from: self)
-    }
+        public func didOpenExternalApplication(component: ActionComponent) {
+            delegate?.didOpenExternalApplication(component: self)
+        }
 
-    internal lazy var threeDS2CompactFlowHandler: AnyThreeDS2ActionHandler = {
-        let handler = ThreeDS2CompactActionHandler(
-            context: context,
-            service: ThreeDSServiceProvider(),
-            appearanceConfiguration: configuration.appearanceConfiguration,
-            delegatedAuthenticationConfiguration: configuration.delegateAuthentication
-        )
-        handler.presentationDelegate = presentationDelegate
-        handler._isDropIn = _isDropIn
-        handler.threeDSRequestorAppURL = configuration.requestorAppURL
+        public func didProvide(_ data: ActionComponentData, from component: ActionComponent) {
+            delegate?.didProvide(data, from: self)
+        }
 
-        return handler
-    }()
+        public func didComplete(from component: ActionComponent) {
+            delegate?.didComplete(from: self)
+        }
 
-    internal lazy var threeDS2ClassicFlowHandler: AnyThreeDS2ActionHandler = {
-        let handler = ThreeDS2ClassicActionHandler(
-            context: context,
-            service: ThreeDSServiceProvider(),
-            appearanceConfiguration: configuration.appearanceConfiguration,
-            delegatedAuthenticationConfiguration: configuration.delegateAuthentication
-        )
-        handler.presentationDelegate = presentationDelegate
-        handler._isDropIn = _isDropIn
-        handler.threeDSRequestorAppURL = configuration.requestorAppURL
-        return handler
-    }()
-
-    private lazy var redirectComponent: AnyRedirectComponent = {
-        let component = RedirectComponent(context: context)
-        component.configuration.style = configuration.redirectComponentStyle
-
-        component.delegate = self
-        component._isDropIn = _isDropIn
-        component.presentationDelegate = presentationDelegate
-
-        return component
-    }()
-}
-
-// This is for the RedirectComponent inside the ThreeDS2Component
-extension ThreeDS2Component: ActionComponentDelegate {
-
-    public func didOpenExternalApplication(component: ActionComponent) {
-        delegate?.didOpenExternalApplication(component: self)
-    }
-
-    public func didProvide(_ data: ActionComponentData, from component: ActionComponent) {
-        delegate?.didProvide(data, from: self)
-    }
-
-    public func didComplete(from component: ActionComponent) {
-        delegate?.didComplete(from: self)
-    }
-
-    public func didFail(with error: Swift.Error, from component: ActionComponent) {
-        delegate?.didFail(with: error, from: self)
-    }
-
-}
-
-extension ThreeDS2Component {
-
-    /// An error that occurred during the use of the 3D Secure 2 component.
-    public enum Error: Swift.Error {
-
-        /// Indicates that the challenge action was provided while no 3D Secure transaction was active.
-        /// This is likely the result of calling handle(_:) with a challenge action after the challenge was already completed,
-        /// or before a fingerprint action was provided.
-        case missingTransaction
-
-        /// Indicates that the Checkout API returned an unexpected `Action` during processing the 3DS2 flow.
-        case unexpectedAction
+        public func didFail(with error: Swift.Error, from component: ActionComponent) {
+            delegate?.didFail(with: error, from: self)
+        }
 
     }
 
-}
+    extension ThreeDS2Component {
+
+        /// An error that occurred during the use of the 3D Secure 2 component.
+        public enum Error: Swift.Error {
+
+            /// Indicates that the challenge action was provided while no 3D Secure transaction was active.
+            /// This is likely the result of calling handle(_:) with a challenge action after the challenge was already completed,
+            /// or before a fingerprint action was provided.
+            case missingTransaction
+
+            /// Indicates that the Checkout API returned an unexpected `Action` during processing the 3DS2 flow.
+            case unexpectedAction
+
+        }
+
+    }
+
+#endif

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentChallengeToken.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentChallengeToken.swift
@@ -4,52 +4,56 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
-import Adyen3DS2
-import Foundation
+#if canImport(Adyen3DS2)
 
-internal extension ThreeDS2Component {
+    import Adyen
+    import Adyen3DS2
+    import Foundation
+
+    internal extension ThreeDS2Component {
     
-    struct ChallengeToken: Decodable { // swiftlint:disable:this explicit_acl
+        struct ChallengeToken: Decodable { // swiftlint:disable:this explicit_acl
         
-        internal let acsReferenceNumber: String
-        internal let acsSignedContent: String
-        internal let acsTransactionIdentifier: String
-        internal let serverTransactionIdentifier: String
-        internal let threeDSRequestorAppURL: URL?
-        internal let delegatedAuthenticationSDKInput: String?
-        internal let paymentInfo: PaymentInfo?
+            internal let acsReferenceNumber: String
+            internal let acsSignedContent: String
+            internal let acsTransactionIdentifier: String
+            internal let serverTransactionIdentifier: String
+            internal let threeDSRequestorAppURL: URL?
+            internal let delegatedAuthenticationSDKInput: String?
+            internal let paymentInfo: PaymentInfo?
 
-        // MARK: - Decoding
+            // MARK: - Decoding
         
-        private enum CodingKeys: String, CodingKey {
-            case acsReferenceNumber
-            case acsSignedContent
-            case acsTransactionIdentifier = "acsTransID"
-            case serverTransactionIdentifier = "threeDSServerTransID"
-            case threeDSRequestorAppURL
-            case delegatedAuthenticationSDKInput
-            case paymentInfo
+            private enum CodingKeys: String, CodingKey {
+                case acsReferenceNumber
+                case acsSignedContent
+                case acsTransactionIdentifier = "acsTransID"
+                case serverTransactionIdentifier = "threeDSServerTransID"
+                case threeDSRequestorAppURL
+                case delegatedAuthenticationSDKInput
+                case paymentInfo
+            }
+        
         }
-        
-    }
     
-}
+    }
 
-internal extension ADYChallengeParameters {
+    internal extension ADYChallengeParameters {
     
-    // swiftlint:disable:next explicit_acl
-    convenience init(
-        challengeToken: ThreeDS2Component.ChallengeToken,
-        threeDSRequestorAppURL: URL?
-    ) {
-        self.init(
-            serverTransactionIdentifier: challengeToken.serverTransactionIdentifier,
-            threeDSRequestorAppURL: threeDSRequestorAppURL,
-            acsTransactionIdentifier: challengeToken.acsTransactionIdentifier,
-            acsReferenceNumber: challengeToken.acsReferenceNumber,
-            acsSignedContent: challengeToken.acsSignedContent
-        )
+        // swiftlint:disable:next explicit_acl
+        convenience init(
+            challengeToken: ThreeDS2Component.ChallengeToken,
+            threeDSRequestorAppURL: URL?
+        ) {
+            self.init(
+                serverTransactionIdentifier: challengeToken.serverTransactionIdentifier,
+                threeDSRequestorAppURL: threeDSRequestorAppURL,
+                acsTransactionIdentifier: challengeToken.acsTransactionIdentifier,
+                acsReferenceNumber: challengeToken.acsReferenceNumber,
+                acsSignedContent: challengeToken.acsSignedContent
+            )
+        }
+    
     }
-    
-}
+
+#endif

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprint.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprint.swift
@@ -4,120 +4,124 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
-import Adyen3DS2
-import Foundation
+#if canImport(Adyen3DS2)
 
-internal extension ThreeDS2Component {
+    import Adyen
+    import Adyen3DS2
+    import Foundation
+
+    internal extension ThreeDS2Component {
     
-    struct Fingerprint: Codable, Equatable { // swiftlint:disable:this explicit_acl
-        internal let deviceInformation: String?
-        internal let sdkEphemeralPublicKey: EphemeralPublicKey?
-        internal let sdkReferenceNumber: String?
-        internal let sdkApplicationIdentifier: String?
-        internal let sdkTransactionIdentifier: String?
+        struct Fingerprint: Codable, Equatable { // swiftlint:disable:this explicit_acl
+            internal let deviceInformation: String?
+            internal let sdkEphemeralPublicKey: EphemeralPublicKey?
+            internal let sdkReferenceNumber: String?
+            internal let sdkApplicationIdentifier: String?
+            internal let sdkTransactionIdentifier: String?
 
-        internal let delegatedAuthenticationSDKOutput: String?
-        internal let deleteDelegatedAuthenticationCredential: Bool?
+            internal let delegatedAuthenticationSDKOutput: String?
+            internal let deleteDelegatedAuthenticationCredential: Bool?
 
-        internal let threeDS2SDKError: String?
+            internal let threeDS2SDKError: String?
 
-        internal init(
-            deviceInformation: String?,
-            sdkEphemeralPublicKey: ThreeDS2Component.Fingerprint.EphemeralPublicKey?,
-            sdkReferenceNumber: String?,
-            sdkApplicationIdentifier: String?,
-            sdkTransactionIdentifier: String?,
-            delegatedAuthenticationSDKOutput: String?,
-            deleteDelegatedAuthenticationCredential: Bool?,
-            threeDS2SDKError: String?
-        ) {
-            self.deviceInformation = deviceInformation
-            self.sdkEphemeralPublicKey = sdkEphemeralPublicKey
-            self.sdkReferenceNumber = sdkReferenceNumber
-            self.sdkApplicationIdentifier = sdkApplicationIdentifier
-            self.sdkTransactionIdentifier = sdkTransactionIdentifier
-            self.delegatedAuthenticationSDKOutput = delegatedAuthenticationSDKOutput
-            self.threeDS2SDKError = threeDS2SDKError
-            self.deleteDelegatedAuthenticationCredential = deleteDelegatedAuthenticationCredential
-        }
+            internal init(
+                deviceInformation: String?,
+                sdkEphemeralPublicKey: ThreeDS2Component.Fingerprint.EphemeralPublicKey?,
+                sdkReferenceNumber: String?,
+                sdkApplicationIdentifier: String?,
+                sdkTransactionIdentifier: String?,
+                delegatedAuthenticationSDKOutput: String?,
+                deleteDelegatedAuthenticationCredential: Bool?,
+                threeDS2SDKError: String?
+            ) {
+                self.deviceInformation = deviceInformation
+                self.sdkEphemeralPublicKey = sdkEphemeralPublicKey
+                self.sdkReferenceNumber = sdkReferenceNumber
+                self.sdkApplicationIdentifier = sdkApplicationIdentifier
+                self.sdkTransactionIdentifier = sdkTransactionIdentifier
+                self.delegatedAuthenticationSDKOutput = delegatedAuthenticationSDKOutput
+                self.threeDS2SDKError = threeDS2SDKError
+                self.deleteDelegatedAuthenticationCredential = deleteDelegatedAuthenticationCredential
+            }
         
-        internal init(threeDS2SDKError: String) {
-            self.threeDS2SDKError = threeDS2SDKError
-            self.deleteDelegatedAuthenticationCredential = nil
-            self.deviceInformation = nil
-            self.sdkEphemeralPublicKey = nil
-            self.sdkReferenceNumber = nil
-            self.sdkApplicationIdentifier = nil
-            self.sdkTransactionIdentifier = nil
-            self.delegatedAuthenticationSDKOutput = nil
-        }
+            internal init(threeDS2SDKError: String) {
+                self.threeDS2SDKError = threeDS2SDKError
+                self.deleteDelegatedAuthenticationCredential = nil
+                self.deviceInformation = nil
+                self.sdkEphemeralPublicKey = nil
+                self.sdkReferenceNumber = nil
+                self.sdkApplicationIdentifier = nil
+                self.sdkTransactionIdentifier = nil
+                self.delegatedAuthenticationSDKOutput = nil
+            }
         
-        internal init(
-            authenticationRequestParameters: AnyAuthenticationRequestParameters,
-            delegatedAuthenticationSDKOutput: String?,
-            deleteDelegatedAuthenticationCredential: Bool?
-        ) throws {
-            let sdkEphemeralPublicKeyData = Data(authenticationRequestParameters.sdkEphemeralPublicKey.utf8)
-            let sdkEphemeralPublicKey = try JSONDecoder().decode(EphemeralPublicKey.self, from: sdkEphemeralPublicKeyData)
+            internal init(
+                authenticationRequestParameters: AnyAuthenticationRequestParameters,
+                delegatedAuthenticationSDKOutput: String?,
+                deleteDelegatedAuthenticationCredential: Bool?
+            ) throws {
+                let sdkEphemeralPublicKeyData = Data(authenticationRequestParameters.sdkEphemeralPublicKey.utf8)
+                let sdkEphemeralPublicKey = try JSONDecoder().decode(EphemeralPublicKey.self, from: sdkEphemeralPublicKeyData)
             
-            self.deviceInformation = authenticationRequestParameters.deviceInformation
-            self.sdkEphemeralPublicKey = sdkEphemeralPublicKey
-            self.sdkReferenceNumber = authenticationRequestParameters.sdkReferenceNumber
-            self.sdkApplicationIdentifier = authenticationRequestParameters.sdkApplicationIdentifier
-            self.sdkTransactionIdentifier = authenticationRequestParameters.sdkTransactionIdentifier
-            self.delegatedAuthenticationSDKOutput = delegatedAuthenticationSDKOutput
-            self.deleteDelegatedAuthenticationCredential = deleteDelegatedAuthenticationCredential
-            self.threeDS2SDKError = nil
-        }
+                self.deviceInformation = authenticationRequestParameters.deviceInformation
+                self.sdkEphemeralPublicKey = sdkEphemeralPublicKey
+                self.sdkReferenceNumber = authenticationRequestParameters.sdkReferenceNumber
+                self.sdkApplicationIdentifier = authenticationRequestParameters.sdkApplicationIdentifier
+                self.sdkTransactionIdentifier = authenticationRequestParameters.sdkTransactionIdentifier
+                self.delegatedAuthenticationSDKOutput = delegatedAuthenticationSDKOutput
+                self.deleteDelegatedAuthenticationCredential = deleteDelegatedAuthenticationCredential
+                self.threeDS2SDKError = nil
+            }
         
-        internal func withDelegatedAuthenticationSDKOutput(
-            delegatedAuthenticationSDKOutput: String?,
-            deleteDelegatedAuthenticationCredential: Bool?
-        ) -> Fingerprint {
-            .init(
-                deviceInformation: deviceInformation,
-                sdkEphemeralPublicKey: sdkEphemeralPublicKey,
-                sdkReferenceNumber: sdkReferenceNumber,
-                sdkApplicationIdentifier: sdkApplicationIdentifier,
-                sdkTransactionIdentifier: sdkTransactionIdentifier,
-                delegatedAuthenticationSDKOutput: delegatedAuthenticationSDKOutput,
-                deleteDelegatedAuthenticationCredential: deleteDelegatedAuthenticationCredential,
-                threeDS2SDKError: threeDS2SDKError
-            )
-        }
+            internal func withDelegatedAuthenticationSDKOutput(
+                delegatedAuthenticationSDKOutput: String?,
+                deleteDelegatedAuthenticationCredential: Bool?
+            ) -> Fingerprint {
+                .init(
+                    deviceInformation: deviceInformation,
+                    sdkEphemeralPublicKey: sdkEphemeralPublicKey,
+                    sdkReferenceNumber: sdkReferenceNumber,
+                    sdkApplicationIdentifier: sdkApplicationIdentifier,
+                    sdkTransactionIdentifier: sdkTransactionIdentifier,
+                    delegatedAuthenticationSDKOutput: delegatedAuthenticationSDKOutput,
+                    deleteDelegatedAuthenticationCredential: deleteDelegatedAuthenticationCredential,
+                    threeDS2SDKError: threeDS2SDKError
+                )
+            }
         
-        private enum CodingKeys: String, CodingKey {
-            case deviceInformation = "sdkEncData"
-            case sdkEphemeralPublicKey = "sdkEphemPubKey"
-            case sdkReferenceNumber
-            case sdkApplicationIdentifier = "sdkAppID"
-            case sdkTransactionIdentifier = "sdkTransID"
-            case delegatedAuthenticationSDKOutput
-            case threeDS2SDKError
-            case deleteDelegatedAuthenticationCredential
-        }
+            private enum CodingKeys: String, CodingKey {
+                case deviceInformation = "sdkEncData"
+                case sdkEphemeralPublicKey = "sdkEphemPubKey"
+                case sdkReferenceNumber
+                case sdkApplicationIdentifier = "sdkAppID"
+                case sdkTransactionIdentifier = "sdkTransID"
+                case delegatedAuthenticationSDKOutput
+                case threeDS2SDKError
+                case deleteDelegatedAuthenticationCredential
+            }
         
-    }
+        }
     
-}
+    }
 
-extension ThreeDS2Component.Fingerprint {
+    extension ThreeDS2Component.Fingerprint {
     
-    internal struct EphemeralPublicKey: Codable, Equatable {
+        internal struct EphemeralPublicKey: Codable, Equatable {
         
-        private let keyType: String
-        private let curve: String
-        private let x: String // swiftlint:disable:this identifier_name
-        private let y: String // swiftlint:disable:this identifier_name
+            private let keyType: String
+            private let curve: String
+            private let x: String // swiftlint:disable:this identifier_name
+            private let y: String // swiftlint:disable:this identifier_name
         
-        private enum CodingKeys: String, CodingKey {
-            case keyType = "kty"
-            case curve = "crv"
-            case x // swiftlint:disable:this identifier_name
-            case y // swiftlint:disable:this identifier_name
+            private enum CodingKeys: String, CodingKey {
+                case keyType = "kty"
+                case curve = "crv"
+                case x // swiftlint:disable:this identifier_name
+                case y // swiftlint:disable:this identifier_name
+            }
+        
         }
-        
-    }
     
-}
+    }
+
+#endif

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprintToken.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprintToken.swift
@@ -4,6 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+#if canImport(Adyen3DS2)
+
 import Foundation
 
 internal extension ThreeDS2Component {
@@ -29,3 +31,5 @@ internal extension ThreeDS2Component {
         }
     }
 }
+
+#endif

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprintToken.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprintToken.swift
@@ -6,30 +6,30 @@
 
 #if canImport(Adyen3DS2)
 
-import Foundation
+    import Foundation
 
-internal extension ThreeDS2Component {
+    internal extension ThreeDS2Component {
     
-    struct FingerprintToken: Decodable { // swiftlint:disable:this explicit_acl
+        struct FingerprintToken: Decodable { // swiftlint:disable:this explicit_acl
         
-        internal let directoryServerIdentifier: String
-        internal let directoryServerPublicKey: String
-        internal let threeDSMessageVersion: String
-        internal let directoryServerRootCertificates: String
-        internal let delegatedAuthenticationSDKInput: String?
-        internal let paymentInfo: PaymentInfo?
-        internal let configuration: ThreeDSConfiguration?
+            internal let directoryServerIdentifier: String
+            internal let directoryServerPublicKey: String
+            internal let threeDSMessageVersion: String
+            internal let directoryServerRootCertificates: String
+            internal let delegatedAuthenticationSDKInput: String?
+            internal let paymentInfo: PaymentInfo?
+            internal let configuration: ThreeDSConfiguration?
         
-        private enum CodingKeys: String, CodingKey {
-            case directoryServerIdentifier = "directoryServerId"
-            case directoryServerPublicKey
-            case threeDSMessageVersion
-            case directoryServerRootCertificates
-            case delegatedAuthenticationSDKInput
-            case paymentInfo
-            case configuration
+            private enum CodingKeys: String, CodingKey {
+                case directoryServerIdentifier = "directoryServerId"
+                case directoryServerPublicKey
+                case threeDSMessageVersion
+                case directoryServerRootCertificates
+                case delegatedAuthenticationSDKInput
+                case paymentInfo
+                case configuration
+            }
         }
     }
-}
 
 #endif

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentThreeDSConfiguration.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentThreeDSConfiguration.swift
@@ -6,34 +6,34 @@
 
 #if canImport(Adyen3DS2)
 
-internal extension ThreeDS2Component {
-    struct ThreeDSConfiguration: Decodable, ThreeDSFeatureChecker {
-        private let version: String
-        internal let featureFlags: [String: Bool]?
+    internal extension ThreeDS2Component {
+        struct ThreeDSConfiguration: Decodable, ThreeDSFeatureChecker {
+            private let version: String
+            internal let featureFlags: [String: Bool]?
         
-        internal enum CodingKeys: String, CodingKey {
-            case version
-            case featureFlags
-        }
-        
-        internal init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            // We first check the version of the object and if it is an unrecognized version we bail out safely.
-            self.version = try container.decode(String.self, forKey: .version)
-            guard version == "1.0" else {
-                self.featureFlags = nil
-                return
+            internal enum CodingKeys: String, CodingKey {
+                case version
+                case featureFlags
             }
-            self.featureFlags = try? container.decode(
-                [String: Bool].self,
-                forKey: .featureFlags
-            )
-        }
         
-        internal func isFeatureEnabled(_ name: String) -> Bool {
-            featureFlags?[name] ?? false
+            internal init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                // We first check the version of the object and if it is an unrecognized version we bail out safely.
+                self.version = try container.decode(String.self, forKey: .version)
+                guard version == "1.0" else {
+                    self.featureFlags = nil
+                    return
+                }
+                self.featureFlags = try? container.decode(
+                    [String: Bool].self,
+                    forKey: .featureFlags
+                )
+            }
+        
+            internal func isFeatureEnabled(_ name: String) -> Bool {
+                featureFlags?[name] ?? false
+            }
         }
     }
-}
 
 #endif

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentThreeDSConfiguration.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentThreeDSConfiguration.swift
@@ -4,6 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+#if canImport(Adyen3DS2)
+
 internal extension ThreeDS2Component {
     struct ThreeDSConfiguration: Decodable, ThreeDSFeatureChecker {
         private let version: String
@@ -33,3 +35,5 @@ internal extension ThreeDS2Component {
         }
     }
 }
+
+#endif

--- a/AdyenCard/Components/Card/ThreeDS2SdkVersion.swift
+++ b/AdyenCard/Components/Card/ThreeDS2SdkVersion.swift
@@ -7,4 +7,8 @@
 import Foundation
 
 /// The 3DS2 SDK version.
-public let threeDS2SdkVersion: String = "2.4.3"
+#if canImport(Adyen3DS2)
+    public let threeDS2SdkVersion: String = "2.4.3"
+#else
+    public let threeDS2SdkVersion: String = ""
+#endif

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -224,7 +224,10 @@ public final class DropInComponent: NSObject,
         handler.delegate = self
         handler.presentationDelegate = self
         handler.configuration.localizationParameters = configuration.localizationParameters
-        handler.configuration.threeDS = configuration.actionComponent.threeDS
+        
+        #if canImport(Adyen3DS2)
+            handler.configuration.threeDS = configuration.actionComponent.threeDS
+        #endif
         handler.configuration.twint = configuration.actionComponent.twint
         return handler
     }()

--- a/AdyenDropIn/Models/DropInConfiguration.swift
+++ b/AdyenDropIn/Models/DropInConfiguration.swift
@@ -85,8 +85,10 @@ public extension DropInComponent {
         
         public init() { /* Empty initializer */ }
         
-        /// Three DS configurations
-        public var threeDS: AdyenActionComponent.Configuration.ThreeDS = .init()
+        #if canImport(Adyen3DS2)
+            /// Three DS configurations
+            public var threeDS: AdyenActionComponent.Configuration.ThreeDS = .init()
+        #endif
         
         /// Twint configurations
         public var twint: AdyenActionComponent.Configuration.Twint?

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -28,8 +28,6 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
 
     private lazy var adyenActionComponent: AdyenActionComponent = {
         let handler = AdyenActionComponent(context: context)
-        handler.configuration.threeDS.delegateAuthentication = ConfigurationConstants.delegatedAuthenticationConfigurations
-        handler.configuration.threeDS.requestorAppURL = ConfigurationConstants.returnUrl
         handler.delegate = self
         handler.presentationDelegate = self
         return handler

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
@@ -68,8 +68,6 @@ internal final class DropInAdvancedFlowExample: InitialDataAdvancedFlowProtocol 
         let configuration = ConfigurationConstants.current.dropInConfiguration
 
         configuration.applePay = try? ConfigurationConstants.current.applePayConfiguration()
-        configuration.actionComponent.threeDS.delegateAuthentication = ConfigurationConstants.delegatedAuthenticationConfigurations
-        configuration.actionComponent.threeDS.requestorAppURL = ConfigurationConstants.returnUrl
         configuration.card = ConfigurationConstants.current.cardDropInConfiguration
         return configuration
     }

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
@@ -48,10 +48,6 @@ extension InitialDataFlowProtocol {
             initialSessionData: data,
             context: context,
             actionComponent: .init(
-                threeDS: .init(
-                    requestorAppURL: ConfigurationConstants.returnUrl,
-                    delegateAuthentication: ConfigurationConstants.delegatedAuthenticationConfigurations
-                ),
                 twint: .init(callbackAppScheme: ConfigurationConstants.returnUrl.scheme!)
             )
         )

--- a/Demo/Common/IntegrationExamples/Session/DropIn/DropInExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/DropIn/DropInExample.swift
@@ -98,7 +98,6 @@ internal final class DropInExample: InitialDataFlowProtocol {
         let configuration = ConfigurationConstants.current.dropInConfiguration
 
         configuration.applePay = try? ConfigurationConstants.current.applePayConfiguration()
-        configuration.actionComponent.threeDS.delegateAuthentication = ConfigurationConstants.delegatedAuthenticationConfigurations
         configuration.card = ConfigurationConstants.current.cardDropInConfiguration
         return configuration
     }

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -69,10 +69,6 @@ internal enum ConfigurationConstants {
         "frequency": "adhoc",
         "remarks": "Remark on mandate"
     ]
-    
-    static var delegatedAuthenticationConfigurations: ThreeDS2Component.Configuration.DelegatedAuthentication {
-        .init(relyingPartyIdentifier: "test-authentication-adyen.netlify.app")
-    }
 
     static var shippingMethods: [PKShippingMethod] = {
         var shippingByCar = PKShippingMethod(label: "By car", amount: NSDecimalNumber(5.0))


### PR DESCRIPTION
# Summary [Required]

Just a quick proof of concept to verify the opt-out strategy for the `Adyen3DS2` SDK. Ideally we should:
- [ ] Group all `Adyen3DS2` related classes into its own module (aka `3DS2`) to reduce the number of conditional imports.
- [ ] In `AdyenActions`, invert the dependency with `Adyen3DS2`.
- [ ] Handle scenarios where errors can come up.

## Ticket
<ticket>
ADR-2169
</ticket>

## Checklist
<!-- Mark completed items with an [x] -->
- [ ] Tested changes locally
- [ ] Added/updated unit tests
- [ ] Verified against acceptance criteria
