### PR TITLE
Github CI - limit concurrent jobs to 1 for API DIff tool and SDK size analysis

### DIFF
--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -15,11 +15,15 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-      
+
 permissions:
   contents: read
-  pull-requests: write 
-      
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:
@@ -40,13 +44,13 @@ jobs:
       run: |
         NEW="${{ env.source }}~${{ env.headGithubRepo }}"
         OLD="${{ env.target }}~${{ env.baseGithubRepo }}"
-        
+
         if [[ '${{ env.targetBranchName || env.noTargetBranch }}' == release/* ]]
         then
             LATEST_TAG=$(git describe --tags --abbrev=0)
-            OLD="$LATEST_TAG~${{ env.baseGithubRepo }}" 
+            OLD="$LATEST_TAG~${{ env.baseGithubRepo }}"
         fi
-        
+
         # Providing the output to the environment
         echo "OLD_VERSION=$OLD" >> $GITHUB_ENV
         echo "NEW_VERSION=$NEW" >> $GITHUB_ENV

--- a/.github/workflows/sdk_size_analysis.yml
+++ b/.github/workflows/sdk_size_analysis.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sdk-size-analysis:
     runs-on: macos-15-xlarge


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

To free up more GitHub CI minutes we can limit more jobs to be canceled on PR branch pushes:
- API diff tool
- SDK size analysis

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes on CI
