### PR TITLE
Uncomment more payment components UI tests 

### DIFF
--- a/.windsurf/rules/file-editing.md
+++ b/.windsurf/rules/file-editing.md
@@ -1,0 +1,97 @@
+# Windsurf/Cascade Specific Tips
+
+This file contains guidance specific to working with Windsurf and the Cascade AI assistant. For general project information, architecture, and development practices, see [AGENTS.md](AGENTS.md).
+
+## File Editing in Windsurf
+
+### Critical: Test Files Require Special Handling
+
+The `edit` and `multi_edit` tools in Windsurf trigger automatic formatters that reformat entire files, creating massive diffs (hundreds of lines) even for small changes. This makes PRs impossible to review.
+
+### Shell Command Technique for Test Files
+
+Use shell commands for precise, line-by-line replacements:
+
+```bash
+# 1. Write new content to temp file
+write_to_file("/tmp/new_test_method.txt", "new test content here")
+
+# 2. Reassemble file with surgical replacement
+head -87 original.swift > /tmp/part1.txt        # Lines before change
+cat /tmp/new_test_method.txt >> /tmp/part1.txt  # New content
+tail -n +168 original.swift >> /tmp/part1.txt   # Lines after change
+mv /tmp/part1.txt original.swift                # Replace original
+```
+
+**Why this works:**
+- No formatters are triggered
+- Only the exact lines you specify are changed
+- Preserves all existing formatting and whitespace
+- Creates clean, reviewable diffs (e.g., 28 insertions/76 deletions vs 224 insertions/140 deletions)
+
+**Steps:**
+1. Identify line numbers: Use `read_file` to find start/end of section to replace
+2. Create new content: Use `write_to_file` to `/tmp/` with new content
+3. Calculate tail offset: `end_line + 1` (e.g., if test ends at line 167, use `tail -n +168`)
+4. Execute replacement: Single command with `head`, `cat`, `tail`, `mv`
+5. **Always clean up temp files** after completion
+
+**Example from real usage:**
+```bash
+# Replaced 94-line test method with clean 32-line version
+# Result: +28 insertions, -76 deletions (pure logical changes)
+# No formatting noise in the 358-line file
+```
+
+### File Editing Guidelines
+
+**For test files:**
+- ❌ **NEVER use edit or multi_edit tools** - They cause massive formatting changes
+- ✅ **Use shell command technique** as documented above
+- ✅ **Always run tests immediately** after rewriting to verify they work
+- ✅ **Clean up temp files** (`rm -f /tmp/*.txt`, patch files, etc.)
+
+**For implementation files:**
+- ✅ Use edit/multi_edit tools as needed
+- ✅ Always run SwiftFormat after edits: `swiftformat path/to/file.swift`
+
+### Command Execution
+
+**CRITICAL - Avoid heredoc syntax:**
+- ❌ **NEVER use heredoc** (`cat > file << 'EOF'`) - These commands hang indefinitely in Windsurf
+- ✅ **Use write_to_file tool** for creating new files
+- ✅ **Use edit tool** for modifying existing implementation files (not test files)
+- ✅ **Use direct commands** without heredoc for all other operations
+
+### Test-Driven Development
+
+When refactoring or rewriting tests:
+1. **Always run tests immediately after changes** - Use `xcodebuild test` with the appropriate scheme
+2. **Verify compilation and passing status** - Never assume tests work without running them
+3. **Report test results** - Show output to confirm success or diagnose failures
+
+**Running specific tests:**
+```bash
+# Run a single test class
+xcodebuild test -project Adyen.xcodeproj -scheme IntegrationUIKitTests \
+  -destination 'platform=iOS Simulator,name=iPhone 15 Pro' \
+  -only-testing:IntegrationTests/CardComponentTests
+
+# Run a single test method
+xcodebuild test -project Adyen.xcodeproj -scheme IntegrationUIKitTests \
+  -destination 'platform=iOS Simulator,name=iPhone 15 Pro' \
+  -only-testing:IntegrationTests/CardComponentTests/testUIConfiguration
+```
+
+## Cleanup Checklist
+
+Before marking work complete:
+- [ ] All temp files removed (`/tmp/*.txt`, patch files)
+- [ ] All tests run and passing
+- [ ] SwiftFormat applied to edited implementation files
+- [ ] Git status clean (no unintended files)
+
+## See Also
+
+- [AGENTS.md](AGENTS.md) - Generic guidance for all AI assistants
+- [TESTING.md](TESTING.md) - Testing guide and patterns

