### PR TITLE
v6: Rename bin value callback

### DIFF
--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -256,7 +256,7 @@ extension CardComponent: CardViewControllerDelegate {
     internal func didChange(bin: String) {
         binThrottler.throttle { [weak self] in
             guard let self else { return }
-            self.configuration.onBinValue?(bin)
+            self.configuration.onBinChange?(bin)
         }
     }
     

--- a/AdyenCard/Components/Card/CardComponentConfiguration.swift
+++ b/AdyenCard/Components/Card/CardComponentConfiguration.swift
@@ -65,9 +65,8 @@ public struct CardComponentConfiguration: CheckoutComponentConfiguration, AnyPer
     /// Indicates whether or not to show the supported card logos under the card number item
     internal var showsSupportedCardLogos: Bool
     
-    // TODO: rename all related parts after aligning
     /// Called when the BIN value changes (first 6-8 digits of the card number).
-    internal var onBinValue: ((String) -> Void)?
+    internal var onBinChange: ((String) -> Void)?
     
     /// Called when card brand(s) are detected from the entered card number.
     internal var onBinLookup: (([CardBrand]) -> Void)?
@@ -213,11 +212,11 @@ extension CardComponentConfiguration {
     
     /// Sets the handler to be called when the BIN value changes.
     /// The BIN is the first 6-8 digits of the card number.
-    /// - Parameter onBinValue: The closure to call with the BIN value.
+    /// - Parameter onBinChange: The closure to call with the BIN value.
     /// - Returns: A modified copy of the configuration.
-    public func onBinValue(_ onBinValue: @escaping (String) -> Void) -> Self {
+    public func onBinChange(_ onBinChange: @escaping (String) -> Void) -> Self {
         var copy = self
-        copy.onBinValue = onBinValue
+        copy.onBinChange = onBinChange
         return copy
     }
     

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -61,7 +61,7 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
                             await MapkitAddressLookupProvider().searchAsync(searchTerm)
                         })
                 )
-                .onBinValue { bin in
+                .onBinChange { bin in
                     print("Here is the bin \(bin)")
                 }
                 .onBinLookup { brands in

--- a/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
@@ -73,7 +73,7 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
                         }
                     )
                 )
-                .onBinValue { bin in
+                .onBinChange { bin in
                     print("Here is the bin \(bin)")
                 }
                 .onBinLookup { brands in

--- a/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
@@ -279,7 +279,7 @@ class BCMCComponentTests: XCTestCase {
         wait(for: [expectationCardType], timeout: 10)
     }
 
-    func test_onBinValue_withCorrectBIN_shouldReturnBINValue() {
+    func test_onBinChange_withCorrectBIN_shouldReturnBINValue() {
         let method = CardPaymentMethod(type: .bcmc, name: "Test name", fundingSource: .debit, brands: [.masterCard])
         let paymentMethod = BCMCPaymentMethod(cardPaymentMethod: method)
         let sut = BCMCComponent(
@@ -293,7 +293,7 @@ class BCMCComponentTests: XCTestCase {
         expectationBin.expectedFulfillmentCount = 1
         expectationBin.assertForOverFulfill = true
         sut.configuration = sut.configuration
-            .onBinValue { value in
+            .onBinChange { value in
                 XCTAssertTrue("67034444".hasPrefix(value))
                 XCTAssertTrue(value.count <= 8)
                 expectationBin.fulfill()
@@ -305,7 +305,7 @@ class BCMCComponentTests: XCTestCase {
         wait(for: [expectationBin], timeout: 10)
     }
     
-    func test_onBinValue_with6DigitsBIN_shouldReturn6Digits() {
+    func test_onBinChange_with6DigitsBIN_shouldReturn6Digits() {
         
         let expectationBinLookup = XCTestExpectation(description: "Bin Lookup Expectation")
         let cardTypeProviderMock = BinInfoProviderMock()
@@ -328,7 +328,7 @@ class BCMCComponentTests: XCTestCase {
 
         let expectationBin = XCTestExpectation(description: "Bin Expectation")
         sut.configuration = sut.configuration
-            .onBinValue { value in
+            .onBinChange { value in
                 XCTAssertTrue("67034444".hasPrefix(value))
                 XCTAssertTrue(value.count <= 8)
                 if value == "67034444" {
@@ -343,7 +343,7 @@ class BCMCComponentTests: XCTestCase {
         wait(for: [expectationBin], timeout: 10)
     }
     
-    func test_onBinValue_with8DigitsBIN_shouldReturn8Digits() {
+    func test_onBinChange_with8DigitsBIN_shouldReturn8Digits() {
         
         let expectationBinLookup = XCTestExpectation(description: "Bin Lookup Expectation")
         let cardTypeProviderMock = BinInfoProviderMock()
@@ -366,7 +366,7 @@ class BCMCComponentTests: XCTestCase {
 
         let expectationBin = XCTestExpectation(description: "Bin Expectation")
         sut.configuration = sut.configuration
-            .onBinValue { value in
+            .onBinChange { value in
                 XCTAssertTrue("67030000".hasPrefix(value))
                 XCTAssertTrue(value.count <= 8)
                 if value == "67030000" {

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -286,7 +286,7 @@ class CardComponentTests: XCTestCase {
 
     }
 
-    func test_onBinValueAndOnBinLookup_whenCardNumberEntered_shouldBeCalledWithCorrectValues() {
+    func test_onBinChangeAndOnBinLookup_whenCardNumberEntered_shouldBeCalledWithCorrectValues() {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
             $0(BinLookupResponse(brands: [CardBrand(type: .americanExpress)]))
@@ -306,7 +306,7 @@ class CardComponentTests: XCTestCase {
         let expectationCardType = XCTestExpectation(description: "CardType Expectation")
         
         sut.configuration = sut.configuration
-            .onBinValue { value in
+            .onBinChange { value in
                 XCTAssertEqual(value, "371449")
                 expectationBin.fulfill()
             }


### PR DESCRIPTION
# Summary [Required]
Rename `onBinValue` to `onBinChange`

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
