### PR TITLE
Release process: Automatically assign release label

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -74,3 +74,15 @@ jobs:
         title: "[Release] ${{ github.event.inputs.sdk-version }}"
         body-path: "${{ github.workspace }}/.tmp/release_notes.md"
         token: ${{ secrets.AUTOMATION_BOT_TOKEN }}
+    
+    - name: Add release label
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        labels: "release"
+
+    - name: Auto approve release PR
+      uses: hmarr/auto-approve-action@v3
+      if: startsWith(github.event.pull_request.head.ref, 'release/')
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -66,6 +66,7 @@ jobs:
     
     # Creates a release/[sdk-version] branch with a PR to develop
     - name: Create Pull Request
+      id: create_pr
       uses: peter-evans/create-pull-request@v7
       with:
         delete-branch: true
@@ -80,9 +81,10 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         labels: "release"
-        issue_number: ${{ steps.create_pr.outputs.pull-request-number }}
+        number: ${{ steps.create_pr.outputs.pull-request-number }}
 
     - name: Auto approve release PR
       uses: hmarr/auto-approve-action@v3
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -80,9 +80,9 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         labels: "release"
+        issue_number: ${{ steps.create_pr.outputs.pull-request-number }}
 
     - name: Auto approve release PR
       uses: hmarr/auto-approve-action@v3
-      if: startsWith(github.event.pull_request.head.ref, 'release/')
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -4,82 +4,102 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
-  pr-validation:
+  validate-and-approve:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Get allowed PR labels
-        id: get-allowed_labels
-        env:
-          PROJECT_ROOT: ${{ github.workspace }}
-        run: |
-          FILE_NAME=.pull-requests-allowed-labels-list
-          FILE_PATH=$PROJECT_ROOT/$FILE_NAME
-          if [[ ! -f "$FILE_PATH" ]]; then
-             echo "Error: $FILE_NAME file doesn't exist in the root of the repository"
-             exit 1
-          fi
-          # Add 'chore', 'improvement', 'release' as allowed labels
-          echo "LABELS=$(cat $FILE_PATH),chore,improvement,release" >> $GITHUB_OUTPUT
-
-      - name: Get PR labels
-        id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.9
-
-      - name: Add release label
+      # ✅ Add release label and approve if this is a release PR
+      - name: Handle release PRs
         if: startsWith(github.event.pull_request.head.ref, 'release/')
-        uses: actions-ecosystem/action-add-labels@v1
+        run: |
+          echo "Release branch PR detected."
+        # Add release label
+      - uses: actions-ecosystem/action-add-labels@v1
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: "release"
 
-      - name: Auto-approve release PR
+      # Auto approve release PRs
+      - uses: hmarr/auto-approve-action@v3
         if: startsWith(github.event.pull_request.head.ref, 'release/')
-        uses: hmarr/auto-approve-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # 📋 Fetch allowed labels for non-release PRs
+      - name: Get allowed PR labels
+        if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
+        id: get-allowed_labels
+        env:
+          PROJECT_ROOT: ${{ github.workspace }}
+        run: |
+          RED='\033[0;31m'
+          NC='\033[0m'
+          FILE_NAME=.pull-requests-allowed-labels-list
+          FILE_PATH=$PROJECT_ROOT/$FILE_NAME
+          if [[ ! -f "$FILE_PATH" ]]; then
+             echo -e "${RED}$FILE_NAME file doesn't exist in the root of the repository${NC}"
+             exit 1
+          fi
+          echo "LABELS=$(cat $FILE_PATH),chore,improvement,release" >> $GITHUB_OUTPUT
+
+      # Get PR labels
+      - name: Get PR labels
+        if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
+        id: pr-labels
+        uses: joerick/pr-labels-action@v1.0.9
+
+      # Validate labels
+      - name: Validate labels
+        if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          valid-labels: ${{ steps.get-allowed_labels.outputs.LABELS }}
+
+      # Validate release notes for non-release PRs
       - name: Validate release notes per label
-        if: "!startsWith(github.event.pull_request.head.ref, 'release/')"
+        if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_LABELS: ${{ steps.pr-labels.outputs.labels }}
           ALLOWED_LABELS: ${{ steps.get-allowed_labels.outputs.LABELS }}
         run: |
