### PR TITLE
Renamed AdyenCheckout into Checkout

### DIFF
--- a/AdyenCheckout/AdyenCheckout+DelegateCallbacks.swift
+++ b/AdyenCheckout/AdyenCheckout+DelegateCallbacks.swift
@@ -15,7 +15,7 @@
 // If not, we check session and pass the work to it.
 // Finally if neither, we will fail/assert/show error.
 
-extension AdyenCheckout: PaymentComponentDelegate {
+extension Checkout: PaymentComponentDelegate {
     
     public func didSubmit(_ data: PaymentComponentData, from component: any PaymentComponent) {
         if let onSubmit = configuration.onSubmit {
@@ -48,7 +48,7 @@ extension AdyenCheckout: PaymentComponentDelegate {
     }
 }
 
-extension AdyenCheckout: ActionComponentDelegate {
+extension Checkout: ActionComponentDelegate {
     public func didProvide(_ data: Adyen.ActionComponentData, from component: any Adyen.ActionComponent) {
         if let onAdditionalDetails = configuration.onAdditionalDetails {
             onAdditionalDetails(data) { [weak self] response in
@@ -75,7 +75,7 @@ extension AdyenCheckout: ActionComponentDelegate {
     }
 }
 
-extension AdyenCheckout: AdyenSessionDelegate {
+extension Checkout: AdyenSessionDelegate {
     public func didComplete(with result: CheckoutResult, component: any Component, session: AdyenSession) {
         finish(with: result)
     }

--- a/AdyenCheckout/AdyenCheckout.swift
+++ b/AdyenCheckout/AdyenCheckout.swift
@@ -19,7 +19,7 @@ import Foundation
 
 /// `AdyenCheckout` is the entry point to the Checkout flow. You initialize it through its static methods for your chosen flow
 /// and it prepares all the required data asynchronously and returns an `AdyenCheckout` instance ready to be used.
-public final class AdyenCheckout: AdyenCheckoutProtocol {
+public final class Checkout: AdyenCheckoutProtocol {
     
     public let paymentMethods: PaymentMethods?
     internal let session: AdyenSessionProtocol?
@@ -54,7 +54,7 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
         sessionData: String,
         configuration: CheckoutConfiguration,
         presentationDelegate: PresentationDelegate? = nil
-    ) async throws -> AdyenCheckout {
+    ) async throws -> Checkout {
         try await setup(
             with: sessionId,
             sessionData: sessionData,
@@ -70,7 +70,7 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
         configuration: CheckoutConfiguration,
         presentationDelegate: PresentationDelegate? = nil,
         provider: AdyenCheckoutProviding = AdyenCheckoutProvider.default
-    ) async throws -> AdyenCheckout {
+    ) async throws -> Checkout {
         try await provider.setup(
             with: sessionId,
             sessionData: sessionData,
@@ -90,7 +90,7 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
         with paymentMethods: PaymentMethods,
         configuration: CheckoutConfiguration,
         presentationDelegate: PresentationDelegate? = nil
-    ) async throws -> AdyenCheckout {
+    ) async throws -> Checkout {
         try await setup(
             with: paymentMethods,
             configuration: configuration,
@@ -104,7 +104,7 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
         configuration: CheckoutConfiguration,
         presentationDelegate: PresentationDelegate? = nil,
         provider: AdyenCheckoutProviding = AdyenCheckoutProvider.default
-    ) async throws -> AdyenCheckout {
+    ) async throws -> Checkout {
         try await provider.setup(
             with: paymentMethods,
             configuration: configuration,

--- a/AdyenCheckout/AdyenCheckoutProtocol.swift
+++ b/AdyenCheckout/AdyenCheckoutProtocol.swift
@@ -28,13 +28,13 @@ internal protocol AdyenCheckoutProviding: AdyenSessionProviding, CheckoutAttempt
         sessionData: String,
         configuration: CheckoutConfiguration,
         presentationDelegate: PresentationDelegate?
-    ) async throws -> AdyenCheckout
+    ) async throws -> Checkout
     
     func setup(
         with paymentMethods: PaymentMethods,
         configuration: CheckoutConfiguration,
         presentationDelegate: PresentationDelegate?
-    ) async throws -> AdyenCheckout
+    ) async throws -> Checkout
 }
 
 internal protocol AdyenSessionProviding {

--- a/AdyenCheckout/AdyenCheckoutProvider.swift
+++ b/AdyenCheckout/AdyenCheckoutProvider.swift
@@ -23,7 +23,7 @@ internal class AdyenCheckoutProvider: AdyenCheckoutProviding {
         sessionData: String,
         configuration: CheckoutConfiguration,
         presentationDelegate: PresentationDelegate?
-    ) async throws -> AdyenCheckout {
+    ) async throws -> Checkout {
         
         let apiClient = APIClient(apiContext: configuration.context.apiContext)
         
@@ -43,7 +43,7 @@ internal class AdyenCheckoutProvider: AdyenCheckoutProviding {
             apiClient: apiClient
         )
         
-        let checkout = try await AdyenCheckout(
+        let checkout = try await Checkout(
             configuration: configuration,
             session: session,
             checkoutAttemptId: checkoutAttemptId,
@@ -64,7 +64,7 @@ internal class AdyenCheckoutProvider: AdyenCheckoutProviding {
         with paymentMethods: PaymentMethods,
         configuration: CheckoutConfiguration,
         presentationDelegate: PresentationDelegate?
-    ) async throws -> AdyenCheckout {
+    ) async throws -> Checkout {
         let apiClient = APIClient(apiContext: configuration.context.apiContext)
         
         // fetch and store checkout attempt id
@@ -73,7 +73,7 @@ internal class AdyenCheckoutProvider: AdyenCheckoutProviding {
             apiClient: apiClient
         )
         
-        let checkout = AdyenCheckout(
+        let checkout = Checkout(
             configuration: configuration,
             paymentMethods: paymentMethods,
             checkoutAttemptId: checkoutAttemptId,

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/BLIKComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/BLIKComponentAdvancedFlowExample.swift
@@ -14,7 +14,7 @@ internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
 
     internal weak var presenter: PresenterExampleProtocol?
 
-    private var adyenCheckout: AdyenCheckout?
+    private var adyenCheckout: Checkout?
     private var adyenComponent: AdyenCheckoutComponent?
 
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
@@ -81,7 +81,7 @@ internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
 
-        let checkout = try await AdyenCheckout.setup(
+        let checkout = try await Checkout.setup(
             with: paymentMethods,
             configuration: configuration,
             presentationDelegate: self

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -14,7 +14,7 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
 
     internal weak var presenter: PresenterExampleProtocol?
 
-    private var adyenCheckout: AdyenCheckout?
+    private var checkout: Checkout?
     private var adyenComponent: AdyenCheckoutComponent?
 
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
@@ -99,13 +99,13 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
 
-        let checkout = try await AdyenCheckout.setup(
+        let checkout = try await Checkout.setup(
             with: paymentMethods,
             configuration: configuration,
             presentationDelegate: self
         )
 
-        self.adyenCheckout = checkout
+        self.checkout = checkout
 
         guard let cardPaymentMethod = paymentMethods.paymentMethod(ofType: CardPaymentMethod.self),
               let component = checkout.createComponent(with: cardPaymentMethod)

--- a/Demo/Common/IntegrationExamples/Session/Components/BLIKComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/BLIKComponentExample.swift
@@ -13,7 +13,7 @@ internal final class BLIKComponentExample: InitialDataFlowProtocol {
     
     internal weak var presenter: PresenterExampleProtocol?
     
-    private var adyenCheckout: AdyenCheckout?
+    private var checkout: Checkout?
     private var adyenComponent: AdyenCheckoutComponent?
     
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
@@ -60,14 +60,14 @@ internal final class BLIKComponentExample: InitialDataFlowProtocol {
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
         
-        let checkout = try await AdyenCheckout.setup(
+        let checkout = try await Checkout.setup(
             with: sessionResponse.sessionId,
             sessionData: sessionResponse.sessionData,
             configuration: configuration,
             presentationDelegate: self
         )
         
-        self.adyenCheckout = checkout
+        self.checkout = checkout
         
         guard let paymentMethods = checkout.paymentMethods,
               let blikPaymentMethod = paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self),

--- a/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
@@ -15,7 +15,7 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
     
     internal weak var presenter: PresenterExampleProtocol?
 
-    private var adyenCheckout: AdyenCheckout?
+    private var checkout: Checkout?
     private var adyenComponent: AdyenCheckoutComponent?
     
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
@@ -91,14 +91,14 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
         
-        let checkout = try await AdyenCheckout.setup(
+        let checkout = try await Checkout.setup(
             with: sessionResponse.sessionId,
             sessionData: sessionResponse.sessionData,
             configuration: configuration,
             presentationDelegate: self
         )
         
-        self.adyenCheckout = checkout
+        self.checkout = checkout
         
         guard let paymentMethods = checkout.paymentMethods,
               let blikPaymentMethod = paymentMethods.paymentMethod(ofType: CardPaymentMethod.self),

--- a/Tests/UnitTests/AdyenCheckout/AdyenCheckoutProviderMock.swift
+++ b/Tests/UnitTests/AdyenCheckout/AdyenCheckoutProviderMock.swift
@@ -13,10 +13,10 @@ import AdyenNetworking
 
 internal class AdyenCheckoutProviderMock: AdyenCheckoutProviding {
     var setupSessionCalled = false
-    var setupWithSessionResult: Result<AdyenCheckout, Error>?
+    var setupWithSessionResult: Result<Checkout, Error>?
     
     var setupPaymentMethodsCalled = false
-    var setupWithPaymentMethodsResult: Result<AdyenCheckout, Error>?
+    var setupWithPaymentMethodsResult: Result<Checkout, Error>?
     
     // For AdyenSessionProviding
     var mockedSessionResult: Result<AdyenSessionProtocol, Error>?
@@ -61,7 +61,7 @@ internal class AdyenCheckoutProviderMock: AdyenCheckoutProviding {
         sessionData: String,
         configuration: CheckoutConfiguration,
         presentationDelegate: PresentationDelegate?
-    ) async throws -> AdyenCheckout {
+    ) async throws -> Checkout {
         setupSessionCalled = true
         
         switch setupWithSessionResult {
@@ -78,7 +78,7 @@ internal class AdyenCheckoutProviderMock: AdyenCheckoutProviding {
         with paymentMethods: PaymentMethods,
         configuration: CheckoutConfiguration,
         presentationDelegate: PresentationDelegate?
-    ) async throws -> AdyenCheckout {
+    ) async throws -> Checkout {
         setupPaymentMethodsCalled = true
         
         switch setupWithPaymentMethodsResult {

--- a/Tests/UnitTests/AdyenCheckout/AdyenCheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/AdyenCheckoutTests.swift
@@ -47,7 +47,7 @@ final class AdyenCheckoutTests: XCTestCase {
             responseConfiguration: .init(installmentOptions: nil, enableStoreDetails: true)
         ))
         
-        let expectedCheckout = AdyenCheckout(
+        let expectedCheckout = Checkout(
             configuration: configuration,
             session: expectedSession,
             paymentMethods: nil,
@@ -56,7 +56,7 @@ final class AdyenCheckoutTests: XCTestCase {
         )
         mockProvider.setupWithSessionResult = .success(expectedCheckout)
 
-        let checkout = try await AdyenCheckout.setup(
+        let checkout = try await Checkout.setup(
             with: "sessionId",
             sessionData: "sessionData",
             configuration: configuration,
@@ -78,7 +78,7 @@ final class AdyenCheckoutTests: XCTestCase {
         mockProvider.setupWithSessionResult = .failure(TestError())
         
         do {
-            _ = try await AdyenCheckout.setup(
+            _ = try await Checkout.setup(
                 with: "sessionId",
                 sessionData: "sessionData",
                 configuration: configuration,
@@ -92,7 +92,7 @@ final class AdyenCheckoutTests: XCTestCase {
     }
 
     func testSetupWithPaymentMethods_Success() async throws {
-        let expectedCheckout = AdyenCheckout(
+        let expectedCheckout = Checkout(
             configuration: configuration,
             session: nil,
             paymentMethods: paymentMethods,
@@ -102,7 +102,7 @@ final class AdyenCheckoutTests: XCTestCase {
         
         mockProvider.setupWithPaymentMethodsResult = .success(expectedCheckout)
         
-        let checkout = try await AdyenCheckout.setup(
+        let checkout = try await Checkout.setup(
             with: paymentMethods,
             configuration: configuration,
             presentationDelegate: nil,
@@ -119,7 +119,7 @@ final class AdyenCheckoutTests: XCTestCase {
         mockProvider.setupWithPaymentMethodsResult = .failure(TestError())
         
         do {
-            _ = try await AdyenCheckout.setup(
+            _ = try await Checkout.setup(
                 with: paymentMethods,
                 configuration: configuration,
                 presentationDelegate: nil,
@@ -203,7 +203,7 @@ final class AdyenCheckoutTests: XCTestCase {
             completion?(CheckoutPaymentsResponse(resultCode: .authorised))
         }
         
-        let sut = AdyenCheckout(
+        let sut = Checkout(
             configuration: configuration,
             checkoutAttemptId: "attemptId",
             presentationDelegate: nil


### PR DESCRIPTION
# Summary [Required]

Rename AdyenCheckout to Checkout for alignment with the Android SDK. 
YT ticket: [COSDK-915](https://youtrack.is.adyen.com/issue/COSDK-915/SDK-setup-alignment)

#Checklist

- [x]  Tested changes locally
- [x]  Added/updated unit tests
- [x]  Verified against acceptance criteria


