### PR TITLE
Fix ApplePay stale state in tests

### DIFF
--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -63,8 +63,8 @@ class ApplePayComponentTest: XCTestCase {
             self.mockDelegate = nil // to prevent false triggering
         }
 
-        presentOnRoot(viewController)
-        
+        viewController.loadViewIfNeeded()
+
         self.sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
 
         waitForExpectations(timeout: 10)


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

This change fixes tests using shared global UI state. Not confirmed, this might be the reason some UI state-related tests are flaky.

<img width="382" height="719" alt="image" src="https://github.com/user-attachments/assets/9a2903f8-a13b-4a40-adf9-5ae7e578d2ef" />