-          IFS=',' read -r -a LABELS_ARRAY <<< "$ALLOWED_LABELS"
-
-          SKIP_LABELS=("chore" "improvement" "release")
+          ALLOWED_LABELS="$ALLOWED_LABELS,chore,improvement"
+          IFS=',' read -r -a ALLOWED_LABELS_ARRAY <<< "$ALLOWED_LABELS"
 
           SHOULD_FAIL_JOB="false"
+
           RED='\033[0;31m'
           NC='\033[0m'
 
-          for LABEL in "${LABELS_ARRAY[@]}"; do
-            LABEL=$(echo "$LABEL" | sed 's/^ *//;s/ *$//')
-            
-            if [[ " ${SKIP_LABELS[*]} " == *" $LABEL "* ]]; then
+          for LABEL in "${ALLOWED_LABELS_ARRAY[@]}"; do
+            LABEL=$(echo "$LABEL" | sed 's/^ *//g' | sed 's/ *$//g')
+            if [[ "$LABEL" == "chore"  || "$LABEL" == "improvement" ]]; then
               continue
             fi
-
             if [[ "$PR_LABELS" == *"$LABEL"* ]]; then
-              NOTE=$(echo "$PR_BODY" | grep -Poz "(?s)<$LABEL>.*?</$LABEL>" || true)
-              if [[ -z "$NOTE" ]]; then
-                echo -e "${RED}Pull requests labeled with '$LABEL' must have a release note in the PR body formatted as '<$LABEL> {{YOUR NOTE}} </$LABEL>'${NC}"
-                SHOULD_FAIL_JOB="true"
+              cmd="awk '/<$LABEL>.*<\/$LABEL>/'"
+              FEATURE_RELEASE_NOTE="$(echo $PR_BODY | eval $cmd)"
+              if [[ -z "$FEATURE_RELEASE_NOTE" ]]; then
+                 echo -e "${RED}Pull requests labeled with '$LABEL' must have the release note in the pull request body in the following format '<$LABEL> {THE RELEASE NOTE}  </$LABEL>'${NC}"
+                 SHOULD_FAIL_JOB="true"
               fi
             fi
           done
-
           if [[ "$SHOULD_FAIL_JOB" == "true" ]]; then
             exit 1
           fi

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -56,10 +56,8 @@ jobs:
           PR_LABELS: ${{ steps.pr-labels.outputs.labels }}
           ALLOWED_LABELS: ${{ steps.get-allowed_labels.outputs.LABELS }}
         run: |
-          # Split allowed labels into an array
           IFS=',' read -r -a LABELS_ARRAY <<< "$ALLOWED_LABELS"
 
-          # Labels that do NOT require release notes
           SKIP_LABELS=("chore" "improvement" "release")
 
           SHOULD_FAIL_JOB="false"
@@ -69,15 +67,12 @@ jobs:
           for LABEL in "${LABELS_ARRAY[@]}"; do
             LABEL=$(echo "$LABEL" | sed 's/^ *//;s/ *$//')
             
-            # Skip labels that do not require release notes
             if [[ " ${SKIP_LABELS[*]} " == *" $LABEL "* ]]; then
               continue
             fi
 
-            # Check if PR has this label
             if [[ "$PR_LABELS" == *"$LABEL"* ]]; then
-              # Look for release note in PR body
-              NOTE=$(echo "$PR_BODY" | awk "/<$LABEL>.*<\/$LABEL>/")
+              NOTE=$(echo "$PR_BODY" | grep -Poz "(?s)<$LABEL>.*?</$LABEL>" || true)
               if [[ -z "$NOTE" ]]; then
                 echo -e "${RED}Pull requests labeled with '$LABEL' must have a release note in the PR body formatted as '<$LABEL> {{YOUR NOTE}} </$LABEL>'${NC}"
                 SHOULD_FAIL_JOB="true"

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -10,41 +10,19 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: write # post PR comment
 
 jobs:
-  validate-and-approve:
+  get-pr-labels:
+    if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Fetch repo
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      # ✅ Add release label and approve if this is a release PR
-      - name: Handle release PRs
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
-        run: |
-          echo "Release branch PR detected."
-        # Add release label
-      - uses: actions-ecosystem/action-add-labels@v1
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "release"
-
-      # Auto approve release PRs
-      - uses: hmarr/auto-approve-action@v3
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      # 📋 Fetch allowed labels for non-release PRs
-      - name: Get allowed PR labels
-        if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
-        id: get-allowed_labels
-        env:
-          PROJECT_ROOT: ${{ github.workspace }}
+      - name: Get the list of allowed pull request labels
         run: |
           RED='\033[0;31m'
           NC='\033[0m'
