### PR TITLE
swiftformat: ignore headers

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -6,7 +6,7 @@
 --decimalgrouping none
 --wrapcollections before-first
 --wraparguments before-first
---header ignore
+--header "\nCopyright (c) Adyen N.V.\n\nThis file is open source and available under the MIT license. See the LICENSE file for more info.\n"
 
 # file options
 --exclude Scripts

--- a/.swiftformat
+++ b/.swiftformat
@@ -6,7 +6,7 @@
 --decimalgrouping none
 --wrapcollections before-first
 --wraparguments before-first
---header "\nCopyright (c) {created.year} Adyen N.V.\n\nThis file is open source and available under the MIT license. See the LICENSE file for more info.\n"
+--header ignore
 
 # file options
 --exclude Scripts

--- a/Adyen/Analytics/AnalyticsProvider/AnalyticsFlavor.swift
+++ b/Adyen/Analytics/AnalyticsProvider/AnalyticsFlavor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
+++ b/Adyen/Analytics/AnalyticsProvider/AnalyticsProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/AnalyticsProvider/AnalyticsProviderProtocol.swift
+++ b/Adyen/Analytics/AnalyticsProvider/AnalyticsProviderProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/AnalyticsProvider/EventAnalyticsProvider.swift
+++ b/Adyen/Analytics/AnalyticsProvider/EventAnalyticsProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Models/AdyenAnalytics.swift
+++ b/Adyen/Analytics/Models/AdyenAnalytics.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Models/AnalyticsConstants.swift
+++ b/Adyen/Analytics/Models/AnalyticsConstants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Models/AnalyticsData.swift
+++ b/Adyen/Analytics/Models/AnalyticsData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Models/AnalyticsEventDataSource.swift
+++ b/Adyen/Analytics/Models/AnalyticsEventDataSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Models/AnalyticsEventError.swift
+++ b/Adyen/Analytics/Models/AnalyticsEventError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Models/AnalyticsEventInfo.swift
+++ b/Adyen/Analytics/Models/AnalyticsEventInfo.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Models/AnalyticsEventLog.swift
+++ b/Adyen/Analytics/Models/AnalyticsEventLog.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Models/AnalyticsValidationError.swift
+++ b/Adyen/Analytics/Models/AnalyticsValidationError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Models/ThreadSafeAnalyticsEventDataSource.swift
+++ b/Adyen/Analytics/Models/ThreadSafeAnalyticsEventDataSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Requests/AnalyticsRequest.swift
+++ b/Adyen/Analytics/Requests/AnalyticsRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Analytics/Requests/InitialAnalyticsRequest.swift
+++ b/Adyen/Analytics/Requests/InitialAnalyticsRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Assets/Generated/LocalizationKey.swift
+++ b/Adyen/Assets/Generated/LocalizationKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/APIContext.swift
+++ b/Adyen/Core/APIClient/APIContext.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/AnalyticsEnvironment.swift
+++ b/Adyen/Core/APIClient/AnalyticsEnvironment.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/Environment.swift
+++ b/Adyen/Core/APIClient/Environment.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/Requests/APIRequest.swift
+++ b/Adyen/Core/APIClient/Requests/APIRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/Requests/AppleWalletPassRequest.swift
+++ b/Adyen/Core/APIClient/Requests/AppleWalletPassRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/Requests/ClientKeyRequest.swift
+++ b/Adyen/Core/APIClient/Requests/ClientKeyRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/Requests/OrderStatusRequest.swift
+++ b/Adyen/Core/APIClient/Requests/OrderStatusRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/Requests/PaymentStatusRequest.swift
+++ b/Adyen/Core/APIClient/Requests/PaymentStatusRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/Responses/AppleWalletPassResponse.swift
+++ b/Adyen/Core/APIClient/Responses/AppleWalletPassResponse.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/Responses/ClientKeyResponse.swift
+++ b/Adyen/Core/APIClient/Responses/ClientKeyResponse.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/Responses/OrderStatusResponse.swift
+++ b/Adyen/Core/APIClient/Responses/OrderStatusResponse.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/APIClient/Responses/PaymentStatusResponse.swift
+++ b/Adyen/Core/APIClient/Responses/PaymentStatusResponse.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/AdyenContext/AdyenContext.swift
+++ b/Adyen/Core/AdyenContext/AdyenContext.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent+Extensions.swift
+++ b/Adyen/Core/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
+++ b/Adyen/Core/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/AbstractPersonalInformationComponent/AddressFormItemInjector.swift
+++ b/Adyen/Core/Components/AbstractPersonalInformationComponent/AddressFormItemInjector.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/AbstractPersonalInformationComponent/EmailFormItemInjector.swift
+++ b/Adyen/Core/Components/AbstractPersonalInformationComponent/EmailFormItemInjector.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/AbstractPersonalInformationComponent/FormItemInjector.swift
+++ b/Adyen/Core/Components/AbstractPersonalInformationComponent/FormItemInjector.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/AbstractPersonalInformationComponent/NameFormItemInjector.swift
+++ b/Adyen/Core/Components/AbstractPersonalInformationComponent/NameFormItemInjector.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/AbstractPersonalInformationComponent/PhoneFormItemInjector.swift
+++ b/Adyen/Core/Components/AbstractPersonalInformationComponent/PhoneFormItemInjector.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/AlreadyPaidPaymentComponent.swift
+++ b/Adyen/Core/Components/AlreadyPaidPaymentComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/AnyCashAppPayConfiguration.swift
+++ b/Adyen/Core/Components/AnyCashAppPayConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/Base/ActionComponentData.swift
+++ b/Adyen/Core/Components/Base/ActionComponentData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/Base/BasicComponentConfiguration.swift
+++ b/Adyen/Core/Components/Base/BasicComponentConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/Base/PartialPaymentError.swift
+++ b/Adyen/Core/Components/Base/PartialPaymentError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
+++ b/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/Installment/InstallmentOptions.swift
+++ b/Adyen/Core/Components/Installment/InstallmentOptions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/InstantPaymentComponent.swift
+++ b/Adyen/Core/Components/InstantPaymentComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Components/StoredPaymentMethodComponent.swift
+++ b/Adyen/Core/Components/StoredPaymentMethodComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/ActionComponent.swift
+++ b/Adyen/Core/Core Protocols/ActionComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/AdyenSessionAware.swift
+++ b/Adyen/Core/Core Protocols/AdyenSessionAware.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/AnyDropInComponent.swift
+++ b/Adyen/Core/Core Protocols/AnyDropInComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/Component.swift
+++ b/Adyen/Core/Core Protocols/Component.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/Details.swift
+++ b/Adyen/Core/Core Protocols/Details.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/DeviceDependent.swift
+++ b/Adyen/Core/Core Protocols/DeviceDependent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/DropInComponentDelegate.swift
+++ b/Adyen/Core/Core Protocols/DropInComponentDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/LoadingComponent.swift
+++ b/Adyen/Core/Core Protocols/LoadingComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/PartialPaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PartialPaymentComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/PartialPaymentDelegate.swift
+++ b/Adyen/Core/Core Protocols/PartialPaymentDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/PaymentAwareComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentAwareComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/PaymentComponentBuilder.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponentBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/PaymentMethod.swift
+++ b/Adyen/Core/Core Protocols/PaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/PresentableComponent.swift
+++ b/Adyen/Core/Core Protocols/PresentableComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/PresentationDelegate.swift
+++ b/Adyen/Core/Core Protocols/PresentationDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/ReadyToSubmitPaymentComponentDelegate.swift
+++ b/Adyen/Core/Core Protocols/ReadyToSubmitPaymentComponentDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/StorePaymentMethodFieldAware.swift
+++ b/Adyen/Core/Core Protocols/StorePaymentMethodFieldAware.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/StoredPaymentMethodsDelegate.swift
+++ b/Adyen/Core/Core Protocols/StoredPaymentMethodsDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/SubmittableComponent.swift
+++ b/Adyen/Core/Core Protocols/SubmittableComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/TrackableComponent.swift
+++ b/Adyen/Core/Core Protocols/TrackableComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Core Protocols/ViewControllerPresenter.swift
+++ b/Adyen/Core/Core Protocols/ViewControllerPresenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Errors/APIError.swift
+++ b/Adyen/Core/Errors/APIError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Errors/AppleWalletError.swift
+++ b/Adyen/Core/Errors/AppleWalletError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Errors/ComponentError.swift
+++ b/Adyen/Core/Errors/ComponentError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Errors/UnknownError.swift
+++ b/Adyen/Core/Errors/UnknownError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Models/CardType.swift
+++ b/Adyen/Core/Models/CardType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Models/DisplayInformation.swift
+++ b/Adyen/Core/Models/DisplayInformation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Models/ShopperInteraction.swift
+++ b/Adyen/Core/Models/ShopperInteraction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/ACHDirectDebitPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/ACHDirectDebitPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/Abstract/AnyCardPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyCardPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
+++ b/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/Abstract/PaymentMethods.swift
+++ b/Adyen/Core/Payment Methods/Abstract/PaymentMethods.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/AffirmPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/AffirmPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/ApplePayPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/ApplePayPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/AtomePaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/AtomePaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/BACSDirectDebitPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/BACSDirectDebitPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/BCMCPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/BCMCPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/BLIKPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/BLIKPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/BoletoPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/BoletoPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/CardPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/CardPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/CashAppPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/CashAppPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/DokuPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/DokuPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/EContextPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/EContextPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/GiftCardPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/GiftCardPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/InstantPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/InstantPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/IssuerListPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/IssuerListPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/MBWayPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/MBWayPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/MealVoucherPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/MealVoucherPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/OnlineBankingPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/OnlineBankingPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/PayByBankUSPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/PayByBankUSPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/PayToPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/PayToPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/QiwiWalletPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/QiwiWalletPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/SEPADirectDebitPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/SEPADirectDebitPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/StoredBCMCPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredBCMCPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/StoredBLIKPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredBLIKPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/StoredCashAppPayPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredCashAppPayPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/StoredInstantPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredInstantPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/StoredPayByBankUSPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredPayByBankUSPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/StoredPayPalPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredPayPalPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/StoredTwintPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredTwintPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/TwintPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/TwintPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/UPIPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/UPIPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/Payment Methods/WeChatPayPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/WeChatPayPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/ToolBar/CancellableToolBar.swift
+++ b/Adyen/Core/ToolBar/CancellableToolBar.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Core/ToolBar/ModalToolbar.swift
+++ b/Adyen/Core/ToolBar/ModalToolbar.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Formatters/AmountFormatter.swift
+++ b/Adyen/Formatters/AmountFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Formatters/BrazilSocialSecurityNumberFormatter.swift
+++ b/Adyen/Formatters/BrazilSocialSecurityNumberFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Formatters/Formatter.swift
+++ b/Adyen/Formatters/Formatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Formatters/IBANFormatter.swift
+++ b/Adyen/Formatters/IBANFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Formatters/NumericFormatter.swift
+++ b/Adyen/Formatters/NumericFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/AdyenCancellable.swift
+++ b/Adyen/Helpers/AdyenCancellable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/AdyenDependencies.swift
+++ b/Adyen/Helpers/AdyenDependencies.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/AdyenScope.swift
+++ b/Adyen/Helpers/AdyenScope.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/AdyenSdkVersion.swift
+++ b/Adyen/Helpers/AdyenSdkVersion.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/ArrayHelpers.swift
+++ b/Adyen/Helpers/ArrayHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/BundleHelpers.swift
+++ b/Adyen/Helpers/BundleHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/ImageLoader/ImageLoader+DependencyKey.swift
+++ b/Adyen/Helpers/ImageLoader/ImageLoader+DependencyKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/ImageLoader/ImageLoader.swift
+++ b/Adyen/Helpers/ImageLoader/ImageLoader.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/ImageLoader/ImageLoaderProvider.swift
+++ b/Adyen/Helpers/ImageLoader/ImageLoaderProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/ImageLoader/UIImageView+ImageLoading.swift
+++ b/Adyen/Helpers/ImageLoader/UIImageView+ImageLoading.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/KeyedDecodingContainerHelpers.swift
+++ b/Adyen/Helpers/KeyedDecodingContainerHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/NSConstraintHelper.swift
+++ b/Adyen/Helpers/NSConstraintHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/NSTextAlignmentHelpers.swift
+++ b/Adyen/Helpers/NSTextAlignmentHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/ResultHelpers.swift
+++ b/Adyen/Helpers/ResultHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/StringHelpers.swift
+++ b/Adyen/Helpers/StringHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/TimeIntervalHelpers.swift
+++ b/Adyen/Helpers/TimeIntervalHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIApplicationHelpers.swift
+++ b/Adyen/Helpers/UIApplicationHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIButtonHelpers.swift
+++ b/Adyen/Helpers/UIButtonHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIColorHelpers.swift
+++ b/Adyen/Helpers/UIColorHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIFontHelpers.swift
+++ b/Adyen/Helpers/UIFontHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIImageViewHelpers.swift
+++ b/Adyen/Helpers/UIImageViewHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UILabelHelpers.swift
+++ b/Adyen/Helpers/UILabelHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIProgressViewHelpers.swift
+++ b/Adyen/Helpers/UIProgressViewHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIViewAnimation.swift
+++ b/Adyen/Helpers/UIViewAnimation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIViewConstraintsHelper.swift
+++ b/Adyen/Helpers/UIViewConstraintsHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIViewControllerHelpers.swift
+++ b/Adyen/Helpers/UIViewControllerHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIViewHelpers.swift
+++ b/Adyen/Helpers/UIViewHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/UIViewRoundingHelpers.swift
+++ b/Adyen/Helpers/UIViewRoundingHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Helpers/URLHelpers.swift
+++ b/Adyen/Helpers/URLHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/Amount.swift
+++ b/Adyen/Model/Amount.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/AnyEncodable.swift
+++ b/Adyen/Model/AnyEncodable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/Balance.swift
+++ b/Adyen/Model/Balance.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/BrowserInfo.swift
+++ b/Adyen/Model/BrowserInfo.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/DelegatedAuthenticationData.swift
+++ b/Adyen/Model/DelegatedAuthenticationData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/Installments.swift
+++ b/Adyen/Model/Installments.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/PartialPaymentOrder.swift
+++ b/Adyen/Model/PartialPaymentOrder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/Payment.swift
+++ b/Adyen/Model/Payment.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/PostalAddress.swift
+++ b/Adyen/Model/PostalAddress.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/PrefilledShopperInformation.swift
+++ b/Adyen/Model/PrefilledShopperInformation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/SDKData.swift
+++ b/Adyen/Model/SDKData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Model/ShopperInformation.swift
+++ b/Adyen/Model/ShopperInformation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Dimensions.swift
+++ b/Adyen/UI/Dimensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/FormItemViewBuilder.swift
+++ b/Adyen/UI/Form/FormItemViewBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/FormView.swift
+++ b/Adyen/UI/Form/FormView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/FormViewController+ViewProtocol.swift
+++ b/Adyen/UI/Form/FormViewController+ViewProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/FormViewController.swift
+++ b/Adyen/UI/Form/FormViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/FormViewItemManager.swift
+++ b/Adyen/UI/Form/FormViewItemManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Address/AddressStyle.swift
+++ b/Adyen/UI/Form/Items/Address/AddressStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Address/AddressViewModel.swift
+++ b/Adyen/UI/Form/Items/Address/AddressViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Address/DefaultAddressViewModelBuilder.swift
+++ b/Adyen/UI/Form/Items/Address/DefaultAddressViewModelBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Address/FormAddressItem+Configuration.swift
+++ b/Adyen/UI/Form/Items/Address/FormAddressItem+Configuration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Address/FormAddressItem.swift
+++ b/Adyen/UI/Form/Items/Address/FormAddressItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Address/FormPostalCodeItem.swift
+++ b/Adyen/UI/Form/Items/Address/FormPostalCodeItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Address/FormRegionPickerItem.swift
+++ b/Adyen/UI/Form/Items/Address/FormRegionPickerItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Address/Picker/FormAddressPickerItem.swift
+++ b/Adyen/UI/Form/Items/Address/Picker/FormAddressPickerItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Address/Picker/FormAddressPickerItemView.swift
+++ b/Adyen/UI/Form/Items/Address/Picker/FormAddressPickerItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Basic Items/FormAttributedLabelItem.swift
+++ b/Adyen/UI/Form/Items/Basic Items/FormAttributedLabelItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Basic Items/FormContainerItem.swift
+++ b/Adyen/UI/Form/Items/Basic Items/FormContainerItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Basic Items/FormLabelItem.swift
+++ b/Adyen/UI/Form/Items/Basic Items/FormLabelItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Basic Items/FormVerticalStackItemView.swift
+++ b/Adyen/UI/Form/Items/Basic Items/FormVerticalStackItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Button/FormButtonItem.swift
+++ b/Adyen/UI/Form/Items/Button/FormButtonItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Button/FormButtonItemStyle.swift
+++ b/Adyen/UI/Form/Items/Button/FormButtonItemStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Button/FormButtonItemView.swift
+++ b/Adyen/UI/Form/Items/Button/FormButtonItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Button/SearchButton/FormSearchButtonItem.swift
+++ b/Adyen/UI/Form/Items/Button/SearchButton/FormSearchButtonItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Button/SearchButton/FormSearchButtonItemView.swift
+++ b/Adyen/UI/Form/Items/Button/SearchButton/FormSearchButtonItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Error/FormErrorItem.swift
+++ b/Adyen/UI/Form/Items/Error/FormErrorItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Error/FormErrorItemStyle.swift
+++ b/Adyen/UI/Form/Items/Error/FormErrorItemStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Error/FormErrorItemView.swift
+++ b/Adyen/UI/Form/Items/Error/FormErrorItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/FormImageItem/FormImageItem.swift
+++ b/Adyen/UI/Form/Items/FormImageItem/FormImageItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/FormItem.swift
+++ b/Adyen/UI/Form/Items/FormItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/FormItemView.swift
+++ b/Adyen/UI/Form/Items/FormItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Phone Number/FormPhoneNumberItem.swift
+++ b/Adyen/UI/Form/Items/Phone Number/FormPhoneNumberItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Phone Number/FormPhoneNumberItemView.swift
+++ b/Adyen/UI/Form/Items/Phone Number/FormPhoneNumberItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Phone Number/Phone Extension Picker/FormPhoneExtensionPickerItem.swift
+++ b/Adyen/UI/Form/Items/Phone Number/Phone Extension Picker/FormPhoneExtensionPickerItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Phone Number/Phone Extension Picker/FormPhoneExtensionPickerItemView.swift
+++ b/Adyen/UI/Form/Items/Phone Number/Phone Extension Picker/FormPhoneExtensionPickerItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Segmented Control/FormSegmentedControlItem.swift
+++ b/Adyen/UI/Form/Items/Segmented Control/FormSegmentedControlItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/SelectableFormItem/SelectableFormItem.swift
+++ b/Adyen/UI/Form/Items/SelectableFormItem/SelectableFormItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/SelectableFormItem/SelectableFormItemStyle.swift
+++ b/Adyen/UI/Form/Items/SelectableFormItem/SelectableFormItemStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/SelectableFormItem/SelectableFormItemView.swift
+++ b/Adyen/UI/Form/Items/SelectableFormItem/SelectableFormItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Separator/FormSeparatorItem.swift
+++ b/Adyen/UI/Form/Items/Separator/FormSeparatorItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Separator/FormSeparatorItemView.swift
+++ b/Adyen/UI/Form/Items/Separator/FormSeparatorItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Spacer/FormSpacerItem.swift
+++ b/Adyen/UI/Form/Items/Spacer/FormSpacerItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Spacer/FormSpacerItemView.swift
+++ b/Adyen/UI/Form/Items/Spacer/FormSpacerItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Split/FormSplitItem.swift
+++ b/Adyen/UI/Form/Items/Split/FormSplitItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Split/FormSplitItemView.swift
+++ b/Adyen/UI/Form/Items/Split/FormSplitItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Text/FormTextInputItem.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextInputItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Text/FormTextInputItemView.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextInputItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Text/FormTextItem.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Text/FormTextItemStyle.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextItemStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Text/FormTextItemView.swift
+++ b/Adyen/UI/Form/Items/Text/FormTextItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Text/TextField.swift
+++ b/Adyen/UI/Form/Items/Text/TextField.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Toggle/FormToggleItem.swift
+++ b/Adyen/UI/Form/Items/Toggle/FormToggleItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Toggle/FormToggleItemStyle.swift
+++ b/Adyen/UI/Form/Items/Toggle/FormToggleItemStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Toggle/FormToggleItemView.swift
+++ b/Adyen/UI/Form/Items/Toggle/FormToggleItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItem.swift
+++ b/Adyen/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItemView.swift
+++ b/Adyen/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value Pickers/Abstract/BasePickerInputControl.swift
+++ b/Adyen/UI/Form/Items/Value Pickers/Abstract/BasePickerInputControl.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value Pickers/Identifier Picker/FormStringPickerItem.swift
+++ b/Adyen/UI/Form/Items/Value Pickers/Identifier Picker/FormStringPickerItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value Pickers/Issuer List Picker/FormIssuerPickerItem.swift
+++ b/Adyen/UI/Form/Items/Value Pickers/Issuer List Picker/FormIssuerPickerItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/FormValueItem.swift
+++ b/Adyen/UI/Form/Items/Value/FormValueItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/FormValueItemView.swift
+++ b/Adyen/UI/Form/Items/Value/FormValueItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/Picker/FormPickerItem.swift
+++ b/Adyen/UI/Form/Items/Value/Picker/FormPickerItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/Picker/FormPickerItemView.swift
+++ b/Adyen/UI/Form/Items/Value/Picker/FormPickerItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/Picker/FormPickerSearchViewController+EmptyView+Style.swift
+++ b/Adyen/UI/Form/Items/Value/Picker/FormPickerSearchViewController+EmptyView+Style.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/Picker/FormPickerSearchViewController+EmptyView.swift
+++ b/Adyen/UI/Form/Items/Value/Picker/FormPickerSearchViewController+EmptyView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/Picker/FormPickerSearchViewController+Style.swift
+++ b/Adyen/UI/Form/Items/Value/Picker/FormPickerSearchViewController+Style.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/Picker/FormPickerSearchViewController.swift
+++ b/Adyen/UI/Form/Items/Value/Picker/FormPickerSearchViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/Selectable/FormSelectableValueItem.swift
+++ b/Adyen/UI/Form/Items/Value/Selectable/FormSelectableValueItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
+++ b/Adyen/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/Validatable/FormValidatableValueItem.swift
+++ b/Adyen/UI/Form/Items/Value/Validatable/FormValidatableValueItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
+++ b/Adyen/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/CoreListDataSource.swift
+++ b/Adyen/UI/List/CoreListDataSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/DiffableListDataSource.swift
+++ b/Adyen/UI/List/DiffableListDataSource.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListCell.swift
+++ b/Adyen/UI/List/ListCell.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListFooterView.swift
+++ b/Adyen/UI/List/ListFooterView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListHeaderView.swift
+++ b/Adyen/UI/List/ListHeaderView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListItem+Icon.swift
+++ b/Adyen/UI/List/ListItem+Icon.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListItem.swift
+++ b/Adyen/UI/List/ListItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListItemStyle.swift
+++ b/Adyen/UI/List/ListItemStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListItemView.swift
+++ b/Adyen/UI/List/ListItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListSection.swift
+++ b/Adyen/UI/List/ListSection.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListSectionFooterStyle.swift
+++ b/Adyen/UI/List/ListSectionFooterStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListSectionHeaderStyle.swift
+++ b/Adyen/UI/List/ListSectionHeaderStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/List/ListViewController.swift
+++ b/Adyen/UI/List/ListViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/ApplePayStyle.swift
+++ b/Adyen/UI/Styles/ApplePayStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/ButtonStyle.swift
+++ b/Adyen/UI/Styles/ButtonStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/CoreColors.swift
+++ b/Adyen/UI/Styles/CoreColors.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/CoreFonts.swift
+++ b/Adyen/UI/Styles/CoreFonts.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/CornerRadiusStyle.swift
+++ b/Adyen/UI/Styles/CornerRadiusStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/FormComponentStyle.swift
+++ b/Adyen/UI/Styles/FormComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/ImageStyle.swift
+++ b/Adyen/UI/Styles/ImageStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/ListComponentStyle.swift
+++ b/Adyen/UI/Styles/ListComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/NavigationStyle.swift
+++ b/Adyen/UI/Styles/NavigationStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/ProgressViewStyle.swift
+++ b/Adyen/UI/Styles/ProgressViewStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/SegmentedControlStyle.swift
+++ b/Adyen/UI/Styles/SegmentedControlStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/TextStyle.swift
+++ b/Adyen/UI/Styles/TextStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Styles/ViewStyle.swift
+++ b/Adyen/UI/Styles/ViewStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/ADYViewController.swift
+++ b/Adyen/UI/View Controllers/ADYViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/AddressLookup/AddressLookupProvider.swift
+++ b/Adyen/UI/View Controllers/AddressLookup/AddressLookupProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/AddressLookup/AddressLookupStyle.swift
+++ b/Adyen/UI/View Controllers/AddressLookup/AddressLookupStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/AddressLookup/AddressLookupViewController+ViewModel.swift
+++ b/Adyen/UI/View Controllers/AddressLookup/AddressLookupViewController+ViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/AddressLookup/AddressLookupViewController.swift
+++ b/Adyen/UI/View Controllers/AddressLookup/AddressLookupViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/AddressLookup/Form/AddressInputFormViewController+ViewModel.swift
+++ b/Adyen/UI/View Controllers/AddressLookup/Form/AddressInputFormViewController+ViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/AddressLookup/Form/AddressInputFormViewController.swift
+++ b/Adyen/UI/View Controllers/AddressLookup/Form/AddressInputFormViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController+EmptyView.swift
+++ b/Adyen/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController+EmptyView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController+Style.swift
+++ b/Adyen/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController+Style.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController+ViewModel.swift
+++ b/Adyen/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController+ViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController.swift
+++ b/Adyen/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/SearchViewController/SearchViewController+InterfaceState.swift
+++ b/Adyen/UI/View Controllers/SearchViewController/SearchViewController+InterfaceState.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/SearchViewController/SearchViewController+ViewModel.swift
+++ b/Adyen/UI/View Controllers/SearchViewController/SearchViewController+ViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/SearchViewController/SearchViewController.swift
+++ b/Adyen/UI/View Controllers/SearchViewController/SearchViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/SecuredViewController.swift
+++ b/Adyen/UI/View Controllers/SecuredViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/View Controllers/ViewControllerDelegate.swift
+++ b/Adyen/UI/View Controllers/ViewControllerDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Views/ContainerView.swift
+++ b/Adyen/UI/Views/ContainerView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Views/CopyLabelView.swift
+++ b/Adyen/UI/Views/CopyLabelView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Views/EmptyStateView.swift
+++ b/Adyen/UI/Views/EmptyStateView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Views/LinkTextView.swift
+++ b/Adyen/UI/Views/LinkTextView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Views/LoadingView.swift
+++ b/Adyen/UI/Views/LoadingView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Views/SubmitButton.swift
+++ b/Adyen/UI/Views/SubmitButton.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Views/SupportedPaymentMethodsView.swift
+++ b/Adyen/UI/Views/SupportedPaymentMethodsView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Views/UISearchBar+Prominent.swift
+++ b/Adyen/UI/Views/UISearchBar+Prominent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/UI/Views/UIView+Accessibility.swift
+++ b/Adyen/UI/Views/UIView+Accessibility.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/AdyenCoder.swift
+++ b/Adyen/Utilities/AdyenCoder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Analytics.swift
+++ b/Adyen/Utilities/Analytics.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/AppLauncher.swift
+++ b/Adyen/Utilities/AppLauncher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/BundleSPMExtension.swift
+++ b/Adyen/Utilities/BundleSPMExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Completion.swift
+++ b/Adyen/Utilities/Completion.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Debugging/Assertion.swift
+++ b/Adyen/Utilities/Debugging/Assertion.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Debugging/Logger.swift
+++ b/Adyen/Utilities/Debugging/Logger.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/External/AllCountriesPhoneExtensions.swift
+++ b/Adyen/Utilities/External/AllCountriesPhoneExtensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/External/AllRegions.swift
+++ b/Adyen/Utilities/External/AllRegions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/External/LocalizableRegionRepository.swift
+++ b/Adyen/Utilities/External/LocalizableRegionRepository.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/External/LogoURLProvider.swift
+++ b/Adyen/Utilities/External/LogoURLProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/External/PhoneExtensionsRepository.swift
+++ b/Adyen/Utilities/External/PhoneExtensionsRepository.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/IBANSpecification.swift
+++ b/Adyen/Utilities/IBANSpecification.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/KeyboardObserver.swift
+++ b/Adyen/Utilities/KeyboardObserver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/LazyOptional.swift
+++ b/Adyen/Utilities/LazyOptional.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Localization.swift
+++ b/Adyen/Utilities/Localization.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/LocalizationParameters.swift
+++ b/Adyen/Utilities/LocalizationParameters.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Non SPM Bundle Extension/CoreBundleExtension.swift
+++ b/Adyen/Utilities/Non SPM Bundle Extension/CoreBundleExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Observable/AdyenObservable.swift
+++ b/Adyen/Utilities/Observable/AdyenObservable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Observable/AdyenObserver.swift
+++ b/Adyen/Utilities/Observable/AdyenObserver.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Observable/EventPublisher.swift
+++ b/Adyen/Utilities/Observable/EventPublisher.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Observable/Observation.swift
+++ b/Adyen/Utilities/Observable/Observation.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Observable/ObservationManager.swift
+++ b/Adyen/Utilities/Observable/ObservationManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/PublicKeyProvider/PublicKeyConsumer.swift
+++ b/Adyen/Utilities/PublicKeyProvider/PublicKeyConsumer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/PublicKeyProvider/PublicKeyProvider.swift
+++ b/Adyen/Utilities/PublicKeyProvider/PublicKeyProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/SizeUtilities.swift
+++ b/Adyen/Utilities/SizeUtilities.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/Throttler.swift
+++ b/Adyen/Utilities/Throttler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Utilities/ViewIdentifierBuilder.swift
+++ b/Adyen/Utilities/ViewIdentifierBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/AddressAnalyticsValidationError.swift
+++ b/Adyen/Validators/AddressAnalyticsValidationError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/BalanceChecker.swift
+++ b/Adyen/Validators/BalanceChecker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/BrazilSocialSecurityNumberValidator.swift
+++ b/Adyen/Validators/BrazilSocialSecurityNumberValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/ClientKeyValidator.swift
+++ b/Adyen/Validators/ClientKeyValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/CountryCodeValidator.swift
+++ b/Adyen/Validators/CountryCodeValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/CurrencyCodeValidator.swift
+++ b/Adyen/Validators/CurrencyCodeValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/DateValidator.swift
+++ b/Adyen/Validators/DateValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/EmailValidator.swift
+++ b/Adyen/Validators/EmailValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/IBANValidator.swift
+++ b/Adyen/Validators/IBANValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/LengthValidator.swift
+++ b/Adyen/Validators/LengthValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/NumericStringValidator.swift
+++ b/Adyen/Validators/NumericStringValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/PhoneNumberValidator.swift
+++ b/Adyen/Validators/PhoneNumberValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/PostalCodeValidator.swift
+++ b/Adyen/Validators/PostalCodeValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/RegularExpressionValidator.swift
+++ b/Adyen/Validators/RegularExpressionValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/ValidationError.swift
+++ b/Adyen/Validators/ValidationError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Adyen/Validators/Validator.swift
+++ b/Adyen/Validators/Validator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/Action.swift
+++ b/AdyenActions/Actions/Action.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/AnyVoucherAction.swift
+++ b/AdyenActions/Actions/AnyVoucherAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/AwaitAction.swift
+++ b/AdyenActions/Actions/AwaitAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/BoletoVoucherAction.swift
+++ b/AdyenActions/Actions/BoletoVoucherAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/DocumentAction.swift
+++ b/AdyenActions/Actions/DocumentAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/DokuVoucherAction.swift
+++ b/AdyenActions/Actions/DokuVoucherAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/EContextATMVoucherAction.swift
+++ b/AdyenActions/Actions/EContextATMVoucherAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/EContextStoresVoucherAction.swift
+++ b/AdyenActions/Actions/EContextStoresVoucherAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/MultibancoVoucherAction.swift
+++ b/AdyenActions/Actions/MultibancoVoucherAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/OXXOVoucherAction.swift
+++ b/AdyenActions/Actions/OXXOVoucherAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/QRCodeAction.swift
+++ b/AdyenActions/Actions/QRCodeAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/RedireactableAwaitAction.swift
+++ b/AdyenActions/Actions/RedireactableAwaitAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/RedirectAction.swift
+++ b/AdyenActions/Actions/RedirectAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/SDKAction.swift
+++ b/AdyenActions/Actions/SDKAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/ThreeDS2Action.swift
+++ b/AdyenActions/Actions/ThreeDS2Action.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/ThreeDS2ChallengeAction.swift
+++ b/AdyenActions/Actions/ThreeDS2ChallengeAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/ThreeDS2FingerprintAction.swift
+++ b/AdyenActions/Actions/ThreeDS2FingerprintAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/TwintSDKAction.swift
+++ b/AdyenActions/Actions/TwintSDKAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/TwintSDKData.swift
+++ b/AdyenActions/Actions/TwintSDKData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/VoucherAction.swift
+++ b/AdyenActions/Actions/VoucherAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/WeChatPaySDKAction.swift
+++ b/AdyenActions/Actions/WeChatPaySDKAction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Actions/WeChatPaySDKData.swift
+++ b/AdyenActions/Actions/WeChatPaySDKData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/AdyenActionComponent.swift
+++ b/AdyenActions/AdyenActionComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/AnyAuthenticationRequestParameters.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/AnyAuthenticationRequestParameters.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/AnyChallengeResult.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/AnyChallengeResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ChallengeParameters.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ChallengeParameters.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/FingerprintServiceParameters.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/FingerprintServiceParameters.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ADYServiceAdapter.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ADYServiceAdapter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/AnyADYTransaction.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/AnyADYTransaction.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ThreeDSServiceLegacy.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ThreeDSServiceLegacy.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceChallengeError.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceChallengeError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceFingerprintError.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceFingerprintError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceProvider.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceable.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/ThreeDSServiceable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/UnknownError+ThreeDSServiceable.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/UnknownError+ThreeDSServiceable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/API/Submit3DS2FingerprintRequest.swift
+++ b/AdyenActions/Components/3DS2/API/Submit3DS2FingerprintRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/API/Submit3DS2FingerprintResponse.swift
+++ b/AdyenActions/Components/3DS2/API/Submit3DS2FingerprintResponse.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDAScreenPresenter.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDAScreenPresenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler+Initializers.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler+Initializers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler+Initializers.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler+Initializers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDSActionHandlerResult.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDSActionHandlerResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/Fingerprint Submitter/ThreeDS2FingerprintSubmitter.swift
+++ b/AdyenActions/Components/3DS2/Fingerprint Submitter/ThreeDS2FingerprintSubmitter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/PaymentInfo.swift
+++ b/AdyenActions/Components/3DS2/PaymentInfo.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/ThreeDS2Component.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2Component.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentChallengeToken.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentChallengeToken.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprint.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprint.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprintToken.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprintToken.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentThreeDSConfiguration.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentThreeDSConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/ThreeDS2Details.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2Details.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/3DS2/ThreeDSResult.swift
+++ b/AdyenActions/Components/3DS2/ThreeDSResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Await/AwaitActionDetails.swift
+++ b/AdyenActions/Components/Await/AwaitActionDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Await/AwaitComponent.swift
+++ b/AdyenActions/Components/Await/AwaitComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Await/PollingComponent.swift
+++ b/AdyenActions/Components/Await/PollingComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Await/PollingHandlerProvider.swift
+++ b/AdyenActions/Components/Await/PollingHandlerProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Base/ActionNavigationBar.swift
+++ b/AdyenActions/Components/Base/ActionNavigationBar.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Base/AnyWeChatPaySDKActionComponent.swift
+++ b/AdyenActions/Components/Base/AnyWeChatPaySDKActionComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Document/DocumentComponent.swift
+++ b/AdyenActions/Components/Document/DocumentComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Document/ShareableComponent.swift
+++ b/AdyenActions/Components/Document/ShareableComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/QRCode/ExpirationTimer.swift
+++ b/AdyenActions/Components/QRCode/ExpirationTimer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/QRCode/QRCodeActionComponent.swift
+++ b/AdyenActions/Components/QRCode/QRCodeActionComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Redirect/BrowserComponent.swift
+++ b/AdyenActions/Components/Redirect/BrowserComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Redirect/NativeRedirectResultRequest.swift
+++ b/AdyenActions/Components/Redirect/NativeRedirectResultRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Redirect/OpenExternalAppDetector+DependencyKey.swift
+++ b/AdyenActions/Components/Redirect/OpenExternalAppDetector+DependencyKey.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Redirect/OpenExternalAppDetector.swift
+++ b/AdyenActions/Components/Redirect/OpenExternalAppDetector.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Redirect/RedirectComponent.swift
+++ b/AdyenActions/Components/Redirect/RedirectComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Redirect/RedirectDetails.swift
+++ b/AdyenActions/Components/Redirect/RedirectDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Redirect/RedirectListener.swift
+++ b/AdyenActions/Components/Redirect/RedirectListener.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/SDK/Twint+Injectable.swift
+++ b/AdyenActions/Components/SDK/Twint+Injectable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
+++ b/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Voucher/AppleWalletPassProvider.swift
+++ b/AdyenActions/Components/Voucher/AppleWalletPassProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Voucher/VoucherComponent.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Voucher/VoucherComponentExtensions.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponentExtensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Components/Voucher/VoucherShareableViewProvider.swift
+++ b/AdyenActions/Components/Voucher/VoucherShareableViewProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Protocols/ActionHandlingComponent.swift
+++ b/AdyenActions/Protocols/ActionHandlingComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/UI Style/ActionComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/ActionComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/UI Style/AwaitComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/AwaitComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/UI Style/DelegatedAuthenticationComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/DelegatedAuthenticationComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/UI Style/DocumentComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/DocumentComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/UI Style/QRCodeComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/QRCodeComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/UI Style/RedirectComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/RedirectComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/UI Style/VoucherComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/VoucherComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Await/AwaitComponentViewModel.swift
+++ b/AdyenActions/UI/View Controllers/Await/AwaitComponentViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Await/AwaitView.swift
+++ b/AdyenActions/UI/View Controllers/Await/AwaitView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Await/AwaitViewController.swift
+++ b/AdyenActions/UI/View Controllers/Await/AwaitViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DAApprovalViewController.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DAApprovalViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DAErrorViewController.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DAErrorViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DARegistrationViewController.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DARegistrationViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationErrorView.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationErrorView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationView.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UIImageViewHelper.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UIImageViewHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UILabelHelper.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UILabelHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UIStackViewHelper.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UIStackViewHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Document/DocumentActionView.swift
+++ b/AdyenActions/UI/View Controllers/Document/DocumentActionView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Document/DocumentActionViewModel.swift
+++ b/AdyenActions/UI/View Controllers/Document/DocumentActionViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/QR Code/Extensions/String+QRCode.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/Extensions/String+QRCode.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/QR Code/Models/QRCodeFlowType.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/Models/QRCodeFlowType.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/QR Code/Models/QRCodeViewStyle.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/Models/QRCodeViewStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/QR Code/QRCodeViewController.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/QRCodeViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/QR Code/QRCodeViewModel.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/QRCodeViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/QR Code/Views/QRCodeView.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/Views/QRCodeView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Voucher/ShareableVoucherView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/ShareableVoucherView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherCardLayer.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherCardLayer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherCardView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherCardView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherSeparatorView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherSeparatorView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherViewController.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherViewModel.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Utilities/BundleSPMExtension.swift
+++ b/AdyenActions/Utilities/BundleSPMExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenActions/Utilities/Non SPM Bundle Extension/ActionsBundleExtension.swift
+++ b/AdyenActions/Utilities/Non SPM Bundle Extension/ActionsBundleExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/BCMC/BCMCComponent.swift
+++ b/AdyenCard/Components/BCMC/BCMCComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CardAnalyticsConfiguration.swift
+++ b/AdyenCard/Components/Card/CardAnalyticsConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CardComponentConfiguration.swift
+++ b/AdyenCard/Components/Card/CardComponentConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CardComponentDelegate.swift
+++ b/AdyenCard/Components/Card/CardComponentDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CardComponentExtensions.swift
+++ b/AdyenCard/Components/Card/CardComponentExtensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CardDetails.swift
+++ b/AdyenCard/Components/Card/CardDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CardViewControllerItemsProvider.swift
+++ b/AdyenCard/Components/Card/CardViewControllerItemsProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/CoBadgedCardAnalyticsConfiguration.swift
+++ b/AdyenCard/Components/Card/CoBadgedCardAnalyticsConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/DummyCardScannerController.swift
+++ b/AdyenCard/Components/Card/DummyCardScannerController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Card/ThreeDS2SdkVersion.swift
+++ b/AdyenCard/Components/Card/ThreeDS2SdkVersion.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent+Extensions.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/GiftCardComponent/GiftCardConfirmationPaymentMethod.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardConfirmationPaymentMethod.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/GiftCardComponent/GiftCardDetails.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/GiftCardComponent/MealVoucherDetails.swift
+++ b/AdyenCard/Components/GiftCardComponent/MealVoucherDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/GiftCardComponent/PartialPaymentMethodDetails.swift
+++ b/AdyenCard/Components/GiftCardComponent/PartialPaymentMethodDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/KCP/KCPDetails.swift
+++ b/AdyenCard/Components/KCP/KCPDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Stored Card/StoredCardAlertManager.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardAlertManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Stored Card/StoredCardComponent.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Components/Stored Card/StoredCardConfiguration.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/DualBrandAccessoryView.swift
+++ b/AdyenCard/Form/DualBrandAccessoryView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCardExpiryDateItem.swift
+++ b/AdyenCard/Form/FormCardExpiryDateItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCardLogosItemView.swift
+++ b/AdyenCard/Form/FormCardLogosItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCardNumberContainerItem.swift
+++ b/AdyenCard/Form/FormCardNumberContainerItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCardNumberItem.swift
+++ b/AdyenCard/Form/FormCardNumberItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCardNumberItemView+ScanCard.swift
+++ b/AdyenCard/Form/FormCardNumberItemView+ScanCard.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCardSecurityCodeItem.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCoBadgedCardItem.swift
+++ b/AdyenCard/Form/FormCoBadgedCardItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCoBadgedCardItemStyle.swift
+++ b/AdyenCard/Form/FormCoBadgedCardItemStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/FormCoBadgedCardItemView.swift
+++ b/AdyenCard/Form/FormCoBadgedCardItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/Installments/FormCardInstallmentsItem.swift
+++ b/AdyenCard/Form/Installments/FormCardInstallmentsItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Form/Installments/InstallmentPickerElement.swift
+++ b/AdyenCard/Form/Installments/InstallmentPickerElement.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Formatters/CardExpiryDateFormatter.swift
+++ b/AdyenCard/Formatters/CardExpiryDateFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Formatters/CardNumberFormatter.swift
+++ b/AdyenCard/Formatters/CardNumberFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Formatters/CardSecurityCodeFormatter.swift
+++ b/AdyenCard/Formatters/CardSecurityCodeFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Utilities/BinLookup/BinLookupRequest.swift
+++ b/AdyenCard/Utilities/BinLookup/BinLookupRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Utilities/BinLookup/BinLookupResponse.swift
+++ b/AdyenCard/Utilities/BinLookup/BinLookupResponse.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Utilities/BinLookup/BinLookupService.swift
+++ b/AdyenCard/Utilities/BinLookup/BinLookupService.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Utilities/BundleSPMExtension.swift
+++ b/AdyenCard/Utilities/BundleSPMExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Utilities/CardType/BinInfoProvider.swift
+++ b/AdyenCard/Utilities/CardType/BinInfoProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Utilities/CardType/CardBrand.swift
+++ b/AdyenCard/Utilities/CardType/CardBrand.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Utilities/CardType/CardTypeDetector.swift
+++ b/AdyenCard/Utilities/CardType/CardTypeDetector.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Utilities/CardType/FallbackCardBrandProvider.swift
+++ b/AdyenCard/Utilities/CardType/FallbackCardBrandProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Utilities/Non SPM Bundle Extension/CardBundleExtension.swift
+++ b/AdyenCard/Utilities/Non SPM Bundle Extension/CardBundleExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Validators/CardExpiryDateValidator.swift
+++ b/AdyenCard/Validators/CardExpiryDateValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Validators/CardHolderNameValidator.swift
+++ b/AdyenCard/Validators/CardHolderNameValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Validators/CardKCPValidators.swift
+++ b/AdyenCard/Validators/CardKCPValidators.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Validators/CardNumberValidator.swift
+++ b/AdyenCard/Validators/CardNumberValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Validators/CardPublicKeyValidator.swift
+++ b/AdyenCard/Validators/CardPublicKeyValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Validators/CardSecurityCodeValidator.swift
+++ b/AdyenCard/Validators/CardSecurityCodeValidator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCard/Validators/CardValidationError.swift
+++ b/AdyenCard/Validators/CardValidationError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/CaptureSessionManager.swift
+++ b/AdyenCardScanner/Sources/CaptureSessionManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/CardImageParser.swift
+++ b/AdyenCardScanner/Sources/CardImageParser.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/CardScanner.swift
+++ b/AdyenCardScanner/Sources/CardScanner.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/CardScannerAssembler.swift
+++ b/AdyenCardScanner/Sources/CardScannerAssembler.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/CardScannerOverlayView.swift
+++ b/AdyenCardScanner/Sources/CardScannerOverlayView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/CardScannerViewController.swift
+++ b/AdyenCardScanner/Sources/CardScannerViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/CardScannerViewModel.swift
+++ b/AdyenCardScanner/Sources/CardScannerViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/Extensions/AVCaptureVideoOrientation+Extensions.swift
+++ b/AdyenCardScanner/Sources/Extensions/AVCaptureVideoOrientation+Extensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/Formatters/ExpirationDateFormatter.swift
+++ b/AdyenCardScanner/Sources/Formatters/ExpirationDateFormatter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/Models/CardScannerError.swift
+++ b/AdyenCardScanner/Sources/Models/CardScannerError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/Models/CreditCard.swift
+++ b/AdyenCardScanner/Sources/Models/CreditCard.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/Protocols/AppOpener.swift
+++ b/AdyenCardScanner/Sources/Protocols/AppOpener.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScanner/Sources/ROIView.swift
+++ b/AdyenCardScanner/Sources/ROIView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScannerTests/CardImageParserTests.swift
+++ b/AdyenCardScannerTests/CardImageParserTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScannerTests/CardScannerViewControllerTests.swift
+++ b/AdyenCardScannerTests/CardScannerViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScannerTests/CardScannerViewModelTests.swift
+++ b/AdyenCardScannerTests/CardScannerViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScannerTests/ExpirationDateFormatterTests.swift
+++ b/AdyenCardScannerTests/ExpirationDateFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScannerTests/Mocks/AppOpenerMock.swift
+++ b/AdyenCardScannerTests/Mocks/AppOpenerMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScannerTests/Mocks/CaptureSessionManagingMock.swift
+++ b/AdyenCardScannerTests/Mocks/CaptureSessionManagingMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScannerTests/Mocks/CardImageParsingMock.swift
+++ b/AdyenCardScannerTests/Mocks/CardImageParsingMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScannerTests/Mocks/CardScannerViewMock.swift
+++ b/AdyenCardScannerTests/Mocks/CardScannerViewMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScannerTests/Mocks/CardScannerViewModelMock.swift
+++ b/AdyenCardScannerTests/Mocks/CardScannerViewModelMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCardScannerTests/Mocks/ExpirationDateFormattingMock.swift
+++ b/AdyenCardScannerTests/Mocks/ExpirationDateFormattingMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCashAppPay/CashAppPayButton/CashAppPayButtonItem.swift
+++ b/AdyenCashAppPay/CashAppPayButton/CashAppPayButtonItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCashAppPay/CashAppPayButton/CashAppPayButtonItemView.swift
+++ b/AdyenCashAppPay/CashAppPayButton/CashAppPayButtonItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCashAppPay/CashAppPayComponent.swift
+++ b/AdyenCashAppPay/CashAppPayComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCashAppPay/CashAppPayConfiguration.swift
+++ b/AdyenCashAppPay/CashAppPayConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenCashAppPay/CashAppPayDetails.swift
+++ b/AdyenCashAppPay/CashAppPayDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitDetails.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Affirm/AffirmComponent.swift
+++ b/AdyenComponents/Affirm/AffirmComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Affirm/AffirmDetails.swift
+++ b/AdyenComponents/Affirm/AffirmDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Apple Pay/ApplePayComponentDelegate.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Apple Pay/ApplePayComponentError.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Apple Pay/ApplePayDetails.swift
+++ b/AdyenComponents/Apple Pay/ApplePayDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Apple Pay/ApplePayNetworksProvider.swift
+++ b/AdyenComponents/Apple Pay/ApplePayNetworksProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Apple Pay/ApplePayPayment.swift
+++ b/AdyenComponents/Apple Pay/ApplePayPayment.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Atome/AtomeAddressViewModelBuilder.swift
+++ b/AdyenComponents/Atome/AtomeAddressViewModelBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Atome/AtomeComponent.swift
+++ b/AdyenComponents/Atome/AtomeComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Atome/AtomeDetails.swift
+++ b/AdyenComponents/Atome/AtomeDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
+++ b/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BACS Direct Debit/BACSDirectDebitDetails.swift
+++ b/AdyenComponents/BACS Direct Debit/BACSDirectDebitDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BACS Direct Debit/Factories/BACSItemsFactory.swift
+++ b/AdyenComponents/BACS Direct Debit/Factories/BACSItemsFactory.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BACS Direct Debit/Models/BACSDirectDebitData.swift
+++ b/AdyenComponents/BACS Direct Debit/Models/BACSDirectDebitData.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BACS Direct Debit/Scenes/Confirmation/BACSConfirmationPresenter.swift
+++ b/AdyenComponents/BACS Direct Debit/Scenes/Confirmation/BACSConfirmationPresenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BACS Direct Debit/Scenes/Confirmation/BACSConfirmationViewController.swift
+++ b/AdyenComponents/BACS Direct Debit/Scenes/Confirmation/BACSConfirmationViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BACS Direct Debit/Scenes/Input/BACSInputFormViewController.swift
+++ b/AdyenComponents/BACS Direct Debit/Scenes/Input/BACSInputFormViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BACS Direct Debit/Scenes/Input/BACSInputPresenter.swift
+++ b/AdyenComponents/BACS Direct Debit/Scenes/Input/BACSInputPresenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BACS Direct Debit/Trackers/BACSDirectDebitComponentTracker.swift
+++ b/AdyenComponents/BACS Direct Debit/Trackers/BACSDirectDebitComponentTracker.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BLIK/BLIKComponent.swift
+++ b/AdyenComponents/BLIK/BLIKComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BLIK/BLIKDetails.swift
+++ b/AdyenComponents/BLIK/BLIKDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BasicPersonalInfoFormComponent/BasicPersonalInfoFormComponent.swift
+++ b/AdyenComponents/BasicPersonalInfoFormComponent/BasicPersonalInfoFormComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/BasicPersonalInfoFormComponent/BasicPersonalInfoFormDetails.swift
+++ b/AdyenComponents/BasicPersonalInfoFormComponent/BasicPersonalInfoFormDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Boleto/BoletoComponent.swift
+++ b/AdyenComponents/Boleto/BoletoComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Boleto/BoletoComponentExtensions.swift
+++ b/AdyenComponents/Boleto/BoletoComponentExtensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Boleto/BoletoDetails.swift
+++ b/AdyenComponents/Boleto/BoletoDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Doku/DokuComponent.swift
+++ b/AdyenComponents/Doku/DokuComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Doku/DokuDetails.swift
+++ b/AdyenComponents/Doku/DokuDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Instant/InstantComponents.swift
+++ b/AdyenComponents/Instant/InstantComponents.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Issuer List/IssuerListDetails.swift
+++ b/AdyenComponents/Issuer List/IssuerListDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Issuer List/IssuerListEmptyView.swift
+++ b/AdyenComponents/Issuer List/IssuerListEmptyView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/MB Way/MBWayComponent.swift
+++ b/AdyenComponents/MB Way/MBWayComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/MB Way/MBWayDetails.swift
+++ b/AdyenComponents/MB Way/MBWayDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
+++ b/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/OnlineBanking/OnlineBankingDetails.swift
+++ b/AdyenComponents/OnlineBanking/OnlineBankingDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent+Configuration.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent+Configuration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent+ConfirmationViewController+Model.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent+ConfirmationViewController+Model.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent+ConfirmationViewController.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent+ConfirmationViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent+Style.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent+Style.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/PayTo/PayToComponent.swift
+++ b/AdyenComponents/PayTo/PayToComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/PayTo/PayToDetails.swift
+++ b/AdyenComponents/PayTo/PayToDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/PayTo/PayToFormPickerItemView.swift
+++ b/AdyenComponents/PayTo/PayToFormPickerItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/PayTo/PayToItemsProvider.swift
+++ b/AdyenComponents/PayTo/PayToItemsProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/PayTo/PayToPayIdentifier.swift
+++ b/AdyenComponents/PayTo/PayToPayIdentifier.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Qiwi Wallet/QiwiWalletComponent.swift
+++ b/AdyenComponents/Qiwi Wallet/QiwiWalletComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/Qiwi Wallet/QiwiWalletDetails.swift
+++ b/AdyenComponents/Qiwi Wallet/QiwiWalletDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
+++ b/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/SEPA Direct Debit/SEPADirectDebitDetails.swift
+++ b/AdyenComponents/SEPA Direct Debit/SEPADirectDebitDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/UPI/UPIComponent.swift
+++ b/AdyenComponents/UPI/UPIComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenComponents/UPI/UPIComponentDetails.swift
+++ b/AdyenComponents/UPI/UPIComponentDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDelegatedAuthentication/AdyenDelegatedAuthentication.swift
+++ b/AdyenDelegatedAuthentication/AdyenDelegatedAuthentication.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Components/PaymentMethodListComponent.swift
+++ b/AdyenDropIn/Components/PaymentMethodListComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Components/PreApplePayComponent.swift
+++ b/AdyenDropIn/Components/PreApplePayComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Components/PreselectedPaymentMethodComponent.swift
+++ b/AdyenDropIn/Components/PreselectedPaymentMethodComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Models/DropInAnalyticsConfiguration.swift
+++ b/AdyenDropIn/Models/DropInAnalyticsConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Models/DropInComponentStyle.swift
+++ b/AdyenDropIn/Models/DropInComponentStyle.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Models/DropInConfiguration.swift
+++ b/AdyenDropIn/Models/DropInConfiguration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Presentation/DimmingPresentationController.swift
+++ b/AdyenDropIn/Presentation/DimmingPresentationController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Presentation/DropInNavigationController.swift
+++ b/AdyenDropIn/Presentation/DropInNavigationController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Presentation/ModalViewController.swift
+++ b/AdyenDropIn/Presentation/ModalViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Presentation/NavigationDelegate.swift
+++ b/AdyenDropIn/Presentation/NavigationDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Presentation/SlideInPresentationAnimator.swift
+++ b/AdyenDropIn/Presentation/SlideInPresentationAnimator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Presentation/WrapperViewController.swift
+++ b/AdyenDropIn/Presentation/WrapperViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
+++ b/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Utilities/ComponentSections.swift
+++ b/AdyenDropIn/Utilities/ComponentSections.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenDropIn/Views/PreApplePayView.swift
+++ b/AdyenDropIn/Views/PreApplePayView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/AnyEncryptor.swift
+++ b/AdyenEncryption/AnyEncryptor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/BankDetailsEncryptor.swift
+++ b/AdyenEncryption/BankDetailsEncryptor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/CardEncryptor.swift
+++ b/AdyenEncryption/CardEncryptor.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/Extensions/DataExtension.swift
+++ b/AdyenEncryption/Extensions/DataExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/Extensions/IntegerExtension.swift
+++ b/AdyenEncryption/Extensions/IntegerExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/Extensions/JSONEncoder+SortedKeys.swift
+++ b/AdyenEncryption/Extensions/JSONEncoder+SortedKeys.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/Extensions/StringExtension.swift
+++ b/AdyenEncryption/Extensions/StringExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/JOSE/Encryption Algorithms/CommonCryptoHelpers.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/CommonCryptoHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/JOSE/Encryption Algorithms/Content Encryption Algorithms/JWAA256CBCHS512Algorithm.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/Content Encryption Algorithms/JWAA256CBCHS512Algorithm.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/JOSE/Encryption Algorithms/Content Encryption Algorithms/JWAEncryptionAlgorithm.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/Content Encryption Algorithms/JWAEncryptionAlgorithm.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryption.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryption.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryptionGenerator.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/JSON Web Encryption/JSONWebEncryptionGenerator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/JOSE/Encryption Algorithms/Key Encryption Algorithms/RSAOAEP256Algorithm.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/Key Encryption Algorithms/RSAOAEP256Algorithm.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/Model/Card.swift
+++ b/AdyenEncryption/Model/Card.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/Model/EncryptedCard.swift
+++ b/AdyenEncryption/Model/EncryptedCard.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/Payload/BankPayload.swift
+++ b/AdyenEncryption/Payload/BankPayload.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/Payload/BinPayload.swift
+++ b/AdyenEncryption/Payload/BinPayload.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/Payload/CardPayload.swift
+++ b/AdyenEncryption/Payload/CardPayload.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenEncryption/Payload/Payload.swift
+++ b/AdyenEncryption/Payload/Payload.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/API/Disable Stored Payments/DisableStoredPaymentMethodRequest.swift
+++ b/AdyenSession/API/Disable Stored Payments/DisableStoredPaymentMethodRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/API/Partial Payments API/Balance check/BalanceCheckRequest.swift
+++ b/AdyenSession/API/Partial Payments API/Balance check/BalanceCheckRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/API/Partial Payments API/Cancel Order/CancelOrderRequest.swift
+++ b/AdyenSession/API/Partial Payments API/Cancel Order/CancelOrderRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/API/Partial Payments API/Create Order/CreateOrderRequest.swift
+++ b/AdyenSession/API/Partial Payments API/Create Order/CreateOrderRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/API/Payment Details/PaymentDetailsRequest.swift
+++ b/AdyenSession/API/Payment Details/PaymentDetailsRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/API/Payments/PaymentsRequest.swift
+++ b/AdyenSession/API/Payments/PaymentsRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/API/SelfRetainingAPIClient.swift
+++ b/AdyenSession/API/SelfRetainingAPIClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/API/Session Setup/SessionSetupRequest.swift
+++ b/AdyenSession/API/Session Setup/SessionSetupRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/API/SessionAPIClient.swift
+++ b/AdyenSession/API/SessionAPIClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/AdyenSession+ActionComponentDelegate.swift
+++ b/AdyenSession/AdyenSession+ActionComponentDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/AdyenSession+DropInComponentDelegate.swift
+++ b/AdyenSession/AdyenSession+DropInComponentDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/AdyenSession+PartialPaymentDelegate.swift
+++ b/AdyenSession/AdyenSession+PartialPaymentDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/AdyenSession+PaymentComponentDelegate.swift
+++ b/AdyenSession/AdyenSession+PaymentComponentDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/AdyenSession+StoredPaymentMethodsDelegate.swift
+++ b/AdyenSession/AdyenSession+StoredPaymentMethodsDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/AdyenSession.swift
+++ b/AdyenSession/AdyenSession.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/AdyenSessionDelegate.swift
+++ b/AdyenSession/AdyenSessionDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSession/AdyenSessionResult.swift
+++ b/AdyenSession/AdyenSessionResult.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenSwiftUI/Present View Controller/FullScreenViewControllerPresenter.swift
+++ b/AdyenSwiftUI/Present View Controller/FullScreenViewControllerPresenter.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenTwint/TwintComponent.swift
+++ b/AdyenTwint/TwintComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenTwint/TwintDetails.swift
+++ b/AdyenTwint/TwintDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenWeChatPay/WeChatPayActionComponent/WeChatPayActionComponent.swift
+++ b/AdyenWeChatPay/WeChatPayActionComponent/WeChatPayActionComponent.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/AdyenWeChatPay/WeChatPayActionComponent/WeChatPayAdditionalDetails.swift
+++ b/AdyenWeChatPay/WeChatPayActionComponent/WeChatPayAdditionalDetails.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Configuration/AnalyticsSettingsView.swift
+++ b/Demo/Common/Configuration/AnalyticsSettingsView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Configuration/ApplePaySettingsView.swift
+++ b/Demo/Common/Configuration/ApplePaySettingsView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Configuration/CardComponentSettingsView.swift
+++ b/Demo/Common/Configuration/CardComponentSettingsView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Configuration/ConfigurationView.swift
+++ b/Demo/Common/Configuration/ConfigurationView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Configuration/ConfigurationViewModel.swift
+++ b/Demo/Common/Configuration/ConfigurationViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Configuration/DropInSettingsView.swift
+++ b/Demo/Common/Configuration/DropInSettingsView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Configuration/SearchBar.swift
+++ b/Demo/Common/Configuration/SearchBar.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Helpers/APIClientHelper.swift
+++ b/Demo/Common/Helpers/APIClientHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Helpers/CodingHelpers.swift
+++ b/Demo/Common/Helpers/CodingHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/IssuerListComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/IssuerListComponentAdvancedFlowExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/ComponentCreationError.swift
+++ b/Demo/Common/IntegrationExamples/ComponentCreationError.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/DemoAddressLookupProvider.swift
+++ b/Demo/Common/IntegrationExamples/DemoAddressLookupProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/MapkitAddressLookupProvider.swift
+++ b/Demo/Common/IntegrationExamples/MapkitAddressLookupProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataAdvancedFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataAdvancedFlowProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/Protocols/PresenterExampleProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/PresenterExampleProtocol.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/Session/Components/InstantPaymentComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/InstantPaymentComponentExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/Session/Components/IssuerListComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/IssuerListComponentExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/IntegrationExamples/Session/DropIn/DropInExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/DropIn/DropInExample.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Models/ComponentsItem.swift
+++ b/Demo/Common/Models/ComponentsItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Models/ExampleContainer.swift
+++ b/Demo/Common/Models/ExampleContainer.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/APIRequest.swift
+++ b/Demo/Common/Networking/APIRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/BalanceCheckRequest.swift
+++ b/Demo/Common/Networking/BalanceCheckRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/CancelOrderRequest.swift
+++ b/Demo/Common/Networking/CancelOrderRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/CreateOrderRequest.swift
+++ b/Demo/Common/Networking/CreateOrderRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/DefaultAPIClient.swift
+++ b/Demo/Common/Networking/DefaultAPIClient.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/DisableStoredPaymentMethodRequest.swift
+++ b/Demo/Common/Networking/DisableStoredPaymentMethodRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/Environment.swift
+++ b/Demo/Common/Networking/Environment.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/PaymentDetailsRequest.swift
+++ b/Demo/Common/Networking/PaymentDetailsRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/PaymentMethodsRequest.swift
+++ b/Demo/Common/Networking/PaymentMethodsRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/PaymentsRequest.swift
+++ b/Demo/Common/Networking/PaymentsRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/Networking/SessionRequest.swift
+++ b/Demo/Common/Networking/SessionRequest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Common/PresentationDelegates/BACSDirectDebitPresentationDelegate.swift
+++ b/Demo/Common/PresentationDelegates/BACSDirectDebitPresentationDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Configuration+secrets.swift
+++ b/Demo/Configuration+secrets.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/SwiftUI/AppDelegate.swift
+++ b/Demo/SwiftUI/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/SwiftUI/ComponentsView.swift
+++ b/Demo/SwiftUI/ComponentsView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/SwiftUI/ComponentsViewModel.swift
+++ b/Demo/SwiftUI/ComponentsViewModel.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/SwiftUI/SceneDelegate.swift
+++ b/Demo/SwiftUI/SceneDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/UIKit/AppDelegate.swift
+++ b/Demo/UIKit/AppDelegate.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/UIKit/ComponentsView.swift
+++ b/Demo/UIKit/ComponentsView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/UIKit/ComponentsViewController.swift
+++ b/Demo/UIKit/ComponentsViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Demo/UIKit/UIView+Helpers.swift
+++ b/Demo/UIKit/UIView+Helpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/ActionComponentDelegateMock.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/ActionComponentDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/AdyenActionComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/AdyenActionComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/Twint+Spy.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/Twint+Spy.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Convenience.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Convenience.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Flows.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Flows.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Await/PollingComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Await/PollingComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewControllerTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewModelMock.swift
+++ b/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewModelMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewModelTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Redirect/RedirectComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Redirect/RedirectComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Redirect/RedirectDetailsTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Redirect/RedirectDetailsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Redirect/RedirectListnerTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Redirect/RedirectListnerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/AppleWalletPassProviderTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/AppleWalletPassProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/BoletoVoucherShareableVoucherViewProviderTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/BoletoVoucherShareableVoucherViewProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/DokuVoucherUITests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/DokuVoucherUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/EContextATMShareableVoucherViewProviderTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/EContextATMShareableVoucherViewProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/EContextStoresVoucherViewControllerProviderTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/EContextStoresVoucherViewControllerProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/MultibancoShareableVoucherViewProviderTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/MultibancoShareableVoucherViewProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/OXXOShareableVoucherViewProviderTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/OXXOShareableVoucherViewProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/VoucherComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/VoucherComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/VoucherShareableViewProviderMock.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/VoucherShareableViewProviderMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/VoucherViewDelegateMock.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/VoucherViewDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Actions Tests/Voucher/VoucherViewTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/VoucherViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/3DS2 Fingerprint Submitter/ThreeDS2FingerprintSubmitterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/3DS2 Fingerprint Submitter/ThreeDS2FingerprintSubmitterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/AnyADYServiceMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/AnyADYServiceMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/AnyRedirectComponentMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/AnyRedirectComponentMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/AnyThreeDS2ActionHandlerMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/AnyThreeDS2ActionHandlerMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/AnyThreeDS2FingerprintSubmitterMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/AnyThreeDS2FingerprintSubmitterMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/AuthenticationServiceMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/AuthenticationServiceMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2Component+FingerprintTokenTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2Component+FingerprintTokenTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2DAScreenPresenterMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2DAScreenPresenterMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests+Constants.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests+Constants.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ServiceLegacyTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ServiceLegacyTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSResultExtension.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSResultExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceProviderTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceableMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceableMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerControllerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerProviderDispatchOnceTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerProviderDispatchOnceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerTestsHelpers.swift
+++ b/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerTestsHelpers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/CardDetailsTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardDetailsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/CardNumbers.swift
+++ b/Tests/IntegrationTests/Card Tests/CardNumbers.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/CardPublicKeyProviderTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardPublicKeyProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/DualBrandAccessoryViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/DualBrandAccessoryViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/FormViewControllerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/FormViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Formatters/BrazilSocialSecurityNumberFormatterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Formatters/BrazilSocialSecurityNumberFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Formatters/CardExpiryDateFormatterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Formatters/CardExpiryDateFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Formatters/CardNumberFormatterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Formatters/CardNumberFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Formatters/CardSecurityCodeFormatterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Formatters/CardSecurityCodeFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormItemViewBuilderTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormItemViewBuilderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Mocks/CardComponentDelegateMock.swift
+++ b/Tests/IntegrationTests/Card Tests/Mocks/CardComponentDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Mocks/CardTypeProviderMock.swift
+++ b/Tests/IntegrationTests/Card Tests/Mocks/CardTypeProviderMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Mocks/OpenExternalAppDetector+Mock.swift
+++ b/Tests/IntegrationTests/Card Tests/Mocks/OpenExternalAppDetector+Mock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Mocks/PublicKeyProviderMock.swift
+++ b/Tests/IntegrationTests/Card Tests/Mocks/PublicKeyProviderMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/StoredCardAlertManagerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardAlertManagerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/StoredPaymentMethodComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredPaymentMethodComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Utilities/CardBrandProviderTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/CardBrandProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Utilities/CardEncryptorCardTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/CardEncryptorCardTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Utilities/CardTypeDetectorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/CardTypeDetectorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Utilities/ThrottlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/ThrottlerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/BrazilSocialSecurityNumberValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/BrazilSocialSecurityNumberValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/CardExpiryDateValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardExpiryDateValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/CardHolderNameValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardHolderNameValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/CardKCPValidatorsTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardKCPValidatorsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/CardNumberValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardNumberValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/CardPublicKeyValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardPublicKeyValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/CardSecurityCodeValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardSecurityCodeValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/EmailValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/EmailValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/NumericStringValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/NumericStringValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/PhoneNumberValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/PhoneNumberValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/PostalCodeValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/PostalCodeValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Validators/RandomStringGenerator.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/RandomStringGenerator.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Card Tests/Views/FormCardExpiryDateItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Views/FormCardExpiryDateItemViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Affirm/AffirmComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Affirm/AffirmComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDelegateMock.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDetailsTest.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDetailsTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayPaymentMethodTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayPaymentMethodTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayPaymentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayPaymentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/Mocks/ApplePayNetworksProvidingMock.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/Mocks/ApplePayNetworksProvidingMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/PreApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/PreApplePayComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Atome/AtomeComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Atome/AtomeComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/BACSDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/BACSDirectDebitComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/DocumentComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/DocumentComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Factories/BACSItemsFactoryTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Factories/BACSItemsFactoryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSConfirmationPresenterProtocolMock.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSConfirmationPresenterProtocolMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSConfirmationViewProtocolMock.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSConfirmationViewProtocolMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSDirectDebitComponentTrackerProtocolMock.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSDirectDebitComponentTrackerProtocolMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSInputFormViewProtocolMock.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSInputFormViewProtocolMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSInputPresenterProtocolMock.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSInputPresenterProtocolMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSItemsFactoryProtocolMock.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSItemsFactoryProtocolMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSRouterProtocolMock.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/BACSRouterProtocolMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/DocumentActionViewDelegateMock.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/DocumentActionViewDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Scenes/Confirmation/BACSConfirmationPresenterTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Scenes/Confirmation/BACSConfirmationPresenterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Scenes/Confirmation/BACSConfirmationViewControllerTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Scenes/Confirmation/BACSConfirmationViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Scenes/Input/BACSInputFormViewControllerTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Scenes/Input/BACSInputFormViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Scenes/Input/BACSInputPresenterTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Scenes/Input/BACSInputPresenterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Trackers/BACSDirectDebitComponentTrackerTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Trackers/BACSDirectDebitComponentTrackerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Boleto/BoletoComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Boleto/BoletoComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Doku/DokuComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Doku/DokuComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Gift Card/PartialPaymentDelegateMock.swift
+++ b/Tests/IntegrationTests/Components Tests/Gift Card/PartialPaymentDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Gift Card/ReadyToSubmitPaymentComponentDelegateMock.swift
+++ b/Tests/IntegrationTests/Components Tests/Gift Card/ReadyToSubmitPaymentComponentDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Instant Payment/InstantPaymentComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Instant Payment/InstantPaymentComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/IssuerList/IssuerListComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/IssuerList/IssuerListComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/MB Way/MBWayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/MB Way/MBWayComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Online Banking/OnlineBankingComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Online Banking/OnlineBankingComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/PayByBankUSComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayByBankUSComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubject.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubject.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/QRCode/QRCodeActionComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/QRCode/QRCodeActionComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/SEPA Tests/IBANFormatterTests.swift
+++ b/Tests/IntegrationTests/Components Tests/SEPA Tests/IBANFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/SEPA Tests/IBANValidatorTests.swift
+++ b/Tests/IntegrationTests/Components Tests/SEPA Tests/IBANValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Seven Eleven Component/BasicPersonalInfoFormComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Seven Eleven Component/BasicPersonalInfoFormComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/Twint/TwintComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Twint/TwintComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Components Tests/UPIComponent/UPIComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/UPIComponent/UPIComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/ComponentManagerTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/ComponentManagerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/DropInActionTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/DropInActionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/DropInDelegateMock.swift
+++ b/Tests/IntegrationTests/DropIn Tests/DropInDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/DropInTestInternal.swift
+++ b/Tests/IntegrationTests/DropIn Tests/DropInTestInternal.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/DropInTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/DropInTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/ModalToolbarTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/ModalToolbarTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/ModalViewControllerTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/ModalViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/Payment Method List/PaymentMethodListComponentDelegateMock.swift
+++ b/Tests/IntegrationTests/DropIn Tests/Payment Method List/PaymentMethodListComponentDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/Payment Method List/PaymentMethodListComponentTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/Payment Method List/PaymentMethodListComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentComponentTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentComponentTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodDelegateMock.swift
+++ b/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Helpers/ErrorMock.swift
+++ b/Tests/IntegrationTests/Helpers/ErrorMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Helpers/UIBarButtonItem+XCTest.swift
+++ b/Tests/IntegrationTests/Helpers/UIBarButtonItem+XCTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Helpers/UIView+Search.swift
+++ b/Tests/IntegrationTests/Helpers/UIView+Search.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Helpers/UIViewController+Search.swift
+++ b/Tests/IntegrationTests/Helpers/UIViewController+Search.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Helpers/XCTestCase+FormAddressItem.swift
+++ b/Tests/IntegrationTests/Helpers/XCTestCase+FormAddressItem.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Helpers/XCTestCase+FormTextItemView.swift
+++ b/Tests/IntegrationTests/Helpers/XCTestCase+FormTextItemView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Helpers/XCTestCase+RootViewController.swift
+++ b/Tests/IntegrationTests/Helpers/XCTestCase+RootViewController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Helpers/XCTestCase+Style.swift
+++ b/Tests/IntegrationTests/Helpers/XCTestCase+Style.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Helpers/XCTestCase+Wait+UIKit.swift
+++ b/Tests/IntegrationTests/Helpers/XCTestCase+Wait+UIKit.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Helpers/XCTestCase+Wait.swift
+++ b/Tests/IntegrationTests/Helpers/XCTestCase+Wait.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Localization/LocalizationTests.swift
+++ b/Tests/IntegrationTests/Localization/LocalizationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Session Tests/SelfRetainingAPIClientTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SelfRetainingAPIClientTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Session Tests/SessionDelegateMock.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UI Components/SubmitButtonTests.swift
+++ b/Tests/IntegrationTests/UI Components/SubmitButtonTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Address/AddressViewModelTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Address/AddressViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Address/FormAddressItemTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Address/FormAddressItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Address/FormAddressPickerItemTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Address/FormAddressPickerItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Error Item/FormErrorItemTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Error Item/FormErrorItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Picker/FormPickerItemTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Picker/FormPickerItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewDelegateMock.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Validatable/FormValidatableItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Validatable/FormValidatableItemViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/View Controllers/AddressInputFormViewControllerTests.swift
+++ b/Tests/IntegrationTests/UIKit/View Controllers/AddressInputFormViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/View Controllers/AddressLookupViewControllerTests.swift
+++ b/Tests/IntegrationTests/UIKit/View Controllers/AddressLookupViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/View Controllers/FormPickerSearchViewControllerTests.swift
+++ b/Tests/IntegrationTests/UIKit/View Controllers/FormPickerSearchViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/View Controllers/SearchViewControllerTests.swift
+++ b/Tests/IntegrationTests/UIKit/View Controllers/SearchViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Views/LinkTextViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Views/LinkTextViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Views/LoadingViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Views/LoadingViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/IntegrationTests/UIKit/Views/SupportedPaymentMethodLogosViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Views/SupportedPaymentMethodLogosViewTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/AffirmComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/AffirmComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/AtomeComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/AtomeComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/BLIKComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/BLIKComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/BoletoComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/BoletoComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/CardComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/CardComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/DokuComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/DokuComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/GiftCardComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/GiftCardComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/IssuerListComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/IssuerListComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/MBWayComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/MBWayComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/OnlineBankingComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/OnlineBankingComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/PayToComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/PayToComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/QRCodeActionComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/QRCodeActionComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Components/UPIComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/UPIComponentUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/Helpers/XCTestCase+SnapshotTesting.swift
+++ b/Tests/SnapshotTests/Helpers/XCTestCase+SnapshotTesting.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/UI/ListViewControllerUITests.swift
+++ b/Tests/SnapshotTests/UI/ListViewControllerUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/SnapshotTests/UI/SecuredViewControllerUITests.swift
+++ b/Tests/SnapshotTests/UI/SecuredViewControllerUITests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/APIClientMock.swift
+++ b/Tests/UnitTests/APIClientMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/AdyenSwiftUI/Present View Controller/FullScreenViewControllerTests.swift
+++ b/Tests/UnitTests/AdyenSwiftUI/Present View Controller/FullScreenViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/AdyenSwiftUI/Present View Controller/TestPresentingView.swift
+++ b/Tests/UnitTests/AdyenSwiftUI/Present View Controller/TestPresentingView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Analytics/AnalyticsEventDataSourceTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsEventDataSourceTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Analytics/AnalyticsEventTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsEventTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Analytics/AnalyticsFlavorTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsFlavorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Analytics/AnalyticsProviderMock.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsProviderMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Analytics/EventAnalyticsProviderTests.swift
+++ b/Tests/UnitTests/Analytics/EventAnalyticsProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Assets/AssetsAccessTests.swift
+++ b/Tests/UnitTests/Assets/AssetsAccessTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/APIContextTests.swift
+++ b/Tests/UnitTests/Core/APIContextTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/ActionTests.swift
+++ b/Tests/UnitTests/Core/ActionTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/AdyenContextTests.swift
+++ b/Tests/UnitTests/Core/AdyenContextTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/BackoffSchedulerTests.swift
+++ b/Tests/UnitTests/Core/BackoffSchedulerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/BankDetailsEncryptorTests.swift
+++ b/Tests/UnitTests/Core/BankDetailsEncryptorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/BrowserInfoTests.swift
+++ b/Tests/UnitTests/Core/BrowserInfoTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/Encryption/JWAA256CBCHS512AlgorithmTests.swift
+++ b/Tests/UnitTests/Core/Encryption/JWAA256CBCHS512AlgorithmTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/Encryption/RSAOAEP256AlgorithmTests.swift
+++ b/Tests/UnitTests/Core/Encryption/RSAOAEP256AlgorithmTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/ImageLoaderTests.swift
+++ b/Tests/UnitTests/Core/ImageLoaderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/ListItemTests.swift
+++ b/Tests/UnitTests/Core/ListItemTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/OpenExternalAppDetectorTests.swift
+++ b/Tests/UnitTests/Core/OpenExternalAppDetectorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Core/SimpleSchedulerTests.swift
+++ b/Tests/UnitTests/Core/SimpleSchedulerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Extension/KeyedDecodingContainerExtensionsTests.swift
+++ b/Tests/UnitTests/Extension/KeyedDecodingContainerExtensionsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Extension/PKPaymentNetworkExtensionsTests.swift
+++ b/Tests/UnitTests/Extension/PKPaymentNetworkExtensionsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Extension/StringExtensionsTests.swift
+++ b/Tests/UnitTests/Extension/StringExtensionsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Extension/TimeIntervalExtensionsTests.swift
+++ b/Tests/UnitTests/Extension/TimeIntervalExtensionsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Extension/UIButtonHelpersTests.swift
+++ b/Tests/UnitTests/Extension/UIButtonHelpersTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Extension/UILabelHelpersTests.swift
+++ b/Tests/UnitTests/Extension/UILabelHelpersTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Extension/URLExtensionsTest.swift
+++ b/Tests/UnitTests/Extension/URLExtensionsTest.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Helpers/PaymentMethods+Equatable.swift
+++ b/Tests/UnitTests/Helpers/PaymentMethods+Equatable.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Helpers/String+UIImage.swift
+++ b/Tests/UnitTests/Helpers/String+UIImage.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Helpers/XCTestCase+Coder.swift
+++ b/Tests/UnitTests/Helpers/XCTestCase+Coder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Helpers/XCTestCase+FirstResponder.swift
+++ b/Tests/UnitTests/Helpers/XCTestCase+FirstResponder.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Helpers/XCTestCase+Result.swift
+++ b/Tests/UnitTests/Helpers/XCTestCase+Result.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/APIClientMock.swift
+++ b/Tests/UnitTests/Mocks/APIClientMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/ActionHandlingComponentMock.swift
+++ b/Tests/UnitTests/Mocks/ActionHandlingComponentMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/AppLauncherMock.swift
+++ b/Tests/UnitTests/Mocks/AppLauncherMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/CancellableMock.swift
+++ b/Tests/UnitTests/Mocks/CancellableMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/CardPaymentMethodMock.swift
+++ b/Tests/UnitTests/Mocks/CardPaymentMethodMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/DummyData/Dummy.swift
+++ b/Tests/UnitTests/Mocks/DummyData/Dummy.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/DummyData/DummyHelper.swift
+++ b/Tests/UnitTests/Mocks/DummyData/DummyHelper.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2022 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/DummyData/DummyPaymentMethods.swift
+++ b/Tests/UnitTests/Mocks/DummyData/DummyPaymentMethods.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/FormatterMock.swift
+++ b/Tests/UnitTests/Mocks/FormatterMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/ImageLoaderMock.swift
+++ b/Tests/UnitTests/Mocks/ImageLoaderMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/MockAddressLookupProvider.swift
+++ b/Tests/UnitTests/Mocks/MockAddressLookupProvider.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/PaymentComponentDelegateMock.swift
+++ b/Tests/UnitTests/Mocks/PaymentComponentDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/PaymentComponentMock.swift
+++ b/Tests/UnitTests/Mocks/PaymentComponentMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/PaymentMethodMock.swift
+++ b/Tests/UnitTests/Mocks/PaymentMethodMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/PostalAddressMocks.swift
+++ b/Tests/UnitTests/Mocks/PostalAddressMocks.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/PresentationDelegateMock.swift
+++ b/Tests/UnitTests/Mocks/PresentationDelegateMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/PresenterMock.swift
+++ b/Tests/UnitTests/Mocks/PresenterMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/PresentingViewControllerMock.swift
+++ b/Tests/UnitTests/Mocks/PresentingViewControllerMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/StoredPaymentMethodMock.swift
+++ b/Tests/UnitTests/Mocks/StoredPaymentMethodMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/URLProtocolMock.swift
+++ b/Tests/UnitTests/Mocks/URLProtocolMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Mocks/ValidatorMock.swift
+++ b/Tests/UnitTests/Mocks/ValidatorMock.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/AdyenCoderTests.swift
+++ b/Tests/UnitTests/Utilities/AdyenCoderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/AmountFormatterTests.swift
+++ b/Tests/UnitTests/Utilities/AmountFormatterTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/AssertsTests.swift
+++ b/Tests/UnitTests/Utilities/AssertsTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/BalanceCheckerTests.swift
+++ b/Tests/UnitTests/Utilities/BalanceCheckerTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/DateValidationTests.swift
+++ b/Tests/UnitTests/Utilities/DateValidationTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/KeyboardObserverTests.swift
+++ b/Tests/UnitTests/Utilities/KeyboardObserverTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/LazyOptionalTests.swift
+++ b/Tests/UnitTests/Utilities/LazyOptionalTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/LengthValidatorTests.swift
+++ b/Tests/UnitTests/Utilities/LengthValidatorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/LogoGeneratorTests.swift
+++ b/Tests/UnitTests/Utilities/LogoGeneratorTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/ObservableTests.swift
+++ b/Tests/UnitTests/Utilities/ObservableTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/ObservableThreadSafetyTests.swift
+++ b/Tests/UnitTests/Utilities/ObservableThreadSafetyTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //

--- a/Tests/UnitTests/Utilities/PhoneExtensionsRepositoryTests.swift
+++ b/Tests/UnitTests/Utilities/PhoneExtensionsRepositoryTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2021 Adyen N.V.
+// Copyright (c) Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

As the new year came, we have `swiftformat` changing headers again, as some files have their filesystem date set in 2026.
In order to not spend time on this, this change forces `swiftformat` to ignore headers. Later we can remove the year from headers completely.

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
