### PR TITLE
Add new address picker UI component

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -628,6 +628,7 @@
 		B62D48C82BBE8F47001EF01A /* XCTestCase+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62D48C22BBE8ED6001EF01A /* XCTestCase+Wait.swift */; };
 		B62F51802E97AAD200610EFD /* TextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62F517F2E97AA6600610EFD /* TextFieldTests.swift */; };
 		B639C0822D8039F600472EBB /* CardScannerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B639C0812D80399800472EBB /* CardScannerController.swift */; };
+		B643C7642EEAD2CF00EF8407 /* FormSectionHeaderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B643C7622EEAD2CF00EF8407 /* FormSectionHeaderItem.swift */; };
 		B65F0EB42ED493250015AC41 /* FormButtonItemViewThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65F0EB32ED493250015AC41 /* FormButtonItemViewThemeTests.swift */; };
 		B65F0EBA2ED89EC00015AC41 /* TestTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65F0EB92ED89EC00015AC41 /* TestTheme.swift */; };
 		B65F0EBB2ED89EC00015AC41 /* TestTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65F0EB92ED89EC00015AC41 /* TestTheme.swift */; };
@@ -2254,6 +2255,7 @@
 		B62D48CA2BBE9059001EF01A /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		B62F517F2E97AA6600610EFD /* TextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTests.swift; sourceTree = "<group>"; };
 		B639C0812D80399800472EBB /* CardScannerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerController.swift; sourceTree = "<group>"; };
+		B643C7622EEAD2CF00EF8407 /* FormSectionHeaderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormSectionHeaderItem.swift; sourceTree = "<group>"; };
 		B65F0EB32ED493250015AC41 /* FormButtonItemViewThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormButtonItemViewThemeTests.swift; sourceTree = "<group>"; };
 		B65F0EB92ED89EC00015AC41 /* TestTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTheme.swift; sourceTree = "<group>"; };
 		B65F0EBD2ED89EC60015AC41 /* FormViewExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormViewExtractor.swift; sourceTree = "<group>"; };
@@ -4155,6 +4157,14 @@
 			path = Form;
 			sourceTree = "<group>";
 		};
+		B643C7632EEAD2CF00EF8407 /* SectionHeader */ = {
+			isa = PBXGroup;
+			children = (
+				B643C7622EEAD2CF00EF8407 /* FormSectionHeaderItem.swift */,
+			);
+			path = SectionHeader;
+			sourceTree = "<group>";
+		};
 		B67D1F572E4615390000C37F /* Components */ = {
 			isa = PBXGroup;
 			children = (
@@ -4830,6 +4840,7 @@
 				E2D12C05221ED15300EF682F /* Toggle */,
 				E2D12BED221D55F800EF682F /* Value */,
 				E7085B062628B29600D0153B /* Value Pickers */,
+				B643C7632EEAD2CF00EF8407 /* SectionHeader */,
 			);
 			path = Items;
 			sourceTree = "<group>";
@@ -8154,6 +8165,7 @@
 				0019C4932E6AE09900B0C3A3 /* FormErrorItemView.swift in Sources */,
 				0019C48D2E6AE08200B0C3A3 /* FormButtonItemView.swift in Sources */,
 				0019C48E2E6AE08200B0C3A3 /* FormButtonItem.swift in Sources */,
+				B643C7642EEAD2CF00EF8407 /* FormSectionHeaderItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Adyen/Core/Configuration/AddressLookupProvider.swift
+++ b/Adyen/Core/Configuration/AddressLookupProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) 2025 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CardComponentConfiguration.swift
+++ b/AdyenCard/Components/Card/CardComponentConfiguration.swift
@@ -65,7 +65,7 @@ public struct CardComponentConfiguration: CheckoutComponentConfiguration, AnyPer
     /// Indicates whether or not to show the supported card logos under the card number item
     internal var showsSupportedCardLogos: Bool
     
-    //TODO: rename all related parts after aligning
+    // TODO: rename all related parts after aligning
     /// Called when the BIN value changes (first 6-8 digits of the card number).
     internal var onBinValue: ((String) -> Void)?
     

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -371,6 +371,7 @@ extension CardViewController {
             guard let pickerItem = items.billingAddressPickerItem else { return nil }
             return pickerItem.withSectionHeader(
                 title: localizedString(.billingAddressSectionTitle, localizationParameters),
+                // TODO: Localize subtitle after aligning on i18n cases with Android
                 subtitle: "Enter the billing address that is linked to the card"
             )
 

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -367,12 +367,12 @@ extension CardViewController {
     private var billingAddressItem: FormItem? {
         
         switch configuration.billingAddress.mode {
-        case .lookup:
-            return items.billingAddressPickerItem
-            
-        case .full:
-            return items.billingAddressPickerItem
-            
+        case .lookup, .full:
+            guard let pickerItem = items.billingAddressPickerItem else { return nil }
+            return pickerItem.withSectionHeader(
+                title: localizedString(.billingAddressSectionTitle, localizationParameters),
+                subtitle: "Enter the billing address that is linked to the card"
+            )
         case .postalCode:
             return items.postalCodeItem
             

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -373,6 +373,7 @@ extension CardViewController {
                 title: localizedString(.billingAddressSectionTitle, localizationParameters),
                 subtitle: "Enter the billing address that is linked to the card"
             )
+
         case .postalCode:
             return items.postalCodeItem
             

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -303,7 +303,10 @@ package final class ACHDirectDebitComponent: PaymentComponent,
         formViewController.append(FormSpacerItem())
         
         if configuration.showBillingAddress {
-            formViewController.append(billingAddressItem)
+            formViewController.append(billingAddressItem.withSectionHeader(
+                title: localizedString(.billingAddressSectionTitle, configuration.localizationParameters),
+                subtitle: nil // TODO: Add subtitle localization key
+            ))
         }
         if configuration.showStorePaymentMethodField {
             formViewController.append(storeDetailsItem)

--- a/AdyenComponents/AbstractPersonalInformationComponent/AddressFormItemInjector.swift
+++ b/AdyenComponents/AbstractPersonalInformationComponent/AddressFormItemInjector.swift
@@ -62,7 +62,11 @@ internal final class AddressFormItemInjector: FormItemInjector, Localizable {
     }
 
     internal func inject(into formViewController: FormViewController) {
-        formViewController.append(item)
+        let sectionTitle = addressType.sectionTitle(with: localizationParameters)
+        formViewController.append(item.withSectionHeader(
+            title: sectionTitle,
+            subtitle: nil // TODO: Add subtitle localization key
+        ))
     }
     
 }

--- a/AdyenUI/AdyenUIConstants.swift
+++ b/AdyenUI/AdyenUIConstants.swift
@@ -12,5 +12,6 @@ package enum AdyenUIConstants {
     package static let defaultBorderWidth = 2.0
 
     package static let stackViewSpacing = 8.0
+    package static let minimumInputHeight = 48.0
     package static let contentInsets = UIEdgeInsets(top: 11, left: 16, bottom: 11, right: 16)
 }

--- a/AdyenUI/UI/Form/FormItemViewBuilder.swift
+++ b/AdyenUI/UI/Form/FormItemViewBuilder.swift
@@ -99,7 +99,7 @@ public struct FormItemViewBuilder {
 
     /// Builds `FormAddressPickerItemView` from `FormAddressPickerItem`.
     package func build(with item: FormAddressPickerItem) -> FormItemView<FormAddressPickerItem> {
-        FormAddressPickerItemView(item: item)
+        FormAddressPickerItemView(item: item, theme: theme)
     }
 
     /// Builds `FormPickerItemView` from `FormPickerItem`.

--- a/AdyenUI/UI/Form/Items/Address/Picker/FormAddressPickerItem.swift
+++ b/AdyenUI/UI/Form/Items/Address/Picker/FormAddressPickerItem.swift
@@ -7,7 +7,6 @@
 @_spi(AdyenInternal) import Adyen
 import UIKit
 
-/// An address form item that allows picking an address on a separate screen.
 package final class FormAddressPickerItem: FormSelectableValueItem<PostalAddress?> {
 
     package enum AddressType {
@@ -34,17 +33,6 @@ package final class FormAddressPickerItem: FormSelectableValueItem<PostalAddress
         }
     }
 
-    /// Initializes the address lookup item.
-    /// - Parameters:
-    ///   - addressType: The type of address to pick
-    ///   - initialCountry: The items displayed side-by-side. Must be two.
-    ///   - prefillAddress: The provided prefill address
-    ///   - style: The `FormComponentStyle` UI style.
-    ///   - localizationParameters: The localization parameters
-    ///   - identifier: The item identifier
-    ///   - addressViewModelBuilder: The builder to build the Address ViewModel
-    ///   - presenter: The presenter to handle view controller presentation
-    ///   - lookupProvider: The optional lookup provider
     package init(
         for addressType: AddressType,
         initialCountry: String,
@@ -244,6 +232,10 @@ extension FormAddressPickerItem.AddressType {
     }
 
     package func title(with localizationParameters: LocalizationParameters?) -> String {
+        localizedString(.addressFieldTitle, localizationParameters)
+    }
+    
+    package func sectionTitle(with localizationParameters: LocalizationParameters?) -> String {
         switch self {
         case .billing: return localizedString(.billingAddressSectionTitle, localizationParameters)
         case .delivery: return localizedString(.deliveryAddressSectionTitle, localizationParameters)

--- a/AdyenUI/UI/Form/Items/SectionHeader/FormSectionHeaderItem.swift
+++ b/AdyenUI/UI/Form/Items/SectionHeader/FormSectionHeaderItem.swift
@@ -1,0 +1,164 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) import Adyen
+import UIKit
+
+/// A container form item that wraps another form item and adds a section title and optional subtitle.
+///
+/// Use this to group form elements with a descriptive header, commonly used for address sections
+/// or other complex form areas that benefit from additional context.
+///
+/// Example:
+/// ```swift
+/// let addressSection = FormSectionHeaderItem(
+///     title: "Billing address",
+///     subtitle: "Enter the billing address linked to the card",
+///     content: addressPickerItem
+/// )
+/// ```
+
+package final class FormSectionHeaderItem<ContentItem: FormItem>: FormItem {
+
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
+    package var subitems: [FormItem] { [content] }
+    package var identifier: String?
+    package let title: String
+    package let subtitle: String?
+    package let content: ContentItem
+
+    package init(
+        title: String,
+        subtitle: String? = nil,
+        content: ContentItem,
+        identifier: String? = nil
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content
+        self.identifier = identifier
+    }
+
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+        let contentView = content.build(with: builder)
+        let view = FormSectionHeaderItemView(
+            title: title,
+            subtitle: subtitle,
+            contentView: contentView,
+            theme: builder.theme
+        )
+        view.accessibilityIdentifier = identifier
+        return view
+    }
+}
+
+// MARK: - FormSectionHeaderItemView
+
+internal final class FormSectionHeaderItemView: UIView, AnyFormItemView {
+
+    internal var childItemViews: [AnyFormItemView] = []
+    private let theme: AdyenTheme
+
+    // MARK: - Subviews
+
+    private lazy var headerStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.spacing = AdyenUIConstants.stackViewSpacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.apply(theme.elements.labels.bodyEmphasized)
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private lazy var subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.apply(theme.elements.labels.subheadline)
+        label.textColor = theme.colors.textSecondary
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private lazy var contentContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    // MARK: - Initialization
+
+    internal init(
+        title: String,
+        subtitle: String?,
+        contentView: AnyFormItemView,
+        theme: AdyenTheme
+    ) {
+        self.theme = theme
+        super.init(frame: .zero)
+
+        setupView(title: title, subtitle: subtitle, contentView: contentView)
+    }
+
+    @available(*, unavailable)
+    internal required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupView(title: String, subtitle: String?, contentView: AnyFormItemView) {
+        preservesSuperviewLayoutMargins = true
+
+        titleLabel.text = title
+        subtitleLabel.text = subtitle
+        subtitleLabel.isHidden = subtitle == nil
+
+        contentContainer.addSubview(contentView)
+        (contentView as UIView).adyen.anchor(inside: contentContainer)
+        childItemViews = [contentView]
+
+        addSubview(headerStackView)
+        addSubview(contentContainer)
+
+        // Header aligned with form margins
+        NSLayoutConstraint.activate([
+            headerStackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+            headerStackView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            headerStackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor)
+        ])
+
+        // Content extends full width (wrapped content handles its own margins)
+        NSLayoutConstraint.activate([
+            contentContainer.topAnchor.constraint(
+                equalTo: headerStackView.bottomAnchor, constant: AdyenUIConstants.stackViewSpacing
+            ),
+            contentContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentContainer.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+
+    // MARK: - AnyFormItemView
+
+    internal func reset() {
+        childItemViews.forEach { $0.reset() }
+    }
+}
+
+// MARK: - Convenience Extension
+
+extension FormItem {
+
+    package func withSectionHeader(title: String, subtitle: String? = nil) -> FormSectionHeaderItem<Self> {
+        FormSectionHeaderItem(title: title, subtitle: subtitle, content: self, identifier: nil)
+    }
+}

--- a/AdyenUI/UI/Form/Items/SectionHeader/FormSectionHeaderItem.swift
+++ b/AdyenUI/UI/Form/Items/SectionHeader/FormSectionHeaderItem.swift
@@ -7,20 +7,6 @@
 @_spi(AdyenInternal) import Adyen
 import UIKit
 
-/// A container form item that wraps another form item and adds a section title and optional subtitle.
-///
-/// Use this to group form elements with a descriptive header, commonly used for address sections
-/// or other complex form areas that benefit from additional context.
-///
-/// Example:
-/// ```swift
-/// let addressSection = FormSectionHeaderItem(
-///     title: "Billing address",
-///     subtitle: "Enter the billing address linked to the card",
-///     content: addressPickerItem
-/// )
-/// ```
-
 package final class FormSectionHeaderItem<ContentItem: FormItem>: FormItem {
 
     package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)

--- a/AdyenUI/UI/Form/Items/SectionHeader/FormSectionHeaderItem.swift
+++ b/AdyenUI/UI/Form/Items/SectionHeader/FormSectionHeaderItem.swift
@@ -61,7 +61,7 @@ internal final class FormSectionHeaderItemView: UIView, AnyFormItemView {
 
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
-        label.apply(theme.elements.labels.bodyEmphasized)
+        label.apply(theme.elements.labels.subtitle)
         label.numberOfLines = 0
         return label
     }()

--- a/AdyenUI/UI/Form/Items/SectionHeader/FormSectionHeaderItem.swift
+++ b/AdyenUI/UI/Form/Items/SectionHeader/FormSectionHeaderItem.swift
@@ -102,6 +102,11 @@ internal final class FormSectionHeaderItemView: UIView, AnyFormItemView {
     // MARK: - Setup
 
     private func setupView(title: String, subtitle: String?, contentView: AnyFormItemView) {
+        configureContent(title: title, subtitle: subtitle, contentView: contentView)
+        setupConstraints()
+    }
+
+    private func configureContent(title: String, subtitle: String?, contentView: AnyFormItemView) {
         preservesSuperviewLayoutMargins = true
 
         titleLabel.text = title
@@ -114,7 +119,9 @@ internal final class FormSectionHeaderItemView: UIView, AnyFormItemView {
 
         addSubview(headerStackView)
         addSubview(contentContainer)
+    }
 
+    private func setupConstraints() {
         // Header aligned with form margins
         NSLayoutConstraint.activate([
             headerStackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),

--- a/AdyenUI/UI/Form/Items/SelectableFormItem/SelectableFormItemView.swift
+++ b/AdyenUI/UI/Form/Items/SelectableFormItem/SelectableFormItemView.swift
@@ -7,10 +7,8 @@
 @_spi(AdyenInternal) import Adyen
 import UIKit
 
-/// A view representing a selectableFormItem item.
-@_spi(AdyenInternal)
-public final class SelectableFormItemView: FormItemView<SelectableFormItem> {
-    
+package final class SelectableFormItemView: FormItemView<SelectableFormItem> {
+
     private enum Constants {
         static let upiLogo = "upiLogo"
         static let checkmarkIcon = "verification_true"
@@ -108,9 +106,7 @@ public final class SelectableFormItemView: FormItemView<SelectableFormItem> {
         customButton.addTarget(self, action: #selector(didSelectItemButton), for: .touchUpInside)
         customButton.translatesAutoresizingMaskIntoConstraints = false
         customButton.preservesSuperviewLayoutMargins = true
-        customButton.accessibilityIdentifier = item.identifier.map {
-            ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "button")
-        }
+        customButton.accessibilityIdentifier = item.identifier.map { ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "button") }
         customButton.addSubview(contentStackView)
 
         contentStackView.isUserInteractionEnabled = false
@@ -124,7 +120,7 @@ public final class SelectableFormItemView: FormItemView<SelectableFormItem> {
     }
 
     /// Initializes the selectable form item view.
-    public required init(item: SelectableFormItem) {
+    package required init(item: SelectableFormItem) {
         super.init(item: item)
         backgroundColor = item.style.backgroundColor
 
@@ -152,12 +148,12 @@ public final class SelectableFormItemView: FormItemView<SelectableFormItem> {
         }
     }
 
-    override public func didMoveToWindow() {
+    override package func didMoveToWindow() {
         super.didMoveToWindow()
         updateIcon()
     }
 
-    override public func layoutSubviews() {
+    override package func layoutSubviews() {
         super.layoutSubviews()
         imageView.adyen.round(using: item.style.imageStyle.cornerRounding)
     }

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerItemView.swift
@@ -7,9 +7,8 @@
 @_spi(AdyenInternal) import Adyen
 import UIKit
 
-@_spi(AdyenInternal)
-public class FormPickerItemView<Value: FormPickable>: FormSelectableValueItemView<Value, FormPickerItem<Value>> {
-    
+package class FormPickerItemView<Value: FormPickable>: FormSelectableValueItemView<Value, FormPickerItem<Value>> {
+
     internal required init(item: FormPickerItem<Value>, theme: AdyenTheme) {
         super.init(item: item, theme: theme)
         item.selectionHandler = { [weak self] in
@@ -29,7 +28,7 @@ public class FormPickerItemView<Value: FormPickable>: FormSelectableValueItemVie
         }
     }
     
-    override public func showValidation() {
+    override package func showValidation() {
         if item.isValid() {
             updateValidationStatus(forced: false)
         } else {
@@ -37,7 +36,7 @@ public class FormPickerItemView<Value: FormPickable>: FormSelectableValueItemVie
         }
     }
     
-    override public func reset() {
+    override package func reset() {
         item.resetValue()
         resetValidationStatus()
     }

--- a/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
@@ -11,132 +11,239 @@ import UIKit
 @_spi(AdyenInternal)
 open class FormSelectableValueItemView<ValueType, ItemType: FormSelectableValueItem<ValueType?>>:
     FormValidatableValueItemView<ValueType?, ItemType> {
-    
+
     internal var numberOfLines: Int = 1 {
         didSet {
             valueLabel.numberOfLines = numberOfLines
         }
     }
-    
+
     override internal var accessibilityLabelView: UIView? { selectionButton }
-    
+
     public required init(item: ItemType, theme: AdyenTheme) {
         super.init(item: item, theme: theme)
-        
+
         addSubview(selectionButton)
-        
+
         configureConstraints()
-        setupObservers()
+        apply(theme)
         
+        setupObservers()
+
         updateValueLabel(with: item.formattedValue)
     }
-    
+
     // MARK: - Views
-    
+
     private lazy var selectionButton: UIButton = {
         let button = UIButton(type: .custom)
         button.addTarget(self, action: #selector(selectionButtonTapped), for: .touchUpInside)
         button.preservesSuperviewLayoutMargins = true
         button.translatesAutoresizingMaskIntoConstraints = false
-        
+
         button.addSubview(itemStackView)
         itemStackView.isUserInteractionEnabled = false
         itemStackView.adyen.anchor(inside: button)
-        
+
         return button
     }()
-    
+
     private lazy var itemStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [contentStackView, alertLabel])
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, containerView, footerLabel])
         stackView.axis = .vertical
         stackView.alignment = .fill
-        stackView.spacing = 8.0
+        stackView.spacing = AdyenUIConstants.stackViewSpacing
         stackView.preservesSuperviewLayoutMargins = true
         stackView.isLayoutMarginsRelativeArrangement = true
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        
+
         return stackView
     }()
-    
+
+    internal lazy var containerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(contentStackView)
+        contentStackView.adyen.anchor(inside: view, with: AdyenUIConstants.contentInsets)
+
+        // Ensure minimum height for empty state
+        view.heightAnchor.constraint(
+            greaterThanOrEqualToConstant: AdyenUIConstants.minimumInputHeight
+        ).isActive = true
+
+        return view
+    }()
+
     private lazy var contentStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [labelStackView, chevronView])
+        let stackView = UIStackView(arrangedSubviews: [valueLabel, chevronView])
         stackView.axis = .horizontal
-        stackView.alignment = .fill
-        stackView.spacing = 8.0
-        stackView.preservesSuperviewLayoutMargins = true
-        
+        stackView.alignment = .center
+        stackView.spacing = AdyenUIConstants.stackViewSpacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
         return stackView
     }()
-    
-    private lazy var labelStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, valueLabel])
-        stackView.axis = .vertical
-        stackView.alignment = .fill
-        stackView.spacing = 8.0
-        
-        return stackView
-    }()
-    
+
     internal lazy var chevronView: UIImageView = {
-        let chevron = UIImage(named: "chevron", in: Bundle.coreInternalResources, compatibleWith: nil)
+        let chevron = UIImage(
+            named: "chevron",
+            in: Bundle.coreInternalResources,
+            compatibleWith: nil
+        )?.withRenderingMode(.alwaysTemplate)
+
         let imageView = UIImageView(image: chevron)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.setContentHuggingPriority(.required, for: .horizontal)
         imageView.widthAnchor.constraint(equalToConstant: 8).isActive = true
         imageView.contentMode = .scaleAspectFit
-        
+
         return imageView
     }()
-    
-    /// The value label view.
+
     internal lazy var valueLabel: UILabel = {
         let valueLabel = ValueLabel()
-        valueLabel.apply(theme.elements.labels.body)
         valueLabel.numberOfLines = numberOfLines
         valueLabel.isAccessibilityElement = false
-        valueLabel.accessibilityIdentifier = item.identifier.map { ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "valueLabel") }
+        valueLabel.accessibilityIdentifier = item.identifier.map {
+            ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "valueLabel")
+        }
 
         return valueLabel
     }()
-    
+
+    internal lazy var footerLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.isAccessibilityElement = false
+        label.accessibilityIdentifier = item.identifier.map {
+            ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "footerLabel")
+        }
+        return label
+    }()
+
     // MARK: - Selection
-    
+
     @objc
     internal func selectionButtonTapped() {
         item.selectionHandler()
     }
-    
+
+    // MARK: - Styling
+
+    private func apply(_ theme: AdyenTheme) {
+        let style = theme.elements.textField
+
+        containerView.backgroundColor = style.containerColor
+        containerView.layer.borderWidth = style.borderWidth
+        containerView.layer.borderColor = style.borderColor.cgColor
+
+        switch style.cornerRadius {
+        case let .fixed(radius):
+            containerView.layer.cornerRadius = radius
+        default:
+            containerView.layer.cornerRadius = AdyenUIConstants.defaultCornerRadius
+        }
+
+        chevronView.tintColor = theme.colors.primary
+        valueLabel.apply(theme.elements.labels.body)
+        footerLabel.apply(theme.elements.labels.subheadline)
+
+        footerLabel.text = item.placeholder
+        footerLabel.isHidden = item.placeholder.isEmpty
+    }
+
+
+    private func updateContainerBorderColor(isValid: Bool) {
+        let style = theme.elements.textField
+        let borderColor = isValid ? style.borderColor : style.errorColor
+        containerView.layer.borderColor = borderColor.cgColor
+    }
+
+    // MARK: - Hint/Error Display
+
+    private func showHint() {
+
+        footerLabel.text = item.placeholder
+        footerLabel.textColor = theme.colors.textSecondary
+        footerLabel.isHidden = item.placeholder.isEmpty
+    }
+
+    private func showError(_ message: String?) {
+        guard let message, !message.isEmpty else {
+            showHint()
+            return
+        }
+        footerLabel.text = message
+        footerLabel.textColor = theme.colors.destructive
+        footerLabel.isHidden = false
+    }
+
     // MARK: - Convenience
-    
+
     private func setupObservers() {
         observe(item.$formattedValue) { [weak self] in
             self?.updateValueLabel(with: $0)
         }
     }
-    
+
     private func updateValueLabel(with formattedValue: String?) {
         accessibilityLabelView?.accessibilityValue = formattedValue
-        
+
         guard let formattedValue, !formattedValue.isEmpty else {
-            valueLabel.text = item.placeholder
-            valueLabel.textColor = theme.colors.textSecondary
+            valueLabel.text = nil
             resetValidationStatus()
             return
         }
-        
+
         valueLabel.text = formattedValue
         valueLabel.textColor = theme.elements.labels.body.color
         showValidation()
     }
-    
+
     private func configureConstraints() {
         selectionButton.adyen.anchor(inside: self)
+    }
+
+    // MARK: - Validation
+
+    override open func updateValidationStatus(forced: Bool = false) {
+        guard forced else {
+            showHint()
+            updateContainerBorderColor(isValid: true)
+            accessibilityLabelView?.accessibilityLabel = item.title
+            return
+        }
+
+        if item.isValid() {
+            showHint()
+            updateContainerBorderColor(isValid: true)
+            accessibilityLabelView?.accessibilityLabel = item.title
+        } else {
+            showError(item.validationFailureMessage)
+            updateContainerBorderColor(isValid: false)
+            accessibilityLabelView?.accessibilityLabel = [
+                item.title,
+                item.validationFailureMessage
+            ].compactMap { $0 }.joined(separator: ", ")
+
+            if let validationStatus = item.validationStatus(),
+               let error = validationStatus.validationError {
+                item.onDidShowValidationError?(error)
+            }
+        }
+    }
+
+    override internal func resetValidationStatus() {
+        showHint()
+        updateContainerBorderColor(isValid: true)
+        accessibilityLabelView?.accessibilityLabel = item.title
     }
 }
 
 /// A label reporting it's intrinsic content size to match the text field of the ``FormTextItemView``
 private class ValueLabel: UILabel {
-    
+
     override var intrinsicContentSize: CGSize {
         let size = super.intrinsicContentSize
         return .init(

--- a/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
@@ -7,9 +7,7 @@
 @_spi(AdyenInternal) import Adyen
 import UIKit
 
-/// An abstract view representing a selectable value item.
-@_spi(AdyenInternal)
-open class FormSelectableValueItemView<ValueType, ItemType: FormSelectableValueItem<ValueType?>>:
+package class FormSelectableValueItemView<ValueType, ItemType: FormSelectableValueItem<ValueType?>>:
     FormValidatableValueItemView<ValueType?, ItemType> {
 
     internal var numberOfLines: Int = 1 {
@@ -20,7 +18,7 @@ open class FormSelectableValueItemView<ValueType, ItemType: FormSelectableValueI
 
     override internal var accessibilityLabelView: UIView? { selectionButton }
 
-    public required init(item: ItemType, theme: AdyenTheme) {
+    package required init(item: ItemType, theme: AdyenTheme) {
         super.init(item: item, theme: theme)
 
         addSubview(selectionButton)
@@ -152,7 +150,6 @@ open class FormSelectableValueItemView<ValueType, ItemType: FormSelectableValueI
         footerLabel.text = item.placeholder
         footerLabel.isHidden = item.placeholder.isEmpty
     }
-
 
     private func updateContainerBorderColor(isValid: Bool) {
         let style = theme.elements.textField

--- a/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -64,7 +64,7 @@ class ACHDirectDebitComponentTests: XCTestCase {
         XCTAssertEqual(sut.bankRoutingNumberItem.placeholder, localizedString(.achAccountLocationFieldTitle, sut.configuration.localizationParameters))
         XCTAssertEqual(sut.bankRoutingNumberItem.validationFailureMessage, localizedString(.achAccountLocationFieldInvalid, sut.configuration.localizationParameters))
         
-        XCTAssertEqual(sut.billingAddressItem.title, localizedString(.billingAddressSectionTitle, sut.configuration.localizationParameters))
+        XCTAssertEqual(sut.billingAddressItem.title, localizedString(.addressFieldTitle, sut.configuration.localizationParameters))
 
         XCTAssertEqual(sut.payButton.title, localizedSubmitButtonTitle(
             with: sut.payment?.amount,

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Address/FormAddressPickerItemViewStyleTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Address/FormAddressPickerItemViewStyleTests.swift
@@ -47,13 +47,13 @@ class FormAddressPickerItemViewStyleTests: XCTestCase {
         XCTAssertEqual(sut.valueLabel.font, expectedFont)
     }
 
-    func test_valueLabel_colorWithPlaceholder_shouldUseThemeTextSecondary() {
+    func test_footerLabel_colorWithPlaceholder_shouldUseThemeTextSecondary() {
         // Given - item has no value, so placeholder is shown
         XCTAssertNil(item.formattedValue)
 
         // Then
         let expectedColor = AdyenTheme.default.colors.textSecondary
-        XCTAssertEqual(sut.valueLabel.textColor, expectedColor)
+        XCTAssertEqual(sut.footerLabel.textColor, expectedColor)
     }
 
     func test_valueLabel_colorWithValue_shouldUseThemeBodyColor() {

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
@@ -96,10 +96,12 @@ class FormSelectableItemViewTests: XCTestCase {
 
     func test_valueUpdate() {
         XCTAssertNil(item.formattedValue)
-        XCTAssertEqual(sut.valueLabel.text, placeholderText)
+        XCTAssertNil(sut.valueLabel.text)
+        XCTAssertEqual(sut.footerLabel.text, placeholderText)
 
         item.formattedValue = ""
-        XCTAssertEqual(sut.valueLabel.text, placeholderText)
+        XCTAssertNil(sut.valueLabel.text)
+        XCTAssertEqual(sut.footerLabel.text, placeholderText)
 
         item.formattedValue = "Hello World"
         XCTAssertEqual(sut.valueLabel.text, item.formattedValue)
@@ -127,12 +129,14 @@ class FormPickerItemViewStyleTests: XCTestCase {
 
     func test_valueLabel_withNoFormattedValue_shouldShowPlaceholder() {
         XCTAssertNil(item.formattedValue)
-        XCTAssertEqual(sut.valueLabel.text, placeholderText)
+        XCTAssertNil(sut.valueLabel.text)
+        XCTAssertEqual(sut.footerLabel.text, placeholderText)
     }
 
     func test_valueLabel_withEmptyFormattedValue_shouldShowPlaceholder() {
         item.formattedValue = ""
-        XCTAssertEqual(sut.valueLabel.text, placeholderText)
+        XCTAssertNil(sut.valueLabel.text)
+        XCTAssertEqual(sut.footerLabel.text, placeholderText)
     }
 
     func test_valueLabel_withFormattedValue_shouldShowValue() {
@@ -171,7 +175,7 @@ class FormPickerItemViewStyleTests: XCTestCase {
         )
     }
 
-    func test_valueLabel_colorWithPlaceholder_shouldUseThemeTextSecondary() {
+    func test_footerLabel_colorWithPlaceholder_shouldUseThemeTextSecondary() {
         // Given
         let customItem = TestFormPickerItem(placeholder: "Placeholder")
         customItem.formattedValue = nil
@@ -180,7 +184,7 @@ class FormPickerItemViewStyleTests: XCTestCase {
         let customSut = FormPickerItemView(item: customItem)
 
         // Then - Now uses theme.colors.textSecondary
-        XCTAssertEqual(customSut.valueLabel.textColor, AdyenTheme.default.colors.textSecondary)
+        XCTAssertEqual(customSut.footerLabel.textColor, AdyenTheme.default.colors.textSecondary)
     }
 
     func test_valueLabel_whenFormattedValueChanges_shouldUpdateColorToThemeBodyColor() {
@@ -188,7 +192,7 @@ class FormPickerItemViewStyleTests: XCTestCase {
         let customItem = TestFormPickerItem()
         customItem.formattedValue = nil
         let customSut = FormPickerItemView(item: customItem)
-        XCTAssertEqual(customSut.valueLabel.textColor, AdyenTheme.default.colors.textSecondary) // placeholder color
+        XCTAssertEqual(customSut.footerLabel.textColor, AdyenTheme.default.colors.textSecondary) // placeholder color
 
         // When
         customItem.formattedValue = "New Value"

--- a/v6_agent_guides/Address_Picker_Redesign_Plan.md
+++ b/v6_agent_guides/Address_Picker_Redesign_Plan.md
@@ -1,0 +1,79 @@
+# Address Picker Redesign Plan (v6)
+
+## Overview
+
+Redesign of the address picker UI component for v6. Creates a generic reusable section header that adds title and subtitle to any form item, applied to the address picker with updated styling.
+
+## Visual Structure
+
+```
+Billing address              (title)
+Enter the billing address... (subtitle)
+
+Address                      (label)
+┌─────────────────────────────────────┐
+│ [empty or address value]          > │  (rounded container + chevron)
+└─────────────────────────────────────┘
+Your billing address         (hint)
+
+[Validation error replaces hint]
+```
+
+## Key Design Decisions
+
+- **Empty container**: No placeholder inside container; hint shows below
+- **Footer label**: Shows placeholder text OR validation error (not both)
+- **Validation**: Red border on container + error message in footer
+
+## Components
+
+### FormSectionHeaderItem
+
+**File**: `AdyenUI/UI/Form/Items/SectionHeader/FormSectionHeaderItem.swift`
+
+Generic wrapper that adds title + subtitle to any FormItem. Uses `package` access level.
+
+### FormSelectableValueItemView (Updated)
+
+**File**: `AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift`
+
+- Added `containerView` with rounded corners and theme styling
+- Added `footerLabel` for hint/validation messages
+- Styling consolidated in `apply(_ theme:)` method
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `AdyenUI/.../SectionHeader/FormSectionHeaderItem.swift` | NEW - Generic section header |
+| `AdyenUI/.../Selectable/FormSelectableValueItemView.swift` | Container + footer label |
+| `AdyenUI/UI/Form/FormItemViewBuilder.swift` | Pass theme to FormAddressPickerItemView |
+| `AdyenUI/AdyenUIConstants.swift` | Added `minimumInputHeight` |
+| `AdyenCard/.../CardViewController.swift` | Wrap picker with section header |
+| `AdyenComponents/.../ACHDirectDebitComponent.swift` | Wrap picker with section header |
+| `AdyenComponents/.../AddressFormItemInjector.swift` | Wrap picker with section header |
+
+## Status
+
+| Step | Status |
+|------|--------|
+| FormSectionHeaderItem + View | Done |
+| FormSelectableValueItemView styling | Done |
+| Card component | Done |
+| ACH component | Done |
+| AddressFormItemInjector | Done |
+| Unit tests | Pending |
+| Snapshots | Pending |
+
+## Remaining Work
+
+- Write tests for FormSectionHeaderItem
+- Write tests for FormSelectableValueItemView styling
+- Regenerate snapshots for Affirm, Atome, Boleto components
+
+## Code Style
+
+- Use `package` access (not `@_spi public`)
+- No docc comments for package/internal members
+- Use `AdyenUIConstants` for spacing
+- Consolidate styling in `apply(_ theme:)` method

--- a/v6_agent_guides/Address_Picker_Redesign_Plan.md
+++ b/v6_agent_guides/Address_Picker_Redesign_Plan.md
@@ -7,14 +7,14 @@ Redesign of the address picker UI component for v6. Creates a generic reusable s
 ## Visual Structure
 
 ```
-Billing address              (title)
-Enter the billing address... (subtitle)
+Billing address              (title - subtitle style)
+Enter the billing address... (subtitle - subheadline style)
 
-Address                      (label)
+Address                      (label - bodyEmphasized style)
 ┌─────────────────────────────────────┐
 │ [empty or address value]          > │  (rounded container + chevron)
 └─────────────────────────────────────┘
-Your billing address         (hint)
+Your billing address         (hint - subheadline style)
 
 [Validation error replaces hint]
 ```
@@ -24,6 +24,15 @@ Your billing address         (hint)
 - **Empty container**: No placeholder inside container; hint shows below
 - **Footer label**: Shows placeholder text OR validation error (not both)
 - **Validation**: Red border on container + error message in footer
+
+## Label Styles
+
+| Element | Style |
+|---------|-------|
+| Section title ("Billing address") | `subtitle` |
+| Section subtitle | `subheadline` |
+| Field label ("Address") | `bodyEmphasized` |
+| Footer hint/error | `subheadline` |
 
 ## Components
 
@@ -43,15 +52,14 @@ Generic wrapper that adds title + subtitle to any FormItem. Uses `package` acces
 
 ## Files Changed
 
-| File | Change |
-|------|--------|
-| `AdyenUI/.../SectionHeader/FormSectionHeaderItem.swift` | NEW - Generic section header |
-| `AdyenUI/.../Selectable/FormSelectableValueItemView.swift` | Container + footer label |
-| `AdyenUI/UI/Form/FormItemViewBuilder.swift` | Pass theme to FormAddressPickerItemView |
-| `AdyenUI/AdyenUIConstants.swift` | Added `minimumInputHeight` |
-| `AdyenCard/.../CardViewController.swift` | Wrap picker with section header |
-| `AdyenComponents/.../ACHDirectDebitComponent.swift` | Wrap picker with section header |
-| `AdyenComponents/.../AddressFormItemInjector.swift` | Wrap picker with section header |
+| New | Modified |
+|-----|----------|
+| `FormSectionHeaderItem.swift` | `FormSelectableValueItemView.swift` |
+| | `CardViewController.swift` |
+| | `ACHDirectDebitComponent.swift` |
+| | `AddressFormItemInjector.swift` |
+| | `FormItemViewBuilder.swift` |
+| | `AdyenUIConstants.swift` |
 
 ## Status
 
@@ -64,12 +72,6 @@ Generic wrapper that adds title + subtitle to any FormItem. Uses `package` acces
 | AddressFormItemInjector | Done |
 | Unit tests | Pending |
 | Snapshots | Pending |
-
-## Remaining Work
-
-- Write tests for FormSectionHeaderItem
-- Write tests for FormSelectableValueItemView styling
-- Regenerate snapshots for Affirm, Atome, Boleto components
 
 ## Code Style
 


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

Redesigned address picker UI with a new generic section header component and updated styling to match text field appearance.

### Changes
- New `FormSectionHeaderItem`. Generic wrapper adding title + subtitle to any form item
- Updated `FormSelectableValueItemView`. rounded container, footer label for hint/validation
- Applied to Card, ACH, Affirm, Atome, Boleto components based on the code dependencies

New views hierarchy:

```
FormSectionHeaderItem
├── titleLabel         "Billing address"
├── subtitleLabel      "Enter the billing address..."
└── FormAddressPickerItem (wrapped)
    └── FormSelectableValueItemView
        ├── titleLabel      "Address"
        ├── containerView   [rounded, themed]
        │   ├── valueLabel  "123 Main St..." or empty
        │   └── chevronView >
        └── footerLabel     "Your billing address" / validation error
```
## Note
This is the first time the PR contains the markdown development plan, @erenbesel @nauaros let me know if it helps to grasp the context and onboard faster or not. I'm just trying to experiment with different workflows.

# Demo [Required for UI changes]
<!-- Add screenshots or link to screen recording demonstrating the changes -->
<!-- Include both light/dark mode and different device sizes if it matters -->

| New billing address section | 
|--------|
| <img width="382" height="719" alt="image" src="https://github.com/user-attachments/assets/30fb436d-5a9f-4a59-bdac-05187441f861" /> |

## Next steps
- move placeholder to one level up (`FormTextItem`-> `FormValidatableValueItem`) 
- move all placeholders out ot text inputs and put them to a footer label shared with validation message


## Ticket [Optional]
<ticket>
COSDK-859
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Add screenshots
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
