### PR TITLE
Migrate `FormButtonItemView` to `AdyenTheme`

### DIFF
--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -20,10 +20,6 @@ permissions:
   contents: read
   pull-requests: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   build:

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -52,7 +52,7 @@
 		0019C4642E6ADFC700B0C3A3 /* CopyLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95A788725C416A60032CF7E /* CopyLabelView.swift */; };
 		0019C4652E6ADFC700B0C3A3 /* SupportedPaymentMethodsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128977A2CC93CB000275487 /* SupportedPaymentMethodsView.swift */; };
 		0019C4662E6ADFC700B0C3A3 /* UIView+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BBB6732A82792100C1A04B /* UIView+Accessibility.swift */; };
-		0019C4672E6ADFC700B0C3A3 /* SubmitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C0E0C0220D7E5E008616F6 /* SubmitButton.swift */; };
+		0019C4672E6ADFC700B0C3A3 /* FormButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C0E0C0220D7E5E008616F6 /* FormButton.swift */; };
 		0019C4682E6ADFC700B0C3A3 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99D2F852665211600BB5B2F /* LoadingView.swift */; };
 		0019C4692E6ADFC700B0C3A3 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DC5A5C2A7BADB200DBF2D1 /* EmptyStateView.swift */; };
 		0019C46A2E6ADFC700B0C3A3 /* UISearchBar+Prominent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B001C12A55C5C10015BFA3 /* UISearchBar+Prominent.swift */; };
@@ -592,7 +592,7 @@
 		B605AC122D8D988D0084D583 /* AdyenCardScanner.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C9FC2C3D2D50D0B700C9D0F3 /* AdyenCardScanner.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B60946132DA562FD00CEE6CF /* CardScannerProviderDispatchOnceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60946122DA562FD00CEE6CF /* CardScannerProviderDispatchOnceTests.swift */; };
 		B60946152DA5656100CEE6CF /* CardScannerTestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60946142DA5656100CEE6CF /* CardScannerTestsHelpers.swift */; };
-		B61CE9152DDDD7C3009B7503 /* SubmitButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61CE9142DDDD7C3009B7503 /* SubmitButtonTests.swift */; };
+		B61CE9152DDDD7C3009B7503 /* FormButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61CE9142DDDD7C3009B7503 /* FormButtonTests.swift */; };
 		B6244E082E327A5300F42780 /* Configuration+secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6244E072E327A5300F42780 /* Configuration+secrets.swift */; };
 		B6244E092E327A5300F42780 /* Configuration+secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6244E072E327A5300F42780 /* Configuration+secrets.swift */; };
 		B6271FEA2EB9F8CD009E9149 /* AdyenLabelStyle+UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6271FE92EB9F8CD009E9149 /* AdyenLabelStyle+UILabel.swift */; };
@@ -2213,7 +2213,7 @@
 		B605AC092D897A930084D583 /* CardScannerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerControllerTests.swift; sourceTree = "<group>"; };
 		B60946122DA562FD00CEE6CF /* CardScannerProviderDispatchOnceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerProviderDispatchOnceTests.swift; sourceTree = "<group>"; };
 		B60946142DA5656100CEE6CF /* CardScannerTestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerTestsHelpers.swift; sourceTree = "<group>"; };
-		B61CE9142DDDD7C3009B7503 /* SubmitButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitButtonTests.swift; sourceTree = "<group>"; };
+		B61CE9142DDDD7C3009B7503 /* FormButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormButtonTests.swift; sourceTree = "<group>"; };
 		B6244DFF2E3224BE00F42780 /* Secrets.template.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.template.xcconfig; sourceTree = "<group>"; };
 		B6244E072E327A5300F42780 /* Configuration+secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+secrets.swift"; sourceTree = "<group>"; };
 		B6244E0A2E3281B800F42780 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
@@ -2438,7 +2438,7 @@
 		E2C0E0B5220B08ED008616F6 /* FormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormView.swift; sourceTree = "<group>"; };
 		E2C0E0B9220B2966008616F6 /* FormTextItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormTextItemView.swift; sourceTree = "<group>"; };
 		E2C0E0BB220B2976008616F6 /* FormItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormItemView.swift; sourceTree = "<group>"; };
-		E2C0E0C0220D7E5E008616F6 /* SubmitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitButton.swift; sourceTree = "<group>"; };
+		E2C0E0C0220D7E5E008616F6 /* FormButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormButton.swift; sourceTree = "<group>"; };
 		E2D05BF12285B98900EC279A /* StoredPaymentMethodComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredPaymentMethodComponent.swift; sourceTree = "<group>"; };
 		E2D12BEE221D560800EF682F /* FormValueItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormValueItem.swift; sourceTree = "<group>"; };
 		E2D12BF0221D561600EF682F /* FormValueItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormValueItemView.swift; sourceTree = "<group>"; };
@@ -4063,7 +4063,7 @@
 		B61CE9132DDDD7B3009B7503 /* UI Components */ = {
 			isa = PBXGroup;
 			children = (
-				B61CE9142DDDD7C3009B7503 /* SubmitButtonTests.swift */,
+				B61CE9142DDDD7C3009B7503 /* FormButtonTests.swift */,
 			);
 			path = "UI Components";
 			sourceTree = "<group>";
@@ -5175,7 +5175,7 @@
 			children = (
 				81B001C12A55C5C10015BFA3 /* UISearchBar+Prominent.swift */,
 				81BBB6732A82792100C1A04B /* UIView+Accessibility.swift */,
-				E2C0E0C0220D7E5E008616F6 /* SubmitButton.swift */,
+				E2C0E0C0220D7E5E008616F6 /* FormButton.swift */,
 				8128977A2CC93CB000275487 /* SupportedPaymentMethodsView.swift */,
 				81A2E3BF2A5C453F00CF5F9C /* LinkTextView.swift */,
 				F95A788725C416A60032CF7E /* CopyLabelView.swift */,
@@ -8010,7 +8010,7 @@
 				B6271FF82EBA3497009E9149 /* AdyenElements.swift in Sources */,
 				0019C4982E6AE0B700B0C3A3 /* FormPhoneExtensionPickerItem.swift in Sources */,
 				0019C4992E6AE0B700B0C3A3 /* FormPhoneExtensionPickerItemView.swift in Sources */,
-				0019C4672E6ADFC700B0C3A3 /* SubmitButton.swift in Sources */,
+				0019C4672E6ADFC700B0C3A3 /* FormButton.swift in Sources */,
 				0019C4682E6ADFC700B0C3A3 /* LoadingView.swift in Sources */,
 				0019C4692E6ADFC700B0C3A3 /* EmptyStateView.swift in Sources */,
 				0019C46A2E6ADFC700B0C3A3 /* UISearchBar+Prominent.swift in Sources */,
@@ -8566,7 +8566,7 @@
 				81DA708A2BDA6075006CE5D5 /* TwintSDKActionTests+Flows.swift in Sources */,
 				F957AA722552DBC80099AD73 /* AnyRedirectComponentMock.swift in Sources */,
 				F9EDB79A239664B500CFB3C9 /* StoredPaymentMethodComponentTests.swift in Sources */,
-				B61CE9152DDDD7C3009B7503 /* SubmitButtonTests.swift in Sources */,
+				B61CE9152DDDD7C3009B7503 /* FormButtonTests.swift in Sources */,
 				F9EDB7982396643A00CFB3C9 /* CardPaymentMethodMock.swift in Sources */,
 				C927084027590FE800D15EA0 /* BACSInputPresenterTests.swift in Sources */,
 				A009837D279859DC007E68C4 /* ACHDirectDebitComponentTests.swift in Sources */,

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -613,6 +613,7 @@
 		B62D48C82BBE8F47001EF01A /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62D48C22BBE8ED6001EF01A /* XCTestCase+Wait.swift */; };
 		B62F51802E97AAD200610EFD /* TextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62F517F2E97AA6600610EFD /* TextFieldTests.swift */; };
 		B639C0822D8039F600472EBB /* CardScannerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B639C0812D80399800472EBB /* CardScannerController.swift */; };
