### PR TITLE
Move text input placeholder to a footer label

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -629,6 +629,9 @@
 		B62F51802E97AAD200610EFD /* TextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62F517F2E97AA6600610EFD /* TextFieldTests.swift */; };
 		B639C0822D8039F600472EBB /* CardScannerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B639C0812D80399800472EBB /* CardScannerController.swift */; };
 		B643C7642EEAD2CF00EF8407 /* FormSectionHeaderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B643C7622EEAD2CF00EF8407 /* FormSectionHeaderItem.swift */; };
+		B643C7662EEC53E200EF8407 /* FormItemView+ValidationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B643C7652EEC53E200EF8407 /* FormItemView+ValidationState.swift */; };
+		B643C7672EEC53E200EF8407 /* FormItemView+ValidationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B643C7652EEC53E200EF8407 /* FormItemView+ValidationState.swift */; };
+		B643C7682EEC53E200EF8407 /* FormItemView+ValidationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B643C7652EEC53E200EF8407 /* FormItemView+ValidationState.swift */; };
 		B65F0EB42ED493250015AC41 /* FormButtonItemViewThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65F0EB32ED493250015AC41 /* FormButtonItemViewThemeTests.swift */; };
 		B65F0EBA2ED89EC00015AC41 /* TestTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65F0EB92ED89EC00015AC41 /* TestTheme.swift */; };
 		B65F0EBB2ED89EC00015AC41 /* TestTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65F0EB92ED89EC00015AC41 /* TestTheme.swift */; };
@@ -2256,6 +2259,7 @@
 		B62F517F2E97AA6600610EFD /* TextFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTests.swift; sourceTree = "<group>"; };
 		B639C0812D80399800472EBB /* CardScannerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerController.swift; sourceTree = "<group>"; };
 		B643C7622EEAD2CF00EF8407 /* FormSectionHeaderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormSectionHeaderItem.swift; sourceTree = "<group>"; };
+		B643C7652EEC53E200EF8407 /* FormItemView+ValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormItemView+ValidationState.swift"; sourceTree = "<group>"; };
 		B65F0EB32ED493250015AC41 /* FormButtonItemViewThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormButtonItemViewThemeTests.swift; sourceTree = "<group>"; };
 		B65F0EB92ED89EC00015AC41 /* TestTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTheme.swift; sourceTree = "<group>"; };
 		B65F0EBD2ED89EC60015AC41 /* FormViewExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormViewExtractor.swift; sourceTree = "<group>"; };
@@ -4433,6 +4437,7 @@
 				F96AE51A26038602009F82BD /* XCTestCase+FormTextItemView.swift */,
 				81825CC02AC59C6400F91912 /* XCTestCase+RootViewController.swift */,
 				C92F6DC026B04B63004BD516 /* XCTestCase+FormAddressItem.swift */,
+				B643C7652EEC53E200EF8407 /* FormItemView+ValidationState.swift */,
 				5A56E15426B6DEF800744CA0 /* XCTestCase+Style.swift */,
 				81B505782A7BE209009B4CB3 /* UIBarButtonItem+XCTest.swift */,
 				8122B9BC2B9A0FF3002FC4D6 /* ErrorMock.swift */,
@@ -8187,6 +8192,7 @@
 				81DF940B2BAAD8EB0001DCBC /* AtomeComponentUITests.swift in Sources */,
 				81DF940C2BAAD8EB0001DCBC /* XCTestCase+FirstResponder.swift in Sources */,
 				81DF940D2BAAD8EB0001DCBC /* OnlineBankingComponentUITests.swift in Sources */,
+				B643C7672EEC53E200EF8407 /* FormItemView+ValidationState.swift in Sources */,
 				81DF940E2BAAD8EB0001DCBC /* SecuredViewControllerUITests.swift in Sources */,
 				814E154B2C87407F00D90D4B /* CardComponentUITests.swift in Sources */,
 				817C90812C3D590C0072A202 /* GiftCardComponentUITests.swift in Sources */,
@@ -8758,6 +8764,7 @@
 				8100F2C02A4C37E4008C09E7 /* FormSelectableItemViewTests.swift in Sources */,
 				E9021DF2225CC6D0009CF7F4 /* RedirectDetailsTests.swift in Sources */,
 				81825CB82AC59C3300F91912 /* UIView+Search.swift in Sources */,
+				B643C7682EEC53E200EF8407 /* FormItemView+ValidationState.swift in Sources */,
 				C981254E2851E9AF006D1374 /* PaymentComponentSubject.swift in Sources */,
 				81A48DC62A5800EA00242341 /* AddressLookupViewControllerTests.swift in Sources */,
 				21B387B62C401C890029101E /* ThreeDS2DAScreenPresenterMock.swift in Sources */,
@@ -9302,6 +9309,7 @@
 				F9CCA3CE296ECC9C00AD643D /* DummyPaymentMethods.swift in Sources */,
 				0022096429A8C39100B2BACD /* DokuComponentUITests.swift in Sources */,
 				F9CCA3C8296ECB9900AD643D /* IssuerListComponentUITests.swift in Sources */,
+				B643C7662EEC53E200EF8407 /* FormItemView+ValidationState.swift in Sources */,
 				B6EE0F412BBEBF7600B9810D /* APIClientMock.swift in Sources */,
 				F9CCA3C7296ECB9900AD643D /* AffirmComponentUITests.swift in Sources */,
 				F9CCA3D1296ECCEE00AD643D /* XCTestCase+FormAddressItem.swift in Sources */,

--- a/AdyenCard/Form/FormCardNumberItem.swift
+++ b/AdyenCard/Form/FormCardNumberItem.swift
@@ -88,7 +88,8 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
         title = localizedString(.cardNumberItemTitle, localizationParameters)
         validator = CardNumberValidator(isLuhnCheckEnabled: true, isEnteredBrandSupported: true)
         formatter = cardNumberFormatter
