### PR TITLE
FIX: PayTo - shopperAccountIdentifier formatting bug with phone number.

### DIFF
--- a/AdyenComponents/PayTo/PayToComponent.swift
+++ b/AdyenComponents/PayTo/PayToComponent.swift
@@ -19,7 +19,7 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
 
     /// The delegate of the component.
     public weak var delegate: PaymentComponentDelegate?
-    
+
     /// Component's configuration
     public var configuration: Configuration
 
@@ -27,7 +27,7 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
     public var paymentMethod: PaymentMethod { payToPaymentMethod }
 
     private let payToPaymentMethod: PayToPaymentMethod
-    
+
     internal lazy var itemsProvider: PayToItemsProviding = {
         PayToItemsProvider(
             style: configuration.style,
@@ -36,18 +36,18 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
             presenter: .init(self)
         )
     }()
-    
+
     /// The viewController for the component.
     public lazy var viewController: UIViewController = SecuredViewController(
         child: formViewController,
         style: configuration.style
     )
-    
+
     /// This indicates that `viewController` expected to be presented modally,
     public var requiresModalPresentation: Bool = true
-    
+
     // MARK: Component specific
-    
+
     /// Currently selected PayId identifier
     private var selectedIdentifier: PayToPayIdentifier = .phone
 
@@ -60,7 +60,7 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
             }
         }
     }
-    
+
     /// Items on PayId segment that can be shown/hidden
     private lazy var payIdDynamicItems: [FormItem] = [
         payIdFlowTitleItem,
@@ -70,7 +70,7 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
         abnInputItem,
         organizationIdInputItem
     ]
-    
+
     /// Items on BSB segment that can be shown/hidden
     private lazy var bsbDynamicItems: [FormItem] = [
         bsbInstructionTitleItem,
@@ -165,7 +165,7 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
     internal lazy var bsbInputItem: FormTextInputItem = {
         itemsProvider.createBsbInputItem()
     }()
-    
+
     /// The continue button item.
     internal lazy var continueButtonItem: FormButtonItem = {
         let item = itemsProvider.createContinueButtonItem()
@@ -183,10 +183,10 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
         )
         formViewController.title = paymentMethod.displayInformation(using: configuration.localizationParameters).title
         formViewController.delegate = self
-        
+
         addTopItems(to: formViewController)
         formViewController.append(FormSpacerItem(numberOfSpaces: 2))
-        
+
         addDynamicItems(to: formViewController)
         addBottomItems(to: formViewController)
 
@@ -195,11 +195,11 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
             formViewController.append(FormSpacerItem(numberOfSpaces: 2))
             formViewController.append(continueButtonItem)
         }
-        
+
         observe(identifierPickerItem.publisher) { [weak self] newValue in
             self?.updatePayIdIdentifier(newValue.element.identifier)
         }
-        
+
         updateInterface()
 
         return formViewController