+		B65F0EB42ED493250015AC41 /* FormButtonItemViewThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65F0EB32ED493250015AC41 /* FormButtonItemViewThemeTests.swift */; };
 		B66CAF3A2DAEB16D0017984C /* DummyCardScannerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66CAF392DAEB16D0017984C /* DummyCardScannerController.swift */; };
 		B67D1F632E4615390000C37F /* DropInAdvancedFlowExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67D1F582E4615390000C37F /* DropInAdvancedFlowExample.swift */; };
 		B67D1F642E4615390000C37F /* DropInExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67D1F602E4615390000C37F /* DropInExample.swift */; };
@@ -2229,6 +2230,7 @@
 		B62D48CA2BBE9059001EF01A /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		B62F517F2E97AA6600610EFD /* TextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTests.swift; sourceTree = "<group>"; };
 		B639C0812D80399800472EBB /* CardScannerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerController.swift; sourceTree = "<group>"; };
+		B65F0EB32ED493250015AC41 /* FormButtonItemViewThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormButtonItemViewThemeTests.swift; sourceTree = "<group>"; };
 		B66CAF392DAEB16D0017984C /* DummyCardScannerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyCardScannerController.swift; sourceTree = "<group>"; };
 		B67D1F532E4615390000C37F /* ApplePayComponentAdvancedFlowExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayComponentAdvancedFlowExample.swift; sourceTree = "<group>"; };
 		B67D1F542E4615390000C37F /* CardComponentAdvancedFlowExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardComponentAdvancedFlowExample.swift; sourceTree = "<group>"; };
@@ -4188,6 +4190,7 @@
 		B6BFF8002EC7249200BAC3B7 /* Theme */ = {
 			isa = PBXGroup;
 			children = (
+				B65F0EB32ED493250015AC41 /* FormButtonItemViewThemeTests.swift */,
 				B6BFF7FF2EC7249200BAC3B7 /* FormTextItemViewThemeTests.swift */,
 				B6C4C6672ECF61E000500BCD /* FormLabelItemTests.swift */,
 				B6BFF8002EC7250000BAC3B7 /* FormSeparatorItemViewThemeTests.swift */,
@@ -8576,6 +8579,7 @@
 				F9EDB796239663F800CFB3C9 /* PaymentComponentMock.swift in Sources */,
 				F9B9F625295485A2008C2E49 /* ThreeDSResultExtension.swift in Sources */,
 				E7D189B025D31936006AD3B7 /* DropInActionTests.swift in Sources */,
+				B65F0EB42ED493250015AC41 /* FormButtonItemViewThemeTests.swift in Sources */,
 				C95903DE275A48D000E7D3BC /* BACSDirectDebitComponentTests.swift in Sources */,
 				81DA70882BDA6075006CE5D5 /* TwintSDKActionTests.swift in Sources */,
 				81825CBB2AC59C4000F91912 /* UIViewController+Search.swift in Sources */,

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationErrorView.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationErrorView.swift
@@ -72,8 +72,8 @@ internal final class DelegatedAuthenticationErrorView: UIView {
         scopeInstance: self
     )
     
-    internal lazy var troubleshootingButton: SubmitButton = {
-        let button = SubmitButton(style: self.style.troubleshootingButtonStyle)
+    internal lazy var troubleshootingButton: FormButton = {
+        let button = FormButton(style: self.style.troubleshootingButtonStyle)
         button.addTarget(self, action: #selector(troubleshootingButtonTapped), for: .touchUpInside)
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "troubleshootingButton")
         button.preservesSuperviewLayoutMargins = true
@@ -107,8 +107,8 @@ internal final class DelegatedAuthenticationErrorView: UIView {
                     
     // MARK: Buttons
 
-    internal lazy var firstButton: SubmitButton = {
-        let button = SubmitButton(style: style.errorButton)
+    internal lazy var firstButton: FormButton = {
+        let button = FormButton(style: style.errorButton)
 
         button.addTarget(self, action: #selector(firstButtonTapped), for: .touchUpInside)
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "primaryButton")

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationView.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationView.swift
@@ -199,8 +199,8 @@ internal final class DelegatedAuthenticationView: UIView {
     
     // MARK: Buttons
 
-    internal lazy var firstButton: SubmitButton = {
-        let button = SubmitButton(style: style.primaryButton)
+    internal lazy var firstButton: FormButton = {
+        let button = FormButton(style: style.primaryButton)
 
         button.addTarget(self, action: #selector(firstButtonTapped), for: .touchUpInside)
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "primaryButton")
@@ -209,8 +209,8 @@ internal final class DelegatedAuthenticationView: UIView {
         return button
     }()
 
-    internal lazy var secondButton: SubmitButton = {
-        let button = SubmitButton(style: style.secondaryButton)
+    internal lazy var secondButton: FormButton = {
+        let button = FormButton(style: style.secondaryButton)
         button.addTarget(self, action: #selector(secondButtonTapped), for: .touchUpInside)
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "secondaryButton")
         button.preservesSuperviewLayoutMargins = true

--- a/AdyenActions/UI/View Controllers/QR Code/QRCodeViewController.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/QRCodeViewController.swift
@@ -75,8 +75,8 @@ internal final class QRCodeViewController: UIViewController, AdyenObserver {
     
     internal private(set) lazy var qrCodeView = QRCodeView(viewModel: viewModel, style: style)
         
-    internal private(set) lazy var actionButton: SubmitButton = {
-        let button = SubmitButton(style: actionButtonStyle)
+    internal private(set) lazy var actionButton: FormButton = {
+        let button = FormButton(style: actionButtonStyle)
         
         button.title = viewModel.actionButtonTitle
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherView.swift
@@ -164,8 +164,8 @@ internal final class VoucherView: UIView, Localizable {
         return currencyLabel
     }()
     
-    private lazy var mainButton: SubmitButton = {
-        let button = SubmitButton(style: model.style.mainButton)
+    private lazy var mainButton: FormButton = {
+        let button = FormButton(style: model.style.mainButton)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.title = model.mainButton
         button.addTarget(self, action: #selector(onMainButtonTap), for: .touchUpInside)

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent+ConfirmationViewController.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent+ConfirmationViewController.swift
@@ -30,7 +30,7 @@ extension PayByBankUSComponent {
         internal lazy var titleLabel = Self.defaultLabel
         internal lazy var subtitleLabel = Self.defaultLabel
         internal lazy var messageLabel = Self.defaultLabel
-        internal let submitButton: SubmitButton
+        internal let submitButton: FormButton
         
         // MARK: UIViewController
         
@@ -42,7 +42,7 @@ extension PayByBankUSComponent {
                 trailingText: model.supportedBanksMoreText
             )
            
-            self.submitButton = SubmitButton(style: model.style.submitButton)
+            self.submitButton = FormButton(style: model.style.submitButton)
             
             super.init(nibName: nil, bundle: nil)
         }

--- a/AdyenUI/UI/Form/FormItemViewBuilder.swift
+++ b/AdyenUI/UI/Form/FormItemViewBuilder.swift
@@ -67,7 +67,7 @@ public struct FormItemViewBuilder {
     /// Builds `FormButtonItemView` from `FormButtonItem`.
     @_spi(AdyenInternal)
     public func build(with item: FormButtonItem) -> FormItemView<FormButtonItem> {
-        FormButtonItemView(item: item)
+        FormButtonItemView(item: item, theme: theme)
     }
 
     /// Builds `FormImageView` from `FormImageItem`.

--- a/AdyenUI/UI/Form/Items/Button/FormButtonItemView.swift
+++ b/AdyenUI/UI/Form/Items/Button/FormButtonItemView.swift
@@ -13,7 +13,7 @@ internal final class FormButtonItemView: FormItemView<FormButtonItem> {
     /// The theme for styling.
     package let theme: AdyenTheme
 
-    /// Initializes the footer item view.
+    /// Initializes the button item view.
     ///
     /// - Parameters:
     ///   - item: The item represented by the view.
@@ -22,40 +22,40 @@ internal final class FormButtonItemView: FormItemView<FormButtonItem> {
         self.theme = theme
         super.init(item: item)
 
-        addSubview(submitButton)
+        addSubview(button)
 
         preservesSuperviewLayoutMargins = true
 
-        bind(item.$showsActivityIndicator, to: submitButton, at: \.showsActivityIndicator)
-        bind(item.$enabled, to: submitButton, at: \.isEnabled)
-        bind(item.$title, to: submitButton, at: \.title)
+        bind(item.$showsActivityIndicator, to: button, at: \.showsActivityIndicator)
+        bind(item.$enabled, to: button, at: \.isEnabled)
+        bind(item.$title, to: button, at: \.title)
 
-        submitButton.adyen.anchor(inside: self.layoutMarginsGuide)
+        button.adyen.anchor(inside: self.layoutMarginsGuide)
     }
 
-    /// Initializes the footer item view with default theme.
+    /// Initializes the button item view with default theme.
     ///
     /// - Parameter item: The item represented by the view.
     internal required convenience init(item: FormButtonItem) {
         self.init(item: item, theme: .default)
     }
 
-    // MARK: - Submit Button
+    // MARK: - Button
 
-    internal lazy var submitButton: SubmitButton = {
-        let submitButton = SubmitButton(theme: theme, style: item.style.button)
+    internal lazy var button: FormButton = {
+        let button = FormButton(theme: theme, style: item.style.button)
 
-        submitButton.addTarget(self, action: #selector(didSelectSubmitButton), for: .touchUpInside)
-        submitButton.accessibilityIdentifier = item.identifier.map {
+        button.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
+        button.accessibilityIdentifier = item.identifier.map {
             ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "button")
         }
 
-        submitButton.preservesSuperviewLayoutMargins = true
-        submitButton.translatesAutoresizingMaskIntoConstraints = false
-        return submitButton
+        button.preservesSuperviewLayoutMargins = true
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
     }()
 
-    @objc internal func didSelectSubmitButton() {
+    @objc internal func didTapButton() {
         item.buttonSelectionHandler?()
     }
 }

--- a/AdyenUI/UI/Form/Items/Button/FormButtonItemView.swift
+++ b/AdyenUI/UI/Form/Items/Button/FormButtonItemView.swift
@@ -9,13 +9,19 @@ import UIKit
 
 /// A view representing a button item.
 internal final class FormButtonItemView: FormItemView<FormButtonItem> {
-    
+
+    /// The theme for styling.
+    package let theme: AdyenTheme
+
     /// Initializes the footer item view.
     ///
-    /// - Parameter item: The item represented by the view.
-    internal required init(item: FormButtonItem) {
+    /// - Parameters:
+    ///   - item: The item represented by the view.
+    ///   - theme: The theme to use for styling.
+    internal init(item: FormButtonItem, theme: AdyenTheme) {
+        self.theme = theme
         super.init(item: item)
-        
+
         addSubview(submitButton)
 
         preservesSuperviewLayoutMargins = true
@@ -23,25 +29,32 @@ internal final class FormButtonItemView: FormItemView<FormButtonItem> {
         bind(item.$showsActivityIndicator, to: submitButton, at: \.showsActivityIndicator)
         bind(item.$enabled, to: submitButton, at: \.isEnabled)
         bind(item.$title, to: submitButton, at: \.title)
-        
+
         submitButton.adyen.anchor(inside: self.layoutMarginsGuide)
     }
-    
+
+    /// Initializes the footer item view with default theme.
+    ///
+    /// - Parameter item: The item represented by the view.
+    internal required convenience init(item: FormButtonItem) {
+        self.init(item: item, theme: .default)
+    }
+
     // MARK: - Submit Button
-    
+
     internal lazy var submitButton: SubmitButton = {
-        let submitButton = SubmitButton(style: item.style.button)
+        let submitButton = SubmitButton(theme: theme, style: item.style.button)
 
         submitButton.addTarget(self, action: #selector(didSelectSubmitButton), for: .touchUpInside)
         submitButton.accessibilityIdentifier = item.identifier.map {
             ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "button")
         }
-        
+
         submitButton.preservesSuperviewLayoutMargins = true
         submitButton.translatesAutoresizingMaskIntoConstraints = false
         return submitButton
     }()
-    
+
     @objc internal func didSelectSubmitButton() {
         item.buttonSelectionHandler?()
     }

--- a/AdyenUI/UI/Views/FormButton.swift
+++ b/AdyenUI/UI/Views/FormButton.swift
@@ -7,16 +7,16 @@
 @_spi(AdyenInternal) import Adyen
 import UIKit
 
-/// A rounded submit button used to submit details.
+/// A rounded button for use in forms.
 @_spi(AdyenInternal)
-public final class SubmitButton: UIControl {
+public final class FormButton: UIControl {
 
     private var style: ButtonStyle
     private var buttonStyle: AdyenButtonStyle = .primary(for: .default)
 
-    /// Initializes the submit button.
+    /// Initializes the form button.
     ///
-    /// - Parameter style: The `SubmitButton` UI style.
+    /// - Parameter style: The `FormButton` UI style.
     public init(style: ButtonStyle) {
         self.style = style
         super.init(frame: .zero)
@@ -34,9 +34,9 @@ public final class SubmitButton: UIControl {
         configureConstraints()
     }
 
-    /// Initializes the submit button.
-    /// - Parameter buttonStyle: The  new `SubmitButton` UI style.
-    /// - Parameter style: The  old`SubmitButton` UI style.
+    /// Initializes the form button.
+    /// - Parameter buttonStyle: The  new `FormButton` UI style.
+    /// - Parameter style: The  old `FormButton` UI style.
     public init(
         theme: AdyenTheme,
         style: ButtonStyle = .init(title: .init(font: .preferredFont(forTextStyle: .body), color: .red))
@@ -180,7 +180,7 @@ public final class SubmitButton: UIControl {
     
 }
 
-extension SubmitButton {
+extension FormButton {
     
     internal final class BackgroundView: UIView {
         

--- a/Tests/IntegrationTests/Actions Tests/Voucher/VoucherViewTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/VoucherViewTests.swift
@@ -35,7 +35,7 @@ class VoucherViewTests: XCTestCase {
 //        check(layer: sut.findView(by: "logo")!.layer, forCornerRounding: style.logoCornerRounding)
 //        check(label: sut.findView(by: "amountLabel")!, forStyle: style.amountLabel)
 //        check(label: sut.findView(by: "currencyLabel")!, forStyle: style.currencyLabel)
-//        check(submitButton: sut.findView(by: "mainButton")! as! SubmitButton, forStyle: style.mainButton)
+//        check(submitButton: sut.findView(by: "mainButton")! as! FormButton, forStyle: style.mainButton)
 //        check(button: sut.findView(by: "secondaryButton")!, forStyle: style.secondaryButton)
 //
 //    }
@@ -89,7 +89,7 @@ class VoucherViewTests: XCTestCase {
         let sut = try getSut(model: mockModel)
         sut.delegate = delegateMock
         
-        let mainButton: SubmitButton? = sut.findView(by: "mainButton")
+        let mainButton: FormButton? = sut.findView(by: "mainButton")
         let secondaryButton: UIButton? = sut.findView(by: "secondaryButton")
         let addToAppleWalletButton: PKAddPassButton? = sut.findView(by: "appleWalletButton")
         

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
@@ -913,11 +913,11 @@ class ThreeDS2ComponentTests: XCTestCase {
             XCTAssertNotNil(descriptionLabel)
             XCTAssertEqual(descriptionLabel?.text, "Approve this transaction to complete your purchase.")
 
-            let firstButton: SubmitButton? = viewController.view.findView(by: "primaryButton")
+            let firstButton: FormButton? = viewController.view.findView(by: "primaryButton")
             XCTAssertNotNil(firstButton)
             XCTAssertEqual(firstButton?.title, "Approve transaction")
 
-            let secondButton: SubmitButton? = viewController.view.findView(by: "secondaryButton")
+            let secondButton: FormButton? = viewController.view.findView(by: "secondaryButton")
             XCTAssertNotNil(secondButton)
             XCTAssertEqual(secondButton?.title, "Other options")
         }
@@ -941,11 +941,11 @@ class ThreeDS2ComponentTests: XCTestCase {
             XCTAssertNotNil(troubleshootingDescriptionLabel)
             XCTAssertEqual(troubleshootingDescriptionLabel?.text, "Ongoing payment issues may be resolved by resetting your Secure Checkout details.")
 
-            let troubleshootingButton: SubmitButton? = controller.view.findView(by: "troubleshootingButton")
+            let troubleshootingButton: FormButton? = controller.view.findView(by: "troubleshootingButton")
             XCTAssertNotNil(troubleshootingButton)
             XCTAssertEqual(troubleshootingButton?.title, "Reset Secure Checkout")
 
-            let firstButton: SubmitButton? = controller.view.findView(by: "primaryButton")
+            let firstButton: FormButton? = controller.view.findView(by: "primaryButton")
             XCTAssertNotNil(firstButton)
             XCTAssertEqual(firstButton?.title, "Approve differently")
         }
@@ -970,10 +970,10 @@ class ThreeDS2ComponentTests: XCTestCase {
             XCTAssertNotNil(descriptionLabel)
             XCTAssertEqual(descriptionLabel?.text, "Check out faster next time with this card")
 
-            let firstButton: SubmitButton? = viewController.view.findView(by: "primaryButton")
+            let firstButton: FormButton? = viewController.view.findView(by: "primaryButton")
             XCTAssertNotNil(firstButton)
             XCTAssertEqual(firstButton?.title, "Use secure checkout")
-            let secondButton: SubmitButton? = viewController.view.findView(by: "secondaryButton")
+            let secondButton: FormButton? = viewController.view.findView(by: "secondaryButton")
             XCTAssertNotNil(secondButton)
             XCTAssertEqual(secondButton?.title, "Not now")
         }
@@ -989,7 +989,7 @@ class ThreeDS2ComponentTests: XCTestCase {
             XCTAssertNotNil(descriptionLabel)
             XCTAssertEqual(descriptionLabel?.text, "Your payment has still been authenticated successfully but the Secure Checkout service was unavailable.")
 
-            let firstButton: SubmitButton? = controller.view.findView(by: "primaryButton")
+            let firstButton: FormButton? = controller.view.findView(by: "primaryButton")
             XCTAssertNotNil(firstButton)
             XCTAssertEqual(firstButton?.title, "Finish")
 

--- a/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -302,7 +302,7 @@ class ACHDirectDebitComponentTests: XCTestCase {
 
         wait(until: routingNumberItemView, at: \.textField.text, is: "121000358")
         
-        payButtonItemViewButton.didSelectSubmitButton()
+        payButtonItemViewButton.didTapButton()
         wait(until: payButtonItemViewButton, at: \.item.showsActivityIndicator, is: true)
         
         wait(for: [expectation], timeout: 100)

--- a/Tests/IntegrationTests/Components Tests/QRCode/QRCodeActionComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/QRCode/QRCodeActionComponentTests.swift
@@ -177,7 +177,7 @@ class QRCodeActionComponentTests: XCTestCase {
         setupRootViewController(qrCodeViewController)
         
         // When
-        let saveAsImageButton: SubmitButton = try XCTUnwrap(qrCodeViewController.view.findView(by: "copyCodeButton"))
+        let saveAsImageButton: FormButton = try XCTUnwrap(qrCodeViewController.view.findView(by: "copyCodeButton"))
         saveAsImageButton.sendActions(for: .touchUpInside)
         
         waitForExpectations(timeout: 10, handler: nil)
@@ -226,7 +226,7 @@ class QRCodeActionComponentTests: XCTestCase {
         setupRootViewController(qrCodeViewController)
         
         // When
-        let saveAsImageButton: SubmitButton = try XCTUnwrap(qrCodeViewController.view.findView(by: "saveAsImageButton"))
+        let saveAsImageButton: FormButton = try XCTUnwrap(qrCodeViewController.view.findView(by: "saveAsImageButton"))
         saveAsImageButton.sendActions(for: .touchUpInside)
         
         waitForExpectations(timeout: 10, handler: nil)

--- a/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentComponentTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentComponentTests.swift
@@ -124,48 +124,49 @@ class PreselectedPaymentComponentTests: XCTestCase {
         formStyle.separatorColor = .red
         formStyle.mainButtonItem = FormButtonItemStyle(button: ButtonStyle(title: TextStyle(font: .systemFont(ofSize: 20), color: .cyan, textAlignment: .center), cornerRadius: 0, background: .brown), background: .red)
         formStyle.secondaryButtonItem = FormButtonItemStyle(button: ButtonStyle(title: TextStyle(font: .systemFont(ofSize: 22), color: .brown, textAlignment: .center), cornerRadius: 0, background: .cyan), background: .black)
-        
+
         var listStyle = sut.listItemStyle
         listStyle.image.backgroundColor = .red
         listStyle.title.color = .white
         listStyle.subtitle.color = .white
-        
+
         component = StoredPaymentMethodComponent(paymentMethod: getStoredCard(), context: Dummy.context)
         sut = PreselectedPaymentMethodComponent(component: component, title: "", style: formStyle, listItemStyle: listStyle)
-        
+
         setupRootViewController(sut.viewController)
-        
+
         let view = sut.viewController.view!
         let listView = view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.defaultComponent")
         let listViewTitle: UILabel! = listView!.findView(by: "titleLabel")
         let listViewSubtitle: UILabel! = listView!.findView(by: "subtitleLabel")
-        
+
         let submitButtonContainer = view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton")
         let submitButton = submitButtonContainer!.findView(by: "button")
         let submitButtonLabel: UILabel! = submitButton!.findView(by: "titleLabel")
-        
+
         let openAllButtonContainer = view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.openAllButton")
         let openAllButton = openAllButtonContainer!.findView(by: "button")
         let openAllButtonLabel: UILabel! = openAllButton!.findView(by: "titleLabel")
-        
+
         let separator = view.findView(by: "separatorLine")
-        
+
         wait(for: .milliseconds(300))
-        
+
         XCTAssertEqual(view.backgroundColor, .green)
         XCTAssertEqual(listViewTitle.textColor, .white)
         XCTAssertEqual(listViewSubtitle.textColor, .white)
-        
-        // TODO: FIX LATER
-//        XCTAssertEqual(submitButtonContainer!.backgroundColor, .red)
-//        XCTAssertEqual(submitButton!.backgroundColor, .brown)
-//        XCTAssertEqual(submitButtonLabel.textColor, .cyan)
-//
-//        XCTAssertEqual(openAllButtonContainer!.backgroundColor, .black)
-//        XCTAssertEqual(openAllButton!.backgroundColor, .cyan)
-//        XCTAssertEqual(openAllButtonLabel.textColor, .brown)
-        
-//        XCTAssertEqual(separator!.backgroundColor, .red)
+
+        // Button and separator styling now use AdyenTheme instead of FormComponentStyle
+        // PreselectedPaymentMethodComponent uses default theme, so elements get default theme colors
+        let defaultButtonStyle = AdyenButtonStyle.primary(for: .default)
+        XCTAssertEqual(submitButton!.backgroundColor, defaultButtonStyle.backgroundColor)
+        XCTAssertEqual(submitButtonLabel.textColor, defaultButtonStyle.textColor)
+
+        XCTAssertEqual(openAllButton!.backgroundColor, defaultButtonStyle.backgroundColor)
+        XCTAssertEqual(openAllButtonLabel.textColor, defaultButtonStyle.textColor)
+
+        // Separator also uses theme colors now (migrated in PR #2)
+        XCTAssertEqual(separator!.backgroundColor, AdyenColors.default.separator)
     }
     
     func testPayButtonTitle() {

--- a/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentComponentTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentComponentTests.swift
@@ -77,7 +77,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
     }
     
     func testPressSubmitButton() {
-        let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton.button")
+        let button: FormButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton.button")
         button.sendActions(for: .touchUpInside)
         
         let expectation = XCTestExpectation(description: "Dummy Expectation")
@@ -93,7 +93,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
 
     func testSubmitButtonLoading() {
         setupRootViewController(sut.viewController)
-        let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton.button")
+        let button: FormButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton.button")
         XCTAssertFalse(button.showsActivityIndicator)
         sut.startLoading(for: component)
 
@@ -105,7 +105,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
     }
     
     func testPressOpenAllButton() {
-        let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.openAllButton.button")
+        let button: FormButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.openAllButton.button")
         button!.sendActions(for: .touchUpInside)
         
         let expectation = XCTestExpectation(description: "Dummy Expectation")

--- a/Tests/IntegrationTests/Helpers/XCTestCase+Style.swift
+++ b/Tests/IntegrationTests/Helpers/XCTestCase+Style.swift
@@ -37,17 +37,17 @@ extension XCTestCase {
         check(layer: button.layer, forCornerRounding: style.cornerRounding)
     }
     
-    /// Checks whether the given style was applied properly to the given `SubmitButton`
+    /// Checks whether the given style was applied properly to the given `FormButton`
     /// - Parameters:
-    ///   - submitButton: `SubmitButton` to check
+    ///   - formButton: `FormButton` to check
     ///   - style: `ButtonStyle` that should be applied
-    func check(submitButton: SubmitButton, forStyle style: ButtonStyle, file: StaticString = #file, line: UInt = #line) {
-        check(label: submitButton.titleLabel, forStyle: style.title)
-        XCTAssertEqual(submitButton.backgroundView.layer.borderColor, style.borderColor?.cgColor)
-        XCTAssertEqual(submitButton.backgroundView.layer.borderWidth, style.borderWidth)
-        XCTAssertEqual(submitButton.backgroundView.backgroundColor, style.backgroundColor)
+    func check(formButton: FormButton, forStyle style: ButtonStyle, file: StaticString = #file, line: UInt = #line) {
+        check(label: formButton.titleLabel, forStyle: style.title)
+        XCTAssertEqual(formButton.backgroundView.layer.borderColor, style.borderColor?.cgColor)
+        XCTAssertEqual(formButton.backgroundView.layer.borderWidth, style.borderWidth)
+        XCTAssertEqual(formButton.backgroundView.backgroundColor, style.backgroundColor)
         
-        check(layer: submitButton.layer, forCornerRounding: style.cornerRounding)
+        check(layer: formButton.layer, forCornerRounding: style.cornerRounding)
     }
     
     /// Checks whether the given corner rounding was applied properly to the given layer

--- a/Tests/IntegrationTests/UI Components/FormButtonTests.swift
+++ b/Tests/IntegrationTests/UI Components/FormButtonTests.swift
@@ -8,7 +8,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
-final class SubmitButtonTests: XCTestCase {
+final class FormButtonTests: XCTestCase {
 
     private let style = ButtonStyle(title: .init(font: .preferredFont(forTextStyle: .body), color: .red))
 
@@ -52,8 +52,8 @@ final class SubmitButtonTests: XCTestCase {
         XCTAssertTrue(sut.isEnabled, "Button should be enabled after activity indicator hides")
     }
 
-    func makeSUT(_ title: String = "Submit") throws -> (SubmitButton, UIActivityIndicatorView) {
-        let sut = SubmitButton(style: style)
+    func makeSUT(_ title: String = "Submit") throws -> (FormButton, UIActivityIndicatorView) {
+        let sut = FormButton(style: style)
         sut.title = title
         let activityIndicatorView: UIActivityIndicatorView = try XCTUnwrap(sut.findView(by: "activityIndicator"))
 

--- a/Tests/IntegrationTests/UIKit/Form/Theme/FormButtonItemViewThemeTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/Theme/FormButtonItemViewThemeTests.swift
@@ -10,39 +10,46 @@ import XCTest
 
 final class FormButtonItemViewThemeTests: XCTestCase {
 
-    // MARK: - Baseline Test (Current Behavior)
+    func test_formButtonItemView_withCustomTheme_shouldApplyThemeColors() throws {
+        // Given - expected colors and custom theme
+        let expectedBackgroundColor: UIColor = .systemPurple
+        let expectedTextColor: UIColor = .systemYellow
 
-    /// This test captures the CURRENT behavior before theme migration.
-    /// SubmitButton is partially migrated - it uses backgroundColor from item.style,
-    /// but titleLabel and cornerRadius use default theme values.
-    func test_formButtonItemView_withCustomStyle_appliesBackgroundFromStyle() throws {
-        // Given - custom button style using the current API
-        let customButtonStyle = ButtonStyle(
-            title: TextStyle(font: .systemFont(ofSize: 18), color: .systemYellow),
-            cornerRounding: .fixed(12),
-            background: .systemPurple
+        let customColors = AdyenColors(
+            primary: expectedBackgroundColor,
+            textOnPrimary: expectedTextColor
         )
-        let itemStyle = FormButtonItemStyle(button: customButtonStyle)
+        let customTheme = AdyenTheme(colors: customColors)
 
-        // When - create view with current init
-        let item = FormButtonItem(style: itemStyle)
+        // When - create view with theme
+        let item = FormButtonItem()
         item.identifier = "testButtonView"
-        item.title = "Submit"
-        let sut = FormButtonItemView(item: item)
+        item.title = "Pay Now"
+        let sut = FormButtonItemView(item: item, theme: customTheme)
 
-        // Then - backgroundColor comes from item.style
+        // Then - button uses expected theme colors
         let submitButton = try XCTUnwrap(sut.submitButton)
-        XCTAssertEqual(submitButton.backgroundColor, .systemPurple)
+        XCTAssertEqual(submitButton.backgroundColor, expectedBackgroundColor)
 
-        // Note: titleLabel currently uses default theme colors (AdyenButtonStyle.primary textColor)
-        // not the style.title.color - this is the partially migrated state
         let titleLabel = try XCTUnwrap(submitButton.titleLabel)
-        let defaultButtonStyle = AdyenButtonStyle.primary(for: .default)
-        XCTAssertEqual(titleLabel.textColor, defaultButtonStyle.textColor)
-
-        // Note: Corner radius also comes from default theme (14.0), not from item.style (12.0)
-        submitButton.layoutIfNeeded()
-        XCTAssertEqual(submitButton.layer.cornerRadius, AdyenUIConstants.defaultCornerRadius)
+        XCTAssertEqual(titleLabel.textColor, expectedTextColor)
     }
 
+    func test_formButtonItemView_convenienceInitializer_shouldUseDefaultTheme() throws {
+        // Given - using old init
+        let item = FormButtonItem()
+        item.title = "Submit"
+        let expectedBackgroundColor = AdyenColors.default.primary
+        let expectedTextColor = AdyenColors.default.textOnPrimary
+
+        // When
+        let sut = FormButtonItemView(item: item)
+
+        // Then - should use default theme colors
+        let submitButton = try XCTUnwrap(sut.submitButton)
+        XCTAssertEqual(submitButton.backgroundColor, expectedBackgroundColor)
+
+        let titleLabel = try XCTUnwrap(submitButton.titleLabel)
+        XCTAssertEqual(titleLabel.textColor, expectedTextColor)
+    }
 }

--- a/Tests/IntegrationTests/UIKit/Form/Theme/FormButtonItemViewThemeTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/Theme/FormButtonItemViewThemeTests.swift
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+@_spi(AdyenInternal) @testable import AdyenUI
+import XCTest
+
+final class FormButtonItemViewThemeTests: XCTestCase {
+
+    // MARK: - Baseline Test (Current Behavior)
+
+    /// This test captures the CURRENT behavior before theme migration.
+    /// SubmitButton is partially migrated - it uses backgroundColor from item.style,
+    /// but titleLabel and cornerRadius use default theme values.
+    func test_formButtonItemView_withCustomStyle_appliesBackgroundFromStyle() throws {
+        // Given - custom button style using the current API
+        let customButtonStyle = ButtonStyle(
+            title: TextStyle(font: .systemFont(ofSize: 18), color: .systemYellow),
+            cornerRounding: .fixed(12),
+            background: .systemPurple
+        )
+        let itemStyle = FormButtonItemStyle(button: customButtonStyle)
+
+        // When - create view with current init
+        let item = FormButtonItem(style: itemStyle)
+        item.identifier = "testButtonView"
+        item.title = "Submit"
+        let sut = FormButtonItemView(item: item)
+
+        // Then - backgroundColor comes from item.style
+        let submitButton = try XCTUnwrap(sut.submitButton)
+        XCTAssertEqual(submitButton.backgroundColor, .systemPurple)
+
+        // Note: titleLabel currently uses default theme colors (AdyenButtonStyle.primary textColor)
+        // not the style.title.color - this is the partially migrated state
+        let titleLabel = try XCTUnwrap(submitButton.titleLabel)
+        let defaultButtonStyle = AdyenButtonStyle.primary(for: .default)
+        XCTAssertEqual(titleLabel.textColor, defaultButtonStyle.textColor)
+
+        // Note: Corner radius also comes from default theme (14.0), not from item.style (12.0)
+        submitButton.layoutIfNeeded()
+        XCTAssertEqual(submitButton.layer.cornerRadius, AdyenUIConstants.defaultCornerRadius)
+    }
+
+}

--- a/Tests/IntegrationTests/UIKit/Form/Theme/FormButtonItemViewThemeTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/Theme/FormButtonItemViewThemeTests.swift
@@ -28,10 +28,10 @@ final class FormButtonItemViewThemeTests: XCTestCase {
         let sut = FormButtonItemView(item: item, theme: customTheme)
 
         // Then - button uses expected theme colors
-        let submitButton = try XCTUnwrap(sut.submitButton)
-        XCTAssertEqual(submitButton.backgroundColor, expectedBackgroundColor)
+        let button = try XCTUnwrap(sut.button)
+        XCTAssertEqual(button.backgroundColor, expectedBackgroundColor)
 
-        let titleLabel = try XCTUnwrap(submitButton.titleLabel)
+        let titleLabel = try XCTUnwrap(button.titleLabel)
         XCTAssertEqual(titleLabel.textColor, expectedTextColor)
     }
 
@@ -46,10 +46,10 @@ final class FormButtonItemViewThemeTests: XCTestCase {
         let sut = FormButtonItemView(item: item)
 
         // Then - should use default theme colors
-        let submitButton = try XCTUnwrap(sut.submitButton)
-        XCTAssertEqual(submitButton.backgroundColor, expectedBackgroundColor)
+        let button = try XCTUnwrap(sut.button)
+        XCTAssertEqual(button.backgroundColor, expectedBackgroundColor)
 
-        let titleLabel = try XCTUnwrap(submitButton.titleLabel)
+        let titleLabel = try XCTUnwrap(button.titleLabel)
         XCTAssertEqual(titleLabel.textColor, expectedTextColor)
     }
 }

--- a/Tests/SnapshotTests/Components/BLIKComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/BLIKComponentUITests.swift
@@ -66,7 +66,7 @@ final class BLIKComponentUITests: XCTestCase {
         
         setupRootViewController(sut.viewController)
 
-        let submitButton: SubmitButton = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.BLIKComponent.payButtonItem.button"))
+        let submitButton: FormButton = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.BLIKComponent.payButtonItem.button"))
 
         let blikCodeView: FormTextInputItemView! = sut.viewController.view.findView(with: "AdyenComponents.BLIKComponent.blikCodeItem")
         self.populate(textItemView: blikCodeView, with: "123456")

--- a/Tests/SnapshotTests/Components/BoletoComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/BoletoComponentUITests.swift
@@ -105,7 +105,7 @@ final class BoletoComponentUITests: XCTestCase {
         let dummyExpectation = XCTestExpectation(description: "Dummy Expectation")
         
         let view = try XCTUnwrap(sut.viewController.view)
-        let submitButton: SubmitButton = try XCTUnwrap(view.findView(by: "payButtonItem.button"))
+        let submitButton: FormButton = try XCTUnwrap(view.findView(by: "payButtonItem.button"))
         let firstNameView: FormTextInputItemView = try XCTUnwrap(view.findView(by: "firstNameItem"))
         let lastNameView: FormTextInputItemView = try XCTUnwrap(view.findView(by: "lastNameItem"))
         let billingAddressView: FormAddressPickerItemView = try XCTUnwrap(view.findView(by: "addressItem"))
@@ -147,7 +147,7 @@ final class BoletoComponentUITests: XCTestCase {
             configuration: mockConfiguration
         )
 
-        let submitButton: SubmitButton = try XCTUnwrap(sut.viewController.view.findView(by: "payButtonItem.button"))
+        let submitButton: FormButton = try XCTUnwrap(sut.viewController.view.findView(by: "payButtonItem.button"))
         submitButton.sendActions(for: .touchUpInside)
 
         verifyViewControllerImage(matching: sut.viewController, named: "boleto_flow_no_name")

--- a/Tests/SnapshotTests/Components/OnlineBankingComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/OnlineBankingComponentUITests.swift
@@ -79,7 +79,7 @@ class OnlineBankingComponentUITests: XCTestCase {
         sut.delegate = delegate
 
         // Then
-        let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenComponents.OnlineBankingComponent.continueButton.button")
+        let button: FormButton! = sut.viewController.view.findView(with: "AdyenComponents.OnlineBankingComponent.continueButton.button")
 
         let didContinueExpectation = XCTestExpectation(description: "Dummy Expectation")
 
@@ -111,7 +111,7 @@ class OnlineBankingComponentUITests: XCTestCase {
 
         UIApplication.shared.adyen.mainKeyWindow?.rootViewController = sut.viewController
        
-        let button: SubmitButton = try XCTUnwrap(
+        let button: FormButton = try XCTUnwrap(
             sut.viewController.view.findView(with: "AdyenComponents.OnlineBankingComponent.continueButton.button")
         )
 

--- a/Tests/SnapshotTests/Components/UPIComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/UPIComponentUITests.swift
@@ -228,7 +228,7 @@ class UPIComponentUITests: XCTestCase {
         let errorItem = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.UPIComponent.errorItem") as? FormErrorItemView)
         XCTAssertTrue(errorItem.isHidden)
         
-        let continueButton: SubmitButton = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.UPIComponent.continueButton.button"))
+        let continueButton: FormButton = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.UPIComponent.continueButton.button"))
         
         // Tapping button with no apps selected - error should be shown
         

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -174,7 +174,7 @@ final class CheckoutComponentBuilderTests: XCTestCase {
     
     // MARK: - Configuration Merging Tests
     
-    func testBuild_MergesGlobalShowsSubmitButtonSetting() throws {
+    func testBuild_MergesGlobalShowsFormButtonSetting() throws {
         // Given
         let paymentMethod = try XCTUnwrap(createBLIKPaymentMethod())
         var blikConfig = BLIKComponentConfiguration()


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->
Theme migration progress (10/25 completed)
✅ FormTextItemView
✅ FormTextInputItemView
✅ FormPhoneNumberItemView
✅ FormCardNumberItemView
✅ FormCardSecurityCodeItemView
✅ FormSpacerItemView
✅ FormSeparatorItemView
✅ FormLabelItem 
FormAttributedLabelItem
FormErrorItemView
✅ **FormButtonItemView << current PR**
FormSearchButtonItemView
✅ FormToggleItemView
FormPickerItemView
FormPhoneExtensionPickerItemView
FormSelectableValueItemView
SelectableFormItemView
BaseFormPickerItemView
FormVerticalStackItemView
FormSplitItemView
FormAddressPickerItemView
FormValueItemView
FormValidatableValueItemView
FormCardLogosItemView
FormCoBadgedCardItemView

Related PR to be merged before this one https://github.com/Adyen/adyen-ios/pull/2325

## Ticket [Optional]
<ticket>
COSDK-775
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
