### PR TITLE
Apple Pay: Dismiss Improvements

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -42,9 +42,9 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     ///   regardless of whether the payment succeeded or failed. This ensures the Apple Pay sheet
     ///   displays the correct status to the user.
     ///
-    /// - Warning: The dismissal behavior depends on the `dismissesAutomatically` configuration:
+    ///   The dismissal behavior depends on the `dismissesAutomatically` configuration:
     ///   - When `true`: The component automatically dismisses the Apple Pay sheet. Do not dismiss it yourself.
-    ///   - When `false` (default): You must dismiss the view controller yourself within the
+    ///   - When `false` (default flow): Dismiss the view controller yourself within the
     ///     `finalizeIfNeeded(with:completion:)` completion block.
     ///
     /// - Note: This component should not be reused. Create a new instance for each payment attempt.

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -17,8 +17,6 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
 
     internal var state: State = .initial
 
-    internal var viewControllerDidFinish: Bool = false
-
     internal let applePayPaymentMethod: ApplePayPaymentMethod
 
     /// The context object for this component.
@@ -39,9 +37,17 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     public weak var applePayDelegate: ApplePayComponentDelegate?
     
     /// Initializes the component.
-    /// - Warning: Do not dismiss this component directly.
-    ///  First, call `didFinalize(with:completion:)` on error or success, then dismiss it.
-    ///  Dismissal should occur within `completion` block.
+    ///
+    /// - Important: After receiving a payment response, you must call `finalizeIfNeeded(with:completion:)`
+    ///   regardless of whether the payment succeeded or failed. This ensures the Apple Pay sheet
+    ///   displays the correct status to the user.
+    ///
+    /// - Warning: The dismissal behavior depends on the `dismissesAutomatically` configuration:
+    ///   - When `true`: The component automatically dismisses the Apple Pay sheet. Do not dismiss it yourself.
+    ///   - When `false` (default): You must dismiss the view controller yourself within the
+    ///     `finalizeIfNeeded(with:completion:)` completion block.
+    ///
+    /// - Note: This component should not be reused. Create a new instance for each payment attempt.
     ///
     /// - Parameter paymentMethod: The Apple Pay payment method. Must include country code.
     /// - Parameter context: The context object for this component.

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -50,7 +50,7 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     ///   - When `false` (default flow): Dismiss the view controller yourself within the
     ///     `finalizeIfNeeded(with:completion:)` completion block.
     ///
