### PR TITLE
Rename `SubmitButton` to `FormButton`

### DIFF
--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -20,10 +20,6 @@ permissions:
   contents: read
   pull-requests: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
 
   build:

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -52,7 +52,7 @@
 		0019C4642E6ADFC700B0C3A3 /* CopyLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95A788725C416A60032CF7E /* CopyLabelView.swift */; };
 		0019C4652E6ADFC700B0C3A3 /* SupportedPaymentMethodsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8128977A2CC93CB000275487 /* SupportedPaymentMethodsView.swift */; };
 		0019C4662E6ADFC700B0C3A3 /* UIView+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BBB6732A82792100C1A04B /* UIView+Accessibility.swift */; };
-		0019C4672E6ADFC700B0C3A3 /* SubmitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C0E0C0220D7E5E008616F6 /* SubmitButton.swift */; };
+		0019C4672E6ADFC700B0C3A3 /* FormButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C0E0C0220D7E5E008616F6 /* FormButton.swift */; };
 		0019C4682E6ADFC700B0C3A3 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F99D2F852665211600BB5B2F /* LoadingView.swift */; };
 		0019C4692E6ADFC700B0C3A3 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81DC5A5C2A7BADB200DBF2D1 /* EmptyStateView.swift */; };
 		0019C46A2E6ADFC700B0C3A3 /* UISearchBar+Prominent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B001C12A55C5C10015BFA3 /* UISearchBar+Prominent.swift */; };
@@ -592,7 +592,7 @@
 		B605AC122D8D988D0084D583 /* AdyenCardScanner.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C9FC2C3D2D50D0B700C9D0F3 /* AdyenCardScanner.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B60946132DA562FD00CEE6CF /* CardScannerProviderDispatchOnceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60946122DA562FD00CEE6CF /* CardScannerProviderDispatchOnceTests.swift */; };
 		B60946152DA5656100CEE6CF /* CardScannerTestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60946142DA5656100CEE6CF /* CardScannerTestsHelpers.swift */; };
-		B61CE9152DDDD7C3009B7503 /* SubmitButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61CE9142DDDD7C3009B7503 /* SubmitButtonTests.swift */; };
+		B61CE9152DDDD7C3009B7503 /* FormButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61CE9142DDDD7C3009B7503 /* FormButtonTests.swift */; };
 		B6244E082E327A5300F42780 /* Configuration+secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6244E072E327A5300F42780 /* Configuration+secrets.swift */; };
 		B6244E092E327A5300F42780 /* Configuration+secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6244E072E327A5300F42780 /* Configuration+secrets.swift */; };
 		B6271FEA2EB9F8CD009E9149 /* AdyenLabelStyle+UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6271FE92EB9F8CD009E9149 /* AdyenLabelStyle+UILabel.swift */; };
