### PR TITLE
Fix dropin render events (3 possible places)

### DIFF
--- a/AdyenDropIn/Components/PreselectedPaymentMethodComponent.swift
+++ b/AdyenDropIn/Components/PreselectedPaymentMethodComponent.swift
@@ -46,6 +46,9 @@ internal final class PreselectedPaymentMethodComponent: ComponentLoader,
     /// Call back when the list is dismissed.
     internal var onCancel: (() -> Void)?
     
+    /// Callback for when the component is loaded on display.
+    internal var onDidLoad: (() -> Void)?
+    
     /// Initializes the pre selected payment component.
     /// - Parameter component: The pre-selected component.
     /// - Parameter title: The title.
@@ -172,7 +175,11 @@ internal final class PreselectedPaymentMethodComponent: ComponentLoader,
     
 }
 
-extension PreselectedPaymentMethodComponent: ViewControllerDelegate {}
+extension PreselectedPaymentMethodComponent: ViewControllerDelegate {
+    func viewDidLoad(viewController: UIViewController) {
+        onDidLoad?()
+    }
+}
 
 @_spi(AdyenInternal)
 extension PreselectedPaymentMethodComponent: TrackableComponent {}

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -72,6 +72,8 @@ public final class DropInComponent: NSObject,
             .retryOnErrorAPIClient()
 
         super.init()
+        
+        sendInitialAnalytics()
     }
 
     /// For testing only