@@ -53,31 +31,23 @@ jobs:
           if [[ ! -f "$FILE_PATH" ]]; then
              echo -e "${RED}$FILE_NAME file doesn't exist in the root of the repository${NC}"
              exit 1
-          fi
-          echo "LABELS=$(cat $FILE_PATH),chore,improvement,release" >> $GITHUB_OUTPUT
+          fi 
+          echo "LABELS=$(cat $FILE_PATH),chore,improvement" >> $GITHUB_OUTPUT
+        id: get-allowed_labels
+        env:
+          PROJECT_ROOT: ${{ github.workspace }}
 
-      # Get PR labels
-      - name: Get PR labels
-        if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
-        id: pr-labels
-        uses: joerick/pr-labels-action@v1.0.9
-
-      # Validate labels
       - name: Validate labels
-        if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
         uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
           valid-labels: ${{ steps.get-allowed_labels.outputs.LABELS }}
 
-      # Validate release notes for non-release PRs
-      - name: Validate release notes per label
-        if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_LABELS: ${{ steps.pr-labels.outputs.labels }}
-          ALLOWED_LABELS: ${{ steps.get-allowed_labels.outputs.LABELS }}
-        run: |
+      - name: Get PR labels
+        uses: joerick/pr-labels-action@v1.0.9
+        id: pr-labels
+
+      - run: |
           ALLOWED_LABELS="$ALLOWED_LABELS,chore,improvement"
           IFS=',' read -r -a ALLOWED_LABELS_ARRAY <<< "$ALLOWED_LABELS"
 
@@ -103,3 +73,7 @@ jobs:
           if [[ "$SHOULD_FAIL_JOB" == "true" ]]; then
             exit 1
           fi
+        env:
+          PR_BODY: ${{github.event.pull_request.body}}
+          PR_LABELS: ${{steps.pr-labels.outputs.labels}}
+          ALLOWED_LABELS: ${{ steps.get-allowed_labels.outputs.LABELS }}

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -15,7 +15,9 @@ permissions:
 jobs:
   # ✅ Auto-tag and approve release branch PRs
   tag-and-approve-release:
-    if: "startsWith(github.event.pull_request.head.ref, 'release/') && ((!contains(github.event.pull_request.user.login, '[bot]')) || github.event.pull_request.user.login == 'github-actions[bot]'))"
+    if: startsWith(github.event.pull_request.head.ref, 'release/') &&
+        ((!contains(github.event.pull_request.user.login, '[bot]')) ||
+         github.event.pull_request.user.login == 'github-actions[bot]')
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +34,9 @@ jobs:
 
   # 📋 Validate labels and release notes for non-release PRs
   validate-pr-labels:
-    if: "!startsWith(github.event.pull_request.head.ref, 'release/') && ((!contains(github.event.pull_request.user.login, '[bot]')) || github.event.pull_request.user.login == 'github-actions[bot]'))"
+    if: "!startsWith(github.event.pull_request.head.ref, 'release/') &&
+        ((!contains(github.event.pull_request.user.login, '[bot]')) ||
+         github.event.pull_request.user.login == 'github-actions[bot]')"
     runs-on: ubuntu-latest
 
     steps:
@@ -42,6 +46,9 @@ jobs:
           fetch-depth: 0
 
       - name: Get the list of allowed pull request labels
+        id: get-allowed_labels
+        env:
+          PROJECT_ROOT: ${{ github.workspace }}
         run: |
           RED='\033[0;31m'
           NC='\033[0m'
@@ -52,9 +59,6 @@ jobs:
              exit 1
           fi
           echo "LABELS=$(cat $FILE_PATH),chore,improvement" >> $GITHUB_OUTPUT
-        id: get-allowed_labels
-        env:
-          PROJECT_ROOT: ${{ github.workspace }}
 
       - name: Validate labels
         uses: jesusvasquez333/verify-pr-label-action@v1.4.0
@@ -63,30 +67,33 @@ jobs:
           valid-labels: ${{ steps.get-allowed_labels.outputs.LABELS }}
 
       - name: Get PR labels
