### PR TITLE
Refactor `FormTextInputItemView` to take `AdyenTheme` as dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,20 @@ fix: Resolve race condition in session handler
 - SwiftFormat is configured with inline commas, no space ranges, and specific wrapping rules
 - All files must include copyright header (auto-applied by SwiftFormat)
 
+**IMPORTANT: Always run SwiftFormat after editing Swift files**
+
+After making any code changes using editing tools, always run SwiftFormat to ensure compliance with the project's formatting rules:
+
+```bash
+# Format a single file
+swiftformat path/to/edited/file.swift
+
+# Format multiple files
+swiftformat AdyenUI/UI/Form/Items/Text/
+```
+
+This prevents unintended whitespace changes and formatting inconsistencies that create noise in pull request diffs and increase reviewer burden.
+
 ### Access Control
 
 Use `@_spi(AdyenInternal)` for internal-but-cross-module APIs. The SDK uses explicit access control levels (`explicit_acl` SwiftLint rule is enabled).

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -641,6 +641,7 @@
 		B67D1F762E4615390000C37F /* CardComponentAdvancedFlowExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67D1F542E4615390000C37F /* CardComponentAdvancedFlowExample.swift */; };
 		B686B6532DEEE2250071AFCA /* FormCardExpiryDateItemViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B686B6522DEEE2250071AFCA /* FormCardExpiryDateItemViewTests.swift */; };
 		B6ABA1C32CA6B058003514E5 /* ListItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ABA1C22CA6B058003514E5 /* ListItemTests.swift */; };
+		B6BFF8012EC7249200BAC3B7 /* FormTextItemViewThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BFF7FF2EC7249200BAC3B7 /* FormTextItemViewThemeTests.swift */; };
 		B6C9DA792D0C3F62005D65C7 /* DualBrandAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C9DA782D0C3F62005D65C7 /* DualBrandAccessoryView.swift */; };
 		B6C9DA7B2D102C91005D65C7 /* DualBrandAccessoryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C9DA7A2D102C91005D65C7 /* DualBrandAccessoryViewTests.swift */; };
 		B6D808032BCD140E00F3F5EB /* AssetsAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91760A62594C5DF00D653BE /* AssetsAccessTests.swift */; };