@@ -212,11 +212,11 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
 }
 
 extension PayToComponent: SubmittableComponent {
-    
+
     public func submit() {
         didSelectContinueButton()
     }
-    
+
     public func validate() -> Bool {
         formViewController.validate()
     }
@@ -230,11 +230,11 @@ extension PayToComponent: TrackableComponent {}
 
 @_spi(AdyenInternal)
 extension PayToComponent: ViewControllerPresenter {
-    
+
     public func presentViewController(_ viewController: UIViewController, animated: Bool) {
         self.viewController.presentViewController(viewController, animated: animated)
     }
-    
+
     public func dismissViewController(animated: Bool) {
         self.viewController.dismissViewController(animated: animated)
     }
@@ -246,7 +246,7 @@ private extension PayToComponent {
 
     func didSelectContinueButton() {
         guard validate() else { return }
-        
+
         startLoading()
 
         let details = PayToDetails(
@@ -257,7 +257,7 @@ private extension PayToComponent {
                 lastName: lastNameInputItem.value
             )
         )
-        
+
         submit(
             data: PaymentComponentData(
                 paymentMethodDetails: details,
@@ -266,12 +266,12 @@ private extension PayToComponent {
             )
         )
     }
-    
+
     func startLoading() {
         continueButtonItem.showsActivityIndicator = true
         formViewController.view.isUserInteractionEnabled = false
     }
-    
+
     func updatePayIdIdentifier(_ newValue: String) {
         guard let newIdentifier = PayToPayIdentifier(rawValue: newValue) else { return }
         selectedIdentifier = newIdentifier
@@ -279,7 +279,7 @@ private extension PayToComponent {
     }
 
     func didChangeSegment(_ index: Int) {
-        
+
         formViewController.view.endEditing(true)
         switch index {
         case 0:
@@ -317,23 +317,23 @@ private extension PayToComponent {
 // MARK: - Private
 
 private extension PayToComponent {
-    
+
     func addTopItems(to formViewController: FormViewController) {
         let topItems: [FormItem] = [
             flowSelectionTitleItem.padding(),
             flowSelectionItem.padding()
         ]
-        
+
         add(topItems, to: formViewController, spacing: 1)
     }
-    
+
     func addDynamicItems(to formViewController: FormViewController) {
         add(
             payIdDynamicItems,
             to: formViewController,
             isHidden: true
         )
-        
+
         formViewController.append(bsbInstructionTitleItem)
         formViewController.append(FormSpacerItem(numberOfSpaces: 2))
         formViewController.append(bsbInputItem)
@@ -346,7 +346,7 @@ private extension PayToComponent {
             firstNameInputItem,
             lastNameInputItem
         ]
-        
+
         add(bottomItems, to: formViewController)
     }
 
@@ -364,12 +364,12 @@ private extension PayToComponent {
             $0.isHidden.wrappedValue = isHidden
         }
     }
-    
+
     func updateInterface() {
         switch selectedPaymentOption {
         case let .payId(identifier):
             resetPayIdItemsVisibility()
-            
+
             switch identifier {
             case .phone:
                 phoneNumberItem.isHidden.wrappedValue = false
@@ -385,7 +385,7 @@ private extension PayToComponent {
             bsbDynamicItems.forEach { $0.isHidden.wrappedValue = false }
         }
     }
-    
+
     func resetPayIdItemsVisibility() {
         let payIdItemsToHide: [FormItem] = [
             phoneNumberItem,
@@ -395,7 +395,7 @@ private extension PayToComponent {
         ]
         payIdItemsToHide.forEach { $0.isHidden.wrappedValue = true }
         bsbDynamicItems.forEach { $0.isHidden.wrappedValue = true }
-        
+
         identifierPickerItem.isHidden.wrappedValue = false
         payIdFlowTitleItem.isHidden.wrappedValue = false
     }

--- a/AdyenComponents/PayTo/PayToComponent.swift
+++ b/AdyenComponents/PayTo/PayToComponent.swift
@@ -19,7 +19,7 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
 
     /// The delegate of the component.
     public weak var delegate: PaymentComponentDelegate?
-
+    
     /// Component's configuration
     public var configuration: Configuration
 
@@ -298,7 +298,8 @@ private extension PayToComponent {
         case let .payId(identifier):
             switch identifier {
             case .phone:
-                phoneNumberItem.phoneNumber
+                // Insert hyphen between prefix and number to match PayTo backend format for accountIdentifier (e.g., +61-012345678)
+                [phoneNumberItem.prefix, phoneNumberItem.value].joined(separator: "-")
             case .email:
                 emailInputItem.value
             case .abn:

--- a/Scripts/test-carthage-integration.sh
+++ b/Scripts/test-carthage-integration.sh
@@ -53,7 +53,7 @@ then
 
   echo "git \"file://$CWD/../\" \"$CURRENT_COMMIT\"" > Cartfile
   echo "github \"adyen/adyen-authentication-ios\" == 3.1.0" >> Cartfile
-  carthage update --use-xcframeworks --configuration Debug
+  carthage update --use-xcframeworks --configuration Debug --no-parallel --verbose
 else
   cd $PROJECT_NAME
 fi

--- a/Scripts/test-carthage-integration.sh
+++ b/Scripts/test-carthage-integration.sh
@@ -53,7 +53,7 @@ then
 
   echo "git \"file://$CWD/../\" \"$CURRENT_COMMIT\"" > Cartfile
   echo "github \"adyen/adyen-authentication-ios\" == 3.1.0" >> Cartfile
-  carthage update --use-xcframeworks --configuration Debug --no-parallel --verbose
+  carthage update --use-xcframeworks --configuration Debug
 else
   cd $PROJECT_NAME
 fi

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -449,7 +449,7 @@ class PayToComponentTests: XCTestCase {
         XCTAssertEqual(delegateMock.didSubmitCallsCount, 1)
     }
     
-    func testPayToComponent_givenPhonePayId_submitsCorrectFormattedAccountIdentifier() throws {
+    func testPayToComponent_givenPhonePayIdPaymentOption_submitsCorrectFormattedAccountIdentifier() throws {
         // Given
         let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
         let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
@@ -490,7 +490,7 @@ class PayToComponentTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
     
-    func testPayToComponent_givenEmailPayId_submitsCorrectAccountIdentifier() throws {
+    func testPayToComponent_givenEmailPayIdPaymentOption_submitsCorrectAccountIdentifier() throws {
         // Given
         let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
         let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
@@ -531,7 +531,7 @@ class PayToComponentTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
     
-    func testPayToComponent_givenAbnPayId_submitsCorrectAccountIdentifier() throws {
+    func testPayToComponent_givenAbnPayIdPaymentOption_submitsCorrectAccountIdentifier() throws {
         // Given
         let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
         let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
@@ -572,7 +572,7 @@ class PayToComponentTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
     
-    func testPayToComponent_givenBSB_submitsCorrectAccountIdentifier() throws {
+    func testPayToComponent_givenBsbPaymentOption_submitsCorrectAccountIdentifier() throws {
         // Given
         let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
         let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -572,6 +572,47 @@ class PayToComponentTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
     
+    func testPayToComponent_givenOrganizationIdPayIdPaymentOption_submitsCorrectAccountIdentifier() throws {
+        // Given
+        let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
+        let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
+        let organizationId = "*hello123.world*"
+        let shopperName = ShopperName(firstName: "Katrina", lastName: "Del Mar")
+        
+        let expectedDetails = PayToDetails(
+            paymentMethod: paymentMethodMock,
+            accountIdentifier: "\(organizationId)",
+            shopperName: shopperName
+        )
+        
+        let sut = PayToComponent(
+            paymentMethod: payToPaymentMethod,
+            context: Dummy.context
+        )
+        sut.selectedPaymentOption = .payId(.organizationId)
+        
+        let delegateMock = PaymentComponentDelegateMock()
+        sut.delegate = delegateMock
+        
+        let didSubmitExpectation = expectation(description: "Delegate's didSubmit must be called")
+        
+        delegateMock.onDidSubmit = { data, _ in
+            // Then
+            didSubmitExpectation.fulfill()
+            let receivedDetails = try? XCTUnwrap(data.paymentMethod as? PayToDetails)
+            XCTAssertTrue(self.payToDetailsEqual(expectedDetails, receivedDetails), "Submitted PayToDetails should match expected details")
+        }
+        
+        // When
+        sut.organizationIdInputItem.value = organizationId
+        sut.firstNameInputItem.value = shopperName.firstName
+        sut.lastNameInputItem.value = shopperName.lastName
+        
+        sut.submit()
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
     func testPayToComponent_givenBsbPaymentOption_submitsCorrectAccountIdentifier() throws {
         // Given
         let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -531,6 +531,47 @@ class PayToComponentTests: XCTestCase {
         waitForExpectations(timeout: 1.0)
     }
     
+    func testPayToComponent_givenAbnPayId_submitsCorrectAccountIdentifier() throws {
+        // Given
+        let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
+        let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
+        let abn = "51824753556" // ABN (Australian Business Number) is a unique 11-digit identifier issued to businesses in Australia
+        let shopperName = ShopperName(firstName: "Katrina", lastName: "Del Mar")
+        
+        let expectedDetails = PayToDetails(
+            paymentMethod: paymentMethodMock,
+            accountIdentifier: "\(abn)", // ensure correct hyphenated format
+            shopperName: shopperName
+        )
+        
+        let sut = PayToComponent(
+            paymentMethod: payToPaymentMethod,
+            context: Dummy.context
+        )
+        sut.selectedPaymentOption = .payId(.abn)
+        
+        let delegateMock = PaymentComponentDelegateMock()
+        sut.delegate = delegateMock
+        
+        let didSubmitExpectation = expectation(description: "Delegate's didSubmit must be called")
+        
+        delegateMock.onDidSubmit = { data, _ in
+            // Then
+            didSubmitExpectation.fulfill()
+            let receivedDetails = try? XCTUnwrap(data.paymentMethod as? PayToDetails)
+            XCTAssertTrue(self.payToDetailsEqual(expectedDetails, receivedDetails), "Submitted PayToDetails should match expected details")
+        }
+        
+        // When
+        sut.abnInputItem.value = abn
+        sut.firstNameInputItem.value = shopperName.firstName
+        sut.lastNameInputItem.value = shopperName.lastName
+        
+        sut.submit()
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
     private func populateValidFields(sut: PayToComponent) throws {
         let phoneNumberItem: FormPhoneNumberItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.phoneNumberItem"))
         let firstNameInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.firstNameTextfield"))

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -19,39 +19,39 @@ class PayToComponentTests: XCTestCase {
             context: Dummy.context
         )
     }
-
+    
     func test_init() throws {
         let sut = try PayToComponent(
             paymentMethod: AdyenCoder.decode(payto),
             context: Dummy.context
         )
-
+        
         XCTAssertNotNil(sut)
     }
-
+    
     func test_paymentMethodType_isPayto() throws {
         XCTAssertEqual(sut.paymentMethod.type, .payTo)
     }
-
+    
     func test_flowSelection_titleLabel_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let flowSelectionTitleLabelItem = sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.flowSelectionTitleLabel") as? UILabel
-
+        
         // Then
         XCTAssertNotNil(flowSelectionTitleLabelItem, "Flow selection title label should exist")
     }
-
+    
     func test_flowSelectionItem_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let flowSelectionItem = sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.flowSelectionSegmentedControl") as? UISegmentedControl
         flowSelectionItem?.selectedSegmentIndex = 1
-
+        
         // Then
         XCTAssertNotNil(flowSelectionItem, "Flow selection item should exist")
     }
@@ -68,7 +68,7 @@ class PayToComponentTests: XCTestCase {
         // Then
         XCTAssertNotNil(phoneNumberItem, "Phone number item should exist")
     }
-
+    
     func test_phoneNumberItem_invalidNumbers() throws {
         // Given
         let invalidNumbers = [
@@ -121,30 +121,30 @@ class PayToComponentTests: XCTestCase {
             XCTAssertTrue(sut.phoneNumberItem.isValid(), "Number \(number) should be valid with leading zero")
         }
     }
-
+    
     func test_payid_titleLabel_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let payIdTitleLabelItem = sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.payIdFlowTitleTitleLabel") as? UILabel
-
+        
         // Then
         XCTAssertNotNil(payIdTitleLabelItem, "PayId flow title label should exist")
     }
-
+    
     func test_identifierPicker_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let identifierPickerItem: PayToFormPickerItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.identifierPicker"))
-
+        
         // Then
         XCTAssertNotNil(identifierPickerItem, "identifier picker should exist")
         XCTAssertFalse(identifierPickerItem.canBecomeFirstResponder)
     }
-
+    
     func test_firstname_textfield() throws {
         sut.firstNameInputItem.value = ""
         XCTAssertFalse(sut.firstNameInputItem.isValid())
@@ -153,14 +153,14 @@ class PayToComponentTests: XCTestCase {
         
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let firstNameInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.firstNameTextfield"))
-
+        
         // Then
         XCTAssertNotNil(firstNameInputItem, "first name input field should exist")
     }
-
+    
     func test_lastname_textfield() throws {
         sut.lastNameInputItem.value = ""
         XCTAssertFalse(sut.lastNameInputItem.isValid())
@@ -169,14 +169,14 @@ class PayToComponentTests: XCTestCase {
         
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let lastNameInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.lastNameTextfield"))
-
+        
         // Then
         XCTAssertNotNil(lastNameInputItem, "last name input field should exist")
     }
-
+    
     func test_email_textfield() throws {
         
         // invalid
@@ -197,14 +197,14 @@ class PayToComponentTests: XCTestCase {
         
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let emailInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.emailTextfield"))
-
+        
         // Then
         XCTAssertNotNil(emailInputItem, "email input field should exist")
     }
-
+    
     func test_abn_textfield() throws {
         
         // only 9 or 11 integers are valid
@@ -227,14 +227,14 @@ class PayToComponentTests: XCTestCase {
         
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let abnInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.abnTextfield"))
-
+        
         // Then
         XCTAssertNotNil(abnInputItem, "abn input field should exist")
     }
-
+    
     func test_organizationID_textfield() throws {
         // invalid
         sut.organizationIdInputItem.value = ""
@@ -264,14 +264,14 @@ class PayToComponentTests: XCTestCase {
         
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let organizationIDInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.organizationIDTextfield"))
-
+        
         // Then
         XCTAssertNotNil(organizationIDInputItem, "organizationID input field should exist")
     }
-
+    
     func test_accountNumber_textfield() throws {
         // invalid
         sut.accountNumberInputItem.value = ""
@@ -293,14 +293,14 @@ class PayToComponentTests: XCTestCase {
         
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let accountNumberInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.accountNumberTextfield"))
-
+        
         // Then
         XCTAssertNotNil(accountNumberInputItem, "Bank account number input field should exist")
     }
-
+    
     func test_bank_state_number_textfield() throws {
         
         // invalid
@@ -327,21 +327,21 @@ class PayToComponentTests: XCTestCase {
         
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let bankStateNumberInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.bankStateBranchTextfield"))
-
+        
         // Then
         XCTAssertNotNil(bankStateNumberInputItem, "Bank state number input field should exist")
     }
-
+    
     func test_payment_instruction_titleLabel_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let paymentInstructionTitleLabelItem = sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.paymentInstructionTitleLabel") as? UILabel
-
+        
         // Then
         XCTAssertNotNil(paymentInstructionTitleLabelItem, "Payment instruction title label should exist")
     }
@@ -349,10 +349,10 @@ class PayToComponentTests: XCTestCase {
     func test_continueButton_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-
+        
         // Check by accessibility identifier
         let continueButton: FormButtonItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.continueButton"))
-
+        
         // Then
         XCTAssertNotNil(continueButton, "ContinueButton should exist")
     }
@@ -371,10 +371,10 @@ class PayToComponentTests: XCTestCase {
             paymentMethod: paymentMethod,
             context: context
         )
-
+        
         // When
         sut.viewDidLoad(viewController: sut.viewController)
-
+        
         // Then
         XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)
         XCTAssertEqual(analyticsProviderMock.infos.count, 1)
@@ -391,20 +391,20 @@ class PayToComponentTests: XCTestCase {
             context: Dummy.context,
             configuration: configuration
         )
-
+        
         try populateValidFields(sut: sut)
-
+        
         let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
         let expectedResult = formViewController.validate()
-
+        
         // When
         let validationResult = sut.validate()
-
+        
         // Then
         XCTAssertTrue(validationResult)
         XCTAssertEqual(expectedResult, validationResult)
     }
-
+    
     func testValidateGivenInvalidInputShouldReturnFormViewControllerValidateResult() throws {
         // Given
         let paymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
@@ -414,39 +414,79 @@ class PayToComponentTests: XCTestCase {
             context: Dummy.context,
             configuration: configuration
         )
-
+        
         let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
         let expectedResult = formViewController.validate()
-
+        
         // When
         let validationResult = sut.validate()
-
+        
         // Then
         XCTAssertFalse(validationResult)
         XCTAssertEqual(expectedResult, validationResult)
     }
-
+    
     func testSubmit_shouldCallPaymentDelegateDidSubmit() throws {
         // Given
         
         sut.viewController.loadViewIfNeeded()
-
+        
         let didSubmitExpectation = XCTestExpectation(description: "Expect delegate.didSubmit() to be called.")
-
+        
         let delegateMock = PaymentComponentDelegateMock()
         sut.delegate = delegateMock
         delegateMock.onDidSubmit = { data, component in
             didSubmitExpectation.fulfill()
         }
-
+        
         try populateValidFields(sut: sut)
-
+        
         // When
         sut.submit()
-
+        
         // Then
         wait(for: [didSubmitExpectation], timeout: 10)
         XCTAssertEqual(delegateMock.didSubmitCallsCount, 1)
+    }
+    
+    func testPayToComponent_submitsCorrectAccountIdentifier_forPhoneNumber() throws {
+        // Given
+        let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
+        let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
+        let phoneNumber = "0666555444"
+        let shopperName = ShopperName(firstName: "Katrina", lastName: "Del Mar")
+        
+        let expectedDetails = PayToDetails(
+            paymentMethod: paymentMethodMock,
+            accountIdentifier: "+61-\(phoneNumber)", // ensure correct hyphenated format
+            shopperName: shopperName
+        )
+        
+        let sut = PayToComponent(
+            paymentMethod: payToPaymentMethod,
+            context: Dummy.context
+        )
+        
+        let delegateMock = PaymentComponentDelegateMock()
+        sut.delegate = delegateMock
+        
+        let didSubmitExpectation = expectation(description: "Delegate's didSubmit must be called")
+        
+        delegateMock.onDidSubmit = { data, _ in
+            // Then
+            didSubmitExpectation.fulfill()
+            let receivedDetails = try? XCTUnwrap(data.paymentMethod as? PayToDetails)
+            XCTAssertTrue(self.payToDetailsEqual(expectedDetails, receivedDetails), "Submitted PayToDetails should match expected details")
+        }
+        
+        // When
+        sut.phoneNumberItem.value = phoneNumber
+        sut.firstNameInputItem.value = shopperName.firstName
+        sut.lastNameInputItem.value = shopperName.lastName
+        
+        sut.submit()
+        
+        waitForExpectations(timeout: 1.0)
     }
     
     private func populateValidFields(sut: PayToComponent) throws {
@@ -457,5 +497,13 @@ class PayToComponentTests: XCTestCase {
         self.populate(textItemView: phoneNumberItem, with: "4123466")
         self.populate(textItemView: firstNameInputItem, with: "test")
         self.populate(textItemView: lastNameInputItem, with: "lastname")
+    }
+    
+    private func payToDetailsEqual(_ lhs: PayToDetails?, _ rhs: PayToDetails?) -> Bool {
+        guard let lhs, let rhs else { return false }
+        
+        return lhs.type == rhs.type &&
+            lhs.shopperName == rhs.shopperName &&
+            lhs.accountIdentifier == rhs.accountIdentifier
     }
 }

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -559,7 +559,7 @@ class PayToComponentTests: XCTestCase {
         guard let lhs, let rhs else { return false }
 
         return lhs.type == rhs.type &&
-        lhs.shopperName == rhs.shopperName &&
-        lhs.accountIdentifier == rhs.accountIdentifier
+            lhs.shopperName == rhs.shopperName &&
+            lhs.accountIdentifier == rhs.accountIdentifier
     }
 }

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -499,7 +499,7 @@ class PayToComponentTests: XCTestCase {
         
         let expectedDetails = PayToDetails(
             paymentMethod: paymentMethodMock,
-            accountIdentifier: "\(email)", // ensure correct hyphenated format
+            accountIdentifier: "\(email)",
             shopperName: shopperName
         )
         
@@ -540,7 +540,7 @@ class PayToComponentTests: XCTestCase {
         
         let expectedDetails = PayToDetails(
             paymentMethod: paymentMethodMock,
-            accountIdentifier: "\(abn)", // ensure correct hyphenated format
+            accountIdentifier: "\(abn)",
             shopperName: shopperName
         )
         
@@ -564,6 +564,49 @@ class PayToComponentTests: XCTestCase {
         
         // When
         sut.abnInputItem.value = abn
+        sut.firstNameInputItem.value = shopperName.firstName
+        sut.lastNameInputItem.value = shopperName.lastName
+        
+        sut.submit()
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testPayToComponent_givenBSB_submitsCorrectAccountIdentifier() throws {
+        // Given
+        let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
+        let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
+        let bsb = "123456" // Unique identifier assigned to an organization
+        let accountNumber = "987654321"
+        let shopperName = ShopperName(firstName: "Katrina", lastName: "Del Mar")
+        
+        let expectedDetails = PayToDetails(
+            paymentMethod: paymentMethodMock,
+            accountIdentifier: "\(bsb)-\(accountNumber)", // ensure correct hyphenated format
+            shopperName: shopperName
+        )
+        
+        let sut = PayToComponent(
+            paymentMethod: payToPaymentMethod,
+            context: Dummy.context
+        )
+        sut.selectedPaymentOption = .BSB
+        
+        let delegateMock = PaymentComponentDelegateMock()
+        sut.delegate = delegateMock
+        
+        let didSubmitExpectation = expectation(description: "Delegate's didSubmit must be called")
+        
+        delegateMock.onDidSubmit = { data, _ in
+            // Then
+            didSubmitExpectation.fulfill()
+            let receivedDetails = try? XCTUnwrap(data.paymentMethod as? PayToDetails)
+            XCTAssertTrue(self.payToDetailsEqual(expectedDetails, receivedDetails), "Submitted PayToDetails should match expected details")
+        }
+        
+        // When
+        sut.bsbInputItem.value = bsb
+        sut.accountNumberInputItem.value = accountNumber
         sut.firstNameInputItem.value = shopperName.firstName
         sut.lastNameInputItem.value = shopperName.lastName
         

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -449,7 +449,7 @@ class PayToComponentTests: XCTestCase {
         XCTAssertEqual(delegateMock.didSubmitCallsCount, 1)
     }
     
-    func testPayToComponent_submitsCorrectAccountIdentifier_forPhoneNumber() throws {
+    func testPayToComponent_givenPhonePayId_submitsCorrectFormattedAccountIdentifier() throws {
         // Given
         let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
         let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
@@ -466,6 +466,7 @@ class PayToComponentTests: XCTestCase {
             paymentMethod: payToPaymentMethod,
             context: Dummy.context
         )
+        sut.selectedPaymentOption = .payId(.phone)
         
         let delegateMock = PaymentComponentDelegateMock()
         sut.delegate = delegateMock
@@ -481,6 +482,47 @@ class PayToComponentTests: XCTestCase {
         
         // When
         sut.phoneNumberItem.value = phoneNumber
+        sut.firstNameInputItem.value = shopperName.firstName
+        sut.lastNameInputItem.value = shopperName.lastName
+        
+        sut.submit()
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testPayToComponent_givenEmailPayId_submitsCorrectAccountIdentifier() throws {
+        // Given
+        let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
+        let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
+        let email = "katrina.mar@email.com"
+        let shopperName = ShopperName(firstName: "Katrina", lastName: "Del Mar")
+        
+        let expectedDetails = PayToDetails(
+            paymentMethod: paymentMethodMock,
+            accountIdentifier: "\(email)", // ensure correct hyphenated format
+            shopperName: shopperName
+        )
+        
+        let sut = PayToComponent(
+            paymentMethod: payToPaymentMethod,
+            context: Dummy.context
+        )
+        sut.selectedPaymentOption = .payId(.email)
+        
+        let delegateMock = PaymentComponentDelegateMock()
+        sut.delegate = delegateMock
+        
+        let didSubmitExpectation = expectation(description: "Delegate's didSubmit must be called")
+        
+        delegateMock.onDidSubmit = { data, _ in
+            // Then
+            didSubmitExpectation.fulfill()
+            let receivedDetails = try? XCTUnwrap(data.paymentMethod as? PayToDetails)
+            XCTAssertTrue(self.payToDetailsEqual(expectedDetails, receivedDetails), "Submitted PayToDetails should match expected details")
+        }
+        
+        // When
+        sut.emailInputItem.value = email
         sut.firstNameInputItem.value = shopperName.firstName
         sut.lastNameInputItem.value = shopperName.lastName
         

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -9,9 +9,9 @@
 import XCTest
 
 class PayToComponentTests: XCTestCase {
-    
+
     var sut: PayToComponent!
-    
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         sut = try PayToComponent(
@@ -19,71 +19,71 @@ class PayToComponentTests: XCTestCase {
             context: Dummy.context
         )
     }
-    
+
     func test_init() throws {
         let sut = try PayToComponent(
             paymentMethod: AdyenCoder.decode(payto),
             context: Dummy.context
         )
-        
+
         XCTAssertNotNil(sut)
     }
-    
+
     func test_paymentMethodType_isPayto() throws {
         XCTAssertEqual(sut.paymentMethod.type, .payTo)
     }
-    
+
     func test_flowSelection_titleLabel_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let flowSelectionTitleLabelItem = sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.flowSelectionTitleLabel") as? UILabel
-        
+
         // Then
         XCTAssertNotNil(flowSelectionTitleLabelItem, "Flow selection title label should exist")
     }
-    
+
     func test_flowSelectionItem_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let flowSelectionItem = sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.flowSelectionSegmentedControl") as? UISegmentedControl
         flowSelectionItem?.selectedSegmentIndex = 1
-        
+
         // Then
         XCTAssertNotNil(flowSelectionItem, "Flow selection item should exist")
     }
-    
+
     func test_phoneNumberItem_viewExists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // When
         let phoneNumberItem: FormPhoneNumberItemView = try XCTUnwrap(
             sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.phoneNumberItem")
         )
-        
+
         // Then
         XCTAssertNotNil(phoneNumberItem, "Phone number item should exist")
     }
-    
+
     func test_phoneNumberItem_invalidNumbers() throws {
         // Given
         let invalidNumbers = [
             "" // Empty phone number
         ]
-        
+
         for number in invalidNumbers {
             // When
             sut.phoneNumberItem.value = number
-            
+
             // Then
             XCTAssertFalse(sut.phoneNumberItem.isValid(), "Number \(number) should be invalid")
         }
     }
-    
+
     func test_phoneNumberItem_validNumbers_withoutLeadingZero() throws {
         // Given
         let validNumbers = [
@@ -95,16 +95,16 @@ class PayToComponentTests: XCTestCase {
             "412345678", // common AU mobile number
             "434567890" // common AU mobile number
         ]
-        
+
         for number in validNumbers {
             // When
             sut.phoneNumberItem.value = number
-            
+
             // Then
             XCTAssertTrue(sut.phoneNumberItem.isValid(), "Number \(number) should be valid without leading zero")
         }
     }
-    
+
     func test_phoneNumberItem_validNumbers_withLeadingZero() throws {
         // Given
         let validNumbersWithZero = [
@@ -112,73 +112,73 @@ class PayToComponentTests: XCTestCase {
             "0412345678",
             "0434567890"
         ]
-        
+
         for number in validNumbersWithZero {
             // When
             sut.phoneNumberItem.value = number
-            
+
             // Then
             XCTAssertTrue(sut.phoneNumberItem.isValid(), "Number \(number) should be valid with leading zero")
         }
     }
-    
+
     func test_payid_titleLabel_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let payIdTitleLabelItem = sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.payIdFlowTitleTitleLabel") as? UILabel
-        
+
         // Then
         XCTAssertNotNil(payIdTitleLabelItem, "PayId flow title label should exist")
     }
-    
+
     func test_identifierPicker_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let identifierPickerItem: PayToFormPickerItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.identifierPicker"))
-        
+
         // Then
         XCTAssertNotNil(identifierPickerItem, "identifier picker should exist")
         XCTAssertFalse(identifierPickerItem.canBecomeFirstResponder)
     }
-    
+
     func test_firstname_textfield() throws {
         sut.firstNameInputItem.value = ""
         XCTAssertFalse(sut.firstNameInputItem.isValid())
         sut.firstNameInputItem.value = "test"
         XCTAssertTrue(sut.firstNameInputItem.isValid())
-        
+
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let firstNameInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.firstNameTextfield"))
-        
+
         // Then
         XCTAssertNotNil(firstNameInputItem, "first name input field should exist")
     }
-    
+
     func test_lastname_textfield() throws {
         sut.lastNameInputItem.value = ""
         XCTAssertFalse(sut.lastNameInputItem.isValid())
         sut.lastNameInputItem.value = "test"
         XCTAssertTrue(sut.lastNameInputItem.isValid())
-        
+
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let lastNameInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.lastNameTextfield"))
-        
+
         // Then
         XCTAssertNotNil(lastNameInputItem, "last name input field should exist")
     }
-    
+
     func test_email_textfield() throws {
-        
+
         // invalid
         sut.emailInputItem.value = ""
         XCTAssertFalse(sut.emailInputItem.isValid())
@@ -187,28 +187,28 @@ class PayToComponentTests: XCTestCase {
         sut.emailInputItem.value = "test@"
         XCTAssertFalse(sut.emailInputItem.isValid())
         sut.emailInputItem.value = "aa@aa.com"
-        
+
         // valid
         XCTAssertTrue(sut.emailInputItem.isValid())
         sut.emailInputItem.value = "user@example.com"
         XCTAssertTrue(sut.emailInputItem.isValid())
         sut.emailInputItem.value = "test-test@example.co.uk"
         XCTAssertTrue(sut.emailInputItem.isValid())
-        
+
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let emailInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.emailTextfield"))
-        
+
         // Then
         XCTAssertNotNil(emailInputItem, "email input field should exist")
     }
-    
+
     func test_abn_textfield() throws {
-        
+
         // only 9 or 11 integers are valid
-        
+
         // invalid
         sut.abnInputItem.value = ""
         XCTAssertFalse(sut.abnInputItem.isValid())
@@ -219,22 +219,22 @@ class PayToComponentTests: XCTestCase {
         sut.abnInputItem.value = "123asd123"
         XCTAssertFalse(sut.abnInputItem.isValid())
         sut.abnInputItem.value = "123456789"
-        
+
         // valid
         XCTAssertTrue(sut.abnInputItem.isValid())
         sut.abnInputItem.value = "12345678900"
         XCTAssertTrue(sut.abnInputItem.isValid())
-        
+
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let abnInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.abnTextfield"))
-        
+
         // Then
         XCTAssertNotNil(abnInputItem, "abn input field should exist")
     }
-    
+
     func test_organizationID_textfield() throws {
         // invalid
         sut.organizationIdInputItem.value = ""
@@ -247,7 +247,7 @@ class PayToComponentTests: XCTestCase {
         XCTAssertFalse(sut.organizationIdInputItem.isValid())
         sut.organizationIdInputItem.value = "!"
         XCTAssertFalse(sut.organizationIdInputItem.isValid())
-        
+
         // valid
         sut.organizationIdInputItem.value = "123123"
         XCTAssertTrue(sut.organizationIdInputItem.isValid())
@@ -261,17 +261,17 @@ class PayToComponentTests: XCTestCase {
         XCTAssertTrue(sut.organizationIdInputItem.isValid())
         sut.organizationIdInputItem.value = "{ }"
         XCTAssertTrue(sut.organizationIdInputItem.isValid())
-        
+
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let organizationIDInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.organizationIDTextfield"))
-        
+
         // Then
         XCTAssertNotNil(organizationIDInputItem, "organizationID input field should exist")
     }
-    
+
     func test_accountNumber_textfield() throws {
         // invalid
         sut.accountNumberInputItem.value = ""
@@ -280,7 +280,7 @@ class PayToComponentTests: XCTestCase {
         XCTAssertFalse(sut.accountNumberInputItem.isValid())
         sut.accountNumberInputItem.value = "\nNew line"
         XCTAssertFalse(sut.accountNumberInputItem.isValid())
-        
+
         // valid
         sut.accountNumberInputItem.value = "Hello!"
         XCTAssertTrue(sut.accountNumberInputItem.isValid())
@@ -290,19 +290,19 @@ class PayToComponentTests: XCTestCase {
         XCTAssertTrue(sut.accountNumberInputItem.isValid())
         sut.accountNumberInputItem.value = " this_is valid -~ "
         XCTAssertTrue(sut.accountNumberInputItem.isValid())
-        
+
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let accountNumberInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.accountNumberTextfield"))
-        
+
         // Then
         XCTAssertNotNil(accountNumberInputItem, "Bank account number input field should exist")
     }
-    
+
     func test_bank_state_number_textfield() throws {
-        
+
         // invalid
         sut.bsbInputItem.value = ""
         XCTAssertFalse(sut.bsbInputItem.isValid())
@@ -316,7 +316,7 @@ class PayToComponentTests: XCTestCase {
         XCTAssertFalse(sut.bsbInputItem.isValid())
         sut.bsbInputItem.value = "12345    "
         XCTAssertFalse(sut.bsbInputItem.isValid())
-        
+
         // valid
         sut.bsbInputItem.value = "123456"
         XCTAssertTrue(sut.bsbInputItem.isValid())
@@ -324,41 +324,41 @@ class PayToComponentTests: XCTestCase {
         XCTAssertTrue(sut.bsbInputItem.isValid())
         sut.bsbInputItem.value = "000000"
         XCTAssertTrue(sut.bsbInputItem.isValid())
-        
+
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let bankStateNumberInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.bankStateBranchTextfield"))
-        
+
         // Then
         XCTAssertNotNil(bankStateNumberInputItem, "Bank state number input field should exist")
     }
-    
+
     func test_payment_instruction_titleLabel_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let paymentInstructionTitleLabelItem = sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.paymentInstructionTitleLabel") as? UILabel
-        
+
         // Then
         XCTAssertNotNil(paymentInstructionTitleLabelItem, "Payment instruction title label should exist")
     }
-    
+
     func test_continueButton_exists() throws {
         // Given
         sut.viewController.loadViewIfNeeded()
-        
+
         // Check by accessibility identifier
         let continueButton: FormButtonItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.continueButton"))
-        
+
         // Then
         XCTAssertNotNil(continueButton, "ContinueButton should exist")
     }
-    
+
     func testViewDidLoadShouldSendInitialCall() throws {
-        
+
         // Given
         let analyticsProviderMock = AnalyticsProviderMock()
         let context = AdyenContext(
@@ -371,17 +371,17 @@ class PayToComponentTests: XCTestCase {
             paymentMethod: paymentMethod,
             context: context
         )
-        
+
         // When
         sut.viewDidLoad(viewController: sut.viewController)
-        
+
         // Then
         XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)
         XCTAssertEqual(analyticsProviderMock.infos.count, 1)
         let infoType = analyticsProviderMock.infos.first?.type
         XCTAssertEqual(infoType, .rendered)
     }
-    
+
     func testValidateGivenValidInputShouldReturnFormViewControllerValidateResult() throws {
         // Given
         let paymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
@@ -391,20 +391,20 @@ class PayToComponentTests: XCTestCase {
             context: Dummy.context,
             configuration: configuration
         )
-        
+
         try populateValidFields(sut: sut)
-        
+
         let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
         let expectedResult = formViewController.validate()
-        
+
         // When
         let validationResult = sut.validate()
-        
+
         // Then
         XCTAssertTrue(validationResult)
         XCTAssertEqual(expectedResult, validationResult)
     }
-    
+
     func testValidateGivenInvalidInputShouldReturnFormViewControllerValidateResult() throws {
         // Given
         let paymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
@@ -414,263 +414,152 @@ class PayToComponentTests: XCTestCase {
             context: Dummy.context,
             configuration: configuration
         )
-        
+
         let formViewController = try XCTUnwrap((sut.viewController as? SecuredViewController<FormViewController>)?.childViewController)
         let expectedResult = formViewController.validate()
-        
+
         // When
         let validationResult = sut.validate()
-        
+
         // Then
         XCTAssertFalse(validationResult)
         XCTAssertEqual(expectedResult, validationResult)
     }
-    
+
     func testSubmit_shouldCallPaymentDelegateDidSubmit() throws {
         // Given
-        
+
         sut.viewController.loadViewIfNeeded()
-        
+
         let didSubmitExpectation = XCTestExpectation(description: "Expect delegate.didSubmit() to be called.")
-        
+
         let delegateMock = PaymentComponentDelegateMock()
         sut.delegate = delegateMock
         delegateMock.onDidSubmit = { data, component in
             didSubmitExpectation.fulfill()
         }
-        
+
         try populateValidFields(sut: sut)
-        
+
         // When
         sut.submit()
-        
+
         // Then
         wait(for: [didSubmitExpectation], timeout: 10)
         XCTAssertEqual(delegateMock.didSubmitCallsCount, 1)
     }
-    
+
     func testPayToComponent_givenPhonePayIdPaymentOption_submitsCorrectFormattedAccountIdentifier() throws {
-        // Given
-        let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
-        let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
-        let phoneNumber = "0666555444"
-        let shopperName = ShopperName(firstName: "Katrina", lastName: "Del Mar")
-        
-        let expectedDetails = PayToDetails(
-            paymentMethod: paymentMethodMock,
-            accountIdentifier: "+61-\(phoneNumber)", // ensure correct hyphenated format
-            shopperName: shopperName
+        try assertPayToComponentDetailsSubmission(
+            option: .payId(.phone),
+            fill: { sut in
+                sut.phoneNumberItem.value = "0666555444"
+            },
+            expectedIdentifier: "+61-0666555444" // ensure correct hyphenated format
         )
-        
-        let sut = PayToComponent(
-            paymentMethod: payToPaymentMethod,
-            context: Dummy.context
-        )
-        sut.selectedPaymentOption = .payId(.phone)
-        
-        let delegateMock = PaymentComponentDelegateMock()
-        sut.delegate = delegateMock
-        
-        let didSubmitExpectation = expectation(description: "Delegate's didSubmit must be called")
-        
-        delegateMock.onDidSubmit = { data, _ in
-            // Then
-            didSubmitExpectation.fulfill()
-            let receivedDetails = try? XCTUnwrap(data.paymentMethod as? PayToDetails)
-            XCTAssertTrue(self.payToDetailsEqual(expectedDetails, receivedDetails), "Submitted PayToDetails should match expected details")
-        }
-        
-        // When
-        sut.phoneNumberItem.value = phoneNumber
-        sut.firstNameInputItem.value = shopperName.firstName
-        sut.lastNameInputItem.value = shopperName.lastName
-        
-        sut.submit()
-        
-        waitForExpectations(timeout: 1.0)
     }
-    
+
     func testPayToComponent_givenEmailPayIdPaymentOption_submitsCorrectAccountIdentifier() throws {
-        // Given
-        let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
-        let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
-        let email = "katrina.mar@email.com"
-        let shopperName = ShopperName(firstName: "Katrina", lastName: "Del Mar")
-        
-        let expectedDetails = PayToDetails(
-            paymentMethod: paymentMethodMock,
-            accountIdentifier: "\(email)",
-            shopperName: shopperName
+        try assertPayToComponentDetailsSubmission(
+            option: .payId(.email),
+            fill: { sut in
+                sut.emailInputItem.value = "katrina.mar@email.com"
+            },
+            expectedIdentifier: "katrina.mar@email.com"
         )
-        
-        let sut = PayToComponent(
-            paymentMethod: payToPaymentMethod,
-            context: Dummy.context
-        )
-        sut.selectedPaymentOption = .payId(.email)
-        
-        let delegateMock = PaymentComponentDelegateMock()
-        sut.delegate = delegateMock
-        
-        let didSubmitExpectation = expectation(description: "Delegate's didSubmit must be called")
-        
-        delegateMock.onDidSubmit = { data, _ in
-            // Then
-            didSubmitExpectation.fulfill()
-            let receivedDetails = try? XCTUnwrap(data.paymentMethod as? PayToDetails)
-            XCTAssertTrue(self.payToDetailsEqual(expectedDetails, receivedDetails), "Submitted PayToDetails should match expected details")
-        }
-        
-        // When
-        sut.emailInputItem.value = email
-        sut.firstNameInputItem.value = shopperName.firstName
-        sut.lastNameInputItem.value = shopperName.lastName
-        
-        sut.submit()
-        
-        waitForExpectations(timeout: 1.0)
     }
-    
+
     func testPayToComponent_givenAbnPayIdPaymentOption_submitsCorrectAccountIdentifier() throws {
-        // Given
-        let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
-        let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
-        let abn = "51824753556" // ABN (Australian Business Number) is a unique 11-digit identifier issued to businesses in Australia
-        let shopperName = ShopperName(firstName: "Katrina", lastName: "Del Mar")
-        
-        let expectedDetails = PayToDetails(
-            paymentMethod: paymentMethodMock,
-            accountIdentifier: "\(abn)",
-            shopperName: shopperName
+        try assertPayToComponentDetailsSubmission(
+            option: .payId(.abn),
+            fill: { sut in
+                sut.abnInputItem.value = "51824753556"
+            },
+            expectedIdentifier: "51824753556"
         )
-        
-        let sut = PayToComponent(
-            paymentMethod: payToPaymentMethod,
-            context: Dummy.context
-        )
-        sut.selectedPaymentOption = .payId(.abn)
-        
-        let delegateMock = PaymentComponentDelegateMock()
-        sut.delegate = delegateMock
-        
-        let didSubmitExpectation = expectation(description: "Delegate's didSubmit must be called")
-        
-        delegateMock.onDidSubmit = { data, _ in
-            // Then
-            didSubmitExpectation.fulfill()
-            let receivedDetails = try? XCTUnwrap(data.paymentMethod as? PayToDetails)
-            XCTAssertTrue(self.payToDetailsEqual(expectedDetails, receivedDetails), "Submitted PayToDetails should match expected details")
-        }
-        
-        // When
-        sut.abnInputItem.value = abn
-        sut.firstNameInputItem.value = shopperName.firstName
-        sut.lastNameInputItem.value = shopperName.lastName
-        
-        sut.submit()
-        
-        waitForExpectations(timeout: 1.0)
     }
-    
+
     func testPayToComponent_givenOrganizationIdPayIdPaymentOption_submitsCorrectAccountIdentifier() throws {
-        // Given
-        let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
-        let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
-        let organizationId = "*hello123.world*"
-        let shopperName = ShopperName(firstName: "Katrina", lastName: "Del Mar")
-        
-        let expectedDetails = PayToDetails(
-            paymentMethod: paymentMethodMock,
-            accountIdentifier: "\(organizationId)",
-            shopperName: shopperName
+        try assertPayToComponentDetailsSubmission(
+            option: .payId(.organizationId),
+            fill: { sut in
+                sut.organizationIdInputItem.value = "*hello123.world*"
+            },
+            expectedIdentifier: "*hello123.world*"
         )
-        
-        let sut = PayToComponent(
-            paymentMethod: payToPaymentMethod,
-            context: Dummy.context
-        )
-        sut.selectedPaymentOption = .payId(.organizationId)
-        
-        let delegateMock = PaymentComponentDelegateMock()
-        sut.delegate = delegateMock
-        
-        let didSubmitExpectation = expectation(description: "Delegate's didSubmit must be called")
-        
-        delegateMock.onDidSubmit = { data, _ in
-            // Then
-            didSubmitExpectation.fulfill()
-            let receivedDetails = try? XCTUnwrap(data.paymentMethod as? PayToDetails)
-            XCTAssertTrue(self.payToDetailsEqual(expectedDetails, receivedDetails), "Submitted PayToDetails should match expected details")
-        }
-        
-        // When
-        sut.organizationIdInputItem.value = organizationId
-        sut.firstNameInputItem.value = shopperName.firstName
-        sut.lastNameInputItem.value = shopperName.lastName
-        
-        sut.submit()
-        
-        waitForExpectations(timeout: 1.0)
     }
-    
+
     func testPayToComponent_givenBsbPaymentOption_submitsCorrectAccountIdentifier() throws {
+        try assertPayToComponentDetailsSubmission(
+            option: .BSB,
+            fill: { sut in
+                sut.bsbInputItem.value = "123456"
+                sut.accountNumberInputItem.value = "987654321"
+            },
+            expectedIdentifier: "123456-987654321" // ensure correct hyphenated format
+        )
+    }
+
+    // MARK: - Helper
+
+    private func assertPayToComponentDetailsSubmission(
+        option: PayToPaymentOption,
+        fill: (PayToComponent) -> Void,
+        expectedIdentifier: String
+    ) throws {
         // Given
         let payToPaymentMethod: PayToPaymentMethod = try AdyenCoder.decode(payto)
         let paymentMethodMock = PaymentMethodMock(type: payToPaymentMethod.type, name: payToPaymentMethod.name)
-        let bsb = "123456" // Unique identifier assigned to an organization
-        let accountNumber = "987654321"
         let shopperName = ShopperName(firstName: "Katrina", lastName: "Del Mar")
-        
+
         let expectedDetails = PayToDetails(
             paymentMethod: paymentMethodMock,
-            accountIdentifier: "\(bsb)-\(accountNumber)", // ensure correct hyphenated format
+            accountIdentifier: expectedIdentifier,
             shopperName: shopperName
         )
-        
-        let sut = PayToComponent(
-            paymentMethod: payToPaymentMethod,
-            context: Dummy.context
-        )
-        sut.selectedPaymentOption = .BSB
-        
+
+        let sut = PayToComponent(paymentMethod: payToPaymentMethod, context: Dummy.context)
+        sut.selectedPaymentOption = option
+
         let delegateMock = PaymentComponentDelegateMock()
         sut.delegate = delegateMock
-        
+
         let didSubmitExpectation = expectation(description: "Delegate's didSubmit must be called")
-        
+
         delegateMock.onDidSubmit = { data, _ in
-            // Then
             didSubmitExpectation.fulfill()
+            // Then
             let receivedDetails = try? XCTUnwrap(data.paymentMethod as? PayToDetails)
-            XCTAssertTrue(self.payToDetailsEqual(expectedDetails, receivedDetails), "Submitted PayToDetails should match expected details")
+            XCTAssertTrue(
+                self.payToDetailsEqual(expectedDetails, receivedDetails),
+                "Submitted PayToDetails should match expected details"
+            )
         }
-        
+
         // When
-        sut.bsbInputItem.value = bsb
-        sut.accountNumberInputItem.value = accountNumber
+        fill(sut)
         sut.firstNameInputItem.value = shopperName.firstName
         sut.lastNameInputItem.value = shopperName.lastName
-        
         sut.submit()
-        
+
         waitForExpectations(timeout: 1.0)
     }
-    
+
     private func populateValidFields(sut: PayToComponent) throws {
         let phoneNumberItem: FormPhoneNumberItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.phoneNumberItem"))
         let firstNameInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.firstNameTextfield"))
         let lastNameInputItem: FormTextInputItemView = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.PayToComponent.lastNameTextfield"))
-        
+
         self.populate(textItemView: phoneNumberItem, with: "4123466")
         self.populate(textItemView: firstNameInputItem, with: "test")
         self.populate(textItemView: lastNameInputItem, with: "lastname")
     }
-    
+
     private func payToDetailsEqual(_ lhs: PayToDetails?, _ rhs: PayToDetails?) -> Bool {
         guard let lhs, let rhs else { return false }
-        
+
         return lhs.type == rhs.type &&
-            lhs.shopperName == rhs.shopperName &&
-            lhs.accountIdentifier == rhs.accountIdentifier
+        lhs.shopperName == rhs.shopperName &&
+        lhs.accountIdentifier == rhs.accountIdentifier
     }
 }

--- a/Tests/SnapshotTests/Components/PayToComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/PayToComponentUITests.swift
@@ -167,7 +167,7 @@ class PayToComponentUITests: XCTestCase {
             XCTAssertTrue(component === sut)
             let details = data.paymentMethod as! PayToDetails
             XCTAssertEqual(details.type, .payTo)
-            XCTAssertEqual(details.accountIdentifier, "+614123466")
+            XCTAssertEqual(details.accountIdentifier, "+61-4123466")
             XCTAssertEqual(details.shopperName?.firstName, "test")
             XCTAssertEqual(details.shopperName?.lastName, "lastname")
 


### PR DESCRIPTION
# Summary

This PR addresses a bug where the `shopperAccountIdentifier`, with the phone number as PayTo identifier, is being sent with the wrong format. Instead using a hyphenated format (e.g. +61-66655544), it was sent like +61666555444. Resulting in a `cancelled` payment request.

## Release Notes

<fixed>
**- PayTo:** Fixed incorrect phone identifier formatting by adding the missing hyphen between country code and local number (e.g. `+61-0666555444`).
</fixed>


## Ticket [Optional]
<ticket>
COSDK-731
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