-        uses: joerick/pr-labels-action@v1.0.9
         id: pr-labels
+        uses: joerick/pr-labels-action@v1.0.9
 
       - name: Validate release notes per label
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ steps.pr-labels.outputs.labels }}
+          ALLOWED_LABELS: ${{ steps.get-allowed_labels.outputs.LABELS }}
         run: |
           ALLOWED_LABELS="$ALLOWED_LABELS,chore,improvement"
           IFS=',' read -r -a ALLOWED_LABELS_ARRAY <<< "$ALLOWED_LABELS"
 
           SHOULD_FAIL_JOB="false"
-
           RED='\033[0;31m'
           NC='\033[0m'
 
           for LABEL in "${ALLOWED_LABELS_ARRAY[@]}"; do
-            LABEL=$(echo "$LABEL" | sed 's/^ *//g' | sed 's/ *$//g')
+            LABEL=$(echo "$LABEL" | sed 's/^ *//;s/ *$//')
             if [[ "$LABEL" == "chore" || "$LABEL" == "improvement" ]]; then
               continue
             fi
             if [[ "$PR_LABELS" == *"$LABEL"* ]]; then
               cmd="awk '/<$LABEL>.*<\/$LABEL>/'"
-              FEATURE_RELEASE_NOTE="$(echo $PR_BODY | eval $cmd)"
+              FEATURE_RELEASE_NOTE="$(echo "$PR_BODY" | eval "$cmd")"
               if [[ -z "$FEATURE_RELEASE_NOTE" ]]; then
-                 echo -e "${RED}Pull requests labeled with '$LABEL' must have the release note in the PR body in the format '<$LABEL> {THE RELEASE NOTE} </$LABEL>'${NC}"
-                 SHOULD_FAIL_JOB="true"
+                echo -e "${RED}Pull requests labeled with '$LABEL' must have a release note in the body formatted as '<$LABEL> {{YOUR NOTE}} </$LABEL>'${NC}"
+                SHOULD_FAIL_JOB="true"
               fi
             fi
           done
@@ -94,7 +101,3 @@ jobs:
           if [[ "$SHOULD_FAIL_JOB" == "true" ]]; then
             exit 1
           fi
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_LABELS: ${{ steps.pr-labels.outputs.labels }}
-          ALLOWED_LABELS: ${{ steps.get-allowed_labels.outputs.LABELS }}

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -13,36 +13,18 @@ permissions:
   pull-requests: write
 
 jobs:
-  # ✅ Handle release branch PRs: assign label
-  release-pr:
-    if: startsWith(github.event.pull_request.head.ref, 'release/') &&
-        ((!contains(github.event.pull_request.user.login, '[bot]')) ||
-         github.event.pull_request.user.login == 'github-actions[bot]')
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Add release label
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "release"
-
-      - name: Mark release PR job as passed
-        run: echo "Release PR detected — label applied, job passes."
-
-  # 📋 Validate labels and release notes for non-release PRs
-  validate-pr-labels:
+  validate-pr:
     if: "((!contains(github.event.pull_request.user.login, '[bot]')) ||
          github.event.pull_request.user.login == 'github-actions[bot]')"
     runs-on: ubuntu-latest
 
     steps:
-      - name: Fetch repo
+      - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Get the list of allowed pull request labels
+      - name: Get allowed PR labels
         id: get-allowed_labels
         env:
           PROJECT_ROOT: ${{ github.workspace }}
@@ -55,17 +37,19 @@ jobs:
              echo -e "${RED}$FILE_NAME file doesn't exist in the root of the repository${NC}"
              exit 1
           fi
-          echo "LABELS=$(cat $FILE_PATH),chore,improvement" >> $GITHUB_OUTPUT
-
-      - name: Validate labels
-        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          valid-labels: ${{ steps.get-allowed_labels.outputs.LABELS }}
+          # Add 'chore', 'improvement', 'release' as allowed labels
+          echo "LABELS=$(cat $FILE_PATH),chore,improvement,release" >> $GITHUB_OUTPUT
 
       - name: Get PR labels
         id: pr-labels
         uses: joerick/pr-labels-action@v1.0.9
+
+      - name: Add release label for release PRs
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "release"
 
       - name: Validate release notes per label
         env:
