### PR TITLE
Label PRs according to their size

### DIFF
--- a/.github/workflows/label_pr_size.yml
+++ b/.github/workflows/label_pr_size.yml
@@ -1,0 +1,39 @@
+name: Label PR size
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label_pr_size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR size
+        uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size:tiny'
+          xs_max_size: '100'
+          s_label: 'size:small'
+          s_max_size: '250'
+          m_label: 'size:medium'
+          m_max_size: '500'
+          l_label: 'size:large'
+          l_max_size: '1000'
+          xl_label: 'size:huge'
+          fail_if_xl: 'false'
+          ignore_line_deletions: 'false'
+          ignore_file_deletions: 'true'
+          files_to_ignore: |
+            "Package.resolved"
+            "*.pbxproj"
+            "*.png"
+            "*.jpg"
+            "*.jpeg"
+            "*.strings"
+            "*/Generated/LocalizationKey.swift"
+            "*.generated.swift"


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

This change adds Github job that labels PRs according to their LOC size:

tiny < 100 lines
small < 250 lines
medium < 500 lines
large < 1000 lines
huge >= 1000 lines

Goal:
- encourages smaller PR sizes, reduces cognitive load required for review
- makes scanning PR list easier, you can review a couple of tiny PRs in a matter of minutes
- decrease PR tunraround time