@@ -2241,6 +2242,7 @@
 		B686B6522DEEE2250071AFCA /* FormCardExpiryDateItemViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardExpiryDateItemViewTests.swift; sourceTree = "<group>"; };
 		B693408F2DAE6ACB0026AD7F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B6ABA1C22CA6B058003514E5 /* ListItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemTests.swift; sourceTree = "<group>"; };
+		B6BFF7FF2EC7249200BAC3B7 /* FormTextItemViewThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormTextItemViewThemeTests.swift; sourceTree = "<group>"; };
 		B6C9DA782D0C3F62005D65C7 /* DualBrandAccessoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DualBrandAccessoryView.swift; sourceTree = "<group>"; };
 		B6C9DA7A2D102C91005D65C7 /* DualBrandAccessoryViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DualBrandAccessoryViewTests.swift; sourceTree = "<group>"; };
 		B6EE0F432BBEBFD000B9810D /* IntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = IntegrationTests.xctestplan; sourceTree = "<group>"; };
@@ -4175,6 +4177,14 @@
 				B686B6522DEEE2250071AFCA /* FormCardExpiryDateItemViewTests.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		B6BFF8002EC7249200BAC3B7 /* Theme */ = {
+			isa = PBXGroup;
+			children = (
+				B6BFF7FF2EC7249200BAC3B7 /* FormTextItemViewThemeTests.swift */,
+			);
+			path = Theme;
 			sourceTree = "<group>";
 		};
 		B6D808242BCD154600F3F5EB /* Helpers */ = {
@@ -6566,6 +6576,7 @@
 			isa = PBXGroup;
 			children = (
 				F99F08612383F29000EBB948 /* FormItems */,
+				B6BFF8002EC7249200BAC3B7 /* Theme */,
 			);
 			path = Form;
 			sourceTree = "<group>";
@@ -8518,6 +8529,7 @@
 				F9976BB526D90C6700D2D7CE /* MultibancoShareableVoucherViewProviderTests.swift in Sources */,
 				E7877803282409FF004A6366 /* ApplePayDelegateMock.swift in Sources */,
 				F99F08642383F2B000EBB948 /* FormTextItemViewTests.swift in Sources */,
+				B6BFF8012EC7249200BAC3B7 /* FormTextItemViewThemeTests.swift in Sources */,
 				F96A25432371AB75007DBF0B /* PaymentComponentDelegateMock.swift in Sources */,
 				F9CA6BC627D7503200D7BE6E /* SessionTests.swift in Sources */,
 				E79A64812490D98F00368E9F /* CardComponentDelegateMock.swift in Sources */,

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -16,11 +16,12 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
     private static let cardSpacing: CGFloat = 4.0
     private static let cardSize = CGSize(width: 24.0, height: 16.0)
     
-    /// Initializes the form card number item view.
-    ///
-    /// - Parameter item: The item represented by the view.
-    internal required init(item: FormCardNumberItem) {
-        super.init(item: item)
+    /// Initializes the form card number item view with theme.
+    /// - Parameters:
+    ///   - item: The item represented by the view.
+    ///   - theme: The theme to use for styling.
+    override internal init(item: FormCardNumberItem, theme: AdyenTheme) {
+        super.init(item: item, theme: theme)
         accessory = .customView(detectedBrandsView)
         if item.supportsCardScanning {
             textField.inputAccessoryView = makeCardScanAccessoryView(
@@ -31,7 +32,7 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
         textField.textContentType = .creditCardNumber
         textField.returnKeyType = .default
         textField.allowsEditingActions = false
-        
+
         observe(item.$initialBrand) { [weak self] _ in
             guard let self else { return }
             self.updateValidationStatus(forced: true)
@@ -42,7 +43,13 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
             self?.detectedBrandsView.updateCurrentLogos(newValue)
         }
     }
-    
+
+    // TODO: Should be deleted after the cleanup phase
+    /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
+    internal required convenience init(item: FormCardNumberItem) {
+        self.init(item: item, theme: .default)
+    }
+
     override public func handleFormattedValueDidChange(_ newValue: String) {
         textField.text = newValue
         updateValidationStatus()

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -44,12 +44,6 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
         }
     }
 
-    // TODO: Should be deleted after the cleanup phase
-    /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
-    internal required convenience init(item: FormCardNumberItem) {
-        self.init(item: item, theme: .default)
-    }
-
     override public func handleFormattedValueDidChange(_ newValue: String) {
         textField.text = newValue
         updateValidationStatus()

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -12,9 +12,13 @@ import UIKit
 
 /// A view representing a form card security code item.
 internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecurityCodeItem> {
-    
-    internal required init(item: FormCardSecurityCodeItem) {
-        super.init(item: item)
+
+    /// Initializes the form card security code item view with theme.
+    /// - Parameters:
+    ///   - item: The item represented by the view.
+    ///   - theme: The theme to use for styling.
+    override internal init(item: FormCardSecurityCodeItem, theme: AdyenTheme) {
+        super.init(item: item, theme: theme)
         accessory = .customView(cardHintView)
         textField.allowsEditingActions = false
         
@@ -38,7 +42,13 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
             self?.becomeFirstResponder()
         }
     }
-    
+
+    // TODO: Should be deleted after the cleanup phase
+    /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
+    internal required convenience init(item: FormCardSecurityCodeItem) {
+        self.init(item: item, theme: .default)
+    }
+
     internal lazy var cardHintView: HintView = {
         let view = HintView(item: self.item)
         view.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "cvvHintIcon")

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -43,12 +43,6 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
         }
     }
 
-    // TODO: Should be deleted after the cleanup phase
-    /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
-    internal required convenience init(item: FormCardSecurityCodeItem) {
-        self.init(item: item, theme: .default)
-    }
-
     internal lazy var cardHintView: HintView = {
         let view = HintView(item: self.item)
         view.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "cvvHintIcon")

--- a/AdyenUI/UI/Form/FormItemViewBuilder.swift
+++ b/AdyenUI/UI/Form/FormItemViewBuilder.swift
@@ -9,28 +9,28 @@ import Foundation
 /// Builds different types of `FormItemView's`  from the corresponding concrete `FormItem`.
 @_spi(AdyenInternal)
 public struct FormItemViewBuilder {
-    
-    /// The theme to use for building views. Optional during migration.
-    package let theme: AdyenTheme?
-    
+
+    /// The theme to use for building views.
+    package let theme: AdyenTheme
+
     /// Initializes the form item view builder.
-    /// - Parameter theme: The theme to use for building views. If nil, views will use item.style.
+    /// - Parameter theme: The theme to use for building views. Defaults to `.default` if nil.
     package init(theme: AdyenTheme? = nil) {
-        self.theme = theme
+        self.theme = theme ?? .default
     }
-    
+
     /// Builds `FormToggleItemView` from `FormToggleItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormToggleItem) -> FormItemView<FormToggleItem> {
         FormToggleItemView(item: item)
     }
-    
+
     /// Builds `FormSplitItemView` from `FormSplitItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormSplitItem) -> FormItemView<FormSplitItem> {
         FormSplitItemView(item: item)
     }
-    
+
     /// Builds `PhoneNumberItemView` from `PhoneNumberItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormPhoneNumberItem) -> FormItemView<FormPhoneNumberItem> {
@@ -39,16 +39,17 @@ public struct FormItemViewBuilder {
 
     /// Builds `FormIssuerPickerItemView` from `FormIssuerPickerItem`.
     @_spi(AdyenInternal)
-    public func build<Value: CustomStringConvertible>(with item: BaseFormPickerItem<Value>) -> BaseFormPickerItemView<Value> {
+    public func build<Value: CustomStringConvertible>(with item: BaseFormPickerItem<Value>)
+        -> BaseFormPickerItemView<Value> {
         BaseFormPickerItemView(item: item)
     }
 
     /// Builds `FormTextInputItemView` from `FormTextInputItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormTextInputItem) -> FormItemView<FormTextInputItem> {
-        FormTextInputItemView(item: item)
+        FormTextInputItemView(item: item, theme: theme)
     }
-    
+
     /// Builds `ListItemView` from `ListItem`.
     @_spi(AdyenInternal)
     public func build(with item: ListItem) -> ListItemView {
@@ -68,7 +69,7 @@ public struct FormItemViewBuilder {
     public func build(with item: FormButtonItem) -> FormItemView<FormButtonItem> {
         FormButtonItemView(item: item)
     }
-    
+
     /// Builds `FormImageView` from `FormImageItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormImageItem) -> FormItemView<FormImageItem> {
@@ -86,7 +87,7 @@ public struct FormItemViewBuilder {
     public func build(with item: FormErrorItem) -> FormItemView<FormErrorItem> {
         FormErrorItemView(item: item)
     }
-    
+
     /// Builds `FormVerticalStackItemView` from `FormAddressItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormAddressItem) -> FormItemView<FormAddressItem> {
@@ -98,31 +99,33 @@ public struct FormItemViewBuilder {
     public func build(with item: FormSpacerItem) -> FormItemView<FormSpacerItem> {
         FormSpacerItemView(item: item)
     }
-    
+
     /// Builds `FormTextItemView` from `FormPostalCodeItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormPostalCodeItem) -> FormItemView<FormPostalCodeItem> {
-        FormTextItemView(item: item)
+        FormTextItemView(item: item, theme: theme)
     }
-    
+
     /// Builds `FormSearchButtonItemView` from `FormSearchButtonItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormSearchButtonItem) -> FormItemView<FormSearchButtonItem> {
         FormSearchButtonItemView(item: item)
     }
-    
+
     /// Builds `FormAddressPickerItemView` from `FormAddressPickerItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormAddressPickerItem) -> FormItemView<FormAddressPickerItem> {
         FormAddressPickerItemView(item: item)
     }
-    
+
     /// Builds `FormPickerItemView` from `FormPickerItem`.
     @_spi(AdyenInternal)
-    public func build<Value>(with item: FormPickerItem<Value>) -> FormItemView<FormPickerItem<Value>> {
+    public func build<Value>(with item: FormPickerItem<Value>) -> FormItemView<
+        FormPickerItem<Value>
+    > {
         FormPickerItemView(item: item)
     }
-    
+
     /// Builds `FormPhoneExtensionPickerItemView` from `FormPhoneExtensionPickerItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormPhoneExtensionPickerItem) -> FormPhoneExtensionPickerItemView {

--- a/AdyenUI/UI/Form/FormItemViewBuilder.swift
+++ b/AdyenUI/UI/Form/FormItemViewBuilder.swift
@@ -14,9 +14,9 @@ public struct FormItemViewBuilder {
     package let theme: AdyenTheme
 
     /// Initializes the form item view builder.
-    /// - Parameter theme: The theme to use for building views. Defaults to `.default` if nil.
-    package init(theme: AdyenTheme? = nil) {
-        self.theme = theme ?? .default
+    /// - Parameter theme: The theme to use for building views. Defaults to `.default`.
+    package init(theme: AdyenTheme = .default) {
+        self.theme = theme
     }
 
     /// Builds `FormToggleItemView` from `FormToggleItem`.
@@ -134,7 +134,7 @@ public struct FormItemViewBuilder {
 
     @_spi(AdyenInternal)
     public static func build(_ item: FormItem) -> AnyFormItemView {
-        let itemView = item.build(with: FormItemViewBuilder(theme: nil))
+        let itemView = item.build(with: FormItemViewBuilder())
         itemView.accessibilityIdentifier = item.identifier
         return itemView
     }

--- a/AdyenUI/UI/Form/Items/Phone Number/FormPhoneNumberItemView.swift
+++ b/AdyenUI/UI/Form/Items/Phone Number/FormPhoneNumberItemView.swift
@@ -19,12 +19,6 @@ internal final class FormPhoneNumberItemView: FormTextItemView<FormPhoneNumberIt
         textField.textContentType = .telephoneNumber
     }
 
-    // TODO: Should be deleted after the cleanup phase
-    /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
-    internal required convenience init(item: FormPhoneNumberItem) {
-        self.init(item: item, theme: .default)
-    }
-    
     override internal var childItemViews: [AnyFormItemView] {
         [phoneExtensionView]
     }

--- a/AdyenUI/UI/Form/Items/Phone Number/FormPhoneNumberItemView.swift
+++ b/AdyenUI/UI/Form/Items/Phone Number/FormPhoneNumberItemView.swift
@@ -19,6 +19,7 @@ internal final class FormPhoneNumberItemView: FormTextItemView<FormPhoneNumberIt
         textField.textContentType = .telephoneNumber
     }
 
+    // TODO: Should be deleted after the cleanup phase
     /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
     internal required convenience init(item: FormPhoneNumberItem) {
         self.init(item: item, theme: .default)

--- a/AdyenUI/UI/Form/Items/Phone Number/FormPhoneNumberItemView.swift
+++ b/AdyenUI/UI/Form/Items/Phone Number/FormPhoneNumberItemView.swift
@@ -9,13 +9,19 @@ import UIKit
 
 internal final class FormPhoneNumberItemView: FormTextItemView<FormPhoneNumberItem> {
     
-    /// Initializes the phone number item view.
-    ///
-    /// - Parameter item: The item represented by the view.
-    internal required init(item: FormPhoneNumberItem) {
-        super.init(item: item)
+    /// Initializes the phone number item view with theme.
+    /// - Parameters:
+    ///   - item: The item represented by the view.
+    ///   - theme: The theme to use for styling.
+    override internal init(item: FormPhoneNumberItem, theme: AdyenTheme) {
+        super.init(item: item, theme: theme)
         applyTextFieldLeftAccessoryView(textField: textField)
         textField.textContentType = .telephoneNumber
+    }
+
+    /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
+    internal required convenience init(item: FormPhoneNumberItem) {
+        self.init(item: item, theme: .default)
     }
     
     override internal var childItemViews: [AnyFormItemView] {

--- a/AdyenUI/UI/Form/Items/Text/FormTextInputItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextInputItemView.swift
@@ -13,20 +13,22 @@ open class FormTextInputItemView: FormTextItemView<FormTextInputItem> {
 
     // MARK: - Initializers
 
-    /// Initializes the text item view.
-    /// - Parameter item: The item represented by the view.
-    public required init(item: FormTextInputItem) {
-        super.init(item: item)
+    /// Initializes the text item view with theme.
+    /// - Parameters:
+    ///   - item: The item represented by the view.
+    ///   - theme: The theme to use for styling.
+    override public init(item: FormTextInputItem, theme: AdyenTheme) {
+        super.init(item: item, theme: theme)
 
         observe(item.$isEnabled) { [weak self] isEnabled in
             guard let self else { return }
             self.textField.isEnabled = isEnabled
             if isEnabled {
                 self.updateValidationStatus()
-                self.textField.textColor = item.style.text.color
+                self.textField.textColor = self.theme.elements.textField.text.color
             } else {
                 self.resetValidationStatus()
-                self.textField.textColor = item.style.text.disabledColor
+                self.textField.textColor = self.theme.elements.textField.text.disabledColor
             }
         }
         
@@ -39,5 +41,10 @@ open class FormTextInputItemView: FormTextItemView<FormTextInputItem> {
         item.focusHandler = { [weak self] in
             self?.becomeFirstResponder()
         }
+    }
+
+    /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
+    public required convenience init(item: FormTextInputItem) {
+        self.init(item: item, theme: .default)
     }
 }

--- a/AdyenUI/UI/Form/Items/Text/FormTextInputItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextInputItemView.swift
@@ -42,10 +42,4 @@ open class FormTextInputItemView: FormTextItemView<FormTextInputItem> {
             self?.becomeFirstResponder()
         }
     }
-
-    // TODO: Should be deleted after the cleanup phase
-    /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
-    public required convenience init(item: FormTextInputItem) {
-        self.init(item: item, theme: .default)
-    }
 }

--- a/AdyenUI/UI/Form/Items/Text/FormTextInputItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextInputItemView.swift
@@ -43,6 +43,7 @@ open class FormTextInputItemView: FormTextItemView<FormTextInputItem> {
         }
     }
 
+    // TODO: Should be deleted after the cleanup phase
     /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
     public required convenience init(item: FormTextInputItem) {
         self.init(item: item, theme: .default)

--- a/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
@@ -140,7 +140,8 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         stackView.axis = .horizontal
         stackView.alignment = .bottom
         stackView.preservesSuperviewLayoutMargins = true
-        
+        stackView.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "entryTextStackView")
+
         return stackView
     }()
     

--- a/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
@@ -39,13 +39,15 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
     
     override public var accessibilityLabelView: UIView? { textField }
 
-    // TODO: To be passed as a dependency by FormViewController.ItemManager
-    package let theme: AdyenTheme = .default
+    /// The theme for styling (accessible to subclasses)
+    package let theme: AdyenTheme
 
-    /// Initializes the text item view.
-    ///
-    /// - Parameter item: The item represented by the view.
-    public required init(item: ItemType) {
+    /// Initializes the text item view with theme.
+    /// - Parameters:
+    ///   - item: The item represented by the view.
+    ///   - theme: The theme to use for styling.
+    public init(item: ItemType, theme: AdyenTheme) {
+        self.theme = theme
         super.init(item: item)
 
         bind(item.$placeholder, to: textField, at: \.placeholder)
@@ -61,8 +63,51 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         observe(item.$validationFailureMessage) { [weak self] newValue in
             self?.alertLabel.text = newValue
         }
-    
-        apply(style: theme.elements.textField)
+
+        configure()
+    }
+
+    /// Satisfies parent's required initializer. Delegates to main initializer with default theme.
+    public required convenience init(item: ItemType) {
+        self.init(item: item, theme: .default)
+    }
+
+    // MARK: - Configuration
+
+    /// Configures all static styling from theme.
+    private func configure() {
+        let style = theme.elements.textField
+
+        // Title
+        titleLabel.font = style.title.font
+        titleLabel.textColor = style.title.color
+        titleLabel.textAlignment = style.title.textAlignment
+
+        // Text field
+        textField.font = style.text.font
+        textField.textColor = style.text.color
+        textField.textAlignment = style.text.textAlignment
+
+        // Placeholder
+        textField.apply(placeholderText: item.placeholder, with: style.placeholder)
+
+        // Container
+        entryTextStackView.backgroundColor = style.containerColor
+        entryTextStackView.layer.borderWidth = style.borderWidth
+
+        // Alert
+        alertLabel.textColor = style.errorColor
+
+        // Corner radius
+        switch style.cornerRadius {
+        case let .fixed(radius):
+            entryTextStackView.layer.cornerRadius = radius
+        default:
+            break
+        }
+
+        // Border styling
+        updateBorderStyling()
     }
     
     override public func reset() {
@@ -105,8 +150,8 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         stackView.alignment = .fill
         stackView.isLayoutMarginsRelativeArrangement = true
         stackView.isHidden = true
-        stackView.layoutMargins.bottom = abs(item.style.text.font.descender)
-        
+        stackView.layoutMargins.bottom = abs(theme.elements.textField.text.font.descender)
+
         return stackView
     }()
     
@@ -285,42 +330,9 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         accessory = .none
     }
 
-    // MARK: - AdyenTheme
+    // MARK: - Border Styling
 
-    /// Applies all the style properties from AdyenTextFieldStyle to the FormTextItemView.
-    ///
-    /// - Parameter style: The style to apply.
-    private func apply(style: AdyenTextFieldStyle) {
-        // Title
-        titleLabel.font = style.title.font
-        titleLabel.textColor = style.title.color
-        titleLabel.textAlignment = style.title.textAlignment
-
-        // Text field
-        textField.font = style.text.font
-        textField.textColor = style.text.color
-        textField.textAlignment = style.text.textAlignment
-
-        // Placeholder
-        textField.apply(placeholderText: item.placeholder, with: style.placeholder)
-
-        // Container
-        entryTextStackView.backgroundColor = style.containerColor
-        entryTextStackView.layer.borderWidth = style.borderWidth
-
-        // Alert
-        alertLabel.textColor = style.errorColor
-
-        switch style.cornerRadius {
-        case let .fixed(radius):
-            entryTextStackView.layer.cornerRadius = radius
-        default:
-            break
-        }
-
-        updateBorderStyling()
-    }
-
+    /// Updates the border color based on editing state.
     private func updateBorderStyling() {
         let borderColor = isEditing ? theme.elements.textField.borderActiveColor : theme.elements.textField.borderColor
         entryTextStackView.layer.borderColor = borderColor.cgColor

--- a/Tests/IntegrationTests/UIKit/Form/Theme/FormTextItemViewThemeTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/Theme/FormTextItemViewThemeTests.swift
@@ -12,183 +12,167 @@ final class FormTextItemViewThemeTests: XCTestCase {
 
     func test_formTextItemView_shouldApplyThemeAttributesCorrectly() {
         let textFieldStyle = makeTextFieldStyle()
-
-        let theme = AdyenTheme(elements: AdyenElements(textField: textFieldStyle))
-        let item = FormTextInputItem()
-        item.title = "Test Title"
-        item.placeholder = "Test Placeholder"
-
-        // When
-        let sut = FormTextItemView(item: item, theme: theme)
-
+        let sut = makeSUT(with: textFieldStyle)
         expect(sut, toMatchStyle: textFieldStyle)
     }
 
     func test_formTextItemView_withDefaultTheme_shouldUseDefaultAttributes() {
-        // Given
-        let item = FormTextInputItem()
         let defaultTheme = AdyenTheme.default
-
-        // When
-        let sut = FormTextItemView(item: item, theme: defaultTheme)
-
-        // Then
-        let containerView: UIStackView? = sut.findView(by: "entryTextStackView")
-        XCTAssertEqual(sut.titleLabel.font, defaultTheme.elements.textField.title.font)
-        XCTAssertEqual(sut.titleLabel.textColor, defaultTheme.elements.textField.title.color)
-        XCTAssertEqual(sut.textField.font, defaultTheme.elements.textField.text.font)
-        XCTAssertEqual(sut.textField.textColor, defaultTheme.elements.textField.text.color)
-        XCTAssertEqual(containerView?.backgroundColor, defaultTheme.elements.textField.containerColor)
-        XCTAssertEqual(sut.alertLabel.textColor, defaultTheme.elements.textField.errorColor)
+        let sut = makeSUT(with: defaultTheme)
+        expect(sut, toMatchStyle: defaultTheme.elements.textField)
     }
 
     func test_formTextItemView_borderColor_shouldUpdateOnEditingStateChange() {
-        // Given
-        let customBorderColor = UIColor.green
-        let customActiveBorderColor = UIColor.orange
+        let sut = makeSUT(borderColor: .green, borderActiveColor: .orange)
+        let containerView = getContainerView(from: sut)
 
-        var textFieldStyle = AdyenTextFieldStyle()
-        textFieldStyle.borderColor = customBorderColor
-        textFieldStyle.borderActiveColor = customActiveBorderColor
-
-        let theme = AdyenTheme(elements: AdyenElements(textField: textFieldStyle))
-        let item = FormTextInputItem()
-
-        // When
-        let sut = FormTextItemView(item: item, theme: theme)
-        let containerView: UIStackView? = sut.findView(by: "entryTextStackView")
-
-        // Then - Not editing
-        XCTAssertEqual(containerView?.layer.borderColor, customBorderColor.cgColor)
-
-        // When - Start editing (trigger via text field delegate)
-        sut.textField.delegate?.textFieldDidBeginEditing?(sut.textField)
-
-        // Then - Editing
-        XCTAssertEqual(containerView?.layer.borderColor, customActiveBorderColor.cgColor)
-
-        // When - Stop editing (trigger via text field delegate)
-        sut.textField.delegate?.textFieldDidEndEditing?(sut.textField)
-
-        // Then - Not editing again
-        XCTAssertEqual(containerView?.layer.borderColor, customBorderColor.cgColor)
+        expectBorderColor(containerView, toBe: .green)
+        triggerEditing(on: sut, isEditing: true)
+        expectBorderColor(containerView, toBe: .orange)
+        triggerEditing(on: sut, isEditing: false)
+        expectBorderColor(containerView, toBe: .green)
     }
 
     func test_formTextInputItemView_isEnabled_shouldApplyCorrectTextColor() {
-        // Given
-        let customTextColor = UIColor.blue
-        let customDisabledTextColor = UIColor.lightGray
-
-        var textFieldStyle = AdyenTextFieldStyle()
-        textFieldStyle.text = AdyenLabelStyle(
-            font: .systemFont(ofSize: 16),
-            color: customTextColor,
-            disabledColor: customDisabledTextColor
-        )
-
-        let theme = AdyenTheme(elements: AdyenElements(textField: textFieldStyle))
         let item = FormTextInputItem()
+        let sut = makeSUT(item: item, textColor: .blue, disabledTextColor: .lightGray)
 
-        // When
-        let sut = FormTextInputItemView(item: item, theme: theme)
-
-        // Then - Initially enabled
-        XCTAssertEqual(sut.textField.textColor, customTextColor)
+        XCTAssertEqual(sut.textField.textColor, .blue)
         XCTAssertTrue(sut.textField.isEnabled)
 
-        // When - Disable
-        item.isEnabled = false
-
-        // Wait for observable to propagate
-        let expectation = XCTestExpectation(description: "Wait for isEnabled change")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.0)
-
-        // Then - Disabled
-        XCTAssertEqual(sut.textField.textColor, customDisabledTextColor)
+        setEnabled(false, on: item)
+        XCTAssertEqual(sut.textField.textColor, .lightGray)
         XCTAssertFalse(sut.textField.isEnabled)
 
-        // When - Re-enable
-        item.isEnabled = true
-
-        let expectation2 = XCTestExpectation(description: "Wait for isEnabled change")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            expectation2.fulfill()
-        }
-        wait(for: [expectation2], timeout: 1.0)
-
-        // Then - Enabled again
-        XCTAssertEqual(sut.textField.textColor, customTextColor)
+        setEnabled(true, on: item)
+        XCTAssertEqual(sut.textField.textColor, .blue)
         XCTAssertTrue(sut.textField.isEnabled)
     }
 
     func test_formTextItemView_convenienceInitializer_shouldUseDefaultTheme() {
-        // Given
-        let item = FormTextInputItem()
-        let theme = AdyenTheme.default
+        let sut = FormTextItemView(item: FormTextInputItem())
+        let defaultTextFieldStyle = AdyenTheme.default.elements.textField
 
-        // When
-        let sut = FormTextItemView(item: item)
+        XCTAssertEqual(sut.titleLabel.font, defaultTextFieldStyle.title.font)
+        XCTAssertEqual(sut.titleLabel.textColor, defaultTextFieldStyle.title.color)
+        XCTAssertEqual(sut.textField.font, defaultTextFieldStyle.text.font)
+        XCTAssertEqual(sut.textField.textColor, defaultTextFieldStyle.text.color)
+    }
 
-        // Then - Verify default theme is applied by checking its attributes
-        XCTAssertEqual(sut.titleLabel.font, theme.elements.textField.title.font)
-        XCTAssertEqual(sut.titleLabel.textColor, theme.elements.textField.title.color)
-        XCTAssertEqual(sut.textField.font, theme.elements.textField.text.font)
-        XCTAssertEqual(sut.textField.textColor, theme.elements.textField.text.color)
+    // MARK: - SUT Factory
+
+    private func makeSUT(
+        item: FormTextInputItem = FormTextInputItem(),
+        with theme: AdyenTheme
+    ) -> FormTextItemView<FormTextInputItem> {
+        FormTextItemView(item: item, theme: theme)
+    }
+
+    private func makeSUT(
+        with textFieldStyle: AdyenTextFieldStyle
+    ) -> FormTextItemView<FormTextInputItem> {
+        let theme = AdyenTheme(elements: AdyenElements(textField: textFieldStyle))
+        return makeSUT(with: theme)
+    }
+
+    private func makeSUT(
+        borderColor: UIColor,
+        borderActiveColor: UIColor
+    ) -> FormTextItemView<FormTextInputItem> {
+        var style = AdyenTextFieldStyle()
+        style.borderColor = borderColor
+        style.borderActiveColor = borderActiveColor
+        return makeSUT(with: style)
+    }
+
+    private func makeSUT(
+        item: FormTextInputItem,
+        textColor: UIColor,
+        disabledTextColor: UIColor
+    ) -> FormTextInputItemView {
+        var style = AdyenTextFieldStyle()
+        style.text = AdyenLabelStyle(
+            font: .systemFont(ofSize: 16),
+            color: textColor,
+            disabledColor: disabledTextColor
+        )
+        let theme = AdyenTheme(elements: AdyenElements(textField: style))
+        return FormTextInputItemView(item: item, theme: theme)
+    }
+
+    // MARK: - Style Factory
+
+    private func makeTextFieldStyle() -> AdyenTextFieldStyle {
+        var style = AdyenTextFieldStyle()
+        style.title = AdyenLabelStyle(font: .systemFont(ofSize: 18, weight: .bold), color: .red)
+        style.text = AdyenLabelStyle(font: .systemFont(ofSize: 16), color: .blue)
+        style.placeholder = AdyenLabelStyle(font: .systemFont(ofSize: 14), color: .gray)
+        style.containerColor = .yellow
+        style.borderColor = .green
+        style.borderWidth = 3.0
+        style.cornerRadius = .fixed(12.0)
+        style.errorColor = .purple
+        return style
+    }
+
+    // MARK: - Assertions
+
+    private func expect(
+        _ sut: FormTextItemView<FormTextInputItem>,
+        toMatchStyle style: AdyenTextFieldStyle,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(sut.titleLabel.font, style.title.font, file: file, line: line)
+        XCTAssertEqual(sut.titleLabel.textColor, style.title.color, file: file, line: line)
+        XCTAssertEqual(sut.textField.font, style.text.font, file: file, line: line)
+        XCTAssertEqual(sut.textField.textColor, style.text.color, file: file, line: line)
+
+        let containerView = getContainerView(from: sut)
+        XCTAssertEqual(containerView?.backgroundColor, style.containerColor, file: file, line: line)
+        XCTAssertEqual(containerView?.layer.borderWidth, style.borderWidth, file: file, line: line)
+        XCTAssertEqual(containerView?.layer.borderColor, style.borderColor.cgColor, file: file, line: line)
+
+        if case let .fixed(radius) = style.cornerRadius {
+            XCTAssertEqual(containerView?.layer.cornerRadius, radius, file: file, line: line)
+        }
+
+        XCTAssertEqual(sut.alertLabel.textColor, style.errorColor, file: file, line: line)
+    }
+
+    private func expectBorderColor(
+        _ containerView: UIStackView?,
+        toBe color: UIColor,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(containerView?.layer.borderColor, color.cgColor, file: file, line: line)
     }
 
     // MARK: - Helpers
 
-    private func makeTextFieldStyle() -> AdyenTextFieldStyle {
-        // Given
-        let customTitleFont = UIFont.systemFont(ofSize: 18, weight: .bold)
-        let customTitleColor = UIColor.red
-        let customTextFont = UIFont.systemFont(ofSize: 16)
-        let customTextColor = UIColor.blue
-        let customPlaceholderFont = UIFont.systemFont(ofSize: 14)
-        let customPlaceholderColor = UIColor.gray
-        let customBackgroundColor = UIColor.yellow
-        let customBorderColor = UIColor.green
-        let customBorderWidth: CGFloat = 3.0
-        let customCornerRadius: CGFloat = 12.0
-        let customErrorColor = UIColor.purple
-
-        var textFieldStyle = AdyenTextFieldStyle()
-        textFieldStyle.title = AdyenLabelStyle(font: customTitleFont, color: customTitleColor)
-        textFieldStyle.text = AdyenLabelStyle(font: customTextFont, color: customTextColor)
-        textFieldStyle.placeholder = AdyenLabelStyle(font: customPlaceholderFont, color: customPlaceholderColor)
-        textFieldStyle.containerColor = customBackgroundColor
-        textFieldStyle.borderColor = customBorderColor
-        textFieldStyle.borderWidth = customBorderWidth
-        textFieldStyle.cornerRadius = .fixed(customCornerRadius)
-        textFieldStyle.errorColor = customErrorColor
-
-        return textFieldStyle
+    private func getContainerView(from sut: FormTextItemView<FormTextInputItem>) -> UIStackView? {
+        sut.findView(by: "entryTextStackView")
     }
 
-    private func expect(_ sut: FormTextItemView<FormTextInputItem>, toMatchStyle textFieldStyle: AdyenTextFieldStyle) {
-        // Then - Title
-        XCTAssertEqual(sut.titleLabel.font, textFieldStyle.title.font)
-        XCTAssertEqual(sut.titleLabel.textColor, textFieldStyle.title.color)
-
-        // Then - Text field
-        XCTAssertEqual(sut.textField.font, textFieldStyle.text.font)
-        XCTAssertEqual(sut.textField.textColor, textFieldStyle.text.color)
-
-        // Then - Container
-        let containerView: UIStackView? = sut.findView(by: "entryTextStackView")
-        XCTAssertEqual(containerView?.backgroundColor, textFieldStyle.containerColor)
-        XCTAssertEqual(containerView?.layer.borderWidth, textFieldStyle.borderWidth)
-        XCTAssertEqual(containerView?.layer.borderColor, textFieldStyle.borderColor.cgColor)
-
-        // Then - Corner radius
-        if case let .fixed(radius) = textFieldStyle.cornerRadius {
-            XCTAssertEqual(containerView?.layer.cornerRadius, radius)
+    private func triggerEditing(on sut: FormTextItemView<FormTextInputItem>, isEditing: Bool) {
+        if isEditing {
+            sut.textField.delegate?.textFieldDidBeginEditing?(sut.textField)
+        } else {
+            sut.textField.delegate?.textFieldDidEndEditing?(sut.textField)
         }
+    }
 
-        // Then - Alert/Error
-        XCTAssertEqual(sut.alertLabel.textColor, textFieldStyle.errorColor)
+    private func setEnabled(_ enabled: Bool, on item: FormTextInputItem) {
+        item.isEnabled = enabled
+        waitForObservableUpdate()
+    }
+
+    private func waitForObservableUpdate() {
+        let expectation = XCTestExpectation(description: "Wait for observable update")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
     }
 }

--- a/Tests/IntegrationTests/UIKit/Form/Theme/FormTextItemViewThemeTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/Theme/FormTextItemViewThemeTests.swift
@@ -1,0 +1,194 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+@_spi(AdyenInternal) @testable import AdyenUI
+import XCTest
+
+final class FormTextItemViewThemeTests: XCTestCase {
+
+    func test_formTextItemView_shouldApplyThemeAttributesCorrectly() {
+        let textFieldStyle = makeTextFieldStyle()
+
+        let theme = AdyenTheme(elements: AdyenElements(textField: textFieldStyle))
+        let item = FormTextInputItem()
+        item.title = "Test Title"
+        item.placeholder = "Test Placeholder"
+
+        // When
+        let sut = FormTextItemView(item: item, theme: theme)
+
+        expect(sut, toMatchStyle: textFieldStyle)
+    }
+
+    func test_formTextItemView_withDefaultTheme_shouldUseDefaultAttributes() {
+        // Given
+        let item = FormTextInputItem()
+        let defaultTheme = AdyenTheme.default
+
+        // When
+        let sut = FormTextItemView(item: item, theme: defaultTheme)
+
+        // Then
+        let containerView: UIStackView? = sut.findView(by: "entryTextStackView")
+        XCTAssertEqual(sut.titleLabel.font, defaultTheme.elements.textField.title.font)
+        XCTAssertEqual(sut.titleLabel.textColor, defaultTheme.elements.textField.title.color)
+        XCTAssertEqual(sut.textField.font, defaultTheme.elements.textField.text.font)
+        XCTAssertEqual(sut.textField.textColor, defaultTheme.elements.textField.text.color)
+        XCTAssertEqual(containerView?.backgroundColor, defaultTheme.elements.textField.containerColor)
+        XCTAssertEqual(sut.alertLabel.textColor, defaultTheme.elements.textField.errorColor)
+    }
+
+    func test_formTextItemView_borderColor_shouldUpdateOnEditingStateChange() {
+        // Given
+        let customBorderColor = UIColor.green
+        let customActiveBorderColor = UIColor.orange
+
+        var textFieldStyle = AdyenTextFieldStyle()
+        textFieldStyle.borderColor = customBorderColor
+        textFieldStyle.borderActiveColor = customActiveBorderColor
+
+        let theme = AdyenTheme(elements: AdyenElements(textField: textFieldStyle))
+        let item = FormTextInputItem()
+
+        // When
+        let sut = FormTextItemView(item: item, theme: theme)
+        let containerView: UIStackView? = sut.findView(by: "entryTextStackView")
+
+        // Then - Not editing
+        XCTAssertEqual(containerView?.layer.borderColor, customBorderColor.cgColor)
+
+        // When - Start editing (trigger via text field delegate)
+        sut.textField.delegate?.textFieldDidBeginEditing?(sut.textField)
+
+        // Then - Editing
+        XCTAssertEqual(containerView?.layer.borderColor, customActiveBorderColor.cgColor)
+
+        // When - Stop editing (trigger via text field delegate)
+        sut.textField.delegate?.textFieldDidEndEditing?(sut.textField)
+
+        // Then - Not editing again
+        XCTAssertEqual(containerView?.layer.borderColor, customBorderColor.cgColor)
+    }
+
+    func test_formTextInputItemView_isEnabled_shouldApplyCorrectTextColor() {
+        // Given
+        let customTextColor = UIColor.blue
+        let customDisabledTextColor = UIColor.lightGray
+
+        var textFieldStyle = AdyenTextFieldStyle()
+        textFieldStyle.text = AdyenLabelStyle(
+            font: .systemFont(ofSize: 16),
+            color: customTextColor,
+            disabledColor: customDisabledTextColor
+        )
+
+        let theme = AdyenTheme(elements: AdyenElements(textField: textFieldStyle))
+        let item = FormTextInputItem()
+
+        // When
+        let sut = FormTextInputItemView(item: item, theme: theme)
+
+        // Then - Initially enabled
+        XCTAssertEqual(sut.textField.textColor, customTextColor)
+        XCTAssertTrue(sut.textField.isEnabled)
+
+        // When - Disable
+        item.isEnabled = false
+
+        // Wait for observable to propagate
+        let expectation = XCTestExpectation(description: "Wait for isEnabled change")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // Then - Disabled
+        XCTAssertEqual(sut.textField.textColor, customDisabledTextColor)
+        XCTAssertFalse(sut.textField.isEnabled)
+
+        // When - Re-enable
+        item.isEnabled = true
+
+        let expectation2 = XCTestExpectation(description: "Wait for isEnabled change")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation2.fulfill()
+        }
+        wait(for: [expectation2], timeout: 1.0)
+
+        // Then - Enabled again
+        XCTAssertEqual(sut.textField.textColor, customTextColor)
+        XCTAssertTrue(sut.textField.isEnabled)
+    }
+
+    func test_formTextItemView_convenienceInitializer_shouldUseDefaultTheme() {
+        // Given
+        let item = FormTextInputItem()
+        let theme = AdyenTheme.default
+
+        // When
+        let sut = FormTextItemView(item: item)
+
+        // Then - Verify default theme is applied by checking its attributes
+        XCTAssertEqual(sut.titleLabel.font, theme.elements.textField.title.font)
+        XCTAssertEqual(sut.titleLabel.textColor, theme.elements.textField.title.color)
+        XCTAssertEqual(sut.textField.font, theme.elements.textField.text.font)
+        XCTAssertEqual(sut.textField.textColor, theme.elements.textField.text.color)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTextFieldStyle() -> AdyenTextFieldStyle {
+        // Given
+        let customTitleFont = UIFont.systemFont(ofSize: 18, weight: .bold)
+        let customTitleColor = UIColor.red
+        let customTextFont = UIFont.systemFont(ofSize: 16)
+        let customTextColor = UIColor.blue
+        let customPlaceholderFont = UIFont.systemFont(ofSize: 14)
+        let customPlaceholderColor = UIColor.gray
+        let customBackgroundColor = UIColor.yellow
+        let customBorderColor = UIColor.green
+        let customBorderWidth: CGFloat = 3.0
+        let customCornerRadius: CGFloat = 12.0
+        let customErrorColor = UIColor.purple
+
+        var textFieldStyle = AdyenTextFieldStyle()
+        textFieldStyle.title = AdyenLabelStyle(font: customTitleFont, color: customTitleColor)
+        textFieldStyle.text = AdyenLabelStyle(font: customTextFont, color: customTextColor)
+        textFieldStyle.placeholder = AdyenLabelStyle(font: customPlaceholderFont, color: customPlaceholderColor)
+        textFieldStyle.containerColor = customBackgroundColor
+        textFieldStyle.borderColor = customBorderColor
+        textFieldStyle.borderWidth = customBorderWidth
+        textFieldStyle.cornerRadius = .fixed(customCornerRadius)
+        textFieldStyle.errorColor = customErrorColor
+
+        return textFieldStyle
+    }
+
+    private func expect(_ sut: FormTextItemView<FormTextInputItem>, toMatchStyle textFieldStyle: AdyenTextFieldStyle) {
+        // Then - Title
+        XCTAssertEqual(sut.titleLabel.font, textFieldStyle.title.font)
+        XCTAssertEqual(sut.titleLabel.textColor, textFieldStyle.title.color)
+
+        // Then - Text field
+        XCTAssertEqual(sut.textField.font, textFieldStyle.text.font)
+        XCTAssertEqual(sut.textField.textColor, textFieldStyle.text.color)
+
+        // Then - Container
+        let containerView: UIStackView? = sut.findView(by: "entryTextStackView")
+        XCTAssertEqual(containerView?.backgroundColor, textFieldStyle.containerColor)
+        XCTAssertEqual(containerView?.layer.borderWidth, textFieldStyle.borderWidth)
+        XCTAssertEqual(containerView?.layer.borderColor, textFieldStyle.borderColor.cgColor)
+
+        // Then - Corner radius
+        if case let .fixed(radius) = textFieldStyle.cornerRadius {
+            XCTAssertEqual(containerView?.layer.cornerRadius, radius)
+        }
+
+        // Then - Alert/Error
+        XCTAssertEqual(sut.alertLabel.textColor, textFieldStyle.errorColor)
+    }
+}


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->
Refactors `FormTextItemView` and its subclasses to accept `AdyenTheme` as a constructor parameter instead of reading from `item.style`. This continues the gradual migration from style-based to theme-based styling.

## What's Changed
- `FormTextItemView`, `FormTextInputItemView`, `FormPhoneNumberItemView`, `FormCardNumberItemView`, and `FormCardSecurityCodeItemView` now accept `theme: AdyenTheme` parameter
- `FormItemViewBuilder` now requires theme (defaults to `.default` if nil)
- Old `init(item:)` methods preserved as convenience initializers for backward compatibility (marked with TODO for cleanup)
- 
## Refactor journey overview
- ✅ Introduce `AdyenTheme` system (#2296)
- ✅ Prepare style-to-theme migration infrastructure (#2310)
- ✅ **Current PR:** Refactor `FormTextItemView` hierarchy to accept theme
- Update all `FormItemView` subclasses to accept theme
- Update `FormViewController` to pass theme to all form items
- Remove backward-compatibility convenience initializers
- Deprecate and remove `FormItemStyle` system

## Ticket [Optional]
<ticket>
COSDK-775
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