@@ -82,18 +66,21 @@ jobs:
 
           for LABEL in "${ALLOWED_LABELS_ARRAY[@]}"; do
             LABEL=$(echo "$LABEL" | sed 's/^ *//g' | sed 's/ *$//g')
-            if [[ "$LABEL" == "chore"  || "$LABEL" == "improvement" || "$LABEL" == "release" ]]; then
+            # Skip labels that do not require release notes
+            if [[ "$LABEL" == "chore" || "$LABEL" == "improvement" || "$LABEL" == "release" ]]; then
               continue
             fi
+
             if [[ "$PR_LABELS" == *"$LABEL"* ]]; then
               cmd="awk '/<$LABEL>.*<\/$LABEL>/'"
-              FEATURE_RELEASE_NOTE="$(echo $PR_BODY | eval $cmd)"
+              FEATURE_RELEASE_NOTE="$(echo "$PR_BODY" | eval "$cmd")"
               if [[ -z "$FEATURE_RELEASE_NOTE" ]]; then
-                 echo -e "${RED}Pull requests labeled with '$LABEL' must have the release note in the pull request body in the following format '<$LABEL> {THE RELEASE NOTE} </$LABEL>'${NC}"
+                 echo -e "${RED}Pull requests labeled with '$LABEL' must have a release note in the PR body formatted as '<$LABEL> {{YOUR NOTE}} </$LABEL>'${NC}"
                  SHOULD_FAIL_JOB="true"
               fi
             fi
           done
+
           if [[ "$SHOULD_FAIL_JOB" == "true" ]]; then
             exit 1
           fi

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -13,8 +13,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  # ✅ Auto-tag and approve release branch PRs
-  tag-and-approve-release:
+  # ✅ Handle release branch PRs: assign label, pass job, no approval
+  release-pr:
     if: startsWith(github.event.pull_request.head.ref, 'release/') &&
         ((!contains(github.event.pull_request.user.login, '[bot]')) ||
          github.event.pull_request.user.login == 'github-actions[bot]')
@@ -27,10 +27,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: "release"
 
-      - name: Auto approve PR
-        uses: hmarr/auto-approve-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Mark release PR job as passed
+        run: echo "Release PR detected — label applied, job passes."
 
   # 📋 Validate labels and release notes for non-release PRs
   validate-pr-labels:

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -53,34 +53,32 @@ jobs:
 
       - name: Validate release notes per label
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_LABELS: ${{ steps.pr-labels.outputs.labels }}
+          PR_BODY: ${{github.event.pull_request.body}}
+          PR_LABELS: ${{steps.pr-labels.outputs.labels}}
           ALLOWED_LABELS: ${{ steps.get-allowed_labels.outputs.LABELS }}
         run: |
           ALLOWED_LABELS="$ALLOWED_LABELS,chore,improvement"
           IFS=',' read -r -a ALLOWED_LABELS_ARRAY <<< "$ALLOWED_LABELS"
 
           SHOULD_FAIL_JOB="false"
+
           RED='\033[0;31m'
           NC='\033[0m'
 
           for LABEL in "${ALLOWED_LABELS_ARRAY[@]}"; do
             LABEL=$(echo "$LABEL" | sed 's/^ *//g' | sed 's/ *$//g')
-            # Skip labels that do not require release notes
-            if [[ "$LABEL" == "chore" || "$LABEL" == "improvement" || "$LABEL" == "release" ]]; then
+            if [[ "$LABEL" == "chore"  || "$LABEL" == "improvement" || "$LABEL" == "release" ]]; then
               continue
             fi
-
             if [[ "$PR_LABELS" == *"$LABEL"* ]]; then
               cmd="awk '/<$LABEL>.*<\/$LABEL>/'"
-              FEATURE_RELEASE_NOTE="$(echo "$PR_BODY" | eval "$cmd")"
+              FEATURE_RELEASE_NOTE="$(echo $PR_BODY | eval $cmd)"
               if [[ -z "$FEATURE_RELEASE_NOTE" ]]; then
-                 echo -e "${RED}Pull requests labeled with '$LABEL' must have a release note in the PR body formatted as '<$LABEL> {{YOUR NOTE}} </$LABEL>'${NC}"
+                 echo -e "${RED}Pull requests labeled with '$LABEL' must have the release note in the pull request body in the following format '<$LABEL> {THE RELEASE NOTE}  </$LABEL>'${NC}"
                  SHOULD_FAIL_JOB="true"
               fi
             fi
           done