--- a/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -74,99 +74,50 @@ class ACHDirectDebitComponentTests: XCTestCase {
         ))
     }
     
-    func testUIConfiguration() {
-        var achComponentStyle = FormComponentStyle()
-        
-        /// Footer
-        achComponentStyle.mainButtonItem.button.title.color = .white
-        achComponentStyle.mainButtonItem.button.title.backgroundColor = .red
-        achComponentStyle.mainButtonItem.button.title.textAlignment = .center
-        achComponentStyle.mainButtonItem.button.title.font = .systemFont(ofSize: 22)
-        achComponentStyle.mainButtonItem.button.backgroundColor = .red
-        achComponentStyle.mainButtonItem.backgroundColor = .brown
-        
-        /// background color
-        achComponentStyle.backgroundColor = .red
-        
-        /// Text field
-        achComponentStyle.textField.text.color = .red
-        achComponentStyle.textField.text.font = .systemFont(ofSize: 13)
-        achComponentStyle.textField.text.textAlignment = .right
-        
-        achComponentStyle.textField.title.backgroundColor = .blue
-        achComponentStyle.textField.title.color = .yellow
-        achComponentStyle.textField.title.font = .systemFont(ofSize: 20)
-        achComponentStyle.textField.title.textAlignment = .center
-        achComponentStyle.textField.backgroundColor = .red
-        
+    func testUIConfiguration() throws {
+        // Given
+        let customColors = AdyenColors(container: .systemYellow, primary: .systemPink, highlight: .systemBlue)
+        let customTheme = AdyenTheme(colors: customColors).primaryButton(backgroundColor: .systemRed, textColor: .white)
+
         let paymentMethod = ACHDirectDebitPaymentMethod(type: .achDirectDebit, name: "Test name")
+        var configuration = ACHDirectDebitComponent.Configuration(billingAddressCountryCodes: ["US", "UK"])
+        configuration.theme = customTheme
         let sut = ACHDirectDebitComponent(
             paymentMethod: paymentMethod,
             context: context,
-            configuration: .init(
-                style: achComponentStyle,
-                billingAddressCountryCodes: ["US", "UK"]
-            ),
+            configuration: configuration,
             publicKeyProvider: PublicKeyProviderMock()
         )
-        
+
+        // When
         setupRootViewController(sut.viewController)
         wait(for: .milliseconds(300))
-        
-        let nameItemView: FormTextItemView<FormTextInputItem>? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.holderNameItem")
-        let nameItemViewTitleLabel: UILabel? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.holderNameItem.titleLabel")
-        let nameItemViewTextField: UITextField? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.holderNameItem.textField")
-        
-        let accountNumberItemView: FormTextItemView<FormTextInputItem>? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankAccountNumberItem")
-        let accountNumberItemTitleLabel: UILabel? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankAccountNumberItem.titleLabel")
-        let accountNumberItemTextField: UITextField? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankAccountNumberItem.textField")
-        
-        let routingNumberItemView: FormTextItemView<FormTextInputItem>? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankRoutingNumberItem")
-        let routingNumberItemTitleLabel: UILabel? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankRoutingNumberItem.titleLabel")
-        let routingNumberItemTextField: UITextField? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankRoutingNumberItem.textField")
-        
-        let payButtonItemViewButton: UIControl? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.payButtonItem.button")
-        let payButtonItemViewButtonTitle: UILabel? = sut.viewController.view.findView(with: "AdyenComponents.ACHDirectDebitComponent.payButtonItem.button.titleLabel")
-        
-        XCTAssertNotNil(sut.viewController.view.findView(by: "AdyenComponents.ACHDirectDebitComponent.billingAddressItem"))
-        // TODO: Fix nameItemView, accountNumberItemView, routingNumberItemView and payButtonItemViewButton UI asserts
-        /// holder name
-//        XCTAssertEqual(nameItemView?.backgroundColor, .red)
-//        XCTAssertEqual(nameItemViewTitleLabel?.backgroundColor, .blue)
-//        XCTAssertEqual(nameItemViewTitleLabel?.textAlignment, .center)
-//        XCTAssertEqual(nameItemViewTitleLabel?.font, .systemFont(ofSize: 20))
-//        XCTAssertEqual(nameItemViewTextField?.backgroundColor, .red)
-//        XCTAssertEqual(nameItemViewTextField?.textAlignment, .right)
-//        XCTAssertEqual(nameItemViewTextField?.textColor, .red)
-//        XCTAssertEqual(nameItemViewTextField?.font, .systemFont(ofSize: 13))
-        
-        /// account number
-//        XCTAssertEqual(accountNumberItemView?.backgroundColor, .red)
-//        XCTAssertEqual(accountNumberItemTitleLabel?.backgroundColor, .blue)
-//        XCTAssertEqual(accountNumberItemTitleLabel?.textAlignment, .center)
-//        XCTAssertEqual(accountNumberItemTitleLabel?.font, .systemFont(ofSize: 20))
-//        XCTAssertEqual(accountNumberItemTextField?.backgroundColor, .red)
-//        XCTAssertEqual(accountNumberItemTextField?.textAlignment, .right)
-//        XCTAssertEqual(accountNumberItemTextField?.textColor, .red)
-//        XCTAssertEqual(accountNumberItemTextField?.font, .systemFont(ofSize: 13))
-        
-        /// routing number
-//        XCTAssertEqual(routingNumberItemView?.backgroundColor, .red)
-//        XCTAssertEqual(routingNumberItemTitleLabel?.backgroundColor, .blue)
-//        XCTAssertEqual(routingNumberItemTitleLabel?.textAlignment, .center)
-//        XCTAssertEqual(routingNumberItemTitleLabel?.font, .systemFont(ofSize: 20))
-//        XCTAssertEqual(routingNumberItemTextField?.backgroundColor, .red)
-//        XCTAssertEqual(routingNumberItemTextField?.textAlignment, .right)
-//        XCTAssertEqual(routingNumberItemTextField?.textColor, .red)
-//        XCTAssertEqual(routingNumberItemTextField?.font, .systemFont(ofSize: 13))
-        
-        /// Test footer
-        // XCTAssertEqual(payButtonItemViewButton?.backgroundColor, .red)
-        
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.backgroundColor, .red)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.textAlignment, .center)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.textColor, .white)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.font, .systemFont(ofSize: 22))
+
+        // Then
+        let view = sut.viewController.view
+        let nameItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(view?.findView(with: "AdyenComponents.ACHDirectDebitComponent.holderNameItem"))
+        let nameItemViewTitleLabel: UILabel = try XCTUnwrap(view?.findView(with: "AdyenComponents.ACHDirectDebitComponent.holderNameItem.titleLabel"))
+        let nameItemViewTextField: UITextField = try XCTUnwrap(view?.findView(with: "AdyenComponents.ACHDirectDebitComponent.holderNameItem.textField"))
+        let accountNumberItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(view?.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankAccountNumberItem"))
+        let accountNumberItemTitleLabel: UILabel = try XCTUnwrap(view?.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankAccountNumberItem.titleLabel"))
+        let accountNumberItemTextField: UITextField = try XCTUnwrap(view?.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankAccountNumberItem.textField"))
+        let routingNumberItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(view?.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankRoutingNumberItem"))
+        let routingNumberItemTitleLabel: UILabel = try XCTUnwrap(view?.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankRoutingNumberItem.titleLabel"))
+        let routingNumberItemTextField: UITextField = try XCTUnwrap(view?.findView(with: "AdyenComponents.ACHDirectDebitComponent.bankRoutingNumberItem.textField"))
+        let payButtonItemView: FormButtonItemView = try XCTUnwrap(view?.findView(with: "AdyenComponents.ACHDirectDebitComponent.payButtonItem"))
+
+        XCTAssertNotNil(view?.findView(by: "AdyenComponents.ACHDirectDebitComponent.billingAddressItem"))
+
+        XCTAssertEqual(nameItemViewTitleLabel.textColor, .systemPink)
+        XCTAssertEqual(nameItemViewTextField.textColor, .systemPink)
+        XCTAssertEqual(accountNumberItemTitleLabel.textColor, .systemPink)
+        XCTAssertEqual(accountNumberItemTextField.textColor, .systemPink)
+        XCTAssertEqual(routingNumberItemTitleLabel.textColor, .systemPink)
+        XCTAssertEqual(routingNumberItemTextField.textColor, .systemPink)
+        XCTAssertEqual(nameItemView.backgroundColor, .systemYellow)
+        XCTAssertEqual(accountNumberItemView.backgroundColor, .systemYellow)
+        XCTAssertEqual(routingNumberItemView.backgroundColor, .systemYellow)
+        XCTAssertEqual(payButtonItemView.button.backgroundColor, .systemRed)
     }
     
     func testPrefillInfo() throws {

--- a/Tests/IntegrationTests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
@@ -60,71 +60,32 @@ class QiwiWalletComponentTests: XCTestCase {
         XCTAssertEqual(sut.button.title, localizedString(LocalizationKey(key: "adyen_continueTo"), sut.configuration.localizationParameters, method.name))
     }
     
-    func testUIConfiguration() {
-        var style = FormComponentStyle()
-        
-        /// Footer
-        style.mainButtonItem.button.title.color = .white
-        style.mainButtonItem.button.title.backgroundColor = .red
-        style.mainButtonItem.button.title.textAlignment = .center
-        style.mainButtonItem.button.title.font = .systemFont(ofSize: 22)
-        style.mainButtonItem.button.backgroundColor = .red
-        style.mainButtonItem.backgroundColor = .brown
-        
-        /// background color
-        style.backgroundColor = .red
-        
-        /// Text field
-        style.textField.text.color = .red
-        style.textField.text.font = .systemFont(ofSize: 13)
-        style.textField.text.textAlignment = .right
-        
-        style.textField.title.backgroundColor = .blue
-        style.textField.title.color = .yellow
-        style.textField.title.font = .systemFont(ofSize: 20)
-        style.textField.title.textAlignment = .center
-        style.textField.backgroundColor = .red
-        
-        let config = QiwiWalletComponent.Configuration(style: style)
+    func testUIConfiguration() throws {
+        // Given
+        let customColors = AdyenColors(container: .systemYellow, primary: .systemPink, highlight: .systemBlue)
+        let customTheme = AdyenTheme(colors: customColors).primaryButton(backgroundColor: .systemRed, textColor: .white)
+
+        var config = QiwiWalletComponent.Configuration()
+        config.theme = customTheme
         let sut = QiwiWalletComponent(paymentMethod: method, context: context, configuration: config)
 
+        // When
         setupRootViewController(sut.viewController)
-        
         wait(for: .milliseconds(300))
-        
-        let phoneNumberView: FormPhoneNumberItemView? = sut.viewController.view.findView(with: "AdyenComponents.QiwiWalletComponent.phoneNumberItem")
-        let phoneNumberViewTitleLabel: UILabel? = sut.viewController.view.findView(with: "AdyenComponents.QiwiWalletComponent.phoneNumberItem.titleLabel")
-        let phoneNumberViewTextField: UITextField? = sut.viewController.view.findView(with: "AdyenComponents.QiwiWalletComponent.phoneNumberItem.textField")
-        
-        let phoneExtensionView: FormPhoneExtensionPickerItemView? = sut.viewController.view.findView(with: "Adyen.FormPhoneNumberItem.phoneExtensionPickerItem")
-        let phoneExtensionViewLabel: UILabel? = sut.viewController.view.findView(with: "Adyen.FormPhoneNumberItem.phoneExtensionPickerItem.label")
-        
-        let payButtonItemViewButton: UIControl? = sut.viewController.view.findView(with: "AdyenComponents.QiwiWalletComponent.payButtonItem.button")
-        let payButtonItemViewButtonTitle: UILabel? = sut.viewController.view.findView(with: "AdyenComponents.QiwiWalletComponent.payButtonItem.button.titleLabel")
-        
-        /// Test phone number field
-        // TODO: Fix phoneNumberView, phoneExtensionViewLabel and payButtonItemViewButton UI asserts
-//        XCTAssertEqual(phoneNumberView?.backgroundColor, .red)
-//        XCTAssertEqual(phoneNumberViewTitleLabel?.textColor, sut.viewController.view.tintColor)
-//        XCTAssertEqual(phoneNumberViewTitleLabel?.backgroundColor, .blue)
-//        XCTAssertEqual(phoneNumberViewTitleLabel?.textAlignment, .center)
-//        XCTAssertEqual(phoneNumberViewTitleLabel?.font, .systemFont(ofSize: 20))
-//        XCTAssertEqual(phoneNumberViewTextField?.backgroundColor, .red)
-//        XCTAssertEqual(phoneNumberViewTextField?.textAlignment, .right)
-//        XCTAssertEqual(phoneNumberViewTextField?.textColor, .red)
-//        XCTAssertEqual(phoneNumberViewTextField?.font, .systemFont(ofSize: 13))
-        
-        /// Test phone extension
-//        XCTAssertEqual(phoneExtensionViewLabel?.textAlignment, .right)
-//        XCTAssertEqual(phoneExtensionViewLabel?.textColor, .red)
-//        XCTAssertEqual(phoneExtensionViewLabel?.font, .systemFont(ofSize: 13))
-        
-        /// Test footer
-//        XCTAssertEqual(payButtonItemViewButton?.backgroundColor, .red)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.backgroundColor, .red)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.textAlignment, .center)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.textColor, .white)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.font, .systemFont(ofSize: 22))
+
+        // Then
+        let view = sut.viewController.view
+        let phoneNumberView: FormPhoneNumberItemView = try XCTUnwrap(view?.findView(with: "AdyenComponents.QiwiWalletComponent.phoneNumberItem"))
+        let phoneNumberViewTitleLabel: UILabel = try XCTUnwrap(view?.findView(with: "AdyenComponents.QiwiWalletComponent.phoneNumberItem.titleLabel"))
+        let phoneNumberViewTextField: UITextField = try XCTUnwrap(view?.findView(with: "AdyenComponents.QiwiWalletComponent.phoneNumberItem.textField"))
+        let phoneExtensionViewLabel: UILabel = try XCTUnwrap(view?.findView(with: "Adyen.FormPhoneNumberItem.phoneExtensionPickerItem.label"))
+        let payButtonItemView: FormButtonItemView = try XCTUnwrap(view?.findView(with: "AdyenComponents.QiwiWalletComponent.payButtonItem"))
+
+        XCTAssertEqual(phoneNumberViewTitleLabel.textColor, .systemPink)
+        XCTAssertEqual(phoneNumberViewTextField.textColor, .systemPink)
+        XCTAssertEqual(phoneExtensionViewLabel.textColor, .systemPink)
+        XCTAssertEqual(phoneNumberView.backgroundColor, .systemYellow)
+        XCTAssertEqual(payButtonItemView.button.backgroundColor, .systemRed)
     }
     
     func testBigTitle() {

--- a/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
@@ -85,85 +85,37 @@ class SEPADirectDebitComponentTests: XCTestCase {
         XCTAssertEqual(sut.button.title, localizedSubmitButtonTitle(with: Dummy.payment.amount, style: .immediate, sut.configuration.localizationParameters))
     }
     
-    func testUIConfiguration() {
-        var sepaComponentStyle = FormComponentStyle()
-        
-        /// Footer
-        sepaComponentStyle.mainButtonItem.button.title.color = .white
-        sepaComponentStyle.mainButtonItem.button.title.backgroundColor = .red
-        sepaComponentStyle.mainButtonItem.button.title.textAlignment = .center
-        sepaComponentStyle.mainButtonItem.button.title.font = .systemFont(ofSize: 22)
-        sepaComponentStyle.mainButtonItem.button.backgroundColor = .red
-        sepaComponentStyle.mainButtonItem.backgroundColor = .brown
-        
-        /// background color
-        sepaComponentStyle.backgroundColor = .red
-        
-        /// Text field
-        sepaComponentStyle.textField.text.color = .red
-        sepaComponentStyle.textField.text.font = .systemFont(ofSize: 13)
-        sepaComponentStyle.textField.text.textAlignment = .right
-        
-        sepaComponentStyle.textField.title.backgroundColor = .blue
-        sepaComponentStyle.textField.title.color = .yellow
-        sepaComponentStyle.textField.title.font = .systemFont(ofSize: 20)
-        sepaComponentStyle.textField.title.textAlignment = .center
-        sepaComponentStyle.textField.backgroundColor = .red
-        
-        let sepaPaymentMethod = SEPADirectDebitPaymentMethod(type: .sepaDirectDebit, name: "Test name")
-        let configuration = SEPADirectDebitComponent.Configuration(style: sepaComponentStyle)
-        let sut = SEPADirectDebitComponent(
-            paymentMethod: sepaPaymentMethod,
-            context: context,
-            configuration: configuration
-        )
-        
-        setupRootViewController(sut.viewController)
-        
-        wait(for: .milliseconds(300))
-        
-        let nameItemView: FormTextItemView<FormTextInputItem>? = sut.viewController.view.findView(with: "AdyenComponents.SEPADirectDebitComponent.nameItem")
-        let nameItemViewTitleLabel: UILabel? = sut.viewController.view.findView(with: "AdyenComponents.SEPADirectDebitComponent.nameItem.titleLabel")
-        let nameItemViewTextField: UITextField? = sut.viewController.view.findView(with: "AdyenComponents.SEPADirectDebitComponent.nameItem.textField")
-        
-        let ibanItemView: FormTextItemView<FormTextInputItem>? = sut.viewController.view.findView(with: "AdyenComponents.SEPADirectDebitComponent.ibanItem")
-        let ibanItemTitleLabel: UILabel? = sut.viewController.view.findView(with: "AdyenComponents.SEPADirectDebitComponent.ibanItem.titleLabel")
-        let ibanItemTextField: UITextField? = sut.viewController.view.findView(with: "AdyenComponents.SEPADirectDebitComponent.ibanItem.textField")
-        
-        let payButtonItemViewButton: UIControl? = sut.viewController.view.findView(with: "AdyenComponents.SEPADirectDebitComponent.payButtonItem.button")
-        let payButtonItemViewButtonTitle: UILabel? = sut.viewController.view.findView(with: "AdyenComponents.SEPADirectDebitComponent.payButtonItem.button.titleLabel")
-        
-        // TODO: Fix nameItemView, ibanItemView, ibanItemTitleLabel, ibanItemTextField, payButtonItemViewButton and payButtonItemViewButtonTitle UI asserts
+    func testUIConfiguration() throws {
+        // Given
+        let customColors = AdyenColors(container: .systemYellow, primary: .systemPink, highlight: .systemBlue)
+        let customTheme = AdyenTheme(colors: customColors).primaryButton(backgroundColor: .systemRed, textColor: .white)
 
-        /// Test card number field
-//        XCTAssertEqual(nameItemView?.backgroundColor, .red)
-//        XCTAssertEqual(nameItemViewTitleLabel?.textColor, sut.viewController.view.tintColor)
-//        XCTAssertEqual(nameItemViewTitleLabel?.backgroundColor, .blue)
-//        XCTAssertEqual(nameItemViewTitleLabel?.textAlignment, .center)
-//        XCTAssertEqual(nameItemViewTitleLabel?.font, .systemFont(ofSize: 20))
-//        XCTAssertEqual(nameItemViewTextField?.backgroundColor, .red)
-//        XCTAssertEqual(nameItemViewTextField?.textAlignment, .right)
-//        XCTAssertEqual(nameItemViewTextField?.textColor, .red)
-//        XCTAssertEqual(nameItemViewTextField?.font, .systemFont(ofSize: 13))
-        
-        /// Test IBAN field
-//        XCTAssertEqual(ibanItemView?.backgroundColor, .red)
-//        XCTAssertEqual(ibanItemTitleLabel?.backgroundColor, .blue)
-//        XCTAssertEqual(ibanItemTitleLabel?.textAlignment, .center)
-//        XCTAssertEqual(ibanItemTitleLabel?.font, .systemFont(ofSize: 20))
-//        XCTAssertEqual(ibanItemTitleLabel?.textColor, .yellow)
-//        XCTAssertEqual(ibanItemTextField?.backgroundColor, .red)
-//        XCTAssertEqual(ibanItemTextField?.textAlignment, .right)
-//        XCTAssertEqual(ibanItemTextField?.textColor, .red)
-//        XCTAssertEqual(ibanItemTextField?.font, .systemFont(ofSize: 13))
-        
-//        /// Test footer
-//        XCTAssertEqual(payButtonItemViewButton?.backgroundColor, .red)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.backgroundColor, .red)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.textAlignment, .center)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.textColor, .white)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.font, .systemFont(ofSize: 22))
-        
+        let sepaPaymentMethod = SEPADirectDebitPaymentMethod(type: .sepaDirectDebit, name: "Test name")
+        var configuration = SEPADirectDebitComponent.Configuration()
+        configuration.theme = customTheme
+        let sut = SEPADirectDebitComponent(paymentMethod: sepaPaymentMethod, context: context, configuration: configuration)
+
+        // When
+        setupRootViewController(sut.viewController)
+        wait(for: .milliseconds(300))
+
+        // Then
+        let view = sut.viewController.view
+        let nameItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(view?.findView(with: "AdyenComponents.SEPADirectDebitComponent.nameItem"))
+        let nameItemViewTitleLabel: UILabel = try XCTUnwrap(view?.findView(with: "AdyenComponents.SEPADirectDebitComponent.nameItem.titleLabel"))
+        let nameItemViewTextField: UITextField = try XCTUnwrap(view?.findView(with: "AdyenComponents.SEPADirectDebitComponent.nameItem.textField"))
+        let ibanItemView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(view?.findView(with: "AdyenComponents.SEPADirectDebitComponent.ibanItem"))
+        let ibanItemTitleLabel: UILabel = try XCTUnwrap(view?.findView(with: "AdyenComponents.SEPADirectDebitComponent.ibanItem.titleLabel"))
+        let ibanItemTextField: UITextField = try XCTUnwrap(view?.findView(with: "AdyenComponents.SEPADirectDebitComponent.ibanItem.textField"))
+        let payButtonItemView: FormButtonItemView = try XCTUnwrap(view?.findView(with: "AdyenComponents.SEPADirectDebitComponent.payButtonItem"))
+
+        XCTAssertEqual(nameItemViewTitleLabel.textColor, .systemPink)
+        XCTAssertEqual(nameItemViewTextField.textColor, .systemPink)
+        XCTAssertEqual(ibanItemTitleLabel.textColor, .systemPink)
+        XCTAssertEqual(ibanItemTextField.textColor, .systemPink)
+        XCTAssertEqual(nameItemView.backgroundColor, .systemYellow)
+        XCTAssertEqual(ibanItemView.backgroundColor, .systemYellow)
+        XCTAssertEqual(payButtonItemView.button.backgroundColor, .systemRed)
     }
     
     func testBigTitle() {

--- a/Tests/IntegrationTests/Components Tests/Seven Eleven Component/BasicPersonalInfoFormComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Seven Eleven Component/BasicPersonalInfoFormComponentTests.swift
@@ -63,93 +63,48 @@ class BasicPersonalInfoFormComponentTests: XCTestCase {
         XCTAssertEqual(sut.button.title, localizedString(LocalizationKey(key: "adyen_confirmPurchase"), sut.configuration.localizationParameters))
     }
 
-    func testUIConfiguration() {
-        var style = FormComponentStyle()
+    func testUIConfiguration() throws {
+        // Given
+        let customColors = AdyenColors(container: .systemYellow, primary: .systemPink, highlight: .systemBlue)
+        let customTheme = AdyenTheme(colors: customColors).primaryButton(backgroundColor: .systemRed, textColor: .white)
 
-        /// Footer
-        style.mainButtonItem.button.title.color = .white
-        style.mainButtonItem.button.title.backgroundColor = .red
-        style.mainButtonItem.button.title.textAlignment = .center
-        style.mainButtonItem.button.title.font = .systemFont(ofSize: 22)
-        style.mainButtonItem.button.backgroundColor = .red
-        style.mainButtonItem.backgroundColor = .brown
+        var config = BasicPersonalInfoFormComponent.Configuration()
+        config.theme = customTheme
+        let sut = SevenElevenComponent(paymentMethod: paymentMethod, context: Dummy.context, configuration: config)
 
-        /// background color
-        style.backgroundColor = .yellow
-
-        /// Text field
-        style.textField.backgroundColor = .cyan
-        style.textField.text.color = .brown
-        style.textField.text.font = .systemFont(ofSize: 13)
-        style.textField.text.textAlignment = .right
-
-        style.textField.title.backgroundColor = .blue
-        style.textField.title.color = .yellow
-        style.textField.title.font = .systemFont(ofSize: 20)
-        style.textField.title.textAlignment = .center
-        style.textField.backgroundColor = .red
-
-        let config = BasicPersonalInfoFormComponent.Configuration(style: style)
-        let sut = SevenElevenComponent(
-            paymentMethod: paymentMethod,
-            context: Dummy.context,
-            configuration: config
-        )
-
+        // When
         setupRootViewController(sut.viewController)
-        
         wait(for: .milliseconds(300))
-        
-        // TODO: Fix assertTextInputUI
-        /// Test firstName field
-//        self.assertTextInputUI(
-//            ViewIdentifier.firstName,
-//            view: sut.viewController.view,
-//            style: style.textField,
-//            isFirstField: true
-//        )
 
-        /// Test lastName field
-//        self.assertTextInputUI(
-//            ViewIdentifier.lastName,
-//            view: sut.viewController.view,
-//            style: style.textField,
-//            isFirstField: false
-//        )
+        // Then
+        let view = sut.viewController.view
+        let firstNameView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(view?.findView(with: ViewIdentifier.firstName))
+        let firstNameTitleLabel: UILabel = try XCTUnwrap(view?.findView(with: ViewIdentifier.firstNameTitleLabel))
+        let firstNameTextField: UITextField = try XCTUnwrap(view?.findView(with: ViewIdentifier.firstNameTextField))
+        let lastNameView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(view?.findView(with: ViewIdentifier.lastName))
+        let lastNameTitleLabel: UILabel = try XCTUnwrap(view?.findView(with: ViewIdentifier.lastNameTitleLabel))
+        let lastNameTextField: UITextField = try XCTUnwrap(view?.findView(with: ViewIdentifier.lastNameTextField))
+        let emailView: FormTextItemView<FormTextInputItem> = try XCTUnwrap(view?.findView(with: ViewIdentifier.email))
+        let emailTitleLabel: UILabel = try XCTUnwrap(view?.findView(with: ViewIdentifier.emailTitleLabel))
+        let emailTextField: UITextField = try XCTUnwrap(view?.findView(with: ViewIdentifier.emailTextField))
+        let phoneNumberView: FormPhoneNumberItemView = try XCTUnwrap(view?.findView(with: ViewIdentifier.phone))
+        let phoneNumberViewTitleLabel: UILabel = try XCTUnwrap(view?.findView(with: ViewIdentifier.phoneTitleLabel))
+        let phoneNumberViewTextField: UITextField = try XCTUnwrap(view?.findView(with: ViewIdentifier.phoneTextField))
+        let payButtonItemView: FormButtonItemView = try XCTUnwrap(view?.findView(with: ViewIdentifier.payButton))
 
-        /// Test email field
-//        self.assertTextInputUI(
-//            ViewIdentifier.email,
-//            view: sut.viewController.view,
-//            style: style.textField,
-//            isFirstField: false
-//        )
-
-        let phoneNumberView: FormPhoneNumberItemView? = sut.viewController.view.findView(with: ViewIdentifier.phone)
-        let phoneNumberViewTitleLabel: UILabel? = sut.viewController.view.findView(with: ViewIdentifier.phoneTitleLabel)
-        let phoneNumberViewTextField: UITextField? = sut.viewController.view.findView(with: ViewIdentifier.phoneTextField)
-
-        /// Test submit button
-        let payButtonItemViewButton: UIControl? = sut.viewController.view.findView(with: ViewIdentifier.payButton)
-        let payButtonItemViewButtonTitle: UILabel? = sut.viewController.view.findView(with: ViewIdentifier.payButtonTitleLabel)
-
-        // TODO: FIX payButtonItemViewButton, payButtonItemViewButtonTitle, phoneNumberView, phoneNumberViewTitleLabel and phoneNumberViewTextField UI asserts
-//        XCTAssertEqual(payButtonItemViewButton?.backgroundColor, .red)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.backgroundColor, .red)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.textAlignment, .center)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.textColor, .white)
-//        XCTAssertEqual(payButtonItemViewButtonTitle?.font, .systemFont(ofSize: 22))
-
-        /// Test phone number field
-//        XCTAssertEqual(phoneNumberView?.backgroundColor, .red)
-//        XCTAssertEqual(phoneNumberViewTitleLabel?.textColor, .yellow)
-//        XCTAssertEqual(phoneNumberViewTitleLabel?.backgroundColor, .blue)
-//        XCTAssertEqual(phoneNumberViewTitleLabel?.textAlignment, .center)
-//        XCTAssertEqual(phoneNumberViewTitleLabel?.font, .systemFont(ofSize: 20))
-//        XCTAssertEqual(phoneNumberViewTextField?.backgroundColor, .red)
-//        XCTAssertEqual(phoneNumberViewTextField?.textAlignment, .right)
-//        XCTAssertEqual(phoneNumberViewTextField?.textColor, .brown)
-//        XCTAssertEqual(phoneNumberViewTextField?.font, .systemFont(ofSize: 13))
+        XCTAssertEqual(firstNameTitleLabel.textColor, .systemPink)
+        XCTAssertEqual(firstNameTextField.textColor, .systemPink)
+        XCTAssertEqual(lastNameTitleLabel.textColor, .systemPink)
+        XCTAssertEqual(lastNameTextField.textColor, .systemPink)
+        XCTAssertEqual(emailTitleLabel.textColor, .systemPink)
+        XCTAssertEqual(emailTextField.textColor, .systemPink)
+        XCTAssertEqual(phoneNumberViewTitleLabel.textColor, .systemPink)
+        XCTAssertEqual(phoneNumberViewTextField.textColor, .systemPink)
+        XCTAssertEqual(firstNameView.backgroundColor, .systemYellow)
+        XCTAssertEqual(lastNameView.backgroundColor, .systemYellow)
+        XCTAssertEqual(emailView.backgroundColor, .systemYellow)
+        XCTAssertEqual(phoneNumberView.backgroundColor, .systemYellow)
+        XCTAssertEqual(payButtonItemView.button.backgroundColor, .systemRed)
     }
 
     private func assertTextInputUI(


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

1. Tests uncommented and rewritten to satisfy new styling options:
- ACHDirectDebitComponentTests
- QiwiWalletComponentTests
- SEPADirectDebitComponentTests
- BasicPersonalInfoFormComponentTests (why not SevenEleven?)

2. I've added specific Cascade rules living in the `.windsurf/rules/`, as I noticed Sonnet 4.5 and Opus started to apply various techniques to edit files, resulting in a complete swift reformatting, and making review impossible

## Ticket [Optional]
<ticket>
COSDK-775
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [ ] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