-        placeholder = localizedString(.cardNumberItemPlaceholder, localizationParameters)
+        // Brand icons are used instead of a placeholder
+        placeholder = nil
         validationFailureMessage = localizedString(.cardNumberItemInvalid, localizationParameters)
         keyboardType = .numberPad
     }

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -23,13 +23,14 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
         textField.allowsEditingActions = false
         
         observe(item.$selectedCard) { [weak self] cardsType in
+            guard let self else { return }
             let number = cardsType == CardType.americanExpress ? "4" : "3"
             let localizedPlaceholder = localizedString(.cardCvcItemPlaceholderDigits, item.localizationParameters, number)
-
-            if let textField = self?.textField, let style = self?.theme.elements.textField {
-                textField.apply(placeholderText: localizedPlaceholder, with: style.placeholder)
-                textField.accessibilityLabel = self?.accessibilityLabel(placeholder: localizedPlaceholder)
-            }
+            
+            // Set placeholder on item - it will be shown in footer label
+            self.item.placeholder = localizedPlaceholder
+            self.showHint()
+            self.textField.accessibilityLabel = self.accessibilityLabel(placeholder: localizedPlaceholder)
         }
 
         observe(item.$displayMode) { [weak self] _ in

--- a/AdyenUI/UI/Form/Items/Text/FormTextItem.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItem.swift
@@ -11,7 +11,6 @@ import UIKit
 @_spi(AdyenInternal)
 open class FormTextItem: FormValidatableValueItem<String>, InputViewRequiringFormItem {
 
-    
     override public var value: String {
         get { publisher.wrappedValue }
         set { publishTransformed(value: newValue) }

--- a/AdyenUI/UI/Form/Items/Text/FormTextItem.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItem.swift
@@ -11,8 +11,6 @@ import UIKit
 @_spi(AdyenInternal)
 open class FormTextItem: FormValidatableValueItem<String>, InputViewRequiringFormItem {
 
-    /// The placeholder of the text field.
-    @AdyenObservable(nil) public var placeholder: String?
     
     override public var value: String {
         get { publisher.wrappedValue }

--- a/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
@@ -46,7 +46,6 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
     public required init(item: ItemType, theme: AdyenTheme) {
         super.init(item: item, theme: theme)
 
-        bind(item.$placeholder, to: textField, at: \.placeholder)
         observe(item.$formattedValue) { [weak self] newValue in
             self?.handleFormattedValueDidChange(newValue)
         }
@@ -56,10 +55,6 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         addSubview(textStackView)
         configureConstraints()
         
-        observe(item.$validationFailureMessage) { [weak self] newValue in
-            self?.alertLabel.text = newValue
-        }
-
         configure()
     }
 
@@ -84,16 +79,9 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         textField.textColor = style.text.color
         textField.textAlignment = style.text.textAlignment
 
-        // Placeholder
-        textField.apply(placeholderText: item.placeholder, with: style.placeholder)
-
         // Container
         entryTextStackView.backgroundColor = style.containerColor
         entryTextStackView.layer.borderWidth = style.borderWidth
-
-        // Alert
-        alertLabel.textColor = style.errorColor
-
         // Corner radius
         switch style.cornerRadius {
         case let .fixed(radius):
@@ -118,7 +106,7 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
     // MARK: - Stack View
     
     private lazy var textStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, entryTextStackView, alertLabel])
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, entryTextStackView, footerLabel])
         stackView.axis = .vertical
         stackView.alignment = .fill
         stackView.spacing = 8.0

--- a/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
@@ -82,6 +82,7 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         // Container
         entryTextStackView.backgroundColor = style.containerColor
         entryTextStackView.layer.borderWidth = style.borderWidth
+
         // Corner radius
         switch style.cornerRadius {
         case let .fixed(radius):
@@ -91,7 +92,7 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         }
 
         // Border styling
-        updateBorderStyling()
+        updateBorderColor()
     }
     
     override public func reset() {
@@ -270,7 +271,7 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
     /// Subclasses can override this method to stay notified when the text field resigns its first responder status.
     open func textFieldDidEndEditing(_ textField: UITextField) {
         isEditing = false
-        updateBorderStyling()
+        updateBorderColor()
         item.onDidEndEditing?()
     }
     
@@ -278,7 +279,7 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
     /// Subclasses can override this method to stay notified when textField became the first responder.
     open func textFieldDidBeginEditing(_ textField: UITextField) {
         isEditing = true
-        updateBorderStyling()
+        updateBorderColor()
         item.onDidBeginEditing?()
     }
     
@@ -291,9 +292,12 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         
         if forceShowValidationStatus {
             accessory = item.isValid() ? .valid : .invalid
+            isShowingValidationError = !item.isValid()
         } else {
             removeAccessoryIfNeeded()
+            isShowingValidationError = false
         }
+        updateBorderColor()
         
         super.updateValidationStatus(forced: forceShowValidationStatus)
     }
@@ -307,6 +311,8 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
 
     override internal func resetValidationStatus() {
         super.resetValidationStatus()
+        isShowingValidationError = false
+        updateBorderColor()
         removeAccessoryIfNeeded()
     }
 
@@ -317,9 +323,21 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
 
     // MARK: - Border Styling
 
-    /// Updates the border color based on editing state.
-    private func updateBorderStyling() {
-        let borderColor = isEditing ? theme.elements.textField.borderActiveColor : theme.elements.textField.borderColor
+    /// Tracks whether a validation error is currently being shown.
+    private var isShowingValidationError = false
+
+    /// Updates the border color based on both editing state and validation state.
+    /// Priority: editing (active color) > validation error (error color) > default (normal color)
+    private func updateBorderColor() {
+        let style = theme.elements.textField
+        let borderColor: UIColor
+        if isEditing {
+            borderColor = style.borderActiveColor
+        } else if isShowingValidationError {
+            borderColor = style.errorColor
+        } else {
+            borderColor = style.borderColor
+        }
         entryTextStackView.layer.borderColor = borderColor.cgColor
     }
 }

--- a/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItem.swift
+++ b/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItem.swift
@@ -11,9 +11,6 @@ import Foundation
 @_spi(AdyenInternal)
 open class FormSelectableValueItem<ValueType: Equatable>: FormValidatableValueItem<ValueType> {
     
-    /// The placeholder of the item.
-    public let placeholder: String
-    
     /// A closure that will be invoked when the item is selected.
     public var selectionHandler: () -> Void
     
@@ -25,12 +22,12 @@ open class FormSelectableValueItem<ValueType: Equatable>: FormValidatableValueIt
         style: FormTextItemStyle,
         placeholder: String
     ) {
-        self.placeholder = placeholder
-        
         selectionHandler = {
             AdyenAssertion.assertionFailure(message: "'selectionHandler' needs to be provided on '\(String(describing: Self.self))'")
         }
         
         super.init(value: value, style: style)
+        
+        self.placeholder = placeholder
     }
 }