-
           if [[ "$SHOULD_FAIL_JOB" == "true" ]]; then
             exit 1
           fi

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -81,20 +81,19 @@ jobs:
           NC='\033[0m'
 
           for LABEL in "${ALLOWED_LABELS_ARRAY[@]}"; do
-            LABEL=$(echo "$LABEL" | sed 's/^ *//;s/ *$//')
-            if [[ "$LABEL" == "chore" || "$LABEL" == "improvement" || "$LABEL" == "release" ]]; then
+            LABEL=$(echo "$LABEL" | sed 's/^ *//g' | sed 's/ *$//g')
+            if [[ "$LABEL" == "chore"  || "$LABEL" == "improvement" || "$LABEL" == "release" ]]; then
               continue
             fi
             if [[ "$PR_LABELS" == *"$LABEL"* ]]; then
               cmd="awk '/<$LABEL>.*<\/$LABEL>/'"
-              FEATURE_RELEASE_NOTE="$(echo "$PR_BODY" | eval "$cmd")"
+              FEATURE_RELEASE_NOTE="$(echo $PR_BODY | eval $cmd)"
               if [[ -z "$FEATURE_RELEASE_NOTE" ]]; then
-                echo -e "${RED}Pull requests labeled with '$LABEL' must have a release note in the body formatted as '<$LABEL> {{YOUR NOTE}} </$LABEL>'${NC}"
-                SHOULD_FAIL_JOB="true"
+                 echo -e "${RED}Pull requests labeled with '$LABEL' must have the release note in the pull request body in the following format '<$LABEL> {THE RELEASE NOTE} </$LABEL>'${NC}"
+                 SHOULD_FAIL_JOB="true"
               fi
             fi
           done
-
           if [[ "$SHOULD_FAIL_JOB" == "true" ]]; then
             exit 1
           fi

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -4,16 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
-  validate-pr:
+  pr-validation:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,12 +23,10 @@ jobs:
         env:
           PROJECT_ROOT: ${{ github.workspace }}
         run: |
-          RED='\033[0;31m'
-          NC='\033[0m'
           FILE_NAME=.pull-requests-allowed-labels-list
           FILE_PATH=$PROJECT_ROOT/$FILE_NAME
           if [[ ! -f "$FILE_PATH" ]]; then
-             echo -e "${RED}$FILE_NAME file doesn't exist in the root of the repository${NC}"
+             echo "Error: $FILE_NAME file doesn't exist in the root of the repository"
              exit 1
           fi
           # Add 'chore', 'improvement', 'release' as allowed labels
@@ -42,41 +36,55 @@ jobs:
         id: pr-labels
         uses: joerick/pr-labels-action@v1.0.9
 
-      - name: Add release label for release PRs
+      - name: Add release label
         if: startsWith(github.event.pull_request.head.ref, 'release/')
         uses: actions-ecosystem/action-add-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: "release"
 
+      - name: Auto-approve release PR
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        uses: hmarr/auto-approve-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Validate release notes per label
+        if: "!startsWith(github.event.pull_request.head.ref, 'release/')"
         env:
-          PR_BODY: ${{github.event.pull_request.body}}
-          PR_LABELS: ${{steps.pr-labels.outputs.labels}}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ steps.pr-labels.outputs.labels }}
           ALLOWED_LABELS: ${{ steps.get-allowed_labels.outputs.LABELS }}
         run: |
-          ALLOWED_LABELS="$ALLOWED_LABELS,chore,improvement"
-          IFS=',' read -r -a ALLOWED_LABELS_ARRAY <<< "$ALLOWED_LABELS"
+          # Split allowed labels into an array
+          IFS=',' read -r -a LABELS_ARRAY <<< "$ALLOWED_LABELS"
+
+          # Labels that do NOT require release notes
+          SKIP_LABELS=("chore" "improvement" "release")
 
           SHOULD_FAIL_JOB="false"
-
           RED='\033[0;31m'
           NC='\033[0m'
 
