### PR TITLE
Disable snapshot testing

### DIFF
--- a/.github/workflows/pr_scan.yml
+++ b/.github/workflows/pr_scan.yml
@@ -69,6 +69,7 @@ jobs:
         resultPath: 'Test-CI-Result.xcresult'
 
     - name: 🌇 Snapshot Tests iPhone
+      if: false  # Temporarily disabled until we stabilize the UI
       run: |
         xcodebuild test \
           -project "${{env.project}}" \
@@ -85,6 +86,7 @@ jobs:
         resultPath: 'Test-Snapshots-Result.xcresult'
 
     - name: 🌇 Snapshot Tests iPad
+      if: false  # Temporarily disabled until we stabilize the UI
       run: |
         xcodebuild test \
           -project "${{env.project}}" \
@@ -99,14 +101,15 @@ jobs:
         scheme: 'SnapshotTests'
         testPlan: 'SnapshotTests'
         resultPath: 'Test-Snapshots-Result-iPad.xcresult'
-        
+
     - name: 🍛 Prepare coverage reports
       run: |
-        bash Scripts/xccov-to-sonarqube-generic.sh Test-Snapshots-Result.xcresult/ > sonarqube-coverage-snapshots.xml
-        sed "s#$PWD/##g" sonarqube-coverage-snapshots.xml > sonarqube_updated_snapshots.xml
+        # TODO: Temporarily commented - re-enable with snapshot tests
+        # bash Scripts/xccov-to-sonarqube-generic.sh Test-Snapshots-Result.xcresult/ > sonarqube-coverage-snapshots.xml
+        # sed "s#$PWD/##g" sonarqube-coverage-snapshots.xml > sonarqube_updated_snapshots.xml
         bash Scripts/xccov-to-sonarqube-generic.sh Test-CI-Result.xcresult/ > sonarqube-coverage-ci.xml
         sed "s#$PWD/##g" sonarqube-coverage-ci.xml > sonarqube_updated_ci.xml
-        
+
     - name: 🧼 SwiftLint
       run: |
         brew install swiftlint
@@ -116,6 +119,6 @@ jobs:
       if: ${{ env.sonarToken != 0 }}
       run: |
         git fetch --unshallow --no-tags
-        sonar-scanner -Dsonar.token=${{ secrets.SONAR_TOKEN }} -Dsonar.coverageReportPaths=sonarqube_updated_CI.xml,sonarqube_updated_snapshots.xml
+        sonar-scanner -Dsonar.token=${{ secrets.SONAR_TOKEN }} -Dsonar.coverageReportPaths=sonarqube_updated_CI.xml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

It is expected snapshots will be failing as we move with the redesign of the SDK.
To save up some time on snapshot regeneration on every PR and keep CI green to detect unit tests failures clearly, this change disables snapshot testing until the team agrees to turn it back again.