--- a/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
@@ -110,16 +110,6 @@ package class FormSelectableValueItemView<ValueType, ItemType: FormSelectableVal
         return valueLabel
     }()
 
-    internal lazy var footerLabel: UILabel = {
-        let label = UILabel()
-        label.numberOfLines = 0
-        label.isAccessibilityElement = false
-        label.accessibilityIdentifier = item.identifier.map {
-            ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "footerLabel")
-        }
-        return label
-    }()
-
     // MARK: - Selection
 
     @objc
@@ -145,35 +135,12 @@ package class FormSelectableValueItemView<ValueType, ItemType: FormSelectableVal
 
         chevronView.tintColor = theme.colors.primary
         valueLabel.apply(theme.elements.labels.body)
-        footerLabel.apply(theme.elements.labels.subheadline)
-
-        footerLabel.text = item.placeholder
-        footerLabel.isHidden = item.placeholder.isEmpty
     }
 
     private func updateContainerBorderColor(isValid: Bool) {
         let style = theme.elements.textField
         let borderColor = isValid ? style.borderColor : style.errorColor
         containerView.layer.borderColor = borderColor.cgColor
-    }
-
-    // MARK: - Hint/Error Display
-
-    private func showHint() {
-
-        footerLabel.text = item.placeholder
-        footerLabel.textColor = theme.colors.textSecondary
-        footerLabel.isHidden = item.placeholder.isEmpty
-    }
-
-    private func showError(_ message: String?) {
-        guard let message, !message.isEmpty else {
-            showHint()
-            return
-        }
-        footerLabel.text = message
-        footerLabel.textColor = theme.colors.destructive
-        footerLabel.isHidden = false
     }
 
     // MARK: - Convenience

--- a/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItem.swift
+++ b/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItem.swift
@@ -11,6 +11,9 @@ import Foundation
 @_spi(AdyenInternal)
 open class FormValidatableValueItem<ValueType: Equatable>: FormValueItem<ValueType, FormTextItemStyle>, ValidatableFormItem {
     
+    /// The placeholder text shown as a hint below the input field.
+    @AdyenObservable(nil) public var placeholder: String?
+    
     /// A message that is displayed when validation fails. Observable.
     @AdyenObservable(nil) public var validationFailureMessage: String?
     

--- a/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
@@ -24,21 +24,20 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
 
     // MARK: - Views
     
-    /// The alert label to be used to indicate an issue with the value
+    /// The footer label used to display hints and validation errors
     ///
-    /// The intended use is to put it inside of a UIStackView as it will be hidden based on the validity of the item
-    internal lazy var alertLabel: UILabel = {
-        let alertLabel = UILabel()
+    /// Shows placeholder hint when valid, validation error when invalid
+    internal lazy var footerLabel: UILabel = {
+        let footerLabel = UILabel()
 
-        alertLabel.apply(theme.elements.labels.subheadline)
-        alertLabel.textColor = theme.colors.destructive
-        alertLabel.isAccessibilityElement = false
-        alertLabel.numberOfLines = 0
-        alertLabel.text = item.validationFailureMessage
-        alertLabel.accessibilityIdentifier = item.identifier.map { ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "alertLabel") }
-        alertLabel.isHidden = true
+        footerLabel.apply(theme.elements.labels.subheadline)
+        footerLabel.textColor = theme.colors.textSecondary
+        footerLabel.isAccessibilityElement = false
+        footerLabel.numberOfLines = 0
+        footerLabel.accessibilityIdentifier = item.identifier.map { ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "footerLabel") }
+        footerLabel.isHidden = true
         
-        return alertLabel
+        return footerLabel
     }()
     
     // MARK: - Convenience
@@ -46,10 +45,6 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
     private func setupObservers() {
         itemObserver = observe(item.publisher) { [weak self] _ in
             self?.updateValidationStatus()
-        }
-        
-        observe(item.$validationFailureMessage) { [weak self] in
-            self?.alertLabel.text = $0
         }
     }
     
@@ -64,30 +59,21 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
     }
     
     open func updateValidationStatus(forced: Bool = false) {
-        
         guard forced else {
-            hideAlertLabel(true)
+            showHint()
             accessibilityLabelView?.accessibilityLabel = item.title
             return
         }
         if item.isValid() {
-            hideAlertLabel(true)
+            showHint()
             accessibilityLabelView?.accessibilityLabel = item.title
         } else {
-            hideAlertLabel(false)
+            showError(item.validationFailureMessage)
             accessibilityLabelView?.accessibilityLabel = [
                 item.title,
                 item.validationFailureMessage
             ].compactMap { $0 }.joined(separator: ", ")
         }
-    }
-    
-    private func hideAlertLabel(_ shouldHide: Bool, animated: Bool = true) {
-        guard shouldHide || alertLabel.text != nil else { return }
-        if !shouldHide {
-            triggerValidationErrorIfNeeded()
-        }
-        alertLabel.adyen.hide(animationKey: "hide_alertLabel", hidden: shouldHide, animated: animated)
     }
     
     private func triggerValidationErrorIfNeeded() {
@@ -98,8 +84,31 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
     }
     
     internal func resetValidationStatus() {
-        hideAlertLabel(true, animated: false)
+        showHint()
         accessibilityLabelView?.accessibilityLabel = item.title
+    }
+
+    // MARK: - Footer Label (Hint/Error Display)
+    
+    package func showHint() {
+        guard let placeholder = item.placeholder, !placeholder.isEmpty else {
+            footerLabel.isHidden = true
+            return
+        }
+        footerLabel.text = placeholder
+        footerLabel.textColor = theme.colors.textSecondary
+        footerLabel.isHidden = false
+    }
+    
+    package func showError(_ message: String?) {
+        guard let message, !message.isEmpty else {
+            showHint()
+            return
+        }
+        footerLabel.text = message
+        footerLabel.textColor = theme.colors.destructive
+        footerLabel.isHidden = false
+        triggerValidationErrorIfNeeded()
     }
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,16 @@
 # In ./CLAUDE.md
 @AGENTS.md