-          for LABEL in "${ALLOWED_LABELS_ARRAY[@]}"; do
-            LABEL=$(echo "$LABEL" | sed 's/^ *//g' | sed 's/ *$//g')
-            if [[ "$LABEL" == "chore"  || "$LABEL" == "improvement" || "$LABEL" == "release" ]]; then
+          for LABEL in "${LABELS_ARRAY[@]}"; do
+            LABEL=$(echo "$LABEL" | sed 's/^ *//;s/ *$//')
+            
+            # Skip labels that do not require release notes
+            if [[ " ${SKIP_LABELS[*]} " == *" $LABEL "* ]]; then
               continue
             fi
+
+            # Check if PR has this label
             if [[ "$PR_LABELS" == *"$LABEL"* ]]; then
-              cmd="awk '/<$LABEL>.*<\/$LABEL>/'"
-              FEATURE_RELEASE_NOTE="$(echo $PR_BODY | eval $cmd)"
-              if [[ -z "$FEATURE_RELEASE_NOTE" ]]; then
-                 echo -e "${RED}Pull requests labeled with '$LABEL' must have the release note in the pull request body in the following format '<$LABEL> {THE RELEASE NOTE}  </$LABEL>'${NC}"
-                 SHOULD_FAIL_JOB="true"
+              # Look for release note in PR body
+              NOTE=$(echo "$PR_BODY" | awk "/<$LABEL>.*<\/$LABEL>/")
+              if [[ -z "$NOTE" ]]; then
+                echo -e "${RED}Pull requests labeled with '$LABEL' must have a release note in the PR body formatted as '<$LABEL> {{YOUR NOTE}} </$LABEL>'${NC}"
+                SHOULD_FAIL_JOB="true"
               fi
             fi
           done
+
           if [[ "$SHOULD_FAIL_JOB" == "true" ]]; then
             exit 1
           fi

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -10,11 +10,12 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write # post PR comment
+  pull-requests: write
 
 jobs:
-  tag-release-branch:
-    if: "startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
+  # ✅ Auto-tag and approve release branch PRs
+  tag-and-approve-release:
+    if: "startsWith(github.event.pull_request.head.ref, 'release/') && ((!contains(github.event.pull_request.user.login, '[bot]')) || github.event.pull_request.user.login == 'github-actions[bot]'))"
     runs-on: ubuntu-latest
 
     steps:
@@ -24,9 +25,16 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: "release"
 
-  get-pr-labels:
-    if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
+      - name: Auto approve PR
+        uses: hmarr/auto-approve-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # 📋 Validate labels and release notes for non-release PRs
+  validate-pr-labels:
+    if: "!startsWith(github.event.pull_request.head.ref, 'release/') && ((!contains(github.event.pull_request.user.login, '[bot]')) || github.event.pull_request.user.login == 'github-actions[bot]'))"
     runs-on: ubuntu-latest
+
     steps:
       - name: Fetch repo
         uses: actions/checkout@v5
@@ -40,9 +48,9 @@ jobs:
           FILE_NAME=.pull-requests-allowed-labels-list
           FILE_PATH=$PROJECT_ROOT/$FILE_NAME
           if [[ ! -f "$FILE_PATH" ]]; then
-             echo -e "${RED}$FILE_NAME file doesn't exits in the root of the respository${NC}"
+             echo -e "${RED}$FILE_NAME file doesn't exist in the root of the repository${NC}"
              exit 1
-          fi 
+          fi
           echo "LABELS=$(cat $FILE_PATH),chore,improvement" >> $GITHUB_OUTPUT
         id: get-allowed_labels
         env:
@@ -51,14 +59,15 @@ jobs:
       - name: Validate labels
         uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           valid-labels: ${{ steps.get-allowed_labels.outputs.LABELS }}
 
       - name: Get PR labels
         uses: joerick/pr-labels-action@v1.0.9
         id: pr-labels
 
-      - run: |
+      - name: Validate release notes per label
+        run: |
           ALLOWED_LABELS="$ALLOWED_LABELS,chore,improvement"
           IFS=',' read -r -a ALLOWED_LABELS_ARRAY <<< "$ALLOWED_LABELS"
 
@@ -69,22 +78,23 @@ jobs:
 
           for LABEL in "${ALLOWED_LABELS_ARRAY[@]}"; do
             LABEL=$(echo "$LABEL" | sed 's/^ *//g' | sed 's/ *$//g')