-    /// - Note: This component should not be reused. Create a new instance for each payment attempt.
+    /// - Note: Do not reuse this component after a payment is authorized. It can be re-presented if the user cancels before authorizing.
     ///
     /// - Parameter paymentMethod: The Apple Pay payment method. Must include country code.
     /// - Parameter context: The context object for this component.

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -22,9 +22,16 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     }
     
     private func handleViewControllerDidFinish() {
-        if case let State.finalized(completion) = state {
+        switch state {
+        case let .finalized(completion):
             completion?()
-        } else {
+        case .initial:
+            // User cancelled without authorizing payment - allow component reuse
+            paymentAuthorizationViewController = nil
+            delegate?.didFail(with: ComponentError.cancelled, from: self)
+        case .submitted:
+            // Payment was authorized but finalizeIfNeeded wasn't called
+            // we call didFail here to not cause a breaking behavior change
             delegate?.didFail(with: ComponentError.cancelled, from: self)
         }
     }

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -12,7 +12,16 @@ import PassKit
 extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     
     public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
-        paymentAuthorizationViewController = nil
+        if configuration.dismissesAutomatically {
+            controller.dismiss(animated: true) { [weak self] in
+                self?.handleViewControllerDidFinish()
+            }
+        } else {
+            handleViewControllerDidFinish()
+        }
+    }
+    
+    private func handleViewControllerDidFinish() {
         if case let State.finalized(completion) = state {
             completion?()
         } else {

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -22,9 +22,16 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
     }
     
     private func handleViewControllerDidFinish() {
-        if case let State.finalized(completion) = state {
+        switch state {
+        case let .finalized(completion):
             completion?()
-        } else {
+        case .initial:
+            // User cancelled without authorizing payment - allow component reuse
+            paymentAuthorizationViewController = nil
+            delegate?.didFail(with: ComponentError.cancelled, from: self)
+        case .submitted:
+            // Payment authorized but finalizeIfNeeded not called
+            // we call didFail here to not cause a breaking behavior change
             delegate?.didFail(with: ComponentError.cancelled, from: self)
         }
     }

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -74,7 +74,7 @@ extension ApplePayComponent {
         /// responsible for dismissing the view controller within the `finalizeIfNeeded(with:completion:)` completion block.
         ///
         /// - Note: Apple recommends dismissing the controller in `paymentAuthorizationViewControllerDidFinish`.
-        ///   Setting this to `true` follows Apple's guidance and may resolve dismissal issues.
+        ///   Setting this to `true` follows Apple's guidance.
         public var dismissesAutomatically: Bool = false
         
         /// The payment request object needed for Apple Pay. Must contain all the required fileds

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -71,7 +71,7 @@ extension ApplePayComponent {
         
         /// When `true`, the component automatically dismisses the `PKPaymentAuthorizationViewController`
         /// when the payment flow completes or is cancelled. When `false` (default), you are
-        /// responsible for dismissing the view controller in their callbacks.
+        /// responsible for dismissing the view controller within the `finalizeIfNeeded(with:completion:)` completion block.
         ///
         /// - Note: Apple recommends dismissing the controller in `paymentAuthorizationViewControllerDidFinish`.
         ///   Setting this to `true` follows Apple's guidance and may resolve dismissal issues.

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -69,6 +69,14 @@ extension ApplePayComponent {
         /// A funding source supported by the merchant. If `nil`, the transaction allows both credit and debit cards.
         public var merchantCapability: CardFundingSource?
         
+        /// When `true`, the component automatically dismisses the `PKPaymentAuthorizationViewController`
+        /// when the payment flow completes or is cancelled. When `false` (default), you are
+        /// responsible for dismissing the view controller in their callbacks.
+        ///
+        /// - Note: Apple recommends dismissing the controller in `paymentAuthorizationViewControllerDidFinish`.
+        ///   Setting this to `true` follows Apple's guidance and may resolve dismissal issues.
+        public var dismissesAutomatically: Bool = false
+        
         /// The payment request object needed for Apple Pay. Must contain all the required fileds
         /// such as `merchantIdentifier`, `summaryItems`, `currencyCode`, and `countryCode`.
         internal var paymentRequest: PKPaymentRequest?

--- a/Demo/Common/Assets/Localizable.xcstrings
+++ b/Demo/Common/Assets/Localizable.xcstrings
@@ -112,9 +112,6 @@
     "Set to country currency" : {
 
     },
-    "Simulate a success or a failure from the didAuthorize delegate method." : {
-
-    },
     "Skip Payment List" : {
 
     },
@@ -134,6 +131,9 @@
 
     },
     "Visibility" : {
+
+    },
+    "When false, simulates a shipping error returned from the didAuthorize delegate method." : {
 
     }
   },

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
@@ -109,16 +109,14 @@ internal final class ApplePayComponentAdvancedFlowExample: InitialDataAdvancedFl
     private func finalize(_ success: Bool, _ message: String) {
         applePayComponent?.finalizeIfNeeded(with: success) { [weak self] in
             guard let self else { return }
-            self.dismissAndShowAlert(success, message)
+            self.showAlert(success, message)
         }
     }
 
-    internal func dismissAndShowAlert(_ success: Bool, _ message: String) {
-        presenter?.dismiss {
-            // Payment is processed. Add your code here.
-            let title = success ? "Success" : "Error"
-            self.presenter?.presentAlert(withTitle: title, message: message)
-        }
+    internal func showAlert(_ success: Bool, _ message: String) {
+        // Payment is processed. Add your code here.
+        let title = success ? "Success" : "Error"
+        self.presenter?.presentAlert(withTitle: title, message: message)
     }
 
     private func presentAlert(with error: Error, retryHandler: (() -> Void)? = nil) {

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
@@ -110,6 +110,7 @@ internal final class ApplePayComponentAdvancedFlowExample: InitialDataAdvancedFl
     private func finalize(_ success: Bool, _ message: String) {
         applePayComponent?.finalizeIfNeeded(with: success) { [weak self] in
             guard let self else { return }
+            // no dismiss as the auto dismiss flag is true
             self.showAlert(success, message)
         }
     }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
@@ -67,6 +67,7 @@ internal final class ApplePayComponentAdvancedFlowExample: InitialDataAdvancedFl
         config.requiredShippingContactFields = [.postalAddress]
         config.requiredBillingContactFields = [.postalAddress]
         config.shippingMethods = ConfigurationConstants.shippingMethods
+        config.dismissesAutomatically = true
 
         let component = try ApplePayComponent(
             paymentMethod: paymentMethod,

--- a/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
@@ -106,6 +106,7 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
     }
 
     internal func dismissAndShowAlert(_ success: Bool, _ message: String) {
+        // dismiss ourselves as the auto dismiss flag is false
         presenter?.dismiss {
             // Payment is processed. Add your code here.
             let title = success ? "Success" : "Error"

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -68,7 +68,6 @@ class ApplePayComponentTest: XCTestCase {
         self.sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
 
         waitForExpectations(timeout: 10)
-        XCTAssertTrue(viewController !== self.sut.viewController)
     }
 
     func testApplePayViewControllerShouldCallFinalizeCompletion() {
@@ -428,8 +427,6 @@ class ApplePayComponentTest: XCTestCase {
     
     func test_DismissesAutomatically_WhenFalse_ShouldCallDidFailImmediately() {
         // Given
-        wait(for: .seconds(2))
-        
         var configuration = ApplePayComponent.Configuration(
             payment: Dummy.createTestApplePayPayment(),
             merchantIdentifier: "test_id"
@@ -462,8 +459,6 @@ class ApplePayComponentTest: XCTestCase {
     
     func test_DismissesAutomatically_WhenFalse_ShouldCallFinalizeCompletionImmediately() {
         // Given
-        wait(for: .seconds(2))
-        
         var configuration = ApplePayComponent.Configuration(
             payment: Dummy.createTestApplePayPayment(),
             merchantIdentifier: "test_id"
@@ -492,77 +487,10 @@ class ApplePayComponentTest: XCTestCase {
         waitForExpectations(timeout: 2)
     }
     
-    func test_DismissesAutomatically_WhenTrue_ShouldCallDidFailAfterDismiss() {
-        // Given
-        wait(for: .seconds(2))
-        
-        var configuration = ApplePayComponent.Configuration(
-            payment: Dummy.createTestApplePayPayment(),
-            merchantIdentifier: "test_id"
-        )
-        configuration.dismissesAutomatically = true
-        
-        sut = try! ApplePayComponent(
-            paymentMethod: paymentMethod,
-            context: Dummy.context,
-            configuration: configuration
-        )
-        sut.delegate = mockDelegate
-        
-        let viewController = sut.viewController
-        let onDidFailExpectation = expectation(description: "didFail should be called")
-        
-        mockDelegate.onDidFail = { error, component in
-            XCTAssertEqual(error as! ComponentError, ComponentError.cancelled)
-            onDidFailExpectation.fulfill()
-        }
-        
-        presentOnRoot(viewController)
-        
-        // When
-        sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
-        
-        // Then - should be called after dismiss animation completes
-        waitForExpectations(timeout: 10)
-    }
-    
-    func test_DismissesAutomatically_WhenTrue_ShouldCallFinalizeCompletionAfterDismiss() {
-        // Given
-        wait(for: .seconds(2))
-        
-        var configuration = ApplePayComponent.Configuration(
-            payment: Dummy.createTestApplePayPayment(),
-            merchantIdentifier: "test_id"
-        )
-        configuration.dismissesAutomatically = true
-        
-        sut = try! ApplePayComponent(
-            paymentMethod: paymentMethod,
-            context: Dummy.context,
-            configuration: configuration
-        )
-        
-        let viewController = sut.viewController
-        let onDidFinalizeExpectation = expectation(description: "finalize completion should be called")
-        
-        presentOnRoot(viewController)
-        
-        sut.finalizeIfNeeded(with: true) {
-            onDidFinalizeExpectation.fulfill()
-        }
-        
-        // When
-        sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
-        
-        // Then - should be called after dismiss animation completes
-        waitForExpectations(timeout: 10)
-    }
-    
     func testViewDidLoadShouldSendInitialCall() throws {
         // Given
         let analyticsProviderMock = AnalyticsProviderMock()
         let context = Dummy.context(with: analyticsProviderMock)
-        let mockViewController = UIViewController()
 
         let configuration = ApplePayComponent.Configuration(
             payment: Dummy.createTestApplePayPayment(),

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -68,6 +68,9 @@ class ApplePayComponentTest: XCTestCase {
         self.sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
 
         waitForExpectations(timeout: 10)
+        
+        // After cancel, component should be reusable with a new view controller
+        XCTAssertTrue(viewController !== self.sut.viewController)
     }
 
     func testApplePayViewControllerShouldCallFinalizeCompletion() {

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -424,6 +424,140 @@ class ApplePayComponentTest: XCTestCase {
         XCTAssertTrue(compareCollections(supportedNetworks, [.masterCard, .elo]))
     }
 
+    // MARK: - dismissesAutomatically Tests
+    
+    func test_DismissesAutomatically_WhenFalse_ShouldCallDidFailImmediately() {
+        // Given
+        wait(for: .seconds(2))
+        
+        var configuration = ApplePayComponent.Configuration(
+            payment: Dummy.createTestApplePayPayment(),
+            merchantIdentifier: "test_id"
+        )
+        configuration.dismissesAutomatically = false
+        
+        sut = try! ApplePayComponent(
+            paymentMethod: paymentMethod,
+            context: Dummy.context,
+            configuration: configuration
+        )
+        sut.delegate = mockDelegate
+        
+        let viewController = sut.viewController
+        let onDidFailExpectation = expectation(description: "didFail should be called")
+        
+        mockDelegate.onDidFail = { error, component in
+            XCTAssertEqual(error as! ComponentError, ComponentError.cancelled)
+            onDidFailExpectation.fulfill()
+        }
+        
+        presentOnRoot(viewController)
+        
+        // When
+        sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
+        
+        // Then - should be called immediately (not waiting for dismiss animation)
+        waitForExpectations(timeout: 2)
+    }
+    
+    func test_DismissesAutomatically_WhenFalse_ShouldCallFinalizeCompletionImmediately() {
+        // Given
+        wait(for: .seconds(2))
+        
+        var configuration = ApplePayComponent.Configuration(
+            payment: Dummy.createTestApplePayPayment(),
+            merchantIdentifier: "test_id"
+        )
+        configuration.dismissesAutomatically = false
+        
+        sut = try! ApplePayComponent(
+            paymentMethod: paymentMethod,
+            context: Dummy.context,
+            configuration: configuration
+        )
+        
+        let viewController = sut.viewController
+        let onDidFinalizeExpectation = expectation(description: "finalize completion should be called")
+        
+        presentOnRoot(viewController)
+        
+        sut.finalizeIfNeeded(with: true) {
+            onDidFinalizeExpectation.fulfill()
+        }
+        
+        // When
+        sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
+        
+        // Then - should be called immediately
+        waitForExpectations(timeout: 2)
+    }
+    
+    func test_DismissesAutomatically_WhenTrue_ShouldCallDidFailAfterDismiss() {
+        // Given
+        wait(for: .seconds(2))
+        
+        var configuration = ApplePayComponent.Configuration(
+            payment: Dummy.createTestApplePayPayment(),
+            merchantIdentifier: "test_id"
+        )
+        configuration.dismissesAutomatically = true
+        
+        sut = try! ApplePayComponent(
+            paymentMethod: paymentMethod,
+            context: Dummy.context,
+            configuration: configuration
+        )
+        sut.delegate = mockDelegate
+        
+        let viewController = sut.viewController
+        let onDidFailExpectation = expectation(description: "didFail should be called")
+        
+        mockDelegate.onDidFail = { error, component in
+            XCTAssertEqual(error as! ComponentError, ComponentError.cancelled)
+            onDidFailExpectation.fulfill()
+        }
+        
+        presentOnRoot(viewController)
+        
+        // When
+        sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
+        
+        // Then - should be called after dismiss animation completes
+        waitForExpectations(timeout: 10)
+    }
+    
+    func test_DismissesAutomatically_WhenTrue_ShouldCallFinalizeCompletionAfterDismiss() {
+        // Given
+        wait(for: .seconds(2))
+        
+        var configuration = ApplePayComponent.Configuration(
+            payment: Dummy.createTestApplePayPayment(),
+            merchantIdentifier: "test_id"
+        )
+        configuration.dismissesAutomatically = true
+        
+        sut = try! ApplePayComponent(
+            paymentMethod: paymentMethod,
+            context: Dummy.context,
+            configuration: configuration
+        )
+        
+        let viewController = sut.viewController
+        let onDidFinalizeExpectation = expectation(description: "finalize completion should be called")
+        
+        presentOnRoot(viewController)
+        
+        sut.finalizeIfNeeded(with: true) {
+            onDidFinalizeExpectation.fulfill()
+        }
+        
+        // When
+        sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
+        
+        // Then - should be called after dismiss animation completes
+        waitForExpectations(timeout: 10)
+    }
+    
     func testViewDidLoadShouldSendInitialCall() throws {
         // Given
         let analyticsProviderMock = AnalyticsProviderMock()

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -67,7 +67,7 @@ class ApplePayComponentTest: XCTestCase {
             self.mockDelegate = nil // to prevent false triggering
         }
 
-        presentOnRoot(viewController)
+        viewController.loadViewIfNeeded()
         
         self.sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
 
@@ -84,7 +84,7 @@ class ApplePayComponentTest: XCTestCase {
         let viewController = sut!.viewController
         let onDidFinalizeExpectation = expectation(description: "Wait for didFinalize call")
 
-        presentOnRoot(viewController)
+        viewController.loadViewIfNeeded()
 
         sut.finalizeIfNeeded(with: true) {
             onDidFinalizeExpectation.fulfill()
@@ -455,7 +455,7 @@ class ApplePayComponentTest: XCTestCase {
             onDidFailExpectation.fulfill()
         }
         
-        presentOnRoot(viewController)
+        viewController.loadViewIfNeeded()
         
         // When
         sut.paymentAuthorizationViewControllerDidFinish(viewController as! PKPaymentAuthorizationViewController)
@@ -481,7 +481,7 @@ class ApplePayComponentTest: XCTestCase {
         let viewController = sut.viewController
         let onDidFinalizeExpectation = expectation(description: "finalize completion should be called")
         
-        presentOnRoot(viewController)
+        viewController.loadViewIfNeeded()
         
         sut.finalizeIfNeeded(with: true) {
             onDidFinalizeExpectation.fulfill()
@@ -516,7 +516,7 @@ class ApplePayComponentTest: XCTestCase {
             onDidFailExpectation.fulfill()
         }
         
-        presentOnRoot(firstViewController)
+        firstViewController.loadViewIfNeeded()
         
         // When - user cancels before authorization (state is .initial)
         sut.paymentAuthorizationViewControllerDidFinish(firstViewController as! PKPaymentAuthorizationViewController)
@@ -552,7 +552,7 @@ class ApplePayComponentTest: XCTestCase {
             onDidSubmitExpectation.fulfill()
         }
         
-        presentOnRoot(firstViewController)
+        firstViewController.loadViewIfNeeded()
         
         // When - payment is authorized (moves to .submitted state)
         let mockPayment = PKPaymentMock.create(withPaymentData: "test_token".data(using: .utf8)!)

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -494,6 +494,83 @@ class ApplePayComponentTest: XCTestCase {
         waitForExpectations(timeout: 2)
     }
     
+    func test_ComponentReuse_WhenCancelledBeforeAuthorization_ShouldAllowReuse() {
+        // Given
+        var configuration = ApplePayComponent.Configuration(
+            payment: Dummy.createTestApplePayPayment(),
+            merchantIdentifier: "test_id"
+        )
+        configuration.dismissesAutomatically = false
+        
+        sut = try! ApplePayComponent(
+            paymentMethod: paymentMethod,
+            context: Dummy.context,
+            configuration: configuration
+        )
+        sut.delegate = mockDelegate
+        
+        let firstViewController = sut.viewController
+        
+        let onDidFailExpectation = expectation(description: "didFail should be called")
+        mockDelegate.onDidFail = { _, _ in
+            onDidFailExpectation.fulfill()
+        }
+        
+        presentOnRoot(firstViewController)
+        
+        // When - user cancels before authorization (state is .initial)
+        sut.paymentAuthorizationViewControllerDidFinish(firstViewController as! PKPaymentAuthorizationViewController)
+        
+        waitForExpectations(timeout: 2)
+        
+        // Then - component should be reusable with a new view controller
+        let secondViewController = sut.viewController
+        XCTAssertTrue(firstViewController !== secondViewController, "A new view controller should be created after cancel")
+    }
+    
+    func test_ComponentReuse_WhenPaymentAuthorized_ShouldNotAllowReuse() {
+        // Given
+        wait(for: .seconds(1))
+        
+        var configuration = ApplePayComponent.Configuration(
+            payment: Dummy.createTestApplePayPayment(),
+            merchantIdentifier: "test_id"
+        )
+        configuration.dismissesAutomatically = false
+        
+        sut = try! ApplePayComponent(
+            paymentMethod: paymentMethod,
+            context: Dummy.context,
+            configuration: configuration
+        )
+        sut.delegate = mockDelegate
+        
+        let firstViewController = sut.viewController
+        
+        let onDidSubmitExpectation = expectation(description: "didSubmit should be called")
+        mockDelegate.onDidSubmit = { _, _ in
+            onDidSubmitExpectation.fulfill()
+        }
+        
+        presentOnRoot(firstViewController)
+        
+        // When - payment is authorized (moves to .submitted state)
+        let mockPayment = PKPaymentMock.create(withPaymentData: "test_token".data(using: .utf8)!)
+        sut.paymentAuthorizationViewController(
+            firstViewController as! PKPaymentAuthorizationViewController,
+            didAuthorizePayment: mockPayment
+        ) { _ in }
+        
+        waitForExpectations(timeout: 5)
+        
+        // Then simulate didFinish without calling finalizeIfNeeded
+        sut.paymentAuthorizationViewControllerDidFinish(firstViewController as! PKPaymentAuthorizationViewController)
+        
+        // Component should NOT be reusable - same view controller returned
+        let secondViewController = sut.viewController
+        XCTAssertTrue(firstViewController === secondViewController, "Same view controller should be returned after authorization")
+    }
+    
     func testViewDidLoadShouldSendInitialCall() throws {
         // Given
         let analyticsProviderMock = AnalyticsProviderMock()


### PR DESCRIPTION
# Summary [Required]

Improves the Apple Pay dismissal flow, tied to a new flag Apple Pay config to preserve current behavior.
If the flag is true, the sheet is dismissed in the `paymentAuthorizationViewControllerDidFinish` as recommended by Apple.

### Use appropriate tags for different types of changes:

<new>
- Added property `dismissesAutomatically` in `ApplePayConfiguration`.
When `true`, the component automatically dismisses the `PKPaymentAuthorizationViewController` when the payment flow completes or is cancelled. 
When `false` (default), you are responsible for dismissing the view controller within the `finalizeIfNeeded(with:completion:)` completion block.
</new>


## Ticket [Optional]
<ticket>
COSDK-217
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