+
+## Workflow Rules
+
+**CRITICAL: Always plan first, never execute without explicit approval.**
+
+1. When asked to implement a feature or change:
+   - First create/update a plan document
+   - Present the plan to the user
+   - **WAIT for explicit approval** before making any code changes
+
+2. Only proceed with implementation when the user says words like:
+   - "proceed", "go ahead", "implement it", "approved", "looks good, do it"
+
+3. If uncertain, always ask: "Should I proceed with implementation?"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,3 +14,50 @@
    - "proceed", "go ahead", "implement it", "approved", "looks good, do it"
 
 3. If uncertain, always ask: "Should I proceed with implementation?"
+
+## Code Editing Rules
+
+**CRITICAL: The `edit` and `multi_edit` tools trigger an internal formatter that differs from SwiftFormat, causing massive formatting diffs.**
+
+**Use shell commands instead:**
+
+1. **Simple replacement:**
+   ```bash
+   sed -i '' 's/old/new/g' file.swift
+   ```
+
+2. **Add line after pattern:**
+   ```bash
+   sed -i '' '/pattern/a\
+   new line' file.swift
+   ```
+
+3. **Multi-line insertion (using perl):**
+   ```bash
+   perl -i -0777 -pe 's/(pattern)/$1\nnew lines/' file.swift
+   ```
+
+4. **Replace entire function (head/tail approach):**
+   ```bash
+   head -n N file.swift > /tmp/part1.swift
+   cat /tmp/new_content.swift >> /tmp/part1.swift
+   tail -n +M file.swift >> /tmp/part1.swift
+   mv /tmp/part1.swift file.swift
+   ```
+
+5. **Create temp files with heredoc:**
+   ```bash
+   cat > /tmp/new_code.swift << 'EOF'
+   // content here
+   EOF
+   ```
+
+**Do NOT use for Swift files:**
+- ❌ `edit` tool
+- ❌ `multi_edit` tool
+- ❌ `write_to_file` for modifications
+
+**Always verify with:**
+```bash
+git diff file.swift
+```

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -69,15 +69,19 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
                 }
         }
         .theme(
-            AdyenTheme(colors: AdyenColors(primary: .systemPurple))
-                .bodyLabel(font: AdyenFonts.default.bodyEmphasized)
-                .destructiveButton(
-                    backgroundColor: .systemRed,
-                    textColor: .white,
-                    disabledBackgroundColor: .systemGray,
-                    disabledTextColor: .lightGray
-                )
-                .cornerRadius(8.0)
+            AdyenTheme(
+                colors:
+                .default
+//                AdyenColors(primary: .systemPurple)
+            )
+            .bodyLabel(font: AdyenFonts.default.bodyEmphasized)
+            .destructiveButton(
+                backgroundColor: .systemRed,
+                textColor: .white,
+                disabledBackgroundColor: .systemGray,
+                disabledTextColor: .lightGray
+            )
+            .cornerRadius(8.0)
         )
         .onSubmit { [weak self] data, handler in
             self?.callPayments(with: data, completion: handler)

--- a/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
@@ -437,7 +437,7 @@ class BCMCComponentTests: XCTestCase {
         
         wait(for: .milliseconds(300))
         
-        let alertLabel: UILabel? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem.alertLabel")
+        let alertLabel: UILabel? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem.footerLabel")
         XCTAssertNotNil(alertLabel)
         XCTAssertEqual(alertLabel?.text, cardNumberView?.item.validationFailureMessage)
         

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -816,7 +816,7 @@ class CardComponentTests: XCTestCase {
 
         let postalCodeItemView: FormTextItemView<FormPostalCodeItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.CardComponent.postalCodeItem"))
         XCTAssertEqual(postalCodeItemView.titleLabel.text, "Postal code")
-        XCTAssertTrue(postalCodeItemView.alertLabel.isHidden)
+        XCTAssertTrue(postalCodeItemView.footerLabel.isHidden)
         
         self.populate(textItemView: postalCodeItemView, with: "12345")
 

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -278,11 +278,11 @@ class CardComponentTests: XCTestCase {
 
         XCTAssertNotNil(securityCodeCvvHint)
         XCTAssertFalse(securityCodeCvvHint!.showFront)
-        XCTAssertEqual(securityCodeItemView?.textField.placeholder, "3 digits")
+        XCTAssertEqual(securityCodeItemView?.footerLabel.text, "3 digits")
 
         self.populate(textItemView: cardNumberItemView!, with: "370000")
         XCTAssertTrue(securityCodeCvvHint!.showFront)
-        XCTAssertEqual(securityCodeItemView?.textField.placeholder, "4 digits")
+        XCTAssertEqual(securityCodeItemView?.footerLabel.text, "4 digits")
 
     }
 
@@ -816,7 +816,7 @@ class CardComponentTests: XCTestCase {
 
         let postalCodeItemView: FormTextItemView<FormPostalCodeItem> = try XCTUnwrap(sut.viewController.view.findView(with: "AdyenCard.CardComponent.postalCodeItem"))
         XCTAssertEqual(postalCodeItemView.titleLabel.text, "Postal code")
-        XCTAssertTrue(postalCodeItemView.footerLabel.isHidden)
+        XCTAssertFalse(postalCodeItemView.isShowingValidationError)
         
         self.populate(textItemView: postalCodeItemView, with: "12345")
 

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
@@ -166,7 +166,7 @@ class FormCardNumberItemTests: XCTestCase {
         let sut = FormCardNumberItem(cardTypeLogos: [], localizationParameters: expectedLocalizationParameters)
         
         XCTAssertEqual(sut.title, localizedString(.cardNumberItemTitle, expectedLocalizationParameters))
-        XCTAssertEqual(sut.placeholder, localizedString(.cardNumberItemPlaceholder, expectedLocalizationParameters))
+        XCTAssertNil(sut.placeholder) // Brand icons are used instead of a placeholder
         XCTAssertEqual(sut.validationFailureMessage, localizedString(.cardNumberItemInvalid, expectedLocalizationParameters))
     }
     
@@ -175,7 +175,7 @@ class FormCardNumberItemTests: XCTestCase {
         let sut = FormCardNumberItem(cardTypeLogos: [], localizationParameters: expectedLocalizationParameters)
         
         XCTAssertEqual(sut.title, localizedString(LocalizationKey(key: "adyen_card_numberItem_title"), expectedLocalizationParameters))
-        XCTAssertEqual(sut.placeholder, localizedString(LocalizationKey(key: "adyen_card_numberItem_placeholder"), expectedLocalizationParameters))
+        XCTAssertNil(sut.placeholder) // Brand icons are used instead of a placeholder
         XCTAssertEqual(sut.validationFailureMessage, localizedString(LocalizationKey(key: "adyen_card_numberItem_invalid"), expectedLocalizationParameters))
     }
     

--- a/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -199,9 +199,9 @@ class ACHDirectDebitComponentTests: XCTestCase {
 
         payButtonItemViewButton?.sendActions(for: .touchUpInside)
 
-        XCTAssertEqual(nameItemView?.alertLabel.text, "Invalid account holder name")
-        XCTAssertEqual(accountNumberItemView?.alertLabel.text, "Invalid account number")
-        XCTAssertEqual(routingNumberItemView?.alertLabel.text, "Invalid ABA routing number")
+        XCTAssertEqual(nameItemView?.footerLabel.text, "Invalid account holder name")
+        XCTAssertEqual(accountNumberItemView?.footerLabel.text, "Invalid account number")
+        XCTAssertEqual(routingNumberItemView?.footerLabel.text, "Invalid ABA routing number")
     }
     
     func testSubmission() throws {

--- a/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
@@ -165,8 +165,8 @@ class SEPADirectDebitComponentTests: XCTestCase {
 
         payButtonItemViewButton?.sendActions(for: .touchUpInside)
 
-        XCTAssertEqual(nameItemView?.alertLabel.text, "Holder name invalid")
-        XCTAssertEqual(ibanItemView?.alertLabel.text, "Invalid account number")
+        XCTAssertEqual(nameItemView?.footerLabel.text, "Holder name invalid")
+        XCTAssertEqual(ibanItemView?.footerLabel.text, "Invalid account number")
 
     }
 

--- a/Tests/IntegrationTests/Helpers/FormItemView+ValidationState.swift
+++ b/Tests/IntegrationTests/Helpers/FormItemView+ValidationState.swift
@@ -1,0 +1,20 @@
+//
+// Copyright (c) 2025 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+@_spi(AdyenInternal) @testable import AdyenUI
+import UIKit
+
+extension FormValidatableValueItemView {
+
+    var isShowingValidationError: Bool {
+        footerLabel.textColor == theme.colors.destructive
+    }
+
+    var isShowingHint: Bool {
+        footerLabel.textColor == theme.colors.textSecondary
+    }
+}

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Address/FormAddressPickerItemViewStyleTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Address/FormAddressPickerItemViewStyleTests.swift
@@ -70,14 +70,18 @@ class FormAddressPickerItemViewStyleTests: XCTestCase {
         XCTAssertEqual(sut.valueLabel.numberOfLines, expectedNumberOfLines)
     }
 
-    // MARK: - AlertLabel Style Tests
+    // MARK: - FooterLabel Style Tests
 
-    func test_alertLabel_font_shouldUseThemeSubheadlineFont() {
+    func test_footerLabel_font_shouldUseThemeSubheadlineFont() {
         let expectedFont = AdyenTheme.default.elements.labels.subheadline.font
         XCTAssertEqual(sut.footerLabel.font, expectedFont)
     }
 
-    func test_alertLabel_color_shouldUseThemeDestructiveColor() {
+    func test_footerLabel_color_shouldUseThemeDestructiveColor() {
+        // Given - force validation to show error state
+        sut.showValidation()
+        
+        // Then
         let expectedColor = AdyenTheme.default.colors.destructive
         XCTAssertEqual(sut.footerLabel.textColor, expectedColor)
     }
@@ -106,7 +110,7 @@ class FormAddressPickerItemViewStyleTests: XCTestCase {
         XCTAssertEqual(sutWithCustomTheme.valueLabel.textColor, expectedColor)
     }
 
-    func test_customTheme_alertLabel_shouldUseCustomDestructiveColor() {
+    func test_customTheme_footerLabel_shouldUseCustomDestructiveColor() {
         // Given
         let expectedColor = UIColor.systemPurple
         var customColors = AdyenColors()
@@ -115,6 +119,7 @@ class FormAddressPickerItemViewStyleTests: XCTestCase {
 
         // When
         let sutWithCustomTheme = makeSUT(theme: customTheme)
+        sutWithCustomTheme.showValidation()
 
         // Then
         XCTAssertEqual(sutWithCustomTheme.footerLabel.textColor, expectedColor)

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Address/FormAddressPickerItemViewStyleTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Address/FormAddressPickerItemViewStyleTests.swift
@@ -74,12 +74,12 @@ class FormAddressPickerItemViewStyleTests: XCTestCase {
 
     func test_alertLabel_font_shouldUseThemeSubheadlineFont() {
         let expectedFont = AdyenTheme.default.elements.labels.subheadline.font
-        XCTAssertEqual(sut.alertLabel.font, expectedFont)
+        XCTAssertEqual(sut.footerLabel.font, expectedFont)
     }
 
     func test_alertLabel_color_shouldUseThemeDestructiveColor() {
         let expectedColor = AdyenTheme.default.colors.destructive
-        XCTAssertEqual(sut.alertLabel.textColor, expectedColor)
+        XCTAssertEqual(sut.footerLabel.textColor, expectedColor)
     }
 
     // MARK: - ChevronView Tests
@@ -117,7 +117,7 @@ class FormAddressPickerItemViewStyleTests: XCTestCase {
         let sutWithCustomTheme = makeSUT(theme: customTheme)
 
         // Then
-        XCTAssertEqual(sutWithCustomTheme.alertLabel.textColor, expectedColor)
+        XCTAssertEqual(sutWithCustomTheme.footerLabel.textColor, expectedColor)
     }
 
     // MARK: - Private

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
@@ -223,28 +223,33 @@ class FormPickerItemViewStyleTests: XCTestCase {
         XCTAssertEqual(sut.valueLabel.font, AdyenTheme.default.elements.labels.body.font)
     }
 
-    // MARK: - AlertLabel Style Tests
+    // MARK: - FooterLabel Style Tests
 
-    func test_alertLabel_color_shouldUseThemeDestructiveColor() {
-        // After migration: alertLabel uses theme.colors.destructive for error color
+    func test_footerLabel_color_shouldUseThemeDestructiveColor() {
+        // Given - force validation to show error state
+        sut.showValidation()
+        
+        // Then - footerLabel uses destructive color when showing error
         let expectedColor = AdyenTheme.default.colors.destructive
         XCTAssertEqual(
-            sut.alertLabel.textColor?.resolvedColor(
+            sut.footerLabel.textColor?.resolvedColor(
                 with: UITraitCollection(userInterfaceStyle: .light)),
             expectedColor.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
         )
     }
 
-    func test_alertLabel_font_shouldUseThemeSubheadlineStyle() {
-        // Then - alertLabel font is styled by theme (in FormValidatableValueItemView)
+    func test_footerLabel_font_shouldUseThemeSubheadlineStyle() {
+        // Then - footerLabel font is styled by theme
         let expectedFont = AdyenTheme.default.elements.labels.subheadline.font
-        XCTAssertEqual(sut.alertLabel.font, expectedFont)
+        XCTAssertEqual(sut.footerLabel.font, expectedFont)
     }
 
-    func test_alertLabel_text_shouldUseItemValidationFailureMessage() {
-        // Given - TestFormPickerItem sets validationFailureMessage in updateValidationFailureMessage()
-        // Then
-        XCTAssertEqual(sut.alertLabel.text, "Please select a value")
+    func test_footerLabel_text_shouldUseItemValidationFailureMessage() {
+        // Given - force validation to show error message
+        sut.showValidation()
+        
+        // Then - TestFormPickerItem sets validationFailureMessage in updateValidationFailureMessage()
+        XCTAssertEqual(sut.footerLabel.text, "Please select a value")
     }
 
     // MARK: - View-Level Style Tests

--- a/Tests/IntegrationTests/UIKit/Form/Theme/FormTextItemViewThemeTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/Theme/FormTextItemViewThemeTests.swift
@@ -11,13 +11,19 @@ import XCTest
 final class FormTextItemViewThemeTests: XCTestCase {
 
     func test_formTextItemView_withDefaultTheme_shouldUseDefaultColors() {
-        // Given
-        let sut = makeSUT()
+        // Given - item with required validation that will fail when empty
+        let expectedErrorMessage = "Required"
+        let item = FormTextInputItem()
+        item.validator = LengthValidator(minimumLength: 1, maximumLength: 100)
+        item.validationFailureMessage = expectedErrorMessage
+        let sut = makeSUT(item: item)
 
-        // Then
+        // Then - trigger validation to show error state
+        sut.showValidation()
         XCTAssertEqual(sut.titleLabel.textColor, AdyenColors.default.primary)
         XCTAssertEqual(sut.textField.textColor, AdyenColors.default.primary)
         XCTAssertEqual(sut.footerLabel.textColor, AdyenColors.default.destructive)
+        XCTAssertEqual(sut.footerLabel.text, expectedErrorMessage)
 
         let containerView = getContainerView(from: sut)
         XCTAssertEqual(containerView?.backgroundColor, AdyenColors.default.container)
@@ -25,18 +31,22 @@ final class FormTextItemViewThemeTests: XCTestCase {
     }
 
     func test_formTextItemView_withCustomColors_shouldApplyToUI() {
-        // Given
+        // Given - item with required validation that will fail when empty
         let customColors = AdyenColors(
             container: .systemYellow,
             containerOutline: .systemPurple,
             primary: .systemPink,
             destructive: .systemOrange
         )
-
+        let item = FormTextInputItem()
+        item.validator = LengthValidator(minimumLength: 1, maximumLength: 100)
+        item.validationFailureMessage = "Required"
+        
         // When
-        let sut = makeSUT(colors: customColors)
+        let sut = makeSUT(item: item, colors: customColors)
 
-        // Then
+        // Then - trigger validation to show error state
+        sut.showValidation()
         XCTAssertEqual(sut.titleLabel.textColor, .systemPink)
         XCTAssertEqual(sut.textField.textColor, .systemPink)
         XCTAssertEqual(sut.footerLabel.textColor, .systemOrange)

--- a/Tests/IntegrationTests/UIKit/Form/Theme/FormTextItemViewThemeTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/Theme/FormTextItemViewThemeTests.swift
@@ -17,7 +17,7 @@ final class FormTextItemViewThemeTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.titleLabel.textColor, AdyenColors.default.primary)
         XCTAssertEqual(sut.textField.textColor, AdyenColors.default.primary)
-        XCTAssertEqual(sut.alertLabel.textColor, AdyenColors.default.destructive)
+        XCTAssertEqual(sut.footerLabel.textColor, AdyenColors.default.destructive)
 
         let containerView = getContainerView(from: sut)
         XCTAssertEqual(containerView?.backgroundColor, AdyenColors.default.container)
@@ -39,7 +39,7 @@ final class FormTextItemViewThemeTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.titleLabel.textColor, .systemPink)
         XCTAssertEqual(sut.textField.textColor, .systemPink)
-        XCTAssertEqual(sut.alertLabel.textColor, .systemOrange)
+        XCTAssertEqual(sut.footerLabel.textColor, .systemOrange)
 
         let containerView = getContainerView(from: sut)
         XCTAssertEqual(containerView?.backgroundColor, .systemYellow)

--- a/Tests/IntegrationTests/UIKit/Form/Theme/FormTextItemViewThemeTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/Theme/FormTextItemViewThemeTests.swift
@@ -27,7 +27,8 @@ final class FormTextItemViewThemeTests: XCTestCase {
 
         let containerView = getContainerView(from: sut)
         XCTAssertEqual(containerView?.backgroundColor, AdyenColors.default.container)
-        XCTAssertEqual(containerView?.layer.borderColor, AdyenColors.default.containerOutline.cgColor)
+        // Error state should show destructive border color
+        XCTAssertEqual(containerView?.layer.borderColor, AdyenColors.default.destructive.cgColor)
     }
 
     func test_formTextItemView_withCustomColors_shouldApplyToUI() {
@@ -41,7 +42,7 @@ final class FormTextItemViewThemeTests: XCTestCase {
         let item = FormTextInputItem()
         item.validator = LengthValidator(minimumLength: 1, maximumLength: 100)
         item.validationFailureMessage = "Required"
-        
+
         // When
         let sut = makeSUT(item: item, colors: customColors)
 
@@ -53,7 +54,8 @@ final class FormTextItemViewThemeTests: XCTestCase {
 
         let containerView = getContainerView(from: sut)
         XCTAssertEqual(containerView?.backgroundColor, .systemYellow)
-        XCTAssertEqual(containerView?.layer.borderColor, UIColor.systemPurple.cgColor)
+        // Error state should show destructive border color
+        XCTAssertEqual(containerView?.layer.borderColor, UIColor.systemOrange.cgColor)
     }
 
     func test_formTextItemView_borderColor_shouldUpdateOnEditingStateChange() {

--- a/Tests/IntegrationTests/UIKit/View Controllers/AddressInputFormViewControllerTests.swift
+++ b/Tests/IntegrationTests/UIKit/View Controllers/AddressInputFormViewControllerTests.swift
@@ -52,22 +52,22 @@ class AddressInputFormViewControllerTests: XCTestCase {
         XCTAssertEqual(provinceOrTerritoryItemView.titleLabel.text, "Province or Territory")
         XCTAssertEqual(postalCodeItemView.titleLabel.text, "Postal code")
 
-        XCTAssertTrue(houseNumberItemView.footerLabel.isHidden)
-        XCTAssertTrue(addressItemView.footerLabel.isHidden)
-        XCTAssertTrue(apartmentSuiteItemView.footerLabel.isHidden)
-        XCTAssertTrue(cityItemView.footerLabel.isHidden)
-        XCTAssertTrue(provinceOrTerritoryItemView.footerLabel.isHidden)
-        XCTAssertTrue(postalCodeItemView.footerLabel.isHidden)
+        XCTAssertFalse(houseNumberItemView.isShowingValidationError)
+        XCTAssertFalse(addressItemView.isShowingValidationError)
+        XCTAssertFalse(apartmentSuiteItemView.isShowingValidationError)
+        XCTAssertFalse(cityItemView.isShowingValidationError)
+        XCTAssertFalse(provinceOrTerritoryItemView.isShowingValidationError)
+        XCTAssertFalse(postalCodeItemView.isShowingValidationError)
         
         let doneButton = try XCTUnwrap(viewController.navigationItem.rightBarButtonItem)
         try doneButton.tap()
         
-        wait { !houseNumberItemView.footerLabel.isHidden }
-        XCTAssertFalse(addressItemView.footerLabel.isHidden)
-        XCTAssertTrue(apartmentSuiteItemView.footerLabel.isHidden)
-        XCTAssertFalse(cityItemView.footerLabel.isHidden)
-        XCTAssertFalse(provinceOrTerritoryItemView.footerLabel.isHidden)
-        XCTAssertFalse(postalCodeItemView.footerLabel.isHidden)
+        wait { houseNumberItemView.isShowingValidationError }
+        XCTAssertTrue(addressItemView.isShowingValidationError)
+        XCTAssertFalse(apartmentSuiteItemView.isShowingValidationError)
+        XCTAssertTrue(cityItemView.isShowingValidationError)
+        XCTAssertTrue(provinceOrTerritoryItemView.isShowingValidationError)
+        XCTAssertTrue(postalCodeItemView.isShowingValidationError)
     }
     
     func testAddressUS() throws {
@@ -107,18 +107,18 @@ class AddressInputFormViewControllerTests: XCTestCase {
         XCTAssertEqual(provinceOrTerritoryItemView.titleLabel.text, "State")
         XCTAssertEqual(postalCodeItemView.titleLabel.text, "Zip code")
 
-        XCTAssertTrue(houseNumberItemView.footerLabel.isHidden)
-        XCTAssertTrue(addressItemView.footerLabel.isHidden)
-        XCTAssertTrue(cityItemView.footerLabel.isHidden)
-        XCTAssertTrue(postalCodeItemView.footerLabel.isHidden)
+        XCTAssertFalse(houseNumberItemView.isShowingValidationError)
+        XCTAssertFalse(addressItemView.isShowingValidationError)
+        XCTAssertFalse(cityItemView.isShowingValidationError)
+        XCTAssertFalse(postalCodeItemView.isShowingValidationError)
 
         let doneButton = try XCTUnwrap(viewController.navigationItem.rightBarButtonItem)
         try doneButton.tap()
         
-        wait(until: houseNumberItemView.footerLabel, at: \.isHidden, is: true)
-        wait(until: addressItemView.footerLabel, at: \.isHidden, is: false)
-        wait(until: cityItemView.footerLabel, at: \.isHidden, is: false)
-        wait(until: postalCodeItemView.footerLabel, at: \.isHidden, is: false)
+        wait { !houseNumberItemView.isShowingValidationError }
+        wait { addressItemView.isShowingValidationError }
+        wait { cityItemView.isShowingValidationError }
+        wait { postalCodeItemView.isShowingValidationError }
     }
 
     func testAddressUK() throws {

--- a/Tests/IntegrationTests/UIKit/View Controllers/AddressInputFormViewControllerTests.swift
+++ b/Tests/IntegrationTests/UIKit/View Controllers/AddressInputFormViewControllerTests.swift
@@ -52,22 +52,22 @@ class AddressInputFormViewControllerTests: XCTestCase {
         XCTAssertEqual(provinceOrTerritoryItemView.titleLabel.text, "Province or Territory")
         XCTAssertEqual(postalCodeItemView.titleLabel.text, "Postal code")
 
-        XCTAssertTrue(houseNumberItemView.alertLabel.isHidden)
-        XCTAssertTrue(addressItemView.alertLabel.isHidden)
-        XCTAssertTrue(apartmentSuiteItemView.alertLabel.isHidden)
-        XCTAssertTrue(cityItemView.alertLabel.isHidden)
-        XCTAssertTrue(provinceOrTerritoryItemView.alertLabel.isHidden)
-        XCTAssertTrue(postalCodeItemView.alertLabel.isHidden)
+        XCTAssertTrue(houseNumberItemView.footerLabel.isHidden)
+        XCTAssertTrue(addressItemView.footerLabel.isHidden)
+        XCTAssertTrue(apartmentSuiteItemView.footerLabel.isHidden)
+        XCTAssertTrue(cityItemView.footerLabel.isHidden)
+        XCTAssertTrue(provinceOrTerritoryItemView.footerLabel.isHidden)
+        XCTAssertTrue(postalCodeItemView.footerLabel.isHidden)
         
         let doneButton = try XCTUnwrap(viewController.navigationItem.rightBarButtonItem)
         try doneButton.tap()
         
-        wait { !houseNumberItemView.alertLabel.isHidden }
-        XCTAssertFalse(addressItemView.alertLabel.isHidden)
-        XCTAssertTrue(apartmentSuiteItemView.alertLabel.isHidden)
-        XCTAssertFalse(cityItemView.alertLabel.isHidden)
-        XCTAssertFalse(provinceOrTerritoryItemView.alertLabel.isHidden)
-        XCTAssertFalse(postalCodeItemView.alertLabel.isHidden)
+        wait { !houseNumberItemView.footerLabel.isHidden }
+        XCTAssertFalse(addressItemView.footerLabel.isHidden)
+        XCTAssertTrue(apartmentSuiteItemView.footerLabel.isHidden)
+        XCTAssertFalse(cityItemView.footerLabel.isHidden)
+        XCTAssertFalse(provinceOrTerritoryItemView.footerLabel.isHidden)
+        XCTAssertFalse(postalCodeItemView.footerLabel.isHidden)
     }
     
     func testAddressUS() throws {
@@ -107,18 +107,18 @@ class AddressInputFormViewControllerTests: XCTestCase {
         XCTAssertEqual(provinceOrTerritoryItemView.titleLabel.text, "State")
         XCTAssertEqual(postalCodeItemView.titleLabel.text, "Zip code")
 
-        XCTAssertTrue(houseNumberItemView.alertLabel.isHidden)
-        XCTAssertTrue(addressItemView.alertLabel.isHidden)
-        XCTAssertTrue(cityItemView.alertLabel.isHidden)
-        XCTAssertTrue(postalCodeItemView.alertLabel.isHidden)
+        XCTAssertTrue(houseNumberItemView.footerLabel.isHidden)
+        XCTAssertTrue(addressItemView.footerLabel.isHidden)
+        XCTAssertTrue(cityItemView.footerLabel.isHidden)
+        XCTAssertTrue(postalCodeItemView.footerLabel.isHidden)
 
         let doneButton = try XCTUnwrap(viewController.navigationItem.rightBarButtonItem)
         try doneButton.tap()
         
-        wait(until: houseNumberItemView.alertLabel, at: \.isHidden, is: true)
-        wait(until: addressItemView.alertLabel, at: \.isHidden, is: false)
-        wait(until: cityItemView.alertLabel, at: \.isHidden, is: false)
-        wait(until: postalCodeItemView.alertLabel, at: \.isHidden, is: false)
+        wait(until: houseNumberItemView.footerLabel, at: \.isHidden, is: true)
+        wait(until: addressItemView.footerLabel, at: \.isHidden, is: false)
+        wait(until: cityItemView.footerLabel, at: \.isHidden, is: false)
+        wait(until: postalCodeItemView.footerLabel, at: \.isHidden, is: false)
     }
 
     func testAddressUK() throws {


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

Refactors form text items to display placeholder text as footer labels instead of `UITextField` placeholders. 

Key changes:
- ❗ Moves placeholder property from `FormTextItem` to `FormValidatableValueItem` base class
- Replaces `alertLabel` with `footerLabel` for unified hint/error display
- Removes `UITextField.placeholder` binding logic from `FormTextItemView`
- Adds showHint()/showError() methods to `FormValidatableValueItemView`
- Updates text stack views to use `footerLabel` instead of `alertLabel`
- Improves accessibility and consistency across the form system

>Introducing `FormValidatableValueItem.showError()/showHint()` might unlock potential opportunity to support errors streaming without huge refactors inside the codebase by pushing validation events into a public stream by doing so in the base class `showError()` implementation. This is one of the compromise ways to make it happen, let's discuss later as a team.

# Demo [Required for UI changes]
<!-- Add screenshots or link to screen recording demonstrating the changes -->
<!-- Include both light/dark mode and different device sizes if it matters -->

| Empty+active | Invalid+inactive | Invalid+active (expiry date) |
|--------|--------|--------|
|  <img width="507" height="950" alt="image" src="https://github.com/user-attachments/assets/a99fe16b-d24c-4a19-9539-ec5152ebad98" /> | <img width="507" height="950" alt="image" src="https://github.com/user-attachments/assets/61d033dc-6fff-4c3f-9f93-8d6e32b11226" /> | <img width="507" height="950" alt="image" src="https://github.com/user-attachments/assets/937ab525-b54c-45ba-b45e-bcb95a8b903b" /> |

| Video |
|-|
| ![Simulator Screen Recording - iPhone 16e - 2025-12-18 at 09 25 21](https://github.com/user-attachments/assets/910c707f-f038-451c-b0f6-4fc3f16b66c3) |


## Ticket [Optional]
<ticket>
COSDK-863
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria

## Next steps
- align on validation use-cases with Android team
- capture use-cases in tests
- align on validation error behavior between platforms
- animate placeholder/validation updates