@@ -203,6 +205,9 @@ public final class DropInComponent: NSObject,
         } else if configuration.allowsSkippingPaymentList,
                   let singleRegularComponent = componentManager.singleRegularComponent {
             setNecessaryDelegates(on: singleRegularComponent)
+            // on this case we also need to send a dropin render event
+            // and there is no other place at the current structure than here
+            sendDidLoadEvent()
             return singleRegularComponent
         } else {
             return paymentMethodListComponent(onCancel: nil)
@@ -257,6 +262,9 @@ public final class DropInComponent: NSObject,
         component.delegate = self
         component.onCancel = onCancel
         component._isDropIn = true
+        component.onDidLoad = { [weak self] in
+            self?.sendDidLoadEvent()
+        }
         return component
     }
 

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -21,7 +21,6 @@ import UIKit
 extension DropInComponent: PaymentMethodListComponentDelegate {
 
     internal func didLoad(_ paymentMethodListComponent: PaymentMethodListComponent) {
-        sendInitialAnalytics()
         sendDidLoadEvent()
     }
     

--- a/Demo/UIKit/ComponentsViewController.swift
+++ b/Demo/UIKit/ComponentsViewController.swift
@@ -203,6 +203,7 @@ extension ComponentsViewController: PresenterExampleProtocol {
 
     internal func dismiss(completion: (() -> Void)?) {
         dismiss(animated: true, completion: completion)
+        currentExample = nil
     }
 }
 

--- a/Tests/IntegrationTests/DropIn Tests/DropInTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/DropInTests.swift
@@ -166,6 +166,24 @@ class DropInTests: XCTestCase {
         XCTAssertEqual(style.formComponent.separatorColor, .green)
         XCTAssertEqual(style.navigation.separatorColor, .green)
     }
+    
+    func test_Initialization_Should_Send_InitialCall() throws {
+        // Given
+        let analyticsProviderMock = AnalyticsProviderMock()
+        analyticsProviderMock._checkoutAttemptId = "testAttemptId"
+        let context = Dummy.context(with: analyticsProviderMock)
+        let config = DropInComponent.Configuration(allowPreselectedPaymentView: false)
+
+        let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsOneClick.data(using: .utf8)!)
+        _ = DropInComponent(
+            paymentMethods: paymentMethods,
+            context: context,
+            configuration: config
+        )
+        
+        XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)
+        XCTAssertEqual(analyticsProviderMock.checkoutAttemptId, "testAttemptId")
+    }
 
     func testViewDidLoadShouldSendRenderCall() throws {
         // Given
@@ -181,19 +199,80 @@ class DropInTests: XCTestCase {
         )
 
         // When
-        sut.sendDidLoadEvent()
+        presentOnRoot(sut.viewController)
 
         // Then
         XCTAssertEqual(analyticsProviderMock.infos.count, 1)
 
         let info = analyticsProviderMock.infos.first
         XCTAssertEqual(info?.type, .rendered)
+        XCTAssertEqual(info?.component, "dropin")
 
         let configDataDict = try XCTUnwrap(info?.configData?.stringOnlyDictionary)
         XCTAssertNotNil(configDataDict)
         XCTAssertEqual(configDataDict["skipPaymentMethodList"], "false")
         XCTAssertEqual(configDataDict["openFirstStoredPaymentMethod"], "false")
         XCTAssertEqual(configDataDict.keys.count, 2)
+    }
+    
+    func test_Should_Send_RenderEvent_For_Preselected() throws {
+        let analyticsProviderMock = AnalyticsProviderMock()
+        let context = Dummy.context(with: analyticsProviderMock)
+        let config = DropInComponent.Configuration(allowPreselectedPaymentView: true)
+
+        let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsOneClick.data(using: .utf8)!)
+        let sut = DropInComponent(
+            paymentMethods: paymentMethods,
+            context: context,
+            configuration: config
+        )
+
+        // When
+        presentOnRoot(sut.viewController)
+        
+        // Then
+        XCTAssertEqual(analyticsProviderMock.infos.count, 1)
+
+        let info = analyticsProviderMock.infos.first
+        XCTAssertEqual(info?.type, .rendered)
+        XCTAssertEqual(info?.component, "dropin")
+    }
+    
+    func test_Should_Send_RenderEvent_For_SkippedPaymentList() throws {
+        // Given
+        let analyticsProviderMock = AnalyticsProviderMock()
+        analyticsProviderMock._checkoutAttemptId = "testAttemptId"
+        let context = Dummy.context(with: analyticsProviderMock)
+        let config = DropInComponent.Configuration(allowsSkippingPaymentList: true)
+
+        let paymentMethods = try JSONDecoder().decode(PaymentMethods.self, from: DropInTests.paymentMethodsWithSingleNonInstant.data(using: .utf8)!)
+        let sut = DropInComponent(
+            paymentMethods: paymentMethods,
+            context: context,
+            configuration: config
+        )
+        
+        // When
+        presentOnRoot(sut.viewController)
+
+        // Then
+        XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)
+        XCTAssertEqual(analyticsProviderMock.checkoutAttemptId, "testAttemptId")
+        XCTAssertEqual(analyticsProviderMock.infos.count, 2)
+
+        // 2 render events, dropin and single component
+        let info = analyticsProviderMock.infos.first
+        XCTAssertEqual(info?.type, .rendered)
+        XCTAssertEqual(info?.component, "dropin")
+        let configDataDict = try XCTUnwrap(info?.configData?.stringOnlyDictionary)
+        XCTAssertNotNil(configDataDict)
+        XCTAssertEqual(configDataDict["skipPaymentMethodList"], "true")
+        XCTAssertEqual(configDataDict["openFirstStoredPaymentMethod"], "true")
+        XCTAssertEqual(configDataDict.keys.count, 2)
+        
+        let info2 = analyticsProviderMock.infos[1]
+        XCTAssertEqual(info2.type, .rendered)
+        XCTAssertEqual(info2.component, "sepadirectdebit")
     }
 
     func testOpenDropInAsList() throws {


### PR DESCRIPTION
# Summary [Required]
Fixes dropin's render events to fire at 3 possible cases:
- Preselected stored payment display
- Payment method list display
- When `allowsSkippingPaymentList` is true and payment list is skipped

## Ticket [Optional]
<ticket>
COSDK-627
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
