### PR TITLE
Github: Resolve missing iOS simulators for API Diff action

### DIFF
--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Select latest Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.2'
-        
+        xcode-version: '16.4'
+
     - name: 🚚 Fetch repo
       uses: actions/checkout@v5
       with:


### PR DESCRIPTION
# Summary 
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

It's nothing new about Github breaking our CI by removing software from images "just because we ran out of disk space", and so on.
This time the iOS simulators are missing, while being a part of image according to [the documentation.](https://github.com/actions/runner-images/blob/macos-15-arm64/20250928.2397/images/macos/macos-15-arm64-Readme.md).

The fix is to use another version of Xcode, so switching from 16.2 to 16.4