### PR TITLE
Fix advanced flow demo alert bug

### DIFF
--- a/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
@@ -137,13 +137,11 @@ internal final class DropInAdvancedFlowExample: InitialDataAdvancedFlowProtocol 
     }
 
     private func dismissAndShowAlert(_ success: Bool, _ message: String) {
-        presenter?.dismiss { [weak self] in
-            // Payment is processed. Add your code here.
+        presenter?.dismiss {
             let title = success ? "Success" : "Error"
-            self?.presenter?.presentAlert(withTitle: title, message: message)
+            self.presenter?.presentAlert(withTitle: title, message: message)
         }
     }
-
 }
 
 extension DropInAdvancedFlowExample: DropInComponentDelegate {


### PR DESCRIPTION
## Summary
This PR introduces a fix to address the missing DropIn alert in the advanced flow demo.
The bug was caused by an early deallocation of the `DropInAdvancedFlowExample`.

## Demo

https://github.com/user-attachments/assets/b0cd30a8-4e65-44ff-a300-c99602136c27

https://github.com/user-attachments/assets/52142a76-eb34-41ba-b327-41023506a956

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
