### PR TITLE
Improve observation mechanisms

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		A09C704327032870004C01AA /* FormCardLogosItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09C704227032870004C01AA /* FormCardLogosItemView.swift */; };
 		A09FB2EB2B8399B700270D51 /* TrackableComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09FB2EA2B8399B700270D51 /* TrackableComponent.swift */; };
 		A09FB2ED2B86051000270D51 /* AnalyticsEventDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09FB2EC2B86051000270D51 /* AnalyticsEventDataSource.swift */; };
+		A0A0B37A2E8FEBC800E8567D /* ObservableThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A0B3792E8FEBC800E8567D /* ObservableThreadSafetyTests.swift */; };
 		A0B180312A2DE445003C608E /* MealVoucherDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B180302A2DE445003C608E /* MealVoucherDetails.swift */; };
 		A0B4B9B12BC027DE00C99926 /* CardComponentEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B4B9B02BC027DE00C99926 /* CardComponentEventTests.swift */; };
 		A0BC64E628F062E400CED2A1 /* AdyenSessionAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BC64E528F062E400CED2A1 /* AdyenSessionAware.swift */; };
@@ -1945,6 +1946,7 @@
 		A09C704227032870004C01AA /* FormCardLogosItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardLogosItemView.swift; sourceTree = "<group>"; };
 		A09FB2EA2B8399B700270D51 /* TrackableComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackableComponent.swift; sourceTree = "<group>"; };
 		A09FB2EC2B86051000270D51 /* AnalyticsEventDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEventDataSource.swift; sourceTree = "<group>"; };
+		A0A0B3792E8FEBC800E8567D /* ObservableThreadSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableThreadSafetyTests.swift; sourceTree = "<group>"; };
 		A0B180302A2DE445003C608E /* MealVoucherDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealVoucherDetails.swift; sourceTree = "<group>"; };
 		A0B4B9B02BC027DE00C99926 /* CardComponentEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardComponentEventTests.swift; sourceTree = "<group>"; };
 		A0BC64E528F062E400CED2A1 /* AdyenSessionAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenSessionAware.swift; sourceTree = "<group>"; };
@@ -5252,6 +5254,7 @@
 				E2B317A12265BC9400C1BB30 /* LengthValidatorTests.swift */,
 				E774A23B25DD72D300503C40 /* LogoGeneratorTests.swift */,
 				E270FDE5225CB40A006C2CD0 /* ObservableTests.swift */,
+				A0A0B3792E8FEBC800E8567D /* ObservableThreadSafetyTests.swift */,
 				F923283925A49559002C5BC4 /* PhoneExtensionsRepositoryTests.swift */,
 			);
 			path = Utilities;
@@ -7321,6 +7324,7 @@
 				B6D808322BCD1F8900F3F5EB /* BalanceCheckerTests.swift in Sources */,
 				B6D808192BCD151F00F3F5EB /* PaymentMethodMock.swift in Sources */,
 				B6D808052BCD147600F3F5EB /* KeyedDecodingContainerExtensionsTests.swift in Sources */,
+				A0A0B37A2E8FEBC800E8567D /* ObservableThreadSafetyTests.swift in Sources */,
 				B6ABA1C32CA6B058003514E5 /* ListItemTests.swift in Sources */,
 				B6D808092BCD147600F3F5EB /* StringExtensionsTests.swift in Sources */,
 				B6D808152BCD151F00F3F5EB /* AppLauncherMock.swift in Sources */,

--- a/Adyen/Utilities/Observable/AdyenObservable.swift
+++ b/Adyen/Utilities/Observable/AdyenObservable.swift
@@ -41,4 +41,7 @@ public final class AdyenObservable<ValueType: Equatable>: EventPublisher {
     
     public var projectedValue: AdyenObservable { self }
     
+    @_spi(AdyenInternal)
+    public let eventHandlersLock: NSLock = .init()
+    
 }

