### PR TITLE
Apple Pay: New delegate for didAuthorize

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -38,6 +38,9 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     /// The delegate changes of ApplePay payment state.
     public weak var applePayDelegate: ApplePayComponentDelegate?
     
+    /// The delegate for handling Apple Pay authorization validation.
+    public weak var authorizationDelegate: ApplePayAuthorizationDelegate?
+    
     /// Initializes the component.
     /// - Warning: Do not dismiss this component directly.
     ///  First, call `didFinalize(with:completion:)` on error or success, then dismiss it.

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -88,7 +88,8 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     public func didFinalize(with success: Bool, completion: (() -> Void)?) {
         if case let .submitted(paymentAuthorizationCompletion) = state {
             state = .finalized(completion)
-            paymentAuthorizationCompletion(success ? .success : .failure)
+            let result = PKPaymentAuthorizationResult(status: success ? .success : .failure, errors: nil)
+            paymentAuthorizationCompletion(result)
         } else {
             state = .initial
             completion?()
@@ -127,7 +128,7 @@ extension ApplePayComponent {
 
     internal enum State {
         case initial
-        case submitted((PKPaymentAuthorizationStatus) -> Void)
+        case submitted((PKPaymentAuthorizationResult) -> Void)
         case finalized((() -> Void)?)
     }
 

--- a/AdyenComponents/Apple Pay/ApplePayComponentDelegate.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentDelegate.swift
@@ -31,5 +31,38 @@ public protocol ApplePayComponentDelegate: AnyObject {
         for payment: ApplePayPayment,
         completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void
     )
+    
+    /// Tells the delegate that the shopper authorized the payment and asks for a validation result.
+    ///
+    /// Use this method to validate the shopper's payment information (e.g., billing/shipping address)
+    /// before the payment is submitted. You can perform synchronous or asynchronous validation,
+    /// including backend calls if needed.
+    ///
+    /// - Parameters:
+    ///   - payment: The authorized payment containing the token, billing/shipping contacts, and shipping method.
+    ///   - completion: The completion handler to call with the validation result.
+    ///   Call with `.success` to proceed, or `.failure` with errors to let the shopper retry.
+    ///
+    /// - Note: Return `.failure` with non-empty `errors` to keep the sheet open for correction.
+    ///   Use `PKPaymentRequest.paymentBillingAddressInvalidError(withKey:localizedDescription:)` or similar
+    ///   factory methods to create field-specific errors. If `errors` is empty on `.failure`, the system dismisses the sheet.
+    ///
+    /// - Note: If not implemented, the payment proceeds automatically.
+    func didAuthorize(
+        _ payment: PKPayment,
+        completion: @escaping (PKPaymentAuthorizationResult) -> Void
+    )
+}
 
+// MARK: - Default Implementations
+
+public extension ApplePayComponentDelegate {
+    
+    /// Default implementation that automatically authorizes the payment.
+    func didAuthorize(
+        _ payment: PKPayment,
+        completion: @escaping (PKPaymentAuthorizationResult) -> Void
+    ) {
+        completion(PKPaymentAuthorizationResult(status: .success, errors: nil))
+    }
 }

--- a/AdyenComponents/Apple Pay/ApplePayComponentDelegate.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentDelegate.swift
@@ -49,7 +49,7 @@ public protocol ApplePayComponentDelegate: AnyObject {
     ///
     /// - Note: If not implemented, the payment proceeds automatically.
     func didAuthorize(
-        _ payment: PKPayment,
+        payment: PKPayment,
         completion: @escaping (PKPaymentAuthorizationResult) -> Void
     )
 }
@@ -60,7 +60,7 @@ public extension ApplePayComponentDelegate {
     
     /// Default implementation that automatically authorizes the payment.
     func didAuthorize(
-        _ payment: PKPayment,
+        payment: PKPayment,
         completion: @escaping (PKPaymentAuthorizationResult) -> Void
     ) {
         completion(PKPaymentAuthorizationResult(status: .success, errors: nil))

--- a/AdyenComponents/Apple Pay/ApplePayComponentDelegate.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentDelegate.swift
@@ -7,7 +7,7 @@
 @_spi(AdyenInternal) import Adyen
 import PassKit
 
-/// Delegates methods that respond to shopper interactions with payment authorization view controller.
+/// Delegate methods that respond to shopper interactions with payment authorization view controller.
 public protocol ApplePayComponentDelegate: AnyObject {
 
     /// Tells the delegate that the shopper selected a shipping address, and asks for an updated payment request.
@@ -31,6 +31,13 @@ public protocol ApplePayComponentDelegate: AnyObject {
         for payment: ApplePayPayment,
         completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void
     )
+}
+
+/// Delegate that handles Apple Pay payment authorization validation.
+///
+/// Implement this protocol to validate the shopper's payment information (e.g., billing/shipping address)
+/// before the payment is submitted to Adyen.
+public protocol ApplePayAuthorizationDelegate: AnyObject {
     
     /// Tells the delegate that the shopper authorized the payment and asks for a validation result.
     ///
@@ -46,23 +53,8 @@ public protocol ApplePayComponentDelegate: AnyObject {
     /// - Note: Return `.failure` with non-empty `errors` to keep the sheet open for correction.
     ///   Use `PKPaymentRequest.paymentBillingAddressInvalidError(withKey:localizedDescription:)` or similar
     ///   factory methods to create field-specific errors. If `errors` is empty on `.failure`, the system dismisses the sheet.
-    ///
-    /// - Note: If not implemented, the payment proceeds automatically.
     func didAuthorize(
         payment: PKPayment,
         completion: @escaping (PKPaymentAuthorizationResult) -> Void
     )
-}
-
-// MARK: - Default Implementations
-
-public extension ApplePayComponentDelegate {
-    
-    /// Default implementation that automatically authorizes the payment.
-    func didAuthorize(
-        payment: PKPayment,
-        completion: @escaping (PKPaymentAuthorizationResult) -> Void
-    ) {
-        completion(PKPaymentAuthorizationResult(status: .success, errors: nil))
-    }
 }

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -34,7 +34,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         // Call the delegate's didAuthorize method for validation
         // If no delegate is set, proceed directly with payment submission
         if let applePayDelegate {
-            applePayDelegate.didAuthorize(payment) { [weak self] result in
+            applePayDelegate.didAuthorize(payment: payment) { [weak self] result in
                 guard let self else { return }
                 if result.status == .success {
                     self.proceedWithSubmission(for: payment, completion: completion)

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -31,10 +31,10 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
             return
         }
 
-        // Call the delegate's didAuthorize method for validation
+        // Call the authorization delegate's didAuthorize method for validation
         // If no delegate is set, proceed directly with payment submission
-        if let applePayDelegate {
-            applePayDelegate.didAuthorize(payment: payment) { [weak self] result in
+        if let authorizationDelegate {
+            authorizationDelegate.didAuthorize(payment: payment) { [weak self] result in
                 guard let self else { return }
                 if result.status == .success {
                     self.proceedWithSubmission(for: payment, completion: completion)

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -23,28 +23,31 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     public func paymentAuthorizationViewController(
         _ controller: PKPaymentAuthorizationViewController,
         didAuthorizePayment payment: PKPayment,
-        completion: @escaping (PKPaymentAuthorizationStatus) -> Void
+        handler completion: @escaping (PKPaymentAuthorizationResult) -> Void
     ) {
         guard payment.token.paymentData.isEmpty == false else {
-            completion(.failure)
+            completion(PKPaymentAuthorizationResult(status: .failure, errors: nil))
             delegate?.didFail(with: Error.invalidToken, from: self)
             return
         }
 
-        state = .submitted(completion)
-        let token = payment.token.paymentData.base64EncodedString()
-        let network = payment.token.paymentMethod.network?.rawValue ?? ""
-        let details = ApplePayDetails(
-            paymentMethod: applePayPaymentMethod,
-            token: token,
-            network: network,
-            billingContact: payment.billingContact,
-            shippingContact: payment.shippingContact,
-            shippingMethod: payment.shippingMethod
-        )
-        submit(data: PaymentComponentData(paymentMethodDetails: details, amount: applePayPayment.amount, order: order))
+        // Call the delegate's didAuthorize method for validation
+        // If no delegate is set, proceed directly with payment submission
+        if let applePayDelegate {
+            applePayDelegate.didAuthorize(payment) { [weak self] result in
+                guard let self else { return }
+                if result.status == .success {
+                    self.proceedWithSubmission(for: payment, completion: completion)
+                } else {
+                    // Validation failed - pass the result back to Apple Pay
+                    completion(result)
+                }
+            }
+        } else {
+            proceedWithSubmission(for: payment, completion: completion)
+        }
     }
-
+    
     public func paymentAuthorizationViewController(
         _ controller: PKPaymentAuthorizationViewController,
         didSelectShippingContact contact: PKContact,
@@ -111,6 +114,28 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
                 delegate?.didFail(with: error, from: self)
             }
         }
+    }
+    
+    private func proceedWithSubmission(
+        for payment: PKPayment,
+        completion: @escaping (PKPaymentAuthorizationResult) -> Void
+    ) {
+        state = .submitted(completion)
+        performSubmit(with: payment)
+    }
+    
+    private func performSubmit(with payment: PKPayment) {
+        let token = payment.token.paymentData.base64EncodedString()
+        let network = payment.token.paymentMethod.network?.rawValue ?? ""
+        let details = ApplePayDetails(
+            paymentMethod: applePayPaymentMethod,
+            token: token,
+            network: network,
+            billingContact: payment.billingContact,
+            shippingContact: payment.shippingContact,
+            shippingMethod: payment.shippingMethod
+        )
+        submit(data: PaymentComponentData(paymentMethodDetails: details, amount: applePayPayment.amount, order: order))
     }
 
 }

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -121,10 +121,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         completion: @escaping (PKPaymentAuthorizationResult) -> Void
     ) {
         state = .submitted(completion)
-        performSubmit(with: payment)
-    }
-    
-    private func performSubmit(with payment: PKPayment) {
+        
         let token = payment.token.paymentData.base64EncodedString()
         let network = payment.token.paymentMethod.network?.rawValue ?? ""
         let details = ApplePayDetails(
@@ -135,7 +132,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
             shippingContact: payment.shippingContact,
             shippingMethod: payment.shippingMethod
         )
+        
         submit(data: PaymentComponentData(paymentMethodDetails: details, amount: applePayPayment.amount, order: order))
     }
-
 }

--- a/Demo/Common/Assets/Localizable.xcstrings
+++ b/Demo/Common/Assets/Localizable.xcstrings
@@ -100,6 +100,9 @@
     "Korean Authentication Mode" : {
 
     },
+    "Return success from didAuthorize" : {
+
+    },
     "Save" : {
 
     },
@@ -107,6 +110,9 @@
 
     },
     "Set to country currency" : {
+
+    },
+    "Simulate a success or a failure from the didAuthorize delegate method." : {
 
     },
     "Skip Payment List" : {

--- a/Demo/Common/Configuration/ApplePaySettingsView.swift
+++ b/Demo/Common/Configuration/ApplePaySettingsView.swift
@@ -27,6 +27,12 @@ internal struct ApplePaySettingsView: View {
                     Toggle(isOn: $viewModel.allowOnboarding) {
                         Text("Allow OnBoarding")
                     }
+                    Toggle(isOn: $viewModel.applePayDidAuthorizeSuccessful) {
+                        Text("Return success from didAuthorize")
+                        Text("When false, simulates a shipping error returned from the didAuthorize delegate method.")
+                            .foregroundColor(.gray)
+                            .font(.footnote)
+                    }
                 }
             }
             .navigationBarTitle("")

--- a/Demo/Common/Configuration/ConfigurationViewModel.swift
+++ b/Demo/Common/Configuration/ConfigurationViewModel.swift
@@ -31,6 +31,7 @@ internal final class ConfigurationViewModel: ObservableObject {
     @Published internal var allowForceCardRedirectAction: Bool = false
     
     @Published internal var applePayMerchantIdentifier: String = ""
+    @Published internal var applePayDidAuthorizeSuccessful: Bool = true
     @Published internal var allowOnboarding: Bool = false
     @Published internal var analyticsIsEnabled: Bool = true
     @Published internal var installmentsEnabled: Bool = false
@@ -68,6 +69,7 @@ internal final class ConfigurationViewModel: ObservableObject {
         self.allowForceCardRedirectAction = configuration.threeDSConfigurationSettings.allowForceCardRedirectAction
         self.applePayMerchantIdentifier = configuration.applePaySettings.merchantIdentifier
         self.allowOnboarding = configuration.applePaySettings.allowOnboarding
+        self.applePayDidAuthorizeSuccessful = configuration.applePaySettings.didAuthorizeSuccessful
         self.analyticsIsEnabled = configuration.analyticsSettings.isEnabled
         self.installmentsEnabled = configuration.cardSettings.enableInstallments
         self.showInstallmentAmount = configuration.cardSettings.showsInstallmentAmount
@@ -109,7 +111,8 @@ internal final class ConfigurationViewModel: ObservableObject {
             ),
             applePaySettings: ApplePaySettings(
                 merchantIdentifier: applePayMerchantIdentifier,
-                allowOnboarding: allowOnboarding
+                allowOnboarding: allowOnboarding,
+                didAuthorizeSuccessful: applePayDidAuthorizeSuccessful
             ),
             analyticsSettings: AnalyticsSettings(isEnabled: analyticsIsEnabled)
         )

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
@@ -75,6 +75,7 @@ internal final class ApplePayComponentAdvancedFlowExample: InitialDataAdvancedFl
         )
         component.delegate = self
         component.applePayDelegate = self
+        component.authorizationDelegate = self
         return component
     }
 
@@ -195,6 +196,10 @@ extension ApplePayComponentAdvancedFlowExample: ApplePayComponentDelegate {
         completion(.init(paymentSummaryItems: items))
     }
 
+}
+
+extension ApplePayComponentAdvancedFlowExample: ApplePayAuthorizationDelegate {
+    
     func didAuthorize(
         payment: PKPayment,
         completion: @escaping (PKPaymentAuthorizationResult) -> Void
@@ -208,6 +213,5 @@ extension ApplePayComponentAdvancedFlowExample: ApplePayComponentDelegate {
             )
             completion(.init(status: .failure, errors: [postalCodeError]))
         }
-        
     }
 }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
@@ -195,4 +195,19 @@ extension ApplePayComponentAdvancedFlowExample: ApplePayComponentDelegate {
         completion(.init(paymentSummaryItems: items))
     }
 
+    func didAuthorize(
+        payment: PKPayment,
+        completion: @escaping (PKPaymentAuthorizationResult) -> Void
+    ) {
+        if ConfigurationConstants.current.applePaySettings.didAuthorizeSuccessful {
+            completion(.init(status: .success, errors: nil))
+        } else {
+            let postalCodeError = PKPaymentRequest.paymentShippingAddressInvalidError(
+                withKey: CNPostalAddressPostalCodeKey,
+                localizedDescription: "Wrong postal code"
+            )
+            completion(.init(status: .failure, errors: [postalCodeError]))
+        }
+        
+    }
 }

--- a/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
@@ -7,6 +7,7 @@
 import Adyen
 import AdyenComponents
 import AdyenSession
+import PassKit
 
 internal final class ApplePayComponentExample: InitialDataFlowProtocol {
 
@@ -90,6 +91,7 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
             configuration: config
         )
         component.delegate = session
+        component.authorizationDelegate = self
         return component
     }
 
@@ -131,4 +133,22 @@ extension ApplePayComponentExample: PresentationDelegate {
     // The implementation of this delegate method is not needed when using AdyenSession
     internal func present(component: PresentableComponent) {}
 
+}
+
+extension ApplePayComponentExample: ApplePayAuthorizationDelegate {
+    
+    func didAuthorize(
+        payment: PKPayment,
+        completion: @escaping (PKPaymentAuthorizationResult) -> Void
+    ) {
+        if ConfigurationConstants.current.applePaySettings.didAuthorizeSuccessful {
+            completion(.init(status: .success, errors: nil))
+        } else {
+            let postalCodeError = PKPaymentRequest.paymentShippingAddressInvalidError(
+                withKey: CNPostalAddressPostalCodeKey,
+                localizedDescription: "Wrong postal code"
+            )
+            completion(.init(status: .failure, errors: [postalCodeError]))
+        }
+    }
 }

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -129,6 +129,7 @@ internal struct ThreeDSConfigurationSettings: Codable {
 internal struct ApplePaySettings: Codable {
     internal var merchantIdentifier: String
     internal var allowOnboarding: Bool = false
+    internal var didAuthorizeSuccessful: Bool = true
 }
 
 internal struct AnalyticsSettings: Codable {
@@ -202,7 +203,8 @@ internal struct DemoAppSettings: Codable {
 
     internal static let defaultApplePaySettings = ApplePaySettings(
         merchantIdentifier: ConfigurationConstants.applePayMerchantIdentifier,
-        allowOnboarding: false
+        allowOnboarding: false,
+        didAuthorizeSuccessful: true
     )
 
     internal static let defaultAnalyticsSettings = AnalyticsSettings(isEnabled: true)

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -14,6 +14,7 @@ class ApplePayComponentTest: XCTestCase {
 
     var mockDelegate: PaymentComponentDelegateMock!
     var mockApplePayDelegate: ApplePayDelegateMock!
+    var mockAuthorizationDelegate: ApplePayAuthorizationDelegateMock!
     var sut: ApplePayComponent!
     lazy var amount = Amount(value: 2, currencyCode: "USD")
     lazy var payment = Payment(amount: amount, countryCode: getRandomCountryCode())
@@ -41,11 +42,13 @@ class ApplePayComponentTest: XCTestCase {
         } else {
             mockApplePayDelegate = ApplePayDelegateMockClassic()
         }
+        mockAuthorizationDelegate = ApplePayAuthorizationDelegateMock()
     }
 
     override func tearDown() {
         sut = nil
         mockDelegate = nil
+        mockAuthorizationDelegate = nil
         
         UIApplication.shared.adyen.mainKeyWindow?.rootViewController?.dismiss(animated: false)
         setupRootViewController(emptyVC)
@@ -469,7 +472,7 @@ class ApplePayComponentTest: XCTestCase {
         wait(for: .seconds(1))
         
         sut.delegate = mockDelegate
-        sut.applePayDelegate = mockApplePayDelegate
+        sut.authorizationDelegate = mockAuthorizationDelegate
         
         let didSubmitExpectation = expectation(description: "didSubmit should be called")
         mockDelegate.onDidSubmit = { data, component in
@@ -477,7 +480,7 @@ class ApplePayComponentTest: XCTestCase {
             didSubmitExpectation.fulfill()
         }
         
-        mockApplePayDelegate.onAuthorize = { payment in
+        mockAuthorizationDelegate.onAuthorize = { payment in
             // Simulate successful validation
             PKPaymentAuthorizationResult(status: .success, errors: nil)
         }
@@ -494,7 +497,7 @@ class ApplePayComponentTest: XCTestCase {
         
         // Then
         waitForExpectations(timeout: 5)
-        XCTAssertNotNil(mockApplePayDelegate.authorizedPayment)
+        XCTAssertNotNil(mockAuthorizationDelegate.authorizedPayment)
     }
     
     func test_didAuthorizeFailure_shouldNotTriggerDidSubmit() {
@@ -502,7 +505,7 @@ class ApplePayComponentTest: XCTestCase {
         wait(for: .seconds(1))
         
         sut.delegate = mockDelegate
-        sut.applePayDelegate = mockApplePayDelegate
+        sut.authorizationDelegate = mockAuthorizationDelegate
         
         var didSubmitCalled = false
         mockDelegate.onDidSubmit = { _, _ in
@@ -511,7 +514,7 @@ class ApplePayComponentTest: XCTestCase {
         
         let authorizationCompletionExpectation = expectation(description: "Authorization completion should be called with failure")
         
-        mockApplePayDelegate.onAuthorize = { payment in
+        mockAuthorizationDelegate.onAuthorize = { payment in
             // Simulate validation failure with specific errors
             let error = PKPaymentRequest.paymentShippingAddressInvalidError(
                 withKey: CNPostalAddressPostalCodeKey,
@@ -536,7 +539,7 @@ class ApplePayComponentTest: XCTestCase {
         // Then
         waitForExpectations(timeout: 5)
         XCTAssertFalse(didSubmitCalled, "didSubmit should not be called when authorization fails")
-        XCTAssertNotNil(mockApplePayDelegate.authorizedPayment)
+        XCTAssertNotNil(mockAuthorizationDelegate.authorizedPayment)
     }
     
     func test_didAuthorizeWithoutDelegate_shouldAutoApproveAndSubmit() {
@@ -544,7 +547,7 @@ class ApplePayComponentTest: XCTestCase {
         wait(for: .seconds(1))
         
         sut.delegate = mockDelegate
-        // Note: applePayDelegate is NOT set - should use default behavior
+        // Note: authorizationDelegate is NOT set - should use default behavior
         
         let didSubmitExpectation = expectation(description: "didSubmit should be called")
         mockDelegate.onDidSubmit = { data, component in
@@ -566,12 +569,12 @@ class ApplePayComponentTest: XCTestCase {
         waitForExpectations(timeout: 5)
     }
     
-    func tes_didAuthorizeWithEmptyToken_shouldFailImmediately() {
+    func test_didAuthorizeWithEmptyToken_shouldFailImmediately() {
         // Given
         wait(for: .seconds(1))
         
         sut.delegate = mockDelegate
-        sut.applePayDelegate = mockApplePayDelegate
+        sut.authorizationDelegate = mockAuthorizationDelegate
         
         let didFailExpectation = expectation(description: "didFail should be called")
         mockDelegate.onDidFail = { error, component in
@@ -580,7 +583,7 @@ class ApplePayComponentTest: XCTestCase {
         }
         
         var authorizeCalled = false
-        mockApplePayDelegate.onAuthorize = { _ in
+        mockAuthorizationDelegate.onAuthorize = { _ in
             authorizeCalled = true
             return PKPaymentAuthorizationResult(status: .success, errors: nil)
         }
@@ -601,36 +604,6 @@ class ApplePayComponentTest: XCTestCase {
         // Then
         waitForExpectations(timeout: 5)
         XCTAssertFalse(authorizeCalled, "didAuthorize should not be called when token is empty")
-    }
-    
-    func test_didAuthorizeWithDelegateUsingDefaultImplementation_shouldAutoApproveAndSubmit() {
-        // Given
-        // Delegate is set but onAuthorize is NOT set - uses default auto-approve behavior
-        wait(for: .seconds(1))
-        
-        sut.delegate = mockDelegate
-        sut.applePayDelegate = mockApplePayDelegate
-        // Note: NOT setting mockApplePayDelegate.onAuthorize - uses default
-        
-        let didSubmitExpectation = expectation(description: "didSubmit should be called")
-        mockDelegate.onDidSubmit = { data, component in
-            XCTAssertTrue(data.paymentMethod is ApplePayDetails)
-            didSubmitExpectation.fulfill()
-        }
-        
-        let mockPayment = PKPaymentMock.create(withPaymentData: "test_token".data(using: .utf8)!)
-        
-        // When
-        sut.paymentAuthorizationViewController(
-            sut.viewController as! PKPaymentAuthorizationViewController,
-            didAuthorizePayment: mockPayment
-        ) { result in
-            // Completion called after finalize
-        }
-        
-        // Then
-        waitForExpectations(timeout: 5)
-        XCTAssertNotNil(mockApplePayDelegate.authorizedPayment, "didAuthorize should still be called")
     }
     
 }

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -464,7 +464,7 @@ class ApplePayComponentTest: XCTestCase {
     
     // MARK: - didAuthorize Tests
     
-    func testDidAuthorizeSuccess_shouldTriggerDidSubmit() {
+    func test_didAuthorizeSuccess_shouldTriggerDidSubmit() {
         // Given
         wait(for: .seconds(1))
         
@@ -497,7 +497,7 @@ class ApplePayComponentTest: XCTestCase {
         XCTAssertNotNil(mockApplePayDelegate.authorizedPayment)
     }
     
-    func testDidAuthorizeFailure_shouldNotTriggerDidSubmit() {
+    func test_didAuthorizeFailure_shouldNotTriggerDidSubmit() {
         // Given
         wait(for: .seconds(1))
         
@@ -539,7 +539,7 @@ class ApplePayComponentTest: XCTestCase {
         XCTAssertNotNil(mockApplePayDelegate.authorizedPayment)
     }
     
-    func testDidAuthorizeWithoutDelegate_shouldAutoApproveAndSubmit() {
+    func test_didAuthorizeWithoutDelegate_shouldAutoApproveAndSubmit() {
         // Given
         wait(for: .seconds(1))
         
@@ -566,7 +566,7 @@ class ApplePayComponentTest: XCTestCase {
         waitForExpectations(timeout: 5)
     }
     
-    func testDidAuthorizeWithEmptyToken_shouldFailImmediately() {
+    func tes_didAuthorizeWithEmptyToken_shouldFailImmediately() {
         // Given
         wait(for: .seconds(1))
         
@@ -603,7 +603,7 @@ class ApplePayComponentTest: XCTestCase {
         XCTAssertFalse(authorizeCalled, "didAuthorize should not be called when token is empty")
     }
     
-    func testDidAuthorizeWithDelegateUsingDefaultImplementation_shouldAutoApproveAndSubmit() {
+    func test_didAuthorizeWithDelegateUsingDefaultImplementation_shouldAutoApproveAndSubmit() {
         // Given
         // Delegate is set but onAuthorize is NOT set - uses default auto-approve behavior
         wait(for: .seconds(1))

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -6,6 +6,7 @@
 
 @_spi(AdyenInternal) @testable import Adyen
 @_spi(AdyenInternal) @testable import AdyenComponents
+import Contacts
 import PassKit
 import XCTest
 
@@ -461,6 +462,246 @@ class ApplePayComponentTest: XCTestCase {
         return contactFieldsPool.randomElement().map { [$0] } ?? []
     }
     
+    // MARK: - didAuthorize Tests
+    
+    func testDidAuthorizeSuccess_shouldTriggerDidSubmit() {
+        // Given
+        wait(for: .seconds(1))
+        
+        sut.delegate = mockDelegate
+        sut.applePayDelegate = mockApplePayDelegate
+        
+        let didSubmitExpectation = expectation(description: "didSubmit should be called")
+        mockDelegate.onDidSubmit = { data, component in
+            XCTAssertTrue(data.paymentMethod is ApplePayDetails)
+            didSubmitExpectation.fulfill()
+        }
+        
+        mockApplePayDelegate.onAuthorize = { payment in
+            // Simulate successful validation
+            PKPaymentAuthorizationResult(status: .success, errors: nil)
+        }
+        
+        let mockPayment = PKPaymentMock.create(withPaymentData: "test_token".data(using: .utf8)!)
+        
+        // When
+        sut.paymentAuthorizationViewController(
+            sut.viewController as! PKPaymentAuthorizationViewController,
+            didAuthorizePayment: mockPayment
+        ) { result in
+            // This completion is called after finalize, not after authorize
+        }
+        
+        // Then
+        waitForExpectations(timeout: 5)
+        XCTAssertNotNil(mockApplePayDelegate.authorizedPayment)
+    }
+    
+    func testDidAuthorizeFailure_shouldNotTriggerDidSubmit() {
+        // Given
+        wait(for: .seconds(1))
+        
+        sut.delegate = mockDelegate
+        sut.applePayDelegate = mockApplePayDelegate
+        
+        var didSubmitCalled = false
+        mockDelegate.onDidSubmit = { _, _ in
+            didSubmitCalled = true
+        }
+        
+        let authorizationCompletionExpectation = expectation(description: "Authorization completion should be called with failure")
+        
+        mockApplePayDelegate.onAuthorize = { payment in
+            // Simulate validation failure with specific errors
+            let error = PKPaymentRequest.paymentShippingAddressInvalidError(
+                withKey: CNPostalAddressPostalCodeKey,
+                localizedDescription: "Invalid postal code"
+            )
+            return PKPaymentAuthorizationResult(status: .failure, errors: [error])
+        }
+        
+        let mockPayment = PKPaymentMock.create(withPaymentData: "test_token".data(using: .utf8)!)
+        
+        // When
+        sut.paymentAuthorizationViewController(
+            sut.viewController as! PKPaymentAuthorizationViewController,
+            didAuthorizePayment: mockPayment
+        ) { result in
+            // Completion should be called with failure result
+            XCTAssertEqual(result.status, .failure)
+            XCTAssertEqual(result.errors?.count, 1)
+            authorizationCompletionExpectation.fulfill()
+        }
+        
+        // Then
+        waitForExpectations(timeout: 5)
+        XCTAssertFalse(didSubmitCalled, "didSubmit should not be called when authorization fails")
+        XCTAssertNotNil(mockApplePayDelegate.authorizedPayment)
+    }
+    
+    func testDidAuthorizeWithoutDelegate_shouldAutoApproveAndSubmit() {
+        // Given
+        wait(for: .seconds(1))
+        
+        sut.delegate = mockDelegate
+        // Note: applePayDelegate is NOT set - should use default behavior
+        
+        let didSubmitExpectation = expectation(description: "didSubmit should be called")
+        mockDelegate.onDidSubmit = { data, component in
+            XCTAssertTrue(data.paymentMethod is ApplePayDetails)
+            didSubmitExpectation.fulfill()
+        }
+        
+        let mockPayment = PKPaymentMock.create(withPaymentData: "test_token".data(using: .utf8)!)
+        
+        // When
+        sut.paymentAuthorizationViewController(
+            sut.viewController as! PKPaymentAuthorizationViewController,
+            didAuthorizePayment: mockPayment
+        ) { result in
+            // Completion called after finalize
+        }
+        
+        // Then
+        waitForExpectations(timeout: 5)
+    }
+    
+    func testDidAuthorizeWithEmptyToken_shouldFailImmediately() {
+        // Given
+        wait(for: .seconds(1))
+        
+        sut.delegate = mockDelegate
+        sut.applePayDelegate = mockApplePayDelegate
+        
+        let didFailExpectation = expectation(description: "didFail should be called")
+        mockDelegate.onDidFail = { error, component in
+            XCTAssertEqual(error as? ApplePayComponent.Error, .invalidToken)
+            didFailExpectation.fulfill()
+        }
+        
+        var authorizeCalled = false
+        mockApplePayDelegate.onAuthorize = { _ in
+            authorizeCalled = true
+            return PKPaymentAuthorizationResult(status: .success, errors: nil)
+        }
+        
+        let mockPayment = PKPaymentMock.create(withPaymentData: Data()) // Empty token
+        
+        let completionExpectation = expectation(description: "Completion should be called with failure")
+        
+        // When
+        sut.paymentAuthorizationViewController(
+            sut.viewController as! PKPaymentAuthorizationViewController,
+            didAuthorizePayment: mockPayment
+        ) { result in
+            XCTAssertEqual(result.status, .failure)
+            completionExpectation.fulfill()
+        }
+        
+        // Then
+        waitForExpectations(timeout: 5)
+        XCTAssertFalse(authorizeCalled, "didAuthorize should not be called when token is empty")
+    }
+    
+    func testDidAuthorizeWithDelegateUsingDefaultImplementation_shouldAutoApproveAndSubmit() {
+        // Given
+        // Delegate is set but onAuthorize is NOT set - uses default auto-approve behavior
+        wait(for: .seconds(1))
+        
+        sut.delegate = mockDelegate
+        sut.applePayDelegate = mockApplePayDelegate
+        // Note: NOT setting mockApplePayDelegate.onAuthorize - uses default
+        
+        let didSubmitExpectation = expectation(description: "didSubmit should be called")
+        mockDelegate.onDidSubmit = { data, component in
+            XCTAssertTrue(data.paymentMethod is ApplePayDetails)
+            didSubmitExpectation.fulfill()
+        }
+        
+        let mockPayment = PKPaymentMock.create(withPaymentData: "test_token".data(using: .utf8)!)
+        
+        // When
+        sut.paymentAuthorizationViewController(
+            sut.viewController as! PKPaymentAuthorizationViewController,
+            didAuthorizePayment: mockPayment
+        ) { result in
+            // Completion called after finalize
+        }
+        
+        // Then
+        waitForExpectations(timeout: 5)
+        XCTAssertNotNil(mockApplePayDelegate.authorizedPayment, "didAuthorize should still be called")
+    }
+    
+}
+
+// MARK: - PKPayment Mock
+
+/// Mock PKPayment for testing purposes.
+/// PKPayment cannot be instantiated directly, so we use a subclass with mocked properties.
+private final class PKPaymentMock: PKPayment {
+    
+    private let _token: PKPaymentToken
+    private let _billingContact: PKContact?
+    private let _shippingContact: PKContact?
+    private let _shippingMethod: PKShippingMethod?
+    
+    override var token: PKPaymentToken { _token }
+    override var billingContact: PKContact? { _billingContact }
+    override var shippingContact: PKContact? { _shippingContact }
+    override var shippingMethod: PKShippingMethod? { _shippingMethod }
+    
+    private init(
+        token: PKPaymentToken,
+        billingContact: PKContact? = nil,
+        shippingContact: PKContact? = nil,
+        shippingMethod: PKShippingMethod? = nil
+    ) {
+        self._token = token
+        self._billingContact = billingContact
+        self._shippingContact = shippingContact
+        self._shippingMethod = shippingMethod
+        super.init()
+    }
+    
+    static func create(
+        withPaymentData paymentData: Data,
+        billingContact: PKContact? = nil,
+        shippingContact: PKContact? = nil,
+        shippingMethod: PKShippingMethod? = nil
+    ) -> PKPaymentMock {
+        let token = PKPaymentTokenMock(paymentData: paymentData)
+        return PKPaymentMock(
+            token: token,
+            billingContact: billingContact,
+            shippingContact: shippingContact,
+            shippingMethod: shippingMethod
+        )
+    }
+}
+
+/// Mock PKPaymentToken for testing purposes.
+private final class PKPaymentTokenMock: PKPaymentToken {
+    
+    private let _paymentData: Data
+    private let _paymentMethod: PKPaymentMethod
+    
+    override var paymentData: Data { _paymentData }
+    override var paymentMethod: PKPaymentMethod { _paymentMethod }
+    
+    init(paymentData: Data) {
+        self._paymentData = paymentData
+        self._paymentMethod = PKPaymentMethodMock()
+        super.init()
+    }
+}
+
+/// Mock PKPaymentMethod for testing purposes.
+private final class PKPaymentMethodMock: PKPaymentMethod {
+    
+    override var network: PKPaymentNetwork? { .visa }
+    override var type: PKPaymentMethodType { .credit }
+    override var displayName: String? { "Test Card" }
 }
 
 extension XCTestCase {

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDelegateMock.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDelegateMock.swift
@@ -47,7 +47,7 @@ final class ApplePayDelegateMockClassic: ApplePayDelegateMock {
     }
     
     func didAuthorize(
-        _ payment: PKPayment,
+        payment: PKPayment,
         completion: @escaping (PKPaymentAuthorizationResult) -> Void
     ) {
         self.authorizedPayment = payment
@@ -95,7 +95,7 @@ final class ApplePayDelegateMockiOS15: ApplePayDelegateMock {
     }
     
     func didAuthorize(
-        _ payment: PKPayment,
+        payment: PKPayment,
         completion: @escaping (PKPaymentAuthorizationResult) -> Void
     ) {
         self.authorizedPayment = payment

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDelegateMock.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDelegateMock.swift
@@ -11,9 +11,11 @@ protocol ApplePayDelegateMock: ApplePayComponentDelegate {
     var contact: PKContact? { get }
     var shippingMethod: PKShippingMethod? { get }
     var couponCode: String? { get }
+    var authorizedPayment: PKPayment? { get }
 
     var onShippingContactChange: ((PKContact, ApplePayPayment) -> PKPaymentRequestShippingContactUpdate)? { get set }
     var onShippingMethodChange: ((PKShippingMethod, ApplePayPayment) -> PKPaymentRequestShippingMethodUpdate)? { get set }
+    var onAuthorize: ((PKPayment) -> PKPaymentAuthorizationResult)? { get set }
 }
 
 final class ApplePayDelegateMockClassic: ApplePayDelegateMock {
@@ -21,9 +23,11 @@ final class ApplePayDelegateMockClassic: ApplePayDelegateMock {
     var contact: PKContact?
     var shippingMethod: PKShippingMethod?
     var couponCode: String?
+    var authorizedPayment: PKPayment?
 
     var onShippingContactChange: ((PKContact, ApplePayPayment) -> PKPaymentRequestShippingContactUpdate)?
     var onShippingMethodChange: ((PKShippingMethod, ApplePayPayment) -> PKPaymentRequestShippingMethodUpdate)?
+    var onAuthorize: ((PKPayment) -> PKPaymentAuthorizationResult)?
 
     func didUpdate(contact: PKContact, for payment: ApplePayPayment, completion: @escaping (PKPaymentRequestShippingContactUpdate) -> Void) {
         self.contact = contact
@@ -41,6 +45,20 @@ final class ApplePayDelegateMockClassic: ApplePayDelegateMock {
     func didUpdate(couponCode: String, for payment: ApplePayPayment, completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void) {
         fatalError("Use ApplePayDelegateMockiOS15")
     }
+    
+    func didAuthorize(
+        _ payment: PKPayment,
+        completion: @escaping (PKPaymentAuthorizationResult) -> Void
+    ) {
+        self.authorizedPayment = payment
+        if let onAuthorize {
+            let result = onAuthorize(payment)
+            completion(result)
+        } else {
+            // Default behavior - auto-approve
+            completion(PKPaymentAuthorizationResult(status: .success, errors: nil))
+        }
+    }
 }
 
 @available(iOS 15.0, *)
@@ -49,9 +67,11 @@ final class ApplePayDelegateMockiOS15: ApplePayDelegateMock {
     var contact: PKContact?
     var shippingMethod: PKShippingMethod?
     var couponCode: String?
+    var authorizedPayment: PKPayment?
 
     var onShippingContactChange: ((PKContact, ApplePayPayment) -> PKPaymentRequestShippingContactUpdate)?
     var onShippingMethodChange: ((PKShippingMethod, ApplePayPayment) -> PKPaymentRequestShippingMethodUpdate)?
+    var onAuthorize: ((PKPayment) -> PKPaymentAuthorizationResult)?
 
     var onCouponChange: ((String, ApplePayPayment) -> PKPaymentRequestCouponCodeUpdate)?
 
@@ -72,5 +92,19 @@ final class ApplePayDelegateMockiOS15: ApplePayDelegateMock {
         self.couponCode = couponCode
         let result = onCouponChange!(couponCode, payment)
         completion(result)
+    }
+    
+    func didAuthorize(
+        _ payment: PKPayment,
+        completion: @escaping (PKPaymentAuthorizationResult) -> Void
+    ) {
+        self.authorizedPayment = payment
+        if let onAuthorize {
+            let result = onAuthorize(payment)
+            completion(result)
+        } else {
+            // Default behavior - auto-approve
+            completion(PKPaymentAuthorizationResult(status: .success, errors: nil))
+        }
     }
 }

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDelegateMock.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDelegateMock.swift
@@ -11,11 +11,9 @@ protocol ApplePayDelegateMock: ApplePayComponentDelegate {
     var contact: PKContact? { get }
     var shippingMethod: PKShippingMethod? { get }
     var couponCode: String? { get }
-    var authorizedPayment: PKPayment? { get }
 
     var onShippingContactChange: ((PKContact, ApplePayPayment) -> PKPaymentRequestShippingContactUpdate)? { get set }
     var onShippingMethodChange: ((PKShippingMethod, ApplePayPayment) -> PKPaymentRequestShippingMethodUpdate)? { get set }
-    var onAuthorize: ((PKPayment) -> PKPaymentAuthorizationResult)? { get set }
 }
 
 final class ApplePayDelegateMockClassic: ApplePayDelegateMock {
@@ -23,11 +21,9 @@ final class ApplePayDelegateMockClassic: ApplePayDelegateMock {
     var contact: PKContact?
     var shippingMethod: PKShippingMethod?
     var couponCode: String?
-    var authorizedPayment: PKPayment?
 
     var onShippingContactChange: ((PKContact, ApplePayPayment) -> PKPaymentRequestShippingContactUpdate)?
     var onShippingMethodChange: ((PKShippingMethod, ApplePayPayment) -> PKPaymentRequestShippingMethodUpdate)?
-    var onAuthorize: ((PKPayment) -> PKPaymentAuthorizationResult)?
 
     func didUpdate(contact: PKContact, for payment: ApplePayPayment, completion: @escaping (PKPaymentRequestShippingContactUpdate) -> Void) {
         self.contact = contact
@@ -45,20 +41,6 @@ final class ApplePayDelegateMockClassic: ApplePayDelegateMock {
     func didUpdate(couponCode: String, for payment: ApplePayPayment, completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void) {
         fatalError("Use ApplePayDelegateMockiOS15")
     }
-    
-    func didAuthorize(
-        payment: PKPayment,
-        completion: @escaping (PKPaymentAuthorizationResult) -> Void
-    ) {
-        self.authorizedPayment = payment
-        if let onAuthorize {
-            let result = onAuthorize(payment)
-            completion(result)
-        } else {
-            // Default behavior - auto-approve
-            completion(PKPaymentAuthorizationResult(status: .success, errors: nil))
-        }
-    }
 }
 
 @available(iOS 15.0, *)
@@ -67,11 +49,9 @@ final class ApplePayDelegateMockiOS15: ApplePayDelegateMock {
     var contact: PKContact?
     var shippingMethod: PKShippingMethod?
     var couponCode: String?
-    var authorizedPayment: PKPayment?
 
     var onShippingContactChange: ((PKContact, ApplePayPayment) -> PKPaymentRequestShippingContactUpdate)?
     var onShippingMethodChange: ((PKShippingMethod, ApplePayPayment) -> PKPaymentRequestShippingMethodUpdate)?
-    var onAuthorize: ((PKPayment) -> PKPaymentAuthorizationResult)?
 
     var onCouponChange: ((String, ApplePayPayment) -> PKPaymentRequestCouponCodeUpdate)?
 
@@ -93,18 +73,21 @@ final class ApplePayDelegateMockiOS15: ApplePayDelegateMock {
         let result = onCouponChange!(couponCode, payment)
         completion(result)
     }
+}
+
+// MARK: - ApplePayAuthorizationDelegate Mock
+
+final class ApplePayAuthorizationDelegateMock: ApplePayAuthorizationDelegate {
+    
+    var authorizedPayment: PKPayment?
+    var onAuthorize: ((PKPayment) -> PKPaymentAuthorizationResult)?
     
     func didAuthorize(
         payment: PKPayment,
         completion: @escaping (PKPaymentAuthorizationResult) -> Void
     ) {
         self.authorizedPayment = payment
-        if let onAuthorize {
-            let result = onAuthorize(payment)
-            completion(result)
-        } else {
-            // Default behavior - auto-approve
-            completion(PKPaymentAuthorizationResult(status: .success, errors: nil))
-        }
+        let result = onAuthorize!(payment)
+        completion(result)
     }
 }


### PR DESCRIPTION
# Summary [Required]

Added a new delegate `ApplePayAuthorizationDelegate` to ApplePayComponent with a method `didAuthorize...`:

That will be called before submit, inside Apple's didAuthorizePayment.... callback.

- Will give the merchants the payment data containing all the updated fields to validate.
- Will expect a result from merchants, either success or failure.
   - Success continues the flow to submit step
   - Failure stops the flow, displays the error merchants provided on the Apple Pay sheet, and gives shoppers a chance to update their payment info
   - If merchants don't provide any errors here on failure, the system closes the Apple Pay UI. This is on merchant's side to be aware but we will document it clearly.

This is a separate delegate property on ApplePayComponent, no breaking changes. For merchants who don't start using this new delegate and its method, the flow will be as it is now.

<new>
New property `authorizationDelegate` on `ApplePayComponent` with a method:
    ```
    func didAuthorize(payment: PKPayment, completion: @escaping (PKPaymentAuthorizationResult) -> Void)
    ```
Called after the shopper authorizes the payment with Apple Pay. 
To use this method, set the `authorizationDelegate` to your delegate object.
Use this method to validate the shopper's payment information (e.g., billing/shipping address) before the payment is submitted. You can perform synchronous or asynchronous validation, including backend calls if needed.
</new>


## Ticket [Optional]
<ticket>
COSDK-858
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [ ] Tested changes locally
- [ ] Added/updated unit tests
- [ ] Verified against acceptance criteria
