### PR TITLE
Remove PAL API calls

### DIFF
--- a/AdyenSession/API/Disable Stored Payments/DisableStoredPaymentMethodRequest.swift
+++ b/AdyenSession/API/Disable Stored Payments/DisableStoredPaymentMethodRequest.swift
@@ -10,8 +10,8 @@ import Foundation
 
 internal struct DisableStoredPaymentMethodRequest: APIRequest {
     
-    internal typealias ResponseType = DisableStoredPaymentMethodResponse
-    
+    internal typealias ResponseType = EmptyResponse
+
     internal let path: String
     
     internal var counter: UInt = 0
@@ -42,5 +42,3 @@ internal struct DisableStoredPaymentMethodRequest: APIRequest {
     }
     
 }
-
-internal struct DisableStoredPaymentMethodResponse: Response {}

--- a/Demo/Common/Helpers/APIClientHelper.swift
+++ b/Demo/Common/Helpers/APIClientHelper.swift
@@ -23,9 +23,4 @@ internal enum ApiClientHelper {
         apiClient.mockedResults = [.success(paymentMethodsResponse), .success(sessionResponse)]
         return apiClient
     }
-    
-    internal static func generatePalApiClient() -> APIClientProtocol {
-        let context = DemoAPIContext(environment: ConfigurationConstants.classicAPIEnvironment)
-        return DefaultAPIClient(apiContext: context)
-    }
 }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
@@ -15,7 +15,6 @@ internal final class DropInAdvancedFlowExample: InitialDataAdvancedFlowProtocol 
     private var dropInComponent: DropInComponent?
 
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
-    private lazy var palApiClient = ApiClientHelper.generatePalApiClient()
 
     internal lazy var context: AdyenContext = generateContext()
 
@@ -285,8 +284,12 @@ extension DropInAdvancedFlowExample: PartialPaymentDelegate {
 
 extension DropInAdvancedFlowExample: StoredPaymentMethodsDelegate {
     internal func disable(storedPaymentMethod: StoredPaymentMethod, completion: @escaping (Bool) -> Void) {
-        let request = DisableStoredPaymentMethodRequest(recurringDetailReference: storedPaymentMethod.identifier)
-        palApiClient.perform(request) { [weak self] result in
+        let request = DisableStoredPaymentMethodRequest(
+            storedPaymentId: storedPaymentMethod.identifier,
+            merchantAccount: ConfigurationConstants.merchantAccount,
+            shopperReference: ConfigurationConstants.shopperReference
+        )
+        apiClient.perform(request) { [weak self] result in
             self?.handleDisableResult(result, completion: completion)
         }
     }
@@ -296,8 +299,8 @@ extension DropInAdvancedFlowExample: StoredPaymentMethodsDelegate {
         case let .failure(error):
             self.presenter?.presentAlert(with: error, retryHandler: nil)
             completion(false)
-        case let .success(response):
-            completion(response.response == .detailsDisabled)
+        case .success:
+            completion(true)
         }
     }
 }

--- a/Demo/Common/IntegrationExamples/Session/DropIn/DropInExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/DropIn/DropInExample.swift
@@ -142,16 +142,3 @@ extension DropInExample: PresentationDelegate {
         // The implementation of this delegate method is not needed when using AdyenSession as the session handles the presentation
     }
 }
-
-extension DropInExample {
-
-    private func handleDisableResult(_ result: Result<DisableStoredPaymentMethodRequest.ResponseType, Error>, completion: (Bool) -> Void) {
-        switch result {
-        case let .failure(error):
-            self.presenter?.presentAlert(with: error, retryHandler: nil)
-            completion(false)
-        case .success:
-            completion(true)
-        }
-    }
-}

--- a/Demo/Common/IntegrationExamples/Session/DropIn/DropInExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/DropIn/DropInExample.swift
@@ -150,8 +150,8 @@ extension DropInExample {
         case let .failure(error):
             self.presenter?.presentAlert(with: error, retryHandler: nil)
             completion(false)
-        case let .success(response):
-            completion(response.response == .detailsDisabled)
+        case .success:
+            completion(true)
         }
     }
 }

--- a/Demo/Common/Networking/DisableStoredPaymentMethodRequest.swift
+++ b/Demo/Common/Networking/DisableStoredPaymentMethodRequest.swift
@@ -10,43 +10,25 @@ import Foundation
 
 internal struct DisableStoredPaymentMethodRequest: APIRequest {
     
-    internal typealias ResponseType = DisableStoredPaymentMethodResponse
+    internal typealias ResponseType = EmptyResponse
     
-    internal let recurringDetailReference: String
-    
-    internal let path = "Recurring/v68/disable"
+    internal let storedPaymentId: String
+    internal let merchantAccount: String
+    internal let shopperReference: String
+
+    internal var path: String { "storedPaymentMethods/\(storedPaymentId)" }
 
     internal var counter: UInt = 0
 
-    internal var method: HTTPMethod = .post
+    internal var method: HTTPMethod = .delete
 
     internal var headers: [String: String] = [:]
 
-    internal var queryParameters: [URLQueryItem] = []
+    internal var queryParameters: [URLQueryItem] { [
+        .init(name: "merchantAccount", value: merchantAccount),
+        .init(name: "shopperReference", value: shopperReference)
+    ] }
 
-    internal func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+    internal func encode(to encoder: Encoder) throws {}
 
-        let configurations = ConfigurationConstants.current
-
-        try container.encode(recurringDetailReference, forKey: .recurringDetailReference)
-        try container.encode(ConfigurationConstants.shopperReference, forKey: .shopperReference)
-        try container.encode(configurations.merchantAccount, forKey: .merchantAccount)
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case recurringDetailReference
-        case shopperReference
-        case merchantAccount
-    }
-}
-
-internal struct DisableStoredPaymentMethodResponse: Response {
-
-    internal enum ResultCode: String, Decodable {
-        case detailsDisabled = "[detail-successfully-disabled]"
-        case allDetailsDisabled = "[all-details-successfully-disabled]"
-    }
-
-    internal let response: ResultCode
 }

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -10,6 +10,7 @@ import XCTest
 @_spi(AdyenInternal) @testable import AdyenActions
 import AdyenComponents
 import AdyenDropIn
+import AdyenNetworking
 
 class SessionTests: XCTestCase {
 
@@ -685,8 +686,8 @@ class SessionTests: XCTestCase {
         
         let apiClient = APIClientMock()
         sut.apiClient = apiClient
-        apiClient.mockedResults = [.success(DisableStoredPaymentMethodResponse())]
-        
+        apiClient.mockedResults = [.success(EmptyResponse())]
+
         let deleteExpectation = expectation(description: "Expect delete call to succeed")
         apiClient.onExecute = { _ in
             deleteExpectation.fulfill()


### PR DESCRIPTION
# Summary 

Remove use of PAL API and use DELETE `storedPaymentMethods/{ID}` instead


## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