-            if [[ "$LABEL" == "chore"  || "$LABEL" == "improvement" ]]; then
+            if [[ "$LABEL" == "chore" || "$LABEL" == "improvement" ]]; then
               continue
             fi
             if [[ "$PR_LABELS" == *"$LABEL"* ]]; then
               cmd="awk '/<$LABEL>.*<\/$LABEL>/'"
               FEATURE_RELEASE_NOTE="$(echo $PR_BODY | eval $cmd)"
               if [[ -z "$FEATURE_RELEASE_NOTE" ]]; then
-                 echo -e "${RED}Pull requests labeled with '$LABEL' must have the release note in the pull request body in the following format '<$LABEL> {THE RELEASE NOTE}  </$LABEL>'${NC}"
+                 echo -e "${RED}Pull requests labeled with '$LABEL' must have the release note in the PR body in the format '<$LABEL> {THE RELEASE NOTE} </$LABEL>'${NC}"
                  SHOULD_FAIL_JOB="true"
               fi
             fi
           done
+
           if [[ "$SHOULD_FAIL_JOB" == "true" ]]; then
             exit 1
           fi
         env:
-          PR_BODY: ${{github.event.pull_request.body}}
-          PR_LABELS: ${{steps.pr-labels.outputs.labels}}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ steps.pr-labels.outputs.labels }}
           ALLOWED_LABELS: ${{ steps.get-allowed_labels.outputs.LABELS }}

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -32,8 +32,7 @@ jobs:
 
   # 📋 Validate labels and release notes for non-release PRs
   validate-pr-labels:
-    if: "!startsWith(github.event.pull_request.head.ref, 'release/') &&
-        ((!contains(github.event.pull_request.user.login, '[bot]')) ||
+    if: "((!contains(github.event.pull_request.user.login, '[bot]')) ||
          github.event.pull_request.user.login == 'github-actions[bot]')"
     runs-on: ubuntu-latest
 

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -13,6 +13,17 @@ permissions:
   pull-requests: write # post PR comment
 
 jobs:
+  tag-release-branch:
+    if: "startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add release label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "release"
+
   get-pr-labels:
     if: "!startsWith(github.event.pull_request.head.ref, 'release/') && !contains(github.event.pull_request.user.login, '[bot]')"
     runs-on: ubuntu-latest

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -14,8 +14,6 @@ permissions:
 
 jobs:
   validate-pr:
-    if: "((!contains(github.event.pull_request.user.login, '[bot]')) ||
-         github.event.pull_request.user.login == 'github-actions[bot]')"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  # ✅ Handle release branch PRs: assign label, pass job, no approval
+  # ✅ Handle release branch PRs: assign label
   release-pr:
     if: startsWith(github.event.pull_request.head.ref, 'release/') &&
         ((!contains(github.event.pull_request.user.login, '[bot]')) ||

--- a/.github/workflows/validate_pr_labels_and_release_notes.yml
+++ b/.github/workflows/validate_pr_labels_and_release_notes.yml
@@ -82,7 +82,7 @@ jobs:
 
           for LABEL in "${ALLOWED_LABELS_ARRAY[@]}"; do
             LABEL=$(echo "$LABEL" | sed 's/^ *//;s/ *$//')
-            if [[ "$LABEL" == "chore" || "$LABEL" == "improvement" ]]; then
+            if [[ "$LABEL" == "chore" || "$LABEL" == "improvement" || "$LABEL" == "release" ]]; then
               continue
             fi
             if [[ "$PR_LABELS" == *"$LABEL"* ]]; then

--- a/.pull-requests-allowed-labels-list
+++ b/.pull-requests-allowed-labels-list
@@ -1,1 +1,1 @@
-new,changed,fixed,removed,deprecated
+new,changed,fixed,removed,deprecated,release

--- a/.pull-requests-allowed-labels-list
+++ b/.pull-requests-allowed-labels-list
@@ -1,1 +1,1 @@
-new,changed,fixed,removed,deprecated,release
+new,changed,fixed,removed,deprecated


### PR DESCRIPTION
## Summary

This PR introduces changes in the "Prepare Release" job
- A `release` label is automatically assigned to the release PR.
- It allows `github-actions[bot]` to approve release PRs.
- Release PRs number of manual approvals **has been reduced from 3 to 2**.

## Checklist
- [x] Tested on Github Actions
