### PR TITLE
Migrate `FormPickerItemView` to `AdyenTheme`

### DIFF
--- a/Adyen/Core/Configuration/AddressLookupProvider.swift
+++ b/Adyen/Core/Configuration/AddressLookupProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) 2023 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Configuration/AddressLookupProvider.swift
+++ b/Adyen/Core/Configuration/AddressLookupProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2025 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -20,7 +20,7 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
     /// - Parameters:
     ///   - item: The item represented by the view.
     ///   - theme: The theme to use for styling.
-    override internal init(item: FormCardNumberItem, theme: AdyenTheme) {
+    internal required init(item: FormCardNumberItem, theme: AdyenTheme) {
         super.init(item: item, theme: theme)
         accessory = .customView(detectedBrandsView)
         if item.supportsCardScanning {

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -17,7 +17,7 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
     /// - Parameters:
     ///   - item: The item represented by the view.
     ///   - theme: The theme to use for styling.
-    override internal init(item: FormCardSecurityCodeItem, theme: AdyenTheme) {
+    internal required init(item: FormCardSecurityCodeItem, theme: AdyenTheme) {
         super.init(item: item, theme: theme)
         accessory = .customView(cardHintView)
         textField.allowsEditingActions = false

--- a/AdyenUI/UI/Form/FormItemViewBuilder.swift
+++ b/AdyenUI/UI/Form/FormItemViewBuilder.swift
@@ -41,7 +41,7 @@ public struct FormItemViewBuilder {
     @_spi(AdyenInternal)
     public func build<Value: CustomStringConvertible>(with item: BaseFormPickerItem<Value>)
         -> BaseFormPickerItemView<Value> {
-        BaseFormPickerItemView(item: item)
+        BaseFormPickerItemView(item: item, theme: theme)
     }
 
     /// Builds `FormTextInputItemView` from `FormTextInputItem`.
@@ -123,7 +123,7 @@ public struct FormItemViewBuilder {
     public func build<Value>(with item: FormPickerItem<Value>) -> FormItemView<
         FormPickerItem<Value>
     > {
-        FormPickerItemView(item: item)
+        FormPickerItemView(item: item, theme: theme)
     }
 
     /// Builds `FormPhoneExtensionPickerItemView` from `FormPhoneExtensionPickerItem`.

--- a/AdyenUI/UI/Form/Items/Address/Picker/FormAddressPickerItemView.swift
+++ b/AdyenUI/UI/Form/Items/Address/Picker/FormAddressPickerItemView.swift
@@ -8,11 +8,11 @@ import Adyen
 
 internal class FormAddressPickerItemView: FormSelectableValueItemView<PostalAddress, FormAddressPickerItem> {
     
-    internal required init(item: FormAddressPickerItem) {
-        super.init(item: item)
+    internal required init(item: FormAddressPickerItem, theme: AdyenTheme) {
+        super.init(item: item, theme: theme)
         self.numberOfLines = 0
     }
-    
+
     override internal func reset() {
         item.value = PostalAddress()
         resetValidationStatus()

--- a/AdyenUI/UI/Form/Items/Phone Number/FormPhoneNumberItemView.swift
+++ b/AdyenUI/UI/Form/Items/Phone Number/FormPhoneNumberItemView.swift
@@ -13,7 +13,7 @@ internal final class FormPhoneNumberItemView: FormTextItemView<FormPhoneNumberIt
     /// - Parameters:
     ///   - item: The item represented by the view.
     ///   - theme: The theme to use for styling.
-    override internal init(item: FormPhoneNumberItem, theme: AdyenTheme) {
+    internal required init(item: FormPhoneNumberItem, theme: AdyenTheme) {
         super.init(item: item, theme: theme)
         applyTextFieldLeftAccessoryView(textField: textField)
         textField.textContentType = .telephoneNumber

--- a/AdyenUI/UI/Form/Items/Text/FormTextInputItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextInputItemView.swift
@@ -17,7 +17,7 @@ open class FormTextInputItemView: FormTextItemView<FormTextInputItem> {
     /// - Parameters:
     ///   - item: The item represented by the view.
     ///   - theme: The theme to use for styling.
-    override public init(item: FormTextInputItem, theme: AdyenTheme) {
+    public required init(item: FormTextInputItem, theme: AdyenTheme) {
         super.init(item: item, theme: theme)
 
         observe(item.$isEnabled) { [weak self] isEnabled in

--- a/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
@@ -39,16 +39,12 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
     
     override public var accessibilityLabelView: UIView? { textField }
 
-    /// The theme for styling (accessible to subclasses)
-    package let theme: AdyenTheme
-
     /// Initializes the text item view with theme.
     /// - Parameters:
     ///   - item: The item represented by the view.
     ///   - theme: The theme to use for styling.
-    public init(item: ItemType, theme: AdyenTheme) {
-        self.theme = theme
-        super.init(item: item)
+    public required init(item: ItemType, theme: AdyenTheme) {
+        super.init(item: item, theme: theme)
 
         bind(item.$placeholder, to: textField, at: \.placeholder)
         observe(item.$formattedValue) { [weak self] newValue in

--- a/AdyenUI/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItemView.swift
@@ -37,9 +37,11 @@ open class BaseFormPickerItemView<T: CustomStringConvertible & Equatable>:
 
     /// Initializes the picker item view.
     ///
-    /// - Parameter item: The item represented by the view.
-    public required init(item: BaseFormPickerItem<T>) {
-        super.init(item: item)
+    /// - Parameters
+    ///   - item: The item represented by the view.
+    ///   - theme: The theme to use for styling.
+    public required init(item: BaseFormPickerItem<T>, theme: AdyenTheme) {
+        super.init(item: item, theme: theme)
         initialize()
         select(value: item.value)
         observe(item.$selectableValues) { [weak self] change in

--- a/AdyenUI/UI/Form/Items/Value/FormValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/FormValueItemView.swift
@@ -13,8 +13,7 @@ open class FormValueItemView<ValueType, Style, ItemType: FormValueItem<ValueType
     FormItemView<ItemType>,
     AnyFormValueItemView {
 
-    // TODO: Pass as a dependency
-    private let theme: AdyenTheme = .default
+    package let theme: AdyenTheme
 
     // MARK: - Title Label
 
@@ -32,8 +31,11 @@ open class FormValueItemView<ValueType, Style, ItemType: FormValueItem<ValueType
 
     /// Initializes the value item view.
     ///
-    /// - Parameter item: The item represented by the view.
-    public required init(item: ItemType) {
+    /// - Parameters:
+    ///   - item: The item represented by the view.
+    ///   - theme: The theme to apply to the view.
+    public required init(item: ItemType, theme: AdyenTheme) {
+        self.theme = theme
         super.init(item: item)
 
         bind(item.$title, to: self.titleLabel, at: \.text)
@@ -41,6 +43,13 @@ open class FormValueItemView<ValueType, Style, ItemType: FormValueItem<ValueType
         tintColor = item.style.tintColor
         backgroundColor = item.style.backgroundColor
         gestureRecognizers = [UITapGestureRecognizer(target: self, action: #selector(becomeFirstResponder))]
+    }
+
+    /// Convenience initializer using the default theme.
+    ///
+    /// - Parameter item: The item represented by the view.
+    public required convenience init(item: ItemType) {
+        self.init(item: item, theme: .default)
     }
     
     override open func didAddSubview(_ subview: UIView) {

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerItemView.swift
@@ -10,8 +10,8 @@ import UIKit
 @_spi(AdyenInternal)
 public class FormPickerItemView<Value: FormPickable>: FormSelectableValueItemView<Value, FormPickerItem<Value>> {
     
-    internal required init(item: FormPickerItem<Value>) {
-        super.init(item: item)
+    internal required init(item: FormPickerItem<Value>, theme: AdyenTheme) {
+        super.init(item: item, theme: theme)
         item.selectionHandler = { [weak self] in
             
             let topPresenter = self?.item.presenter

--- a/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
@@ -20,8 +20,8 @@ open class FormSelectableValueItemView<ValueType, ItemType: FormSelectableValueI
     
     override internal var accessibilityLabelView: UIView? { selectionButton }
     
-    public required init(item: ItemType) {
-        super.init(item: item)
+    public required init(item: ItemType, theme: AdyenTheme) {
+        super.init(item: item, theme: theme)
         
         addSubview(selectionButton)
         
@@ -90,7 +90,8 @@ open class FormSelectableValueItemView<ValueType, ItemType: FormSelectableValueI
     
     /// The value label view.
     internal lazy var valueLabel: UILabel = {
-        let valueLabel = ValueLabel(style: item.style.text)
+        let valueLabel = ValueLabel()
+        valueLabel.apply(theme.elements.labels.body)
         valueLabel.numberOfLines = numberOfLines
         valueLabel.isAccessibilityElement = false
         valueLabel.accessibilityIdentifier = item.identifier.map { ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "valueLabel") }
@@ -118,13 +119,13 @@ open class FormSelectableValueItemView<ValueType, ItemType: FormSelectableValueI
         
         guard let formattedValue, !formattedValue.isEmpty else {
             valueLabel.text = item.placeholder
-            valueLabel.textColor = item.style.placeholderText?.color ?? .Adyen.componentPlaceholderText
+            valueLabel.textColor = theme.colors.textSecondary
             resetValidationStatus()
             return
         }
         
         valueLabel.text = formattedValue
-        valueLabel.textColor = item.style.text.color
+        valueLabel.textColor = theme.elements.labels.body.color
         showValidation()
     }
     

--- a/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
@@ -15,16 +15,13 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
     
     private var itemObserver: Observation?
 
-    // TODO: Pass as dependency
-    private let theme: AdyenTheme = .default
-
-    public required init(item: ItemType) {
-        super.init(item: item)
+    public required init(item: ItemType, theme: AdyenTheme) {
+        super.init(item: item, theme: theme)
         
         setupObservers()
         updateValidationStatus()
     }
-    
+
     // MARK: - Views
     
     /// The alert label to be used to indicate an issue with the value
@@ -32,9 +29,9 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
     /// The intended use is to put it inside of a UIStackView as it will be hidden based on the validity of the item
     internal lazy var alertLabel: UILabel = {
         let alertLabel = UILabel()
-        alertLabel.textColor = item.style.errorColor
-        // TODO: Replace AdyenTheme with config's object theme style
+
         alertLabel.apply(theme.elements.labels.subheadline)
+        alertLabel.textColor = theme.colors.destructive
         alertLabel.isAccessibilityElement = false
         alertLabel.numberOfLines = 0
         alertLabel.text = item.validationFailureMessage

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
@@ -11,52 +11,281 @@ import XCTest
 
 private let placeholderText = "Placeholder"
 
+// MARK: - Mocks for FormSelectableValueItemView tests
+
 private class FormSelectableValueItemMock: FormSelectableValueItem<String?> {
-    required init() {
-        super.init(value: "", style: .init(), placeholder: placeholderText)
+    required convenience init() {
+        self.init(style: .init(), title: "Title", placeholder: placeholderText)
+    }
+
+    init(style: FormTextItemStyle, title: String = "Title", placeholder: String = placeholderText) {
+        super.init(value: nil, style: style, placeholder: placeholder)
+        self.title = title
     }
 }
 
-private class FormSelectableValueItemViewMock: FormSelectableValueItemView<String, FormSelectableValueItemMock> {}
+private class FormSelectableValueItemViewMock: FormSelectableValueItemView<
+    String, FormSelectableValueItemMock
+>
+{}
+
+// MARK: - Test Item (concrete subclass of abstract FormPickerItem)
+
+/// Concrete test implementation of FormPickerItem for testing FormPickerItemView
+private class TestFormPickerItem: FormPickerItem<FormPickerElement> {
+
+    convenience init(
+        style: FormTextItemStyle = .init(),
+        title: String = "Title",
+        placeholder: String = placeholderText,
+        preselectedValue: FormPickerElement? = nil,
+        selectableValues: [FormPickerElement] = []
+    ) {
+        self.init(
+            preselectedValue: preselectedValue,
+            selectableValues: selectableValues,
+            title: title,
+            placeholder: placeholder,
+            style: style,
+            presenter: nil
+        )
+    }
+
+    override public func resetValue() {
+        value = nil
+        formattedValue = nil
+    }
+
+    override public func updateValidationFailureMessage() {
+        validationFailureMessage = "Please select a value"
+    }
+
+    override public func updateFormattedValue() {
+        formattedValue = value?.title
+    }
+}
+
+// MARK: - Tests for FormSelectableValueItemView
 
 class FormSelectableItemViewTests: XCTestCase {
-    
+
     private var item: FormSelectableValueItemMock!
     private var sut: FormSelectableValueItemViewMock!
-    
+
     override func setUp() {
         item = FormSelectableValueItemMock()
         sut = FormSelectableValueItemViewMock(item: item)
     }
-    
+
     override func tearDown() {
         item = nil
         sut = nil
-        
         AdyenAssertion.listener = nil
     }
-    
+
     func testSelectionHandler() {
         AdyenAssertion.listener = { message in
-            XCTAssertEqual(message, "'selectionHandler' needs to be provided on 'FormSelectableValueItemMock'")
+            XCTAssertEqual(
+                message, "'selectionHandler' needs to be provided on 'FormSelectableValueItemMock'"
+            )
         }
         sut.selectionButtonTapped()
-        
+
         let expectation = expectation(description: "selection handler is called")
         item.selectionHandler = { expectation.fulfill() }
         sut.selectionButtonTapped()
         waitForExpectations(timeout: 10)
     }
-    
+
     func testValueUpdate() {
-        
         XCTAssertNil(item.formattedValue)
         XCTAssertEqual(sut.valueLabel.text, placeholderText)
-        
+
         item.formattedValue = ""
         XCTAssertEqual(sut.valueLabel.text, placeholderText)
-        
+
         item.formattedValue = "Hello World"
         XCTAssertEqual(sut.valueLabel.text, item.formattedValue)
+    }
+}
+
+// MARK: - Tests for FormPickerItemView (real production class)
+
+class FormPickerItemViewStyleTests: XCTestCase {
+
+    private var item: TestFormPickerItem!
+    private var sut: FormPickerItemView<FormPickerElement>!
+
+    override func setUp() {
+        item = TestFormPickerItem()
+        sut = FormPickerItemView(item: item)
+    }
+
+    override func tearDown() {
+        item = nil
+        sut = nil
+    }
+
+    // MARK: - Value Update Tests
+
+    func testValueLabel_withNoFormattedValue_shouldShowPlaceholder() {
+        XCTAssertNil(item.formattedValue)
+        XCTAssertEqual(sut.valueLabel.text, placeholderText)
+    }
+
+    func testValueLabel_withEmptyFormattedValue_shouldShowPlaceholder() {
+        item.formattedValue = ""
+        XCTAssertEqual(sut.valueLabel.text, placeholderText)
+    }
+
+    func testValueLabel_withFormattedValue_shouldShowValue() {
+        item.formattedValue = "Hello World"
+        XCTAssertEqual(sut.valueLabel.text, item.formattedValue)
+    }
+
+    // MARK: - Style Tests (Baseline before theme migration)
+
+    func testTitleLabel_shouldUseThemeBodyEmphasizedStyle() {
+        // Then - titleLabel is styled by theme (already migrated in FormValueItemView)
+        let expectedFont = AdyenTheme.default.elements.labels.bodyEmphasized.font
+        XCTAssertEqual(sut.titleLabel.font, expectedFont)
+    }
+
+    func testTitleLabel_shouldDisplayItemTitle() {
+        // Given
+        let customItem = TestFormPickerItem(title: "Custom Title")
+        let customSut = FormPickerItemView(item: customItem)
+
+        // Then
+        XCTAssertEqual(customSut.titleLabel.text, "Custom Title")
+    }
+
+    func testValueLabel_colorWithValue_shouldUseStyleTextColor() {
+        // Given - Current behavior: uses item.style.text.color
+        var style = FormTextItemStyle()
+        style.text.color = .systemBlue
+        let customItem = TestFormPickerItem(style: style)
+        customItem.formattedValue = "Has Value"
+
+        // When
+        let customSut = FormPickerItemView(item: customItem)
+
+        // Then - Currently reads from item.style.text.color
+        XCTAssertEqual(customSut.valueLabel.textColor, .systemBlue)
+    }
+
+    func testValueLabel_colorWithPlaceholder_shouldUsePlaceholderColor() {
+        // Given - Current behavior: uses item.style.placeholderText?.color
+        var style = FormTextItemStyle()
+        style.placeholderText = TextStyle(font: .systemFont(ofSize: 14), color: .systemGray)
+        let customItem = TestFormPickerItem(style: style, placeholder: "Placeholder")
+        customItem.formattedValue = nil
+
+        // When
+        let customSut = FormPickerItemView(item: customItem)
+
+        // Then - Currently reads from item.style.placeholderText?.color
+        XCTAssertEqual(customSut.valueLabel.textColor, .systemGray)
+    }
+
+    func testValueLabel_whenFormattedValueChanges_shouldUpdateColorToTextColor() {
+        // Given
+        var style = FormTextItemStyle()
+        style.text.color = .systemGreen
+        style.placeholderText = TextStyle(font: .systemFont(ofSize: 14), color: .systemGray)
+        let customItem = TestFormPickerItem(style: style)
+        customItem.formattedValue = nil
+        let customSut = FormPickerItemView(item: customItem)
+        XCTAssertEqual(customSut.valueLabel.textColor, .systemGray) // placeholder color
+
+        // When
+        customItem.formattedValue = "New Value"
+
+        // Then
+        XCTAssertEqual(customSut.valueLabel.textColor, .systemGreen) // text color
+    }
+
+    func testChevronView_shouldExist() {
+        XCTAssertNotNil(sut.chevronView)
+        XCTAssertNotNil(sut.chevronView.image)
+    }
+
+    // MARK: - TitleLabel Complete Style Tests
+
+    func testTitleLabel_color_shouldUseThemeBodyEmphasizedColor() {
+        // Then - titleLabel color is styled by theme (already migrated in FormValueItemView)
+        let expectedColor = AdyenTheme.default.elements.labels.bodyEmphasized.color
+        XCTAssertEqual(sut.titleLabel.textColor, expectedColor)
+    }
+
+    // MARK: - ValueLabel Font Tests
+
+    func testValueLabel_font_shouldUseStyleTextFont() {
+        // Given - Current behavior: uses item.style.text font
+        var style = FormTextItemStyle()
+        let customFont = UIFont.systemFont(ofSize: 20, weight: .bold)
+        style.text.font = customFont
+        let customItem = TestFormPickerItem(style: style)
+
+        // When
+        let customSut = FormPickerItemView(item: customItem)
+
+        // Then - Currently reads from item.style.text.font
+        XCTAssertEqual(customSut.valueLabel.font, customFont)
+    }
+
+    // MARK: - AlertLabel Style Tests
+
+    func testAlertLabel_color_shouldUseThemeSubheadlineColor() {
+        // BUG DOCUMENTATION: alertLabel.textColor is set to item.style.errorColor, but then
+        // alertLabel.apply(theme.elements.labels.subheadline) OVERWRITES it with the subheadline color.
+        // This means item.style.errorColor is never actually displayed.
+        // The current actual behavior uses theme.elements.labels.subheadline.color (not errorColor)
+        let expectedColor = AdyenTheme.default.elements.labels.subheadline.color
+        XCTAssertEqual(
+            sut.alertLabel.textColor?.resolvedColor(
+                with: UITraitCollection(userInterfaceStyle: .light)),
+            expectedColor.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
+        )
+    }
+
+    func testAlertLabel_font_shouldUseThemeSubheadlineStyle() {
+        // Then - alertLabel font is styled by theme (in FormValidatableValueItemView)
+        let expectedFont = AdyenTheme.default.elements.labels.subheadline.font
+        XCTAssertEqual(sut.alertLabel.font, expectedFont)
+    }
+
+    func testAlertLabel_text_shouldUseItemValidationFailureMessage() {
+        // Given - TestFormPickerItem sets validationFailureMessage in updateValidationFailureMessage()
+        // Then
+        XCTAssertEqual(sut.alertLabel.text, "Please select a value")
+    }
+
+    // MARK: - View-Level Style Tests
+
+    func testView_tintColor_shouldUseStyleTintColor() {
+        // Given - Current behavior: uses item.style.tintColor
+        var style = FormTextItemStyle()
+        style.tintColor = .systemPurple
+        let customItem = TestFormPickerItem(style: style)
+
+        // When
+        let customSut = FormPickerItemView(item: customItem)
+
+        // Then - Currently reads from item.style.tintColor
+        XCTAssertEqual(customSut.tintColor, .systemPurple)
+    }
+
+    func testView_backgroundColor_shouldUseStyleBackgroundColor() {
+        // Given - Current behavior: uses item.style.backgroundColor
+        var style = FormTextItemStyle()
+        style.backgroundColor = .systemYellow
+        let customItem = TestFormPickerItem(style: style)
+
+        // When
+        let customSut = FormPickerItemView(item: customItem)
+
+        // Then - Currently reads from item.style.backgroundColor
+        XCTAssertEqual(customSut.backgroundColor, .systemYellow)
     }
 }

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
@@ -24,10 +24,7 @@ private class FormSelectableValueItemMock: FormSelectableValueItem<String?> {
     }
 }
 
-private class FormSelectableValueItemViewMock: FormSelectableValueItemView<
-    String, FormSelectableValueItemMock
->
-{}
+private class FormSelectableValueItemViewMock: FormSelectableValueItemView<String, FormSelectableValueItemMock> {}
 
 // MARK: - Test Item (concrete subclass of abstract FormPickerItem)
 

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
@@ -160,49 +160,46 @@ class FormPickerItemViewStyleTests: XCTestCase {
         XCTAssertEqual(customSut.titleLabel.text, "Custom Title")
     }
 
-    func test_valueLabel_colorWithValue_shouldUseStyleTextColor() {
-        // Given - Current behavior: uses item.style.text.color
-        var style = FormTextItemStyle()
-        style.text.color = .systemBlue
-        let customItem = TestFormPickerItem(style: style)
+    func test_valueLabel_colorWithValue_shouldUseThemeBodyColor() {
+        // Given
+        let customItem = TestFormPickerItem()
         customItem.formattedValue = "Has Value"
 
         // When
         let customSut = FormPickerItemView(item: customItem)
 
-        // Then - Currently reads from item.style.text.color
-        XCTAssertEqual(customSut.valueLabel.textColor, .systemBlue)
+        // Then - Now uses theme.elements.labels.body.color
+        XCTAssertEqual(
+            customSut.valueLabel.textColor, AdyenTheme.default.elements.labels.body.color
+        )
     }
 
-    func test_valueLabel_colorWithPlaceholder_shouldUsePlaceholderColor() {
-        // Given - Current behavior: uses item.style.placeholderText?.color
-        var style = FormTextItemStyle()
-        style.placeholderText = TextStyle(font: .systemFont(ofSize: 14), color: .systemGray)
-        let customItem = TestFormPickerItem(style: style, placeholder: "Placeholder")
+    func test_valueLabel_colorWithPlaceholder_shouldUseThemeTextSecondary() {
+        // Given
+        let customItem = TestFormPickerItem(placeholder: "Placeholder")
         customItem.formattedValue = nil
 
         // When
         let customSut = FormPickerItemView(item: customItem)
 
-        // Then - Currently reads from item.style.placeholderText?.color
-        XCTAssertEqual(customSut.valueLabel.textColor, .systemGray)
+        // Then - Now uses theme.colors.textSecondary
+        XCTAssertEqual(customSut.valueLabel.textColor, AdyenTheme.default.colors.textSecondary)
     }
 
-    func test_valueLabel_whenFormattedValueChanges_shouldUpdateColorToTextColor() {
+    func test_valueLabel_whenFormattedValueChanges_shouldUpdateColorToThemeBodyColor() {
         // Given
-        var style = FormTextItemStyle()
-        style.text.color = .systemGreen
-        style.placeholderText = TextStyle(font: .systemFont(ofSize: 14), color: .systemGray)
-        let customItem = TestFormPickerItem(style: style)
+        let customItem = TestFormPickerItem()
         customItem.formattedValue = nil
         let customSut = FormPickerItemView(item: customItem)
-        XCTAssertEqual(customSut.valueLabel.textColor, .systemGray) // placeholder color
+        XCTAssertEqual(customSut.valueLabel.textColor, AdyenTheme.default.colors.textSecondary) // placeholder color
 
         // When
         customItem.formattedValue = "New Value"
 
-        // Then
-        XCTAssertEqual(customSut.valueLabel.textColor, .systemGreen) // text color
+        // Then - Now uses theme.elements.labels.body.color
+        XCTAssertEqual(
+            customSut.valueLabel.textColor, AdyenTheme.default.elements.labels.body.color
+        )
     }
 
     func test_chevronView_shouldExist() {
@@ -220,28 +217,16 @@ class FormPickerItemViewStyleTests: XCTestCase {
 
     // MARK: - ValueLabel Font Tests
 
-    func test_valueLabel_font_shouldUseStyleTextFont() {
-        // Given - Current behavior: uses item.style.text font
-        var style = FormTextItemStyle()
-        let customFont = UIFont.systemFont(ofSize: 20, weight: .bold)
-        style.text.font = customFont
-        let customItem = TestFormPickerItem(style: style)
-
-        // When
-        let customSut = FormPickerItemView(item: customItem)
-
-        // Then - Currently reads from item.style.text.font
-        XCTAssertEqual(customSut.valueLabel.font, customFont)
+    func test_valueLabel_font_shouldUseThemeBodyFont() {
+        // Then - Now uses theme.elements.labels.body.font
+        XCTAssertEqual(sut.valueLabel.font, AdyenTheme.default.elements.labels.body.font)
     }
 
     // MARK: - AlertLabel Style Tests
 
-    func test_alertLabel_color_shouldUseThemeSubheadlineColor() {
-        // BUG DOCUMENTATION: alertLabel.textColor is set to item.style.errorColor, but then
-        // alertLabel.apply(theme.elements.labels.subheadline) OVERWRITES it with the subheadline color.
-        // This means item.style.errorColor is never actually displayed.
-        // The current actual behavior uses theme.elements.labels.subheadline.color (not errorColor)
-        let expectedColor = AdyenTheme.default.elements.labels.subheadline.color
+    func test_alertLabel_color_shouldUseThemeDestructiveColor() {
+        // After migration: alertLabel uses theme.colors.destructive for error color
+        let expectedColor = AdyenTheme.default.colors.destructive
         XCTAssertEqual(
             sut.alertLabel.textColor?.resolvedColor(
                 with: UITraitCollection(userInterfaceStyle: .light)),

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
@@ -83,7 +83,7 @@ class FormSelectableItemViewTests: XCTestCase {
         AdyenAssertion.listener = nil
     }
 
-    func testSelectionHandler() {
+    func test_selectionHandler() {
         AdyenAssertion.listener = { message in
             XCTAssertEqual(
                 message, "'selectionHandler' needs to be provided on 'FormSelectableValueItemMock'"
@@ -97,7 +97,7 @@ class FormSelectableItemViewTests: XCTestCase {
         waitForExpectations(timeout: 10)
     }
 
-    func testValueUpdate() {
+    func test_valueUpdate() {
         XCTAssertNil(item.formattedValue)
         XCTAssertEqual(sut.valueLabel.text, placeholderText)
 
@@ -128,30 +128,30 @@ class FormPickerItemViewStyleTests: XCTestCase {
 
     // MARK: - Value Update Tests
 
-    func testValueLabel_withNoFormattedValue_shouldShowPlaceholder() {
+    func test_valueLabel_withNoFormattedValue_shouldShowPlaceholder() {
         XCTAssertNil(item.formattedValue)
         XCTAssertEqual(sut.valueLabel.text, placeholderText)
     }
 
-    func testValueLabel_withEmptyFormattedValue_shouldShowPlaceholder() {
+    func test_valueLabel_withEmptyFormattedValue_shouldShowPlaceholder() {
         item.formattedValue = ""
         XCTAssertEqual(sut.valueLabel.text, placeholderText)
     }
 
-    func testValueLabel_withFormattedValue_shouldShowValue() {
+    func test_valueLabel_withFormattedValue_shouldShowValue() {
         item.formattedValue = "Hello World"
         XCTAssertEqual(sut.valueLabel.text, item.formattedValue)
     }
 
     // MARK: - Style Tests (Baseline before theme migration)
 
-    func testTitleLabel_shouldUseThemeBodyEmphasizedStyle() {
+    func test_titleLabel_shouldUseThemeBodyEmphasizedStyle() {
         // Then - titleLabel is styled by theme (already migrated in FormValueItemView)
         let expectedFont = AdyenTheme.default.elements.labels.bodyEmphasized.font
         XCTAssertEqual(sut.titleLabel.font, expectedFont)
     }
 
-    func testTitleLabel_shouldDisplayItemTitle() {
+    func test_titleLabel_shouldDisplayItemTitle() {
         // Given
         let customItem = TestFormPickerItem(title: "Custom Title")
         let customSut = FormPickerItemView(item: customItem)
@@ -160,7 +160,7 @@ class FormPickerItemViewStyleTests: XCTestCase {
         XCTAssertEqual(customSut.titleLabel.text, "Custom Title")
     }
 
-    func testValueLabel_colorWithValue_shouldUseStyleTextColor() {
+    func test_valueLabel_colorWithValue_shouldUseStyleTextColor() {
         // Given - Current behavior: uses item.style.text.color
         var style = FormTextItemStyle()
         style.text.color = .systemBlue
@@ -174,7 +174,7 @@ class FormPickerItemViewStyleTests: XCTestCase {
         XCTAssertEqual(customSut.valueLabel.textColor, .systemBlue)
     }
 
-    func testValueLabel_colorWithPlaceholder_shouldUsePlaceholderColor() {
+    func test_valueLabel_colorWithPlaceholder_shouldUsePlaceholderColor() {
         // Given - Current behavior: uses item.style.placeholderText?.color
         var style = FormTextItemStyle()
         style.placeholderText = TextStyle(font: .systemFont(ofSize: 14), color: .systemGray)
@@ -188,7 +188,7 @@ class FormPickerItemViewStyleTests: XCTestCase {
         XCTAssertEqual(customSut.valueLabel.textColor, .systemGray)
     }
 
-    func testValueLabel_whenFormattedValueChanges_shouldUpdateColorToTextColor() {
+    func test_valueLabel_whenFormattedValueChanges_shouldUpdateColorToTextColor() {
         // Given
         var style = FormTextItemStyle()
         style.text.color = .systemGreen
@@ -205,14 +205,14 @@ class FormPickerItemViewStyleTests: XCTestCase {
         XCTAssertEqual(customSut.valueLabel.textColor, .systemGreen) // text color
     }
 
-    func testChevronView_shouldExist() {
+    func test_chevronView_shouldExist() {
         XCTAssertNotNil(sut.chevronView)
         XCTAssertNotNil(sut.chevronView.image)
     }
 
     // MARK: - TitleLabel Complete Style Tests
 
-    func testTitleLabel_color_shouldUseThemeBodyEmphasizedColor() {
+    func test_titleLabel_color_shouldUseThemeBodyEmphasizedColor() {
         // Then - titleLabel color is styled by theme (already migrated in FormValueItemView)
         let expectedColor = AdyenTheme.default.elements.labels.bodyEmphasized.color
         XCTAssertEqual(sut.titleLabel.textColor, expectedColor)
@@ -220,7 +220,7 @@ class FormPickerItemViewStyleTests: XCTestCase {
 
     // MARK: - ValueLabel Font Tests
 
-    func testValueLabel_font_shouldUseStyleTextFont() {
+    func test_valueLabel_font_shouldUseStyleTextFont() {
         // Given - Current behavior: uses item.style.text font
         var style = FormTextItemStyle()
         let customFont = UIFont.systemFont(ofSize: 20, weight: .bold)
@@ -236,7 +236,7 @@ class FormPickerItemViewStyleTests: XCTestCase {
 
     // MARK: - AlertLabel Style Tests
 
-    func testAlertLabel_color_shouldUseThemeSubheadlineColor() {
+    func test_alertLabel_color_shouldUseThemeSubheadlineColor() {
         // BUG DOCUMENTATION: alertLabel.textColor is set to item.style.errorColor, but then
         // alertLabel.apply(theme.elements.labels.subheadline) OVERWRITES it with the subheadline color.
         // This means item.style.errorColor is never actually displayed.
@@ -249,13 +249,13 @@ class FormPickerItemViewStyleTests: XCTestCase {
         )
     }
 
-    func testAlertLabel_font_shouldUseThemeSubheadlineStyle() {
+    func test_alertLabel_font_shouldUseThemeSubheadlineStyle() {
         // Then - alertLabel font is styled by theme (in FormValidatableValueItemView)
         let expectedFont = AdyenTheme.default.elements.labels.subheadline.font
         XCTAssertEqual(sut.alertLabel.font, expectedFont)
     }
 
-    func testAlertLabel_text_shouldUseItemValidationFailureMessage() {
+    func test_alertLabel_text_shouldUseItemValidationFailureMessage() {
         // Given - TestFormPickerItem sets validationFailureMessage in updateValidationFailureMessage()
         // Then
         XCTAssertEqual(sut.alertLabel.text, "Please select a value")
@@ -263,7 +263,7 @@ class FormPickerItemViewStyleTests: XCTestCase {
 
     // MARK: - View-Level Style Tests
 
-    func testView_tintColor_shouldUseStyleTintColor() {
+    func test_view_tintColor_shouldUseStyleTintColor() {
         // Given - Current behavior: uses item.style.tintColor
         var style = FormTextItemStyle()
         style.tintColor = .systemPurple
@@ -276,7 +276,7 @@ class FormPickerItemViewStyleTests: XCTestCase {
         XCTAssertEqual(customSut.tintColor, .systemPurple)
     }
 
-    func testView_backgroundColor_shouldUseStyleBackgroundColor() {
+    func test_view_backgroundColor_shouldUseStyleBackgroundColor() {
         // Given - Current behavior: uses item.style.backgroundColor
         var style = FormTextItemStyle()
         style.backgroundColor = .systemYellow

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableValueItemViewStyleTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableValueItemViewStyleTests.swift
@@ -1,0 +1,5 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

## Theme migration progress (14/23 completed)
### Completed
FormTextItemView
FormTextInputItemView
FormPhoneNumberItemView
FormCardNumberItemView
FormCardSecurityCodeItemView
FormSeparatorItemView
FormButtonItemView
FormToggleItemView
FormValueItemView (base class)
FormValidatableValueItemView (base class)

### Current PR
✅ FormSelectableValueItemView
✅ FormPickerItemView
✅ BaseFormPickerItemView
✅ FormAddressPickerItemView

### Not yet migrated
FormSpacerItemView
FormErrorItemView
FormSearchButtonItemView
FormSplitItemView
SelectableFormItemView
FormPhoneExtensionPickerItemView
FormVerticalStackItemView
FormCardLogosItemView
FormCoBadgedCardItemView

## Ticket [Optional]
<ticket>
COSDK-775
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