--- a/Adyen/Utilities/Observable/AdyenObserver.swift
+++ b/Adyen/Utilities/Observable/AdyenObserver.swift
@@ -40,7 +40,8 @@ public extension AdyenObserver {
         // Set the initial value.
         target[keyPath: keyPath] = observable.wrappedValue
         
-        return observe(observable, eventHandler: { [unowned target] newValue in
+        return observe(observable, eventHandler: { [weak target] newValue in
+            guard let target else { return }
             target[keyPath: keyPath] = newValue
         })
     }
@@ -62,7 +63,8 @@ public extension AdyenObserver {
         // Set the initial value.
         target[keyPath: keyPath] = observable.wrappedValue
 
-        return observe(observable, eventHandler: { [unowned target] newValue in
+        return observe(observable, eventHandler: { [weak target] newValue in
+            guard let target else { return }
             target[keyPath: keyPath] = newValue
         })
     }
@@ -86,7 +88,8 @@ public extension AdyenObserver {
         // Set the initial value.
         target[keyPath: keyPath] = transformation(observable.wrappedValue)
 
-        return observe(observable, eventHandler: { [unowned target] newValue in
+        return observe(observable, eventHandler: { [weak target] newValue in
+            guard let target else { return }
             target[keyPath: keyPath] = transformation(newValue)
         })
     }
@@ -110,7 +113,8 @@ public extension AdyenObserver {
         // Set the initial value.
         target[keyPath: keyPath] = observable.wrappedValue[keyPath: originKeyPath]
 
-        return observe(observable, eventHandler: { [unowned target] newValue in
+        return observe(observable, eventHandler: { [weak target] newValue in
+            guard let target else { return }
             target[keyPath: keyPath] = newValue[keyPath: originKeyPath]
         })
     }
@@ -134,7 +138,8 @@ public extension AdyenObserver {
         // Set the initial value.
         target[keyPath: keyPath] = observable.wrappedValue[keyPath: originKeyPath]
 
-        return observe(observable, eventHandler: { [unowned target] newValue in
+        return observe(observable, eventHandler: { [weak target] newValue in
+            guard let target else { return }
             target[keyPath: keyPath] = newValue[keyPath: originKeyPath]
         })
     }

--- a/Adyen/Utilities/Observable/EventPublisher.swift
+++ b/Adyen/Utilities/Observable/EventPublisher.swift
@@ -58,10 +58,10 @@ public extension EventPublisher {
     }
     
     @discardableResult
-    private func handleWithinLock<T>(action: () throws -> T) rethrows -> T {
+    private func handleWithinLock<T>(action: () -> T) -> T {
         defer { eventHandlersLock.unlock() }
         eventHandlersLock.lock()
-        return try action()
+        return action()
     }
     
 }

--- a/Adyen/Utilities/Observable/EventPublisher.swift
+++ b/Adyen/Utilities/Observable/EventPublisher.swift
@@ -15,6 +15,8 @@ public protocol EventPublisher: AnyObject {
     /// The event handlers that are attached to the publisher.
     var eventHandlers: [EventHandlerToken: EventHandler<Event>] { get set }
     
+    @_spi(AdyenInternal)
+    var eventHandlersLock: NSLock { get }
 }
 
 @_spi(AdyenInternal)
@@ -26,7 +28,9 @@ public extension EventPublisher {
     /// - Returns: A token, used to identify and later remove the event handler.
     func addEventHandler(_ eventHandler: @escaping EventHandler<Event>) -> EventHandlerToken {
         let token = EventHandlerToken()
-        eventHandlers[token] = eventHandler
+        handleWithinLock {
+            eventHandlers[token] = eventHandler
+        }
         
         return token
     }
@@ -35,16 +39,29 @@ public extension EventPublisher {
     ///
     /// - Parameter token: The token associated with the event handler to remove.
     func removeEventHandler(with token: EventHandlerToken) {
-        eventHandlers.removeValue(forKey: token)
+        handleWithinLock {
+            eventHandlers.removeValue(forKey: token)
+        }
     }
     
     /// Publishes an event.
     ///
     /// - Parameter event: The event to publish.
     func publish(_ event: Event) {
-        eventHandlers.forEach { _, eventHandler in
+        let handlers = handleWithinLock {
+            Array(eventHandlers.values)
+        }
+        
+        handlers.forEach { eventHandler in
             eventHandler(event)
         }
+    }
+    
+    @discardableResult
+    private func handleWithinLock<T>(action: () throws -> T) rethrows -> T {
+        defer { eventHandlersLock.unlock() }
+        eventHandlersLock.lock()
+        return try action()
     }
     
 }

--- a/Adyen/Utilities/Observable/EventPublisher.swift
+++ b/Adyen/Utilities/Observable/EventPublisher.swift
@@ -28,7 +28,7 @@ public extension EventPublisher {
     /// - Returns: A token, used to identify and later remove the event handler.
     func addEventHandler(_ eventHandler: @escaping EventHandler<Event>) -> EventHandlerToken {
         let token = EventHandlerToken()
-        handleWithinLock {
+        eventHandlersLock.withLock {
             eventHandlers[token] = eventHandler
         }
         
@@ -39,7 +39,7 @@ public extension EventPublisher {
     ///
     /// - Parameter token: The token associated with the event handler to remove.
     func removeEventHandler(with token: EventHandlerToken) {
-        handleWithinLock {
+        _ = eventHandlersLock.withLock {
             eventHandlers.removeValue(forKey: token)
         }
     }
@@ -48,7 +48,7 @@ public extension EventPublisher {
     ///
     /// - Parameter event: The event to publish.
     func publish(_ event: Event) {
-        let handlers = handleWithinLock {
+        let handlers = eventHandlersLock.withLock {
             Array(eventHandlers.values)
         }
         
@@ -57,13 +57,8 @@ public extension EventPublisher {
         }
     }
     
-    @discardableResult
-    private func handleWithinLock<T>(action: () -> T) -> T {
-        defer { eventHandlersLock.unlock() }
-        eventHandlersLock.lock()
-        return action()
-    }
-    
+    // default extension to satisfy lib evolution
+    var eventHandlersLock: NSLock { NSLock() }
 }
 
 /// Alias for a closure that handles an event.

--- a/Adyen/Utilities/Observable/ObservationManager.swift
+++ b/Adyen/Utilities/Observable/ObservationManager.swift
@@ -9,8 +9,17 @@ import Foundation
 /// Manages all the observations of an observer.
 internal class ObservationManager {
     
+    private var observations = [Observation]()
+    private let lock = NSLock()
+    
     deinit {
-        observations.forEach {
+        let observationsToRemove = handleWithinLock {
+            let copy = observations
+            observations = []
+            return copy
+        }
+        
+        observationsToRemove.forEach {
             $0.unobserveHandler()
         }
     }
@@ -23,21 +32,27 @@ internal class ObservationManager {
         let observation = Observation(unobserveHandler: { [weak eventPublisher] in
             eventPublisher?.removeEventHandler(with: eventHandlerToken)
         })
-        observations.append(observation)
+        
+        handleWithinLock {
+            observations.append(observation)
+        }
         
         return observation
     }
     
     internal func remove(_ observation: Observation) {
-        guard let index = observations.firstIndex(of: observation) else {
-            return
+        handleWithinLock {
+            observations.removeAll { element in
+                element == observation
+            }
         }
-        
-        observations.remove(at: index)
-        
         observation.unobserveHandler()
     }
     
-    private var observations = [Observation]()
-    
+    @discardableResult
+    private func handleWithinLock<T>(action: () throws -> T) rethrows -> T {
+        defer { lock.unlock() }
+        lock.lock()
+        return try action()
+    }
 }

--- a/Adyen/Utilities/Observable/ObservationManager.swift
+++ b/Adyen/Utilities/Observable/ObservationManager.swift
@@ -50,9 +50,9 @@ internal class ObservationManager {
     }
     
     @discardableResult
-    private func handleWithinLock<T>(action: () throws -> T) rethrows -> T {
+    private func handleWithinLock<T>(action: () -> T) -> T {
         defer { lock.unlock() }
         lock.lock()
-        return try action()
+        return action()
     }
 }

--- a/Adyen/Utilities/Observable/ObservationManager.swift
+++ b/Adyen/Utilities/Observable/ObservationManager.swift
@@ -13,7 +13,7 @@ internal class ObservationManager {
     private let lock = NSLock()
     
     deinit {
-        let observationsToRemove = handleWithinLock {
+        let observationsToRemove = lock.withLock {
             let copy = observations
             observations = []
             return copy
@@ -33,7 +33,7 @@ internal class ObservationManager {
             eventPublisher?.removeEventHandler(with: eventHandlerToken)
         })
         
-        handleWithinLock {
+        lock.withLock {
             observations.append(observation)
         }
         
@@ -41,18 +41,11 @@ internal class ObservationManager {
     }
     
     internal func remove(_ observation: Observation) {
-        handleWithinLock {
+        lock.withLock {
             observations.removeAll { element in
                 element == observation
             }
         }
         observation.unobserveHandler()
-    }
-    
-    @discardableResult
-    private func handleWithinLock<T>(action: () -> T) -> T {
-        defer { lock.unlock() }
-        lock.lock()
-        return action()
     }
 }

--- a/Tests/UnitTests/Utilities/ObservableThreadSafetyTests.swift
+++ b/Tests/UnitTests/Utilities/ObservableThreadSafetyTests.swift
@@ -1,0 +1,437 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+import XCTest
+
+/// Tests for thread-safety of the Observable system with NSLock implementation
+/// These tests verify that the Observable's internal locks prevent crashes and data corruption
+class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
+    
+    // MARK: - Dictionary Corruption Tests
+
+    // These tests would crash or corrupt data if locks weren't working
+    
+    func testConcurrentHandlerAdditionDoesNotCorruptDictionary() {
+        let observable = AdyenObservable("test")
+        let iterations = 1000
+        
+        // Concurrently add handlers - would crash without proper locking
+        DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+            _ = observable.addEventHandler { _ in }
+        }
+        
+        // If we got here without crashing, locks are working
+        // Verify dictionary is in valid state by triggering all handlers
+        var callCount = 0
+        _ = observable.addEventHandler { _ in
+            callCount += 1
+        }
+        
+        observable.wrappedValue = "trigger"
+        
+        // Should have called the new handler plus all the concurrent ones
+        XCTAssertGreaterThan(callCount, 0)
+    }
+    
+    func testConcurrentHandlerRemovalDoesNotCorruptDictionary() {
+        let observable = AdyenObservable("test")
+        let iterations = 1000
+        
+        // Add many handlers
+        var tokens = [EventHandlerToken]()
+        for _ in 0..<iterations {
+            let token = observable.addEventHandler { _ in }
+            tokens.append(token)
+        }
+        
+        // Concurrently remove them - would crash without proper locking
+        DispatchQueue.concurrentPerform(iterations: iterations) { index in
+            observable.removeEventHandler(with: tokens[index])
+        }
+        
+        // Dictionary should be empty or nearly empty
+        observable.wrappedValue = "test"
+        
+        // If we got here without crashing, locks are working
+        XCTAssertTrue(true)
+    }
+    
+    func testConcurrentAddAndRemoveDoesNotCrash() {
+        let observable = AdyenObservable(0)
+        let iterations = 500
+        let expectation = expectation(description: "All operations complete")
+        expectation.expectedFulfillmentCount = iterations * 2
+        
+        // Simultaneously add and remove handlers
+        DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+            let token = observable.addEventHandler { _ in }
+            expectation.fulfill()
+            
+            DispatchQueue.global().async {
+                observable.removeEventHandler(with: token)
+                expectation.fulfill()
+            }
+        }
+        
+        wait(for: [expectation], timeout: 10.0)
+        
+        // If we got here, the locks prevented dictionary corruption
+        observable.wrappedValue = 999
+        XCTAssertEqual(observable.wrappedValue, 999)
+    }
+    
+    func testConcurrentPublishDoesNotCrashDuringIteration() {
+        let observable = AdyenObservable(0)
+        
+        // Add handlers that take time to execute
+        for _ in 0..<50 {
+            _ = observable.addEventHandler { _ in
+                // Simulate work
+                usleep(100) // 0.1ms
+            }
+        }
+        
+        // Publish from multiple threads simultaneously
+        // Without locks, this would crash when iterating eventHandlers
+        DispatchQueue.concurrentPerform(iterations: 100) { index in
+            observable.wrappedValue = index
+        }
+        
+        // If we got here without crashing, the lock protected the iteration
+        XCTAssertTrue(true)
+    }
+    
+    func testConcurrentPublishAndModifyHandlers() {
+        let observable = AdyenObservable(0)
+        let duration: TimeInterval = 2.0
+        let startTime = Date()
+        
+        var tokens = [EventHandlerToken]()
+        for _ in 0..<20 {
+            tokens.append(observable.addEventHandler { _ in })
+        }
+        
+        // Thread 1: Continuously publish
+        DispatchQueue.global(qos: .userInitiated).async {
+            var counter = 0
+            while Date().timeIntervalSince(startTime) < duration {
+                observable.wrappedValue = counter
+                counter += 1
+                usleep(1000) // 1ms
+            }
+        }
+        
+        // Thread 2: Continuously add handlers
+        DispatchQueue.global(qos: .userInitiated).async {
+            while Date().timeIntervalSince(startTime) < duration {
+                _ = observable.addEventHandler { _ in }
+                usleep(1500) // 1.5ms
+            }
+        }
+        
+        // Thread 3: Continuously remove handlers
+        DispatchQueue.global(qos: .userInitiated).async {
+            var index = 0
+            while Date().timeIntervalSince(startTime) < duration {
+                if index < tokens.count {
+                    observable.removeEventHandler(with: tokens[index])
+                    index += 1
+                }
+                usleep(2000) // 2ms
+            }
+        }
+        
+        // Wait for all operations to complete
+        Thread.sleep(forTimeInterval: duration + 0.5)
+        
+        // If we got here without crashing, locks are working correctly
+        observable.wrappedValue = 999
+        XCTAssertEqual(observable.wrappedValue, 999)
+    }
+    
+    // MARK: - Observer Manager Thread Safety Tests
+    
+    func testConcurrentObservationAdditionDoesNotCorruptArray() {
+        let observable = AdyenObservable("test")
+        let iterations = 1000
+        
+        // Concurrently add observations - would crash without proper locking
+        DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+            _ = observe(observable) { _ in }
+        }
+        
+        // Trigger all observations
+        observable.wrappedValue = "trigger"
+        
+        // If we got here without crashing, the ObservationManager's lock is working
+        XCTAssertTrue(true)
+    }
+    
+    func testConcurrentObservationRemovalDoesNotCorruptArray() {
+        let observable = AdyenObservable("test")
+        let iterations = 500
+        
+        var observations = [Observation]()
+        for _ in 0..<iterations {
+            observations.append(observe(observable) { _ in })
+        }
+        
+        // Concurrently remove observations - would crash without proper locking
+        DispatchQueue.concurrentPerform(iterations: iterations) { index in
+            remove(observations[index])
+        }
+        
+        // If we got here without crashing, the ObservationManager's lock is working
+        observable.wrappedValue = "test"
+        XCTAssertTrue(true)
+    }
+    
+    func testConcurrentObserveAndRemove() {
+        let observable = AdyenObservable(0)
+        let duration: TimeInterval = 2.0
+        let startTime = Date()
+        
+        var observationCounter = 0
+        
+        // Thread 1: Continuously add observations
+        DispatchQueue.global(qos: .userInitiated).async {
+            while Date().timeIntervalSince(startTime) < duration {
+                _ = self.observe(observable) { _ in
+                    // Handler
+                }
+                observationCounter += 1
+                usleep(500)
+            }
+        }
+        
+        // Thread 2: Continuously publish
+        DispatchQueue.global(qos: .userInitiated).async {
+            var counter = 0
+            while Date().timeIntervalSince(startTime) < duration {
+                observable.wrappedValue = counter
+                counter += 1
+                usleep(1000)
+            }
+        }
+        
+        Thread.sleep(forTimeInterval: duration + 0.5)
+        
+        // If we got here without crashing, locks are working
+        XCTAssertGreaterThan(observationCounter, 0)
+    }
+    
+    // MARK: - Race Condition Detection Tests
+    
+    func testPublishWhileAddingHandlersDoesNotSkipHandlers() {
+        let observable = AdyenObservable(0)
+        let handlerCount = 100
+        
+        // Use atomic counter (OSAtomic is deprecated, use class with lock)
+        let counter = AtomicCounter()
+        
+        // Add handlers while publishing
+        DispatchQueue.global().async {
+            for _ in 0..<handlerCount {
+                _ = observable.addEventHandler { _ in
+                    counter.increment()
+                }
+                usleep(100)
+            }
+        }
+        
+        // Publish multiple times
+        DispatchQueue.global().async {
+            for i in 0..<50 {
+                observable.wrappedValue = i
+                usleep(200)
+            }
+        }
+        
+        Thread.sleep(forTimeInterval: 2.0)
+        
+        // Final publish to trigger all handlers
+        observable.wrappedValue = 999
+        Thread.sleep(forTimeInterval: 0.1)
+        
+        // Should have received calls (exact count depends on timing)
+        XCTAssertGreaterThan(counter.value, 0)
+    }
+    
+    func testRemovingHandlerDuringPublishDoesNotCrash() {
+        let observable = AdyenObservable(0)
+        
+        // Add handlers with slow execution
+        var tokens = [EventHandlerToken]()
+        for _ in 0..<50 {
+            let token = observable.addEventHandler { _ in
+                usleep(1000) // 1ms - slow handler
+            }
+            tokens.append(token)
+        }
+        
+        // Start publishing
+        DispatchQueue.global().async {
+            for i in 0..<100 {
+                observable.wrappedValue = i
+                usleep(500)
+            }
+        }
+        
+        // Remove handlers while publishing
+        DispatchQueue.global().async {
+            usleep(5000) // Wait a bit for publishing to start
+            for token in tokens {
+                observable.removeEventHandler(with: token)
+                usleep(200)
+            }
+        }
+        
+        Thread.sleep(forTimeInterval: 2.0)
+        
+        // If we got here, the lock prevented crashes during concurrent iteration/modification
+        XCTAssertTrue(true)
+    }
+    
+    // MARK: - Memory Safety Tests
+    
+    func testObservableDeallocationDuringConcurrentAccess() {
+        var observable: AdyenObservable<Int>? = AdyenObservable(0)
+        weak var weakObservable = observable
+        
+        // Add handlers
+        for _ in 0..<20 {
+            _ = observable?.addEventHandler { _ in
+                usleep(1000)
+            }
+        }
+        
+        // Start concurrent operations
+        DispatchQueue.global().async {
+            for i in 0..<50 {
+                observable?.wrappedValue = i
+                usleep(500)
+            }
+        }
+        
+        // Deallocate while operations are happening
+        usleep(10000) // 10ms
+        observable = nil
+        
+        Thread.sleep(forTimeInterval: 0.5)
+        
+        // Observable should be deallocated
+        XCTAssertNil(weakObservable)
+    }
+    
+    func testObserverDeallocationDuringConcurrentPublish() {
+        let observable = AdyenObservable(0)
+        
+        autoreleasepool {
+            let observer = TestObserver()
+            
+            // Add observation
+            observer.observe(observable) { _ in
+                usleep(1000)
+            }
+            
+            // Start publishing
+            DispatchQueue.global().async {
+                for i in 0..<100 {
+                    observable.wrappedValue = i
+                    usleep(500)
+                }
+            }
+            
+            // Observer deallocates while publishing
+            usleep(10000)
+        }
+        
+        Thread.sleep(forTimeInterval: 0.5)
+        
+        // Should not crash
+        observable.wrappedValue = 999
+        XCTAssertEqual(observable.wrappedValue, 999)
+    }
+    
+    // MARK: - Stress Tests
+    
+    func testExtremeConcurrency() {
+        let observable = AdyenObservable(0)
+        let duration: TimeInterval = 3.0
+        let startTime = Date()
+        
+        // Multiple threads doing different operations simultaneously
+        let group = DispatchGroup()
+        
+        // Thread 1-3: Publishing
+        for _ in 0..<3 {
+            group.enter()
+            DispatchQueue.global().async {
+                var counter = 0
+                while Date().timeIntervalSince(startTime) < duration {
+                    observable.wrappedValue = counter
+                    counter += 1
+                    usleep(100)
+                }
+                group.leave()
+            }
+        }
+        
+        // Thread 4-5: Adding handlers
+        for _ in 0..<2 {
+            group.enter()
+            DispatchQueue.global().async {
+                while Date().timeIntervalSince(startTime) < duration {
+                    _ = observable.addEventHandler { _ in }
+                    usleep(300)
+                }
+                group.leave()
+            }
+        }
+        
+        // Thread 6: Adding and removing handlers
+        group.enter()
+        DispatchQueue.global().async {
+            while Date().timeIntervalSince(startTime) < duration {
+                let token = observable.addEventHandler { _ in }
+                usleep(200)
+                observable.removeEventHandler(with: token)
+                usleep(200)
+            }
+            group.leave()
+        }
+        
+        group.wait()
+        
+        // If we survived this chaos, locks are working correctly
+        observable.wrappedValue = 999
+        XCTAssertEqual(observable.wrappedValue, 999)
+    }
+    
+    // MARK: - Helper Classes
+    
+    class TestObserver: AdyenObserver {
+        var value: String = ""
+    }
+    
+    class AtomicCounter {
+        private var _value = 0
+        private let lock = NSLock()
+        
+        var value: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return _value
+        }
+        
+        func increment() {
+            lock.lock()
+            _value += 1
+            lock.unlock()
+        }
+    }
+}

--- a/Tests/UnitTests/Utilities/ObservableThreadSafetyTests.swift
+++ b/Tests/UnitTests/Utilities/ObservableThreadSafetyTests.swift
@@ -24,17 +24,17 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
             _ = observable.addEventHandler { _ in }
         }
         
-        // If we got here without crashing, locks are working
-        // Verify dictionary is in valid state by triggering all handlers
-        var callCount = 0
+        // If we got here without crashing, the dictionary wasn't corrupted
+        // Now verify the dictionary is in a valid state by adding and triggering a new handler
+        var newHandlerCalled = false
         _ = observable.addEventHandler { _ in
-            callCount += 1
+            newHandlerCalled = true
         }
         
         observable.wrappedValue = "trigger"
         
-        // Should have called the new handler plus all the concurrent ones
-        XCTAssertGreaterThan(callCount, 0)
+        // The new handler should have been called, proving dictionary is functional
+        XCTAssertTrue(newHandlerCalled, "Dictionary should be in valid state after concurrent additions")
     }
     
     func testConcurrentHandlerRemovalDoesNotCorruptDictionary() {
@@ -53,11 +53,11 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
             observable.removeEventHandler(with: tokens[index])
         }
         
-        // Dictionary should be empty or nearly empty
+        // If we got here without crashing, the dictionary wasn't corrupted
+        // Verify it's still functional by publishing
         observable.wrappedValue = "test"
         
-        // If we got here without crashing, locks are working
-        XCTAssertTrue(true)
+        XCTAssertTrue(true, "Dictionary survived concurrent removals without corruption")
     }
     
     func testConcurrentAddAndRemoveDoesNotCrash() {
@@ -66,7 +66,7 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         let expectation = expectation(description: "All operations complete")
         expectation.expectedFulfillmentCount = iterations * 2
         
-        // Simultaneously add and remove handlers
+        // Simultaneously add and remove handlers from different threads
         DispatchQueue.concurrentPerform(iterations: iterations) { _ in
             let token = observable.addEventHandler { _ in }
             expectation.fulfill()
@@ -80,8 +80,9 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         wait(for: [expectation], timeout: 10.0)
         
         // If we got here, the locks prevented dictionary corruption
+        // Verify observable still works
         observable.wrappedValue = 999
-        XCTAssertEqual(observable.wrappedValue, 999)
+        XCTAssertEqual(observable.wrappedValue, 999, "Observable should still be functional")
     }
     
     func testConcurrentPublishDoesNotCrashDuringIteration() {
@@ -90,19 +91,18 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         // Add handlers that take time to execute
         for _ in 0..<50 {
             _ = observable.addEventHandler { _ in
-                // Simulate work
-                usleep(100) // 0.1ms
+                usleep(100) // 0.1ms - simulate work
             }
         }
         
         // Publish from multiple threads simultaneously
-        // Without locks, this would crash when iterating eventHandlers
+        // Without locks, this would crash when iterating eventHandlers while they're being modified
         DispatchQueue.concurrentPerform(iterations: 100) { index in
             observable.wrappedValue = index
         }
         
         // If we got here without crashing, the lock protected the iteration
-        XCTAssertTrue(true)
+        XCTAssertTrue(true, "Concurrent publishing didn't crash during handler iteration")
     }
     
     func testConcurrentPublishAndModifyHandlers() {
@@ -148,9 +148,9 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         // Wait for all operations to complete
         Thread.sleep(forTimeInterval: duration + 0.5)
         
-        // If we got here without crashing, locks are working correctly
+        // If we got here without crashing, locks prevented race conditions
         observable.wrappedValue = 999
-        XCTAssertEqual(observable.wrappedValue, 999)
+        XCTAssertEqual(observable.wrappedValue, 999, "Observable survived extreme concurrent access")
     }
     
     // MARK: - Observer Manager Thread Safety Tests
@@ -159,16 +159,16 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         let observable = AdyenObservable("test")
         let iterations = 1000
         
-        // Concurrently add observations - would crash without proper locking
+        // Concurrently add observations - would crash without proper locking in ObservationManager
         DispatchQueue.concurrentPerform(iterations: iterations) { _ in
             _ = observe(observable) { _ in }
         }
         
-        // Trigger all observations
+        // If we got here without crashing, ObservationManager's array wasn't corrupted
+        // Trigger all observations to verify they're functional
         observable.wrappedValue = "trigger"
         
-        // If we got here without crashing, the ObservationManager's lock is working
-        XCTAssertTrue(true)
+        XCTAssertTrue(true, "ObservationManager survived concurrent observation additions")
     }
     
     func testConcurrentObservationRemovalDoesNotCorruptArray() {
@@ -180,14 +180,79 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
             observations.append(observe(observable) { _ in })
         }
         
-        // Concurrently remove observations - would crash without proper locking
+        // Concurrently remove observations - would crash without proper locking in ObservationManager
         DispatchQueue.concurrentPerform(iterations: iterations) { index in
             remove(observations[index])
         }
         
-        // If we got here without crashing, the ObservationManager's lock is working
+        // If we got here without crashing, ObservationManager's array wasn't corrupted
         observable.wrappedValue = "test"
-        XCTAssertTrue(true)
+        XCTAssertTrue(true, "ObservationManager survived concurrent observation removals")
+    }
+    
+    func testObservationManagerDeinitCleansUpObservations() {
+        let observable = AdyenObservable(0)
+        var handlerCallCount = 0
+        
+        // Create observer in autoreleasepool so it gets deallocated
+        autoreleasepool {
+            let observer = TestObserver()
+            
+            // Add multiple observations
+            for _ in 0..<10 {
+                observer.observe(observable) { _ in
+                    handlerCallCount += 1
+                }
+            }
+            
+            // Trigger handlers - should be called
+            observable.wrappedValue = 1
+            XCTAssertEqual(handlerCallCount, 10, "All handlers should be called before observer deallocation")
+            
+            handlerCallCount = 0
+            
+            // Observer will be deallocated here, triggering ObservationManager.deinit
+        }
+        
+        // After observer deallocation, handlers should be removed
+        observable.wrappedValue = 2
+        
+        XCTAssertEqual(handlerCallCount, 0, "Handlers should be removed after observer deallocation")
+    }
+    
+    func testObservationManagerDeinitDuringConcurrentPublish() {
+        let observable = AdyenObservable(0)
+        
+        autoreleasepool {
+            let observer = TestObserver()
+            
+            // Add observations
+            for _ in 0..<20 {
+                observer.observe(observable) { _ in
+                    usleep(1000) // Slow handler
+                }
+            }
+            
+            // Start publishing on background thread
+            DispatchQueue.global().async {
+                for i in 0..<100 {
+                    observable.wrappedValue = i
+                    usleep(500)
+                }
+            }
+            
+            // Let some publishes happen
+            usleep(10000) // 10ms
+            
+            // Observer deallocates while publishing is happening
+            // ObservationManager.deinit should safely clean up
+        }
+        
+        Thread.sleep(forTimeInterval: 0.5)
+        
+        // Should not crash when observer is deallocated during concurrent publishing
+        observable.wrappedValue = 999
+        XCTAssertEqual(observable.wrappedValue, 999, "Observable should work after observer cleanup during concurrent access")
     }
     
     func testConcurrentObserveAndRemove() {
@@ -195,6 +260,7 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         let duration: TimeInterval = 2.0
         let startTime = Date()
         
+        // Note: observationCounter is accessed from single thread only, no lock needed
         var observationCounter = 0
         
         // Thread 1: Continuously add observations
@@ -220,8 +286,8 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         
         Thread.sleep(forTimeInterval: duration + 0.5)
         
-        // If we got here without crashing, locks are working
-        XCTAssertGreaterThan(observationCounter, 0)
+        // If we got here without crashing, locks prevented race conditions
+        XCTAssertGreaterThan(observationCounter, 0, "Should have added observations during test")
     }
     
     // MARK: - Race Condition Detection Tests
@@ -230,10 +296,10 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         let observable = AdyenObservable(0)
         let handlerCount = 100
         
-        // Use atomic counter (OSAtomic is deprecated, use class with lock)
+        // Use atomic counter to track handler calls safely
         let counter = AtomicCounter()
         
-        // Add handlers while publishing
+        // Thread 1: Add handlers while publishing is happening
         DispatchQueue.global().async {
             for _ in 0..<handlerCount {
                 _ = observable.addEventHandler { _ in
@@ -243,7 +309,7 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
             }
         }
         
-        // Publish multiple times
+        // Thread 2: Publish multiple times while handlers are being added
         DispatchQueue.global().async {
             for i in 0..<50 {
                 observable.wrappedValue = i
@@ -253,18 +319,18 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         
         Thread.sleep(forTimeInterval: 2.0)
         
-        // Final publish to trigger all handlers
+        // Final publish to trigger all handlers that were successfully added
         observable.wrappedValue = 999
         Thread.sleep(forTimeInterval: 0.1)
         
-        // Should have received calls (exact count depends on timing)
-        XCTAssertGreaterThan(counter.value, 0)
+        // Should have received calls (exact count depends on timing of when handlers were added)
+        XCTAssertGreaterThan(counter.value, 0, "Handlers added during publishing should still be called")
     }
     
     func testRemovingHandlerDuringPublishDoesNotCrash() {
         let observable = AdyenObservable(0)
         
-        // Add handlers with slow execution
+        // Add handlers with slow execution to increase chance of concurrent access
         var tokens = [EventHandlerToken]()
         for _ in 0..<50 {
             let token = observable.addEventHandler { _ in
@@ -273,7 +339,7 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
             tokens.append(token)
         }
         
-        // Start publishing
+        // Thread 1: Start publishing
         DispatchQueue.global().async {
             for i in 0..<100 {
                 observable.wrappedValue = i
@@ -281,7 +347,7 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
             }
         }
         
-        // Remove handlers while publishing
+        // Thread 2: Remove handlers while publishing is iterating over them
         DispatchQueue.global().async {
             usleep(5000) // Wait a bit for publishing to start
             for token in tokens {
@@ -293,7 +359,7 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         Thread.sleep(forTimeInterval: 2.0)
         
         // If we got here, the lock prevented crashes during concurrent iteration/modification
-        XCTAssertTrue(true)
+        XCTAssertTrue(true, "Removing handlers during publish didn't cause iterator invalidation")
     }
     
     // MARK: - Memory Safety Tests
@@ -309,7 +375,7 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
             }
         }
         
-        // Start concurrent operations
+        // Start concurrent operations that will continue briefly after deallocation
         DispatchQueue.global().async {
             for i in 0..<50 {
                 observable?.wrappedValue = i
@@ -317,14 +383,14 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
             }
         }
         
-        // Deallocate while operations are happening
-        usleep(10000) // 10ms
+        // Deallocate observable while operations are happening
+        usleep(10000) // 10ms - let some operations start
         observable = nil
         
         Thread.sleep(forTimeInterval: 0.5)
         
-        // Observable should be deallocated
-        XCTAssertNil(weakObservable)
+        // Observable should be deallocated without crashing
+        XCTAssertNil(weakObservable, "Observable should be deallocated")
     }
     
     func testObserverDeallocationDuringConcurrentPublish() {
@@ -346,15 +412,15 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
                 }
             }
             
-            // Observer deallocates while publishing
-            usleep(10000)
+            // Observer deallocates while publishing is happening
+            usleep(10000) // 10ms
         }
         
         Thread.sleep(forTimeInterval: 0.5)
         
-        // Should not crash
+        // Should not crash when observer is deallocated during publishing
         observable.wrappedValue = 999
-        XCTAssertEqual(observable.wrappedValue, 999)
+        XCTAssertEqual(observable.wrappedValue, 999, "Observable should work after observer deallocation")
     }
     
     // MARK: - Stress Tests
@@ -367,7 +433,7 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         // Multiple threads doing different operations simultaneously
         let group = DispatchGroup()
         
-        // Thread 1-3: Publishing
+        // Threads 1-3: Publishing
         for _ in 0..<3 {
             group.enter()
             DispatchQueue.global().async {
@@ -381,7 +447,7 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
             }
         }
         
-        // Thread 4-5: Adding handlers
+        // Threads 4-5: Adding handlers
         for _ in 0..<2 {
             group.enter()
             DispatchQueue.global().async {
@@ -409,7 +475,7 @@ class ObservableThreadSafetyTests: XCTestCase, AdyenObserver {
         
         // If we survived this chaos, locks are working correctly
         observable.wrappedValue = 999
-        XCTAssertEqual(observable.wrappedValue, 999)
+        XCTAssertEqual(observable.wrappedValue, 999, "Observable survived extreme concurrent stress test")
     }
     
     // MARK: - Helper Classes


### PR DESCRIPTION
# Summary [Required]
This PR attempts to improve the observation mechanism handling by adding thread safety and memory access checks.
- NSLock to access/modify observations
- NSLock to access/modify eventHandlers which internally access observations as well
- Replace usages of `unowned` with `weak` because...

It also aims to reduce the chances of issue #2256

## Release Notes [Optional]
<fixed>
- For apps built with [Xcode 26](https://developer.apple.com/documentation/xcode-release-notes/xcode-26-release-notes): a crash caused by `ObservationManager` no longer occurs when a Component is deallocated.
</fixed>

## Ticket [Optional]
<ticket>
COSDK-641
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [ ] Tested changes locally
- [ ] Added/updated unit tests
- [ ] Verified against acceptance criteria
