### PR TITLE
Update 3ds2 sdk version - 2.4.4

### DIFF
--- a/Adyen.podspec
+++ b/Adyen.podspec
@@ -77,7 +77,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Actions' do |plugin|
     plugin.dependency 'Adyen/Core'
-    plugin.dependency 'Adyen3DS2', '2.4.3'
+    plugin.dependency 'Adyen3DS2', '2.4.4'
     plugin.source_files = 'AdyenActions/**/*.swift'
     plugin.exclude_files = 'AdyenActions/**/BundleSPMExtension.swift'
     plugin.resource_bundles = {

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -10408,7 +10408,7 @@
 			repositoryURL = "https://github.com/Adyen/adyen-3ds2-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 2.4.3;
+				version = 2.4.4;
 			};
 		};
 		F94D65E42B0365C30095D61E /* XCRemoteSwiftPackageReference "adyen-authentication-ios" */ = {

--- a/AdyenCard/Components/Card/ThreeDS2SdkVersion.swift
+++ b/AdyenCard/Components/Card/ThreeDS2SdkVersion.swift
@@ -7,4 +7,4 @@
 import Foundation
 
 /// The 3DS2 SDK version.
-public let threeDS2SdkVersion: String = "2.4.3"
+public let threeDS2SdkVersion: String = "2.4.4"

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "adyen/adyen-3ds2-ios" == 2.4.3
+github "adyen/adyen-3ds2-ios" == 2.4.4
 github "adyen/adyen-networking-ios" == 3.0.1
 github "adyen/adyen-wechatpay-ios" == 2.1.0
 github "adyen/adyen-authentication-ios" == 3.1.0

--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/Adyen/adyen-3ds2-ios",
-            exact: "2.4.3"
+            exact: "2.4.4"
         ),
         .package(
             url: "https://github.com/Adyen/adyen-authentication-ios",

--- a/Scripts/generate_docc_documentation.sh
+++ b/Scripts/generate_docc_documentation.sh
@@ -87,7 +87,7 @@ let package = Package(
         .package(
             name: \"Adyen3DS2\",
             url: \"https://github.com/Adyen/adyen-3ds2-ios\",
-            .exact(Version(2, 4, 3))
+            .exact(Version(2, 4, 4))
         ),
         .package(
             name: \"AdyenNetworking\",


### PR DESCRIPTION
# Summary [Required]
Updating the release of the 3ds2 sdk to version 2.4.4.

## Release Notes [Optional]
### Use appropriate tags for different types of changes:
<changed>
Updated [3D Secure 2 SDK to version 2.4.4](https://github.com/Adyen/adyen-3ds2-ios/releases/tag/2.4.4)
   - Updated to support device information spec 1.7 and memory warnings fixture. 
</changed>