@@ -2213,7 +2213,7 @@
 		B605AC092D897A930084D583 /* CardScannerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerControllerTests.swift; sourceTree = "<group>"; };
 		B60946122DA562FD00CEE6CF /* CardScannerProviderDispatchOnceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerProviderDispatchOnceTests.swift; sourceTree = "<group>"; };
 		B60946142DA5656100CEE6CF /* CardScannerTestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerTestsHelpers.swift; sourceTree = "<group>"; };
-		B61CE9142DDDD7C3009B7503 /* SubmitButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitButtonTests.swift; sourceTree = "<group>"; };
+		B61CE9142DDDD7C3009B7503 /* FormButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormButtonTests.swift; sourceTree = "<group>"; };
 		B6244DFF2E3224BE00F42780 /* Secrets.template.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.template.xcconfig; sourceTree = "<group>"; };
 		B6244E072E327A5300F42780 /* Configuration+secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+secrets.swift"; sourceTree = "<group>"; };
 		B6244E0A2E3281B800F42780 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
@@ -2438,7 +2438,7 @@
 		E2C0E0B5220B08ED008616F6 /* FormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormView.swift; sourceTree = "<group>"; };
 		E2C0E0B9220B2966008616F6 /* FormTextItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormTextItemView.swift; sourceTree = "<group>"; };
 		E2C0E0BB220B2976008616F6 /* FormItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormItemView.swift; sourceTree = "<group>"; };
-		E2C0E0C0220D7E5E008616F6 /* SubmitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitButton.swift; sourceTree = "<group>"; };
+		E2C0E0C0220D7E5E008616F6 /* FormButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormButton.swift; sourceTree = "<group>"; };
 		E2D05BF12285B98900EC279A /* StoredPaymentMethodComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredPaymentMethodComponent.swift; sourceTree = "<group>"; };
 		E2D12BEE221D560800EF682F /* FormValueItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormValueItem.swift; sourceTree = "<group>"; };
 		E2D12BF0221D561600EF682F /* FormValueItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormValueItemView.swift; sourceTree = "<group>"; };
@@ -4063,7 +4063,7 @@
 		B61CE9132DDDD7B3009B7503 /* UI Components */ = {
 			isa = PBXGroup;
 			children = (
-				B61CE9142DDDD7C3009B7503 /* SubmitButtonTests.swift */,
+				B61CE9142DDDD7C3009B7503 /* FormButtonTests.swift */,
 			);
 			path = "UI Components";
 			sourceTree = "<group>";
@@ -5175,7 +5175,7 @@
 			children = (
 				81B001C12A55C5C10015BFA3 /* UISearchBar+Prominent.swift */,
 				81BBB6732A82792100C1A04B /* UIView+Accessibility.swift */,
-				E2C0E0C0220D7E5E008616F6 /* SubmitButton.swift */,
+				E2C0E0C0220D7E5E008616F6 /* FormButton.swift */,
 				8128977A2CC93CB000275487 /* SupportedPaymentMethodsView.swift */,
 				81A2E3BF2A5C453F00CF5F9C /* LinkTextView.swift */,
 				F95A788725C416A60032CF7E /* CopyLabelView.swift */,
@@ -8010,7 +8010,7 @@
 				B6271FF82EBA3497009E9149 /* AdyenElements.swift in Sources */,
 				0019C4982E6AE0B700B0C3A3 /* FormPhoneExtensionPickerItem.swift in Sources */,
 				0019C4992E6AE0B700B0C3A3 /* FormPhoneExtensionPickerItemView.swift in Sources */,
-				0019C4672E6ADFC700B0C3A3 /* SubmitButton.swift in Sources */,
+				0019C4672E6ADFC700B0C3A3 /* FormButton.swift in Sources */,
 				0019C4682E6ADFC700B0C3A3 /* LoadingView.swift in Sources */,
 				0019C4692E6ADFC700B0C3A3 /* EmptyStateView.swift in Sources */,
 				0019C46A2E6ADFC700B0C3A3 /* UISearchBar+Prominent.swift in Sources */,
@@ -8566,7 +8566,7 @@
 				81DA708A2BDA6075006CE5D5 /* TwintSDKActionTests+Flows.swift in Sources */,
 				F957AA722552DBC80099AD73 /* AnyRedirectComponentMock.swift in Sources */,
 				F9EDB79A239664B500CFB3C9 /* StoredPaymentMethodComponentTests.swift in Sources */,
-				B61CE9152DDDD7C3009B7503 /* SubmitButtonTests.swift in Sources */,
+				B61CE9152DDDD7C3009B7503 /* FormButtonTests.swift in Sources */,
 				F9EDB7982396643A00CFB3C9 /* CardPaymentMethodMock.swift in Sources */,
 				C927084027590FE800D15EA0 /* BACSInputPresenterTests.swift in Sources */,
 				A009837D279859DC007E68C4 /* ACHDirectDebitComponentTests.swift in Sources */,

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationErrorView.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationErrorView.swift
@@ -72,8 +72,8 @@ internal final class DelegatedAuthenticationErrorView: UIView {
         scopeInstance: self
     )
     
-    internal lazy var troubleshootingButton: SubmitButton = {
-        let button = SubmitButton(style: self.style.troubleshootingButtonStyle)
+    internal lazy var troubleshootingButton: FormButton = {
+        let button = FormButton(style: self.style.troubleshootingButtonStyle)
         button.addTarget(self, action: #selector(troubleshootingButtonTapped), for: .touchUpInside)
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "troubleshootingButton")
         button.preservesSuperviewLayoutMargins = true
@@ -107,8 +107,8 @@ internal final class DelegatedAuthenticationErrorView: UIView {
                     
     // MARK: Buttons
 
-    internal lazy var firstButton: SubmitButton = {
-        let button = SubmitButton(style: style.errorButton)
+    internal lazy var firstButton: FormButton = {
+        let button = FormButton(style: style.errorButton)
 
         button.addTarget(self, action: #selector(firstButtonTapped), for: .touchUpInside)
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "primaryButton")

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationView.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationView.swift
@@ -199,8 +199,8 @@ internal final class DelegatedAuthenticationView: UIView {
     
     // MARK: Buttons
 
-    internal lazy var firstButton: SubmitButton = {
-        let button = SubmitButton(style: style.primaryButton)
+    internal lazy var firstButton: FormButton = {
+        let button = FormButton(style: style.primaryButton)
 
         button.addTarget(self, action: #selector(firstButtonTapped), for: .touchUpInside)
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "primaryButton")
@@ -209,8 +209,8 @@ internal final class DelegatedAuthenticationView: UIView {
         return button
     }()
 
-    internal lazy var secondButton: SubmitButton = {
-        let button = SubmitButton(style: style.secondaryButton)
+    internal lazy var secondButton: FormButton = {
+        let button = FormButton(style: style.secondaryButton)
         button.addTarget(self, action: #selector(secondButtonTapped), for: .touchUpInside)
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "secondaryButton")
         button.preservesSuperviewLayoutMargins = true

--- a/AdyenActions/UI/View Controllers/QR Code/QRCodeViewController.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/QRCodeViewController.swift
@@ -75,8 +75,8 @@ internal final class QRCodeViewController: UIViewController, AdyenObserver {
     
     internal private(set) lazy var qrCodeView = QRCodeView(viewModel: viewModel, style: style)
         
-    internal private(set) lazy var actionButton: SubmitButton = {
-        let button = SubmitButton(style: actionButtonStyle)
+    internal private(set) lazy var actionButton: FormButton = {
+        let button = FormButton(style: actionButtonStyle)
         
         button.title = viewModel.actionButtonTitle
         button.accessibilityIdentifier = ViewIdentifierBuilder.build(

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherView.swift
@@ -164,8 +164,8 @@ internal final class VoucherView: UIView, Localizable {
         return currencyLabel
     }()
     
-    private lazy var mainButton: SubmitButton = {
-        let button = SubmitButton(style: model.style.mainButton)
+    private lazy var mainButton: FormButton = {
+        let button = FormButton(style: model.style.mainButton)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.title = model.mainButton
         button.addTarget(self, action: #selector(onMainButtonTap), for: .touchUpInside)

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent+ConfirmationViewController.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent+ConfirmationViewController.swift
@@ -30,7 +30,7 @@ extension PayByBankUSComponent {
         internal lazy var titleLabel = Self.defaultLabel
         internal lazy var subtitleLabel = Self.defaultLabel
         internal lazy var messageLabel = Self.defaultLabel
-        internal let submitButton: SubmitButton
+        internal let submitButton: FormButton
         
         // MARK: UIViewController
         
@@ -42,7 +42,7 @@ extension PayByBankUSComponent {
                 trailingText: model.supportedBanksMoreText
             )
            
-            self.submitButton = SubmitButton(style: model.style.submitButton)
+            self.submitButton = FormButton(style: model.style.submitButton)
             
             super.init(nibName: nil, bundle: nil)
         }

--- a/AdyenUI/UI/Form/Items/Button/FormButtonItemView.swift
+++ b/AdyenUI/UI/Form/Items/Button/FormButtonItemView.swift
@@ -45,7 +45,7 @@ internal final class FormButtonItemView: FormItemView<FormButtonItem> {
     internal lazy var button: FormButton = {
         let button = FormButton(theme: theme, style: item.style.button)
 
-        button.addTarget(self, action: #selector(didSelectSubmitButton), for: .touchUpInside)
+        button.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
         button.accessibilityIdentifier = item.identifier.map {
             ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "button")
         }
@@ -55,7 +55,7 @@ internal final class FormButtonItemView: FormItemView<FormButtonItem> {
         return button
     }()
 
-    @objc internal func didSelectSubmitButton() {
+    @objc internal func didTapButton() {
         item.buttonSelectionHandler?()
     }
 }

--- a/AdyenUI/UI/Form/Items/Button/FormButtonItemView.swift
+++ b/AdyenUI/UI/Form/Items/Button/FormButtonItemView.swift
@@ -13,7 +13,7 @@ internal final class FormButtonItemView: FormItemView<FormButtonItem> {
     /// The theme for styling.
     package let theme: AdyenTheme
 
-    /// Initializes the footer item view.
+    /// Initializes the button item view.
     ///
     /// - Parameters:
     ///   - item: The item represented by the view.
@@ -22,37 +22,37 @@ internal final class FormButtonItemView: FormItemView<FormButtonItem> {
         self.theme = theme
         super.init(item: item)
 
-        addSubview(submitButton)
+        addSubview(button)
 
         preservesSuperviewLayoutMargins = true
 
-        bind(item.$showsActivityIndicator, to: submitButton, at: \.showsActivityIndicator)
-        bind(item.$enabled, to: submitButton, at: \.isEnabled)
-        bind(item.$title, to: submitButton, at: \.title)
+        bind(item.$showsActivityIndicator, to: button, at: \.showsActivityIndicator)
+        bind(item.$enabled, to: button, at: \.isEnabled)
+        bind(item.$title, to: button, at: \.title)
 
-        submitButton.adyen.anchor(inside: self.layoutMarginsGuide)
+        button.adyen.anchor(inside: self.layoutMarginsGuide)
     }
 
-    /// Initializes the footer item view with default theme.
+    /// Initializes the button item view with default theme.
     ///
     /// - Parameter item: The item represented by the view.
     internal required convenience init(item: FormButtonItem) {
         self.init(item: item, theme: .default)
     }
 
-    // MARK: - Submit Button
+    // MARK: - Button
 
-    internal lazy var submitButton: SubmitButton = {
-        let submitButton = SubmitButton(theme: theme, style: item.style.button)
+    internal lazy var button: FormButton = {
+        let button = FormButton(theme: theme, style: item.style.button)
 
-        submitButton.addTarget(self, action: #selector(didSelectSubmitButton), for: .touchUpInside)
-        submitButton.accessibilityIdentifier = item.identifier.map {
+        button.addTarget(self, action: #selector(didSelectSubmitButton), for: .touchUpInside)
+        button.accessibilityIdentifier = item.identifier.map {
             ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "button")
         }
 
-        submitButton.preservesSuperviewLayoutMargins = true
-        submitButton.translatesAutoresizingMaskIntoConstraints = false
-        return submitButton
+        button.preservesSuperviewLayoutMargins = true
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
     }()
 
     @objc internal func didSelectSubmitButton() {

--- a/AdyenUI/UI/Views/FormButton.swift
+++ b/AdyenUI/UI/Views/FormButton.swift
@@ -36,7 +36,7 @@ public final class FormButton: UIControl {
 
     /// Initializes the form button.
     /// - Parameter buttonStyle: The  new `FormButton` UI style.
-    /// - Parameter style: The  old`FormButton` UI style.
+    /// - Parameter style: The  old `FormButton` UI style.
     public init(
         theme: AdyenTheme,
         style: ButtonStyle = .init(title: .init(font: .preferredFont(forTextStyle: .body), color: .red))

--- a/AdyenUI/UI/Views/FormButton.swift
+++ b/AdyenUI/UI/Views/FormButton.swift
@@ -9,14 +9,14 @@ import UIKit
 
 /// A rounded submit button used to submit details.
 @_spi(AdyenInternal)
-public final class SubmitButton: UIControl {
+public final class FormButton: UIControl {
 
     private var style: ButtonStyle
     private var buttonStyle: AdyenButtonStyle = .primary(for: .default)
 
     /// Initializes the submit button.
     ///
-    /// - Parameter style: The `SubmitButton` UI style.
+    /// - Parameter style: The `FormButton` UI style.
     public init(style: ButtonStyle) {
         self.style = style
         super.init(frame: .zero)
@@ -35,8 +35,8 @@ public final class SubmitButton: UIControl {
     }
 
     /// Initializes the submit button.
-    /// - Parameter buttonStyle: The  new `SubmitButton` UI style.
-    /// - Parameter style: The  old`SubmitButton` UI style.
+    /// - Parameter buttonStyle: The  new `FormButton` UI style.
+    /// - Parameter style: The  old`FormButton` UI style.
     public init(
         theme: AdyenTheme,
         style: ButtonStyle = .init(title: .init(font: .preferredFont(forTextStyle: .body), color: .red))
@@ -180,7 +180,7 @@ public final class SubmitButton: UIControl {
     
 }
 
-extension SubmitButton {
+extension FormButton {
     
     internal final class BackgroundView: UIView {
         

--- a/AdyenUI/UI/Views/FormButton.swift
+++ b/AdyenUI/UI/Views/FormButton.swift
@@ -7,14 +7,14 @@
 @_spi(AdyenInternal) import Adyen
 import UIKit
 
-/// A rounded submit button used to submit details.
+/// A rounded button for use in forms.
 @_spi(AdyenInternal)
 public final class FormButton: UIControl {
 
     private var style: ButtonStyle
     private var buttonStyle: AdyenButtonStyle = .primary(for: .default)
 
-    /// Initializes the submit button.
+    /// Initializes the form button.
     ///
     /// - Parameter style: The `FormButton` UI style.
     public init(style: ButtonStyle) {
@@ -34,7 +34,7 @@ public final class FormButton: UIControl {
         configureConstraints()
     }
 
-    /// Initializes the submit button.
+    /// Initializes the form button.
     /// - Parameter buttonStyle: The  new `FormButton` UI style.
     /// - Parameter style: The  old`FormButton` UI style.
     public init(

--- a/Tests/IntegrationTests/Actions Tests/Voucher/VoucherViewTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/VoucherViewTests.swift
@@ -35,7 +35,7 @@ class VoucherViewTests: XCTestCase {
 //        check(layer: sut.findView(by: "logo")!.layer, forCornerRounding: style.logoCornerRounding)
 //        check(label: sut.findView(by: "amountLabel")!, forStyle: style.amountLabel)
 //        check(label: sut.findView(by: "currencyLabel")!, forStyle: style.currencyLabel)
-//        check(submitButton: sut.findView(by: "mainButton")! as! SubmitButton, forStyle: style.mainButton)
+//        check(submitButton: sut.findView(by: "mainButton")! as! FormButton, forStyle: style.mainButton)
 //        check(button: sut.findView(by: "secondaryButton")!, forStyle: style.secondaryButton)
 //
 //    }
@@ -89,7 +89,7 @@ class VoucherViewTests: XCTestCase {
         let sut = try getSut(model: mockModel)
         sut.delegate = delegateMock
         
-        let mainButton: SubmitButton? = sut.findView(by: "mainButton")
+        let mainButton: FormButton? = sut.findView(by: "mainButton")
         let secondaryButton: UIButton? = sut.findView(by: "secondaryButton")
         let addToAppleWalletButton: PKAddPassButton? = sut.findView(by: "appleWalletButton")
         

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
@@ -913,11 +913,11 @@ class ThreeDS2ComponentTests: XCTestCase {
             XCTAssertNotNil(descriptionLabel)
             XCTAssertEqual(descriptionLabel?.text, "Approve this transaction to complete your purchase.")
 
-            let firstButton: SubmitButton? = viewController.view.findView(by: "primaryButton")
+            let firstButton: FormButton? = viewController.view.findView(by: "primaryButton")
             XCTAssertNotNil(firstButton)
             XCTAssertEqual(firstButton?.title, "Approve transaction")
 
-            let secondButton: SubmitButton? = viewController.view.findView(by: "secondaryButton")
+            let secondButton: FormButton? = viewController.view.findView(by: "secondaryButton")
             XCTAssertNotNil(secondButton)
             XCTAssertEqual(secondButton?.title, "Other options")
         }
@@ -941,11 +941,11 @@ class ThreeDS2ComponentTests: XCTestCase {
             XCTAssertNotNil(troubleshootingDescriptionLabel)
             XCTAssertEqual(troubleshootingDescriptionLabel?.text, "Ongoing payment issues may be resolved by resetting your Secure Checkout details.")
 
-            let troubleshootingButton: SubmitButton? = controller.view.findView(by: "troubleshootingButton")
+            let troubleshootingButton: FormButton? = controller.view.findView(by: "troubleshootingButton")
             XCTAssertNotNil(troubleshootingButton)
             XCTAssertEqual(troubleshootingButton?.title, "Reset Secure Checkout")
 
-            let firstButton: SubmitButton? = controller.view.findView(by: "primaryButton")
+            let firstButton: FormButton? = controller.view.findView(by: "primaryButton")
             XCTAssertNotNil(firstButton)
             XCTAssertEqual(firstButton?.title, "Approve differently")
         }
@@ -970,10 +970,10 @@ class ThreeDS2ComponentTests: XCTestCase {
             XCTAssertNotNil(descriptionLabel)
             XCTAssertEqual(descriptionLabel?.text, "Check out faster next time with this card")
 
-            let firstButton: SubmitButton? = viewController.view.findView(by: "primaryButton")
+            let firstButton: FormButton? = viewController.view.findView(by: "primaryButton")
             XCTAssertNotNil(firstButton)
             XCTAssertEqual(firstButton?.title, "Use secure checkout")
-            let secondButton: SubmitButton? = viewController.view.findView(by: "secondaryButton")
+            let secondButton: FormButton? = viewController.view.findView(by: "secondaryButton")
             XCTAssertNotNil(secondButton)
             XCTAssertEqual(secondButton?.title, "Not now")
         }
@@ -989,7 +989,7 @@ class ThreeDS2ComponentTests: XCTestCase {
             XCTAssertNotNil(descriptionLabel)
             XCTAssertEqual(descriptionLabel?.text, "Your payment has still been authenticated successfully but the Secure Checkout service was unavailable.")
 
-            let firstButton: SubmitButton? = controller.view.findView(by: "primaryButton")
+            let firstButton: FormButton? = controller.view.findView(by: "primaryButton")
             XCTAssertNotNil(firstButton)
             XCTAssertEqual(firstButton?.title, "Finish")
 

--- a/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -302,7 +302,7 @@ class ACHDirectDebitComponentTests: XCTestCase {
 
         wait(until: routingNumberItemView, at: \.textField.text, is: "121000358")
         
-        payButtonItemViewButton.didSelectSubmitButton()
+        payButtonItemViewButton.didTapButton()
         wait(until: payButtonItemViewButton, at: \.item.showsActivityIndicator, is: true)
         
         wait(for: [expectation], timeout: 100)

--- a/Tests/IntegrationTests/Components Tests/QRCode/QRCodeActionComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/QRCode/QRCodeActionComponentTests.swift
@@ -177,7 +177,7 @@ class QRCodeActionComponentTests: XCTestCase {
         setupRootViewController(qrCodeViewController)
         
         // When
-        let saveAsImageButton: SubmitButton = try XCTUnwrap(qrCodeViewController.view.findView(by: "copyCodeButton"))
+        let saveAsImageButton: FormButton = try XCTUnwrap(qrCodeViewController.view.findView(by: "copyCodeButton"))
         saveAsImageButton.sendActions(for: .touchUpInside)
         
         waitForExpectations(timeout: 10, handler: nil)
@@ -226,7 +226,7 @@ class QRCodeActionComponentTests: XCTestCase {
         setupRootViewController(qrCodeViewController)
         
         // When
-        let saveAsImageButton: SubmitButton = try XCTUnwrap(qrCodeViewController.view.findView(by: "saveAsImageButton"))
+        let saveAsImageButton: FormButton = try XCTUnwrap(qrCodeViewController.view.findView(by: "saveAsImageButton"))
         saveAsImageButton.sendActions(for: .touchUpInside)
         
         waitForExpectations(timeout: 10, handler: nil)

--- a/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentComponentTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentComponentTests.swift
@@ -77,7 +77,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
     }
     
     func testPressSubmitButton() {
-        let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton.button")
+        let button: FormButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton.button")
         button.sendActions(for: .touchUpInside)
         
         let expectation = XCTestExpectation(description: "Dummy Expectation")
@@ -93,7 +93,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
 
     func testSubmitButtonLoading() {
         setupRootViewController(sut.viewController)
-        let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton.button")
+        let button: FormButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.submitButton.button")
         XCTAssertFalse(button.showsActivityIndicator)
         sut.startLoading(for: component)
 
@@ -105,7 +105,7 @@ class PreselectedPaymentComponentTests: XCTestCase {
     }
     
     func testPressOpenAllButton() {
-        let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.openAllButton.button")
+        let button: FormButton! = sut.viewController.view.findView(with: "AdyenDropIn.PreselectedPaymentMethodComponent.openAllButton.button")
         button!.sendActions(for: .touchUpInside)
         
         let expectation = XCTestExpectation(description: "Dummy Expectation")

--- a/Tests/IntegrationTests/Helpers/XCTestCase+Style.swift
+++ b/Tests/IntegrationTests/Helpers/XCTestCase+Style.swift
@@ -39,15 +39,15 @@ extension XCTestCase {
     
     /// Checks whether the given style was applied properly to the given `FormButton`
     /// - Parameters:
-    ///   - submitButton: `FormButton` to check
+    ///   - formButton: `FormButton` to check
     ///   - style: `ButtonStyle` that should be applied
-    func check(submitButton: FormButton, forStyle style: ButtonStyle, file: StaticString = #file, line: UInt = #line) {
-        check(label: submitButton.titleLabel, forStyle: style.title)
-        XCTAssertEqual(submitButton.backgroundView.layer.borderColor, style.borderColor?.cgColor)
-        XCTAssertEqual(submitButton.backgroundView.layer.borderWidth, style.borderWidth)
-        XCTAssertEqual(submitButton.backgroundView.backgroundColor, style.backgroundColor)
+    func check(formButton: FormButton, forStyle style: ButtonStyle, file: StaticString = #file, line: UInt = #line) {
+        check(label: formButton.titleLabel, forStyle: style.title)
+        XCTAssertEqual(formButton.backgroundView.layer.borderColor, style.borderColor?.cgColor)
+        XCTAssertEqual(formButton.backgroundView.layer.borderWidth, style.borderWidth)
+        XCTAssertEqual(formButton.backgroundView.backgroundColor, style.backgroundColor)
         
-        check(layer: submitButton.layer, forCornerRounding: style.cornerRounding)
+        check(layer: formButton.layer, forCornerRounding: style.cornerRounding)
     }
     
     /// Checks whether the given corner rounding was applied properly to the given layer

--- a/Tests/IntegrationTests/Helpers/XCTestCase+Style.swift
+++ b/Tests/IntegrationTests/Helpers/XCTestCase+Style.swift
@@ -37,11 +37,11 @@ extension XCTestCase {
         check(layer: button.layer, forCornerRounding: style.cornerRounding)
     }
     
-    /// Checks whether the given style was applied properly to the given `SubmitButton`
+    /// Checks whether the given style was applied properly to the given `FormButton`
     /// - Parameters:
-    ///   - submitButton: `SubmitButton` to check
+    ///   - submitButton: `FormButton` to check
     ///   - style: `ButtonStyle` that should be applied
-    func check(submitButton: SubmitButton, forStyle style: ButtonStyle, file: StaticString = #file, line: UInt = #line) {
+    func check(submitButton: FormButton, forStyle style: ButtonStyle, file: StaticString = #file, line: UInt = #line) {
         check(label: submitButton.titleLabel, forStyle: style.title)
         XCTAssertEqual(submitButton.backgroundView.layer.borderColor, style.borderColor?.cgColor)
         XCTAssertEqual(submitButton.backgroundView.layer.borderWidth, style.borderWidth)

--- a/Tests/IntegrationTests/UI Components/FormButtonTests.swift
+++ b/Tests/IntegrationTests/UI Components/FormButtonTests.swift
@@ -8,7 +8,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
-final class SubmitButtonTests: XCTestCase {
+final class FormButtonTests: XCTestCase {
 
     private let style = ButtonStyle(title: .init(font: .preferredFont(forTextStyle: .body), color: .red))
 
@@ -52,8 +52,8 @@ final class SubmitButtonTests: XCTestCase {
         XCTAssertTrue(sut.isEnabled, "Button should be enabled after activity indicator hides")
     }
 
-    func makeSUT(_ title: String = "Submit") throws -> (SubmitButton, UIActivityIndicatorView) {
-        let sut = SubmitButton(style: style)
+    func makeSUT(_ title: String = "Submit") throws -> (FormButton, UIActivityIndicatorView) {
+        let sut = FormButton(style: style)
         sut.title = title
         let activityIndicatorView: UIActivityIndicatorView = try XCTUnwrap(sut.findView(by: "activityIndicator"))
 

--- a/Tests/IntegrationTests/UIKit/Form/Theme/FormButtonItemViewThemeTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/Theme/FormButtonItemViewThemeTests.swift
@@ -28,10 +28,10 @@ final class FormButtonItemViewThemeTests: XCTestCase {
         let sut = FormButtonItemView(item: item, theme: customTheme)
 
         // Then - button uses expected theme colors
-        let submitButton = try XCTUnwrap(sut.submitButton)
-        XCTAssertEqual(submitButton.backgroundColor, expectedBackgroundColor)
+        let button = try XCTUnwrap(sut.button)
+        XCTAssertEqual(button.backgroundColor, expectedBackgroundColor)
 
-        let titleLabel = try XCTUnwrap(submitButton.titleLabel)
+        let titleLabel = try XCTUnwrap(button.titleLabel)
         XCTAssertEqual(titleLabel.textColor, expectedTextColor)
     }
 
@@ -46,10 +46,10 @@ final class FormButtonItemViewThemeTests: XCTestCase {
         let sut = FormButtonItemView(item: item)
 
         // Then - should use default theme colors
-        let submitButton = try XCTUnwrap(sut.submitButton)
-        XCTAssertEqual(submitButton.backgroundColor, expectedBackgroundColor)
+        let button = try XCTUnwrap(sut.button)
+        XCTAssertEqual(button.backgroundColor, expectedBackgroundColor)
 
-        let titleLabel = try XCTUnwrap(submitButton.titleLabel)
+        let titleLabel = try XCTUnwrap(button.titleLabel)
         XCTAssertEqual(titleLabel.textColor, expectedTextColor)
     }
 }

--- a/Tests/SnapshotTests/Components/BLIKComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/BLIKComponentUITests.swift
@@ -66,7 +66,7 @@ final class BLIKComponentUITests: XCTestCase {
         
         setupRootViewController(sut.viewController)
 
-        let submitButton: SubmitButton = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.BLIKComponent.payButtonItem.button"))
+        let submitButton: FormButton = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.BLIKComponent.payButtonItem.button"))
 
         let blikCodeView: FormTextInputItemView! = sut.viewController.view.findView(with: "AdyenComponents.BLIKComponent.blikCodeItem")
         self.populate(textItemView: blikCodeView, with: "123456")

--- a/Tests/SnapshotTests/Components/BoletoComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/BoletoComponentUITests.swift
@@ -105,7 +105,7 @@ final class BoletoComponentUITests: XCTestCase {
         let dummyExpectation = XCTestExpectation(description: "Dummy Expectation")
         
         let view = try XCTUnwrap(sut.viewController.view)
-        let submitButton: SubmitButton = try XCTUnwrap(view.findView(by: "payButtonItem.button"))
+        let submitButton: FormButton = try XCTUnwrap(view.findView(by: "payButtonItem.button"))
         let firstNameView: FormTextInputItemView = try XCTUnwrap(view.findView(by: "firstNameItem"))
         let lastNameView: FormTextInputItemView = try XCTUnwrap(view.findView(by: "lastNameItem"))
         let billingAddressView: FormAddressPickerItemView = try XCTUnwrap(view.findView(by: "addressItem"))
@@ -147,7 +147,7 @@ final class BoletoComponentUITests: XCTestCase {
             configuration: mockConfiguration
         )
 
-        let submitButton: SubmitButton = try XCTUnwrap(sut.viewController.view.findView(by: "payButtonItem.button"))
+        let submitButton: FormButton = try XCTUnwrap(sut.viewController.view.findView(by: "payButtonItem.button"))
         submitButton.sendActions(for: .touchUpInside)
 
         verifyViewControllerImage(matching: sut.viewController, named: "boleto_flow_no_name")

--- a/Tests/SnapshotTests/Components/OnlineBankingComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/OnlineBankingComponentUITests.swift
@@ -79,7 +79,7 @@ class OnlineBankingComponentUITests: XCTestCase {
         sut.delegate = delegate
 
         // Then
-        let button: SubmitButton! = sut.viewController.view.findView(with: "AdyenComponents.OnlineBankingComponent.continueButton.button")
+        let button: FormButton! = sut.viewController.view.findView(with: "AdyenComponents.OnlineBankingComponent.continueButton.button")
 
         let didContinueExpectation = XCTestExpectation(description: "Dummy Expectation")
 
@@ -111,7 +111,7 @@ class OnlineBankingComponentUITests: XCTestCase {
 
         UIApplication.shared.adyen.mainKeyWindow?.rootViewController = sut.viewController
        
-        let button: SubmitButton = try XCTUnwrap(
+        let button: FormButton = try XCTUnwrap(
             sut.viewController.view.findView(with: "AdyenComponents.OnlineBankingComponent.continueButton.button")
         )
 

--- a/Tests/SnapshotTests/Components/UPIComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/UPIComponentUITests.swift
@@ -228,7 +228,7 @@ class UPIComponentUITests: XCTestCase {
         let errorItem = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.UPIComponent.errorItem") as? FormErrorItemView)
         XCTAssertTrue(errorItem.isHidden)
         
-        let continueButton: SubmitButton = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.UPIComponent.continueButton.button"))
+        let continueButton: FormButton = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenComponents.UPIComponent.continueButton.button"))
         
         // Tapping button with no apps selected - error should be shown
         

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -174,7 +174,7 @@ final class CheckoutComponentBuilderTests: XCTestCase {
     
     // MARK: - Configuration Merging Tests
     
-    func testBuild_MergesGlobalShowsSubmitButtonSetting() throws {
+    func testBuild_MergesGlobalShowsFormButtonSetting() throws {
         // Given
         let paymentMethod = try XCTUnwrap(createBLIKPaymentMethod())
         var blikConfig = BLIKComponentConfiguration()


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

Previously, `FormButtonItemView` served as a wrapper around the `SubmitButton`. It is always added as a subview and all the logic hardcoded to serve as a submit/pay button. 
However, in reality, this button is reused as:
- submit/pay
- continue 
- open all
- apply giftcard

Obviously, existing naming is obscure and misleading. This change aims to improve code readability and remove obscurity.

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
