### PR TITLE
Renaming AdyenCheckoutComponent & AdyenActionComponent

### DIFF
--- a/Adyen.docc/API Reference.md
+++ b/Adyen.docc/API Reference.md
@@ -90,7 +90,7 @@ The Adyen DropIn/Components SDK API Reference.
 
 ### Action-handling components
 
-- ``AdyenActionComponent``
+- ``CheckoutActionComponent``
 - ``VoucherComponent``
 - ``QRCodeActionComponent``
 - ``AwaitComponent``

--- a/Adyen.docc/AdvancedFlow.md
+++ b/Adyen.docc/AdvancedFlow.md
@@ -131,11 +131,11 @@ When `/payments` or `/payments/details` responds with a non-final result and an 
     }
     
     @Tab(Components) {  
-        In case of using individual components, create and persist an instance of ``AdyenActionComponent``:
+        In case of using individual components, create and persist an instance of ``CheckoutActionComponent``:
 
         ```swift
-        lazy var actionComponent: AdyenActionComponent = {
-            let handler = AdyenActionComponent(context: context)
+        lazy var actionComponent: CheckoutActionComponent = {
+            let handler = CheckoutActionComponent(context: context)
             handler.delegate = self
             handler.presentationDelegate = self
             return handler

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -497,7 +497,7 @@
 		A03056D32DEDED2F00ED7014 /* AdyenCheckoutProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03056D02DEDED2F00ED7014 /* AdyenCheckoutProtocol.swift */; };
 		A03056D42DEDED2F00ED7014 /* CheckoutComponentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03056D12DEDED2F00ED7014 /* CheckoutComponentBuilder.swift */; };
 		A03056D52DEDED2F00ED7014 /* AdyenCheckout.docc in Sources */ = {isa = PBXBuildFile; fileRef = A03056CD2DEDED2F00ED7014 /* AdyenCheckout.docc */; };
-		A03056D62DEDED2F00ED7014 /* AdyenCheckoutComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03056CF2DEDED2F00ED7014 /* AdyenCheckoutComponent.swift */; };
+		A03056D62DEDED2F00ED7014 /* CheckoutPaymentComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03056CF2DEDED2F00ED7014 /* CheckoutPaymentComponent.swift */; };
 		A03056D72DEDED2F00ED7014 /* AdyenCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03056CE2DEDED2F00ED7014 /* AdyenCheckout.swift */; };
 		A03056D82DEDED2F00ED7014 /* AdyenCheckout.h in Headers */ = {isa = PBXBuildFile; fileRef = A03056CC2DEDED2F00ED7014 /* AdyenCheckout.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A03056DA2DEF331100ED7014 /* AdyenCheckout+DelegateCallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03056D92DEF32FD00ED7014 /* AdyenCheckout+DelegateCallbacks.swift */; };
@@ -931,7 +931,7 @@
 		E745185D25FBDDC7000BDCCF /* Payload.swift in Sources */ = {isa = PBXBuildFile; fileRef = E745185C25FBDDC7000BDCCF /* Payload.swift */; };
 		E7451A052600EC8D000BDCCF /* CardComponentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7451A042600EC8D000BDCCF /* CardComponentConfiguration.swift */; };
 		E7451A112600EDE0000BDCCF /* StoredCardConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7451A102600EDE0000BDCCF /* StoredCardConfiguration.swift */; };
-		E745256925C1C9E1006A941F /* AdyenActionComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9789C6F23F1924B000B4B2B /* AdyenActionComponent.swift */; };
+		E745256925C1C9E1006A941F /* CheckoutActionComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9789C6F23F1924B000B4B2B /* CheckoutActionComponent.swift */; };
 		E746E67127B3FA700076BB71 /* InstantComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E746E67027B3FA700076BB71 /* InstantComponents.swift */; };
 		E74CE3DF26727EB1008231D2 /* DropInComponentDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74CE3DE26727EB1008231D2 /* DropInComponentDelegateMock.swift */; };
 		E74D918325AF3FE600743B0C /* CardBrandProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74D918225AF3FE600743B0C /* CardBrandProviderTests.swift */; };
@@ -1083,7 +1083,7 @@
 		F919DF9724E6E2810027976E /* StoredCardComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F919DF9624E6E2810027976E /* StoredCardComponent.swift */; };
 		F919DF9924EA64680027976E /* CardPublicKeyProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F919DF9824EA64680027976E /* CardPublicKeyProviderTests.swift */; };
 		F919DFA024EABCC10027976E /* StoredCardComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F919DF9F24EABCC10027976E /* StoredCardComponentTests.swift */; };
-		F919DFA224ED599D0027976E /* AdyenActionComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F919DFA124ED599D0027976E /* AdyenActionComponentTests.swift */; };
+		F919DFA224ED599D0027976E /* CheckoutActionComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F919DFA124ED599D0027976E /* CheckoutActionComponentTests.swift */; };
 		F92326B025A3669E002C5BC4 /* AdyenEncryption.h in Headers */ = {isa = PBXBuildFile; fileRef = F92326AE25A3669E002C5BC4 /* AdyenEncryption.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F92326BD25A366D9002C5BC4 /* CardPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DAF822241D6000697074 /* CardPayload.swift */; };
 		F92326BE25A366D9002C5BC4 /* CardEncryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3DAF922241D6000697074 /* CardEncryptor.swift */; };
@@ -2162,7 +2162,7 @@
 		A03056CC2DEDED2F00ED7014 /* AdyenCheckout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AdyenCheckout.h; sourceTree = "<group>"; };
 		A03056CD2DEDED2F00ED7014 /* AdyenCheckout.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = AdyenCheckout.docc; sourceTree = "<group>"; };
 		A03056CE2DEDED2F00ED7014 /* AdyenCheckout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenCheckout.swift; sourceTree = "<group>"; };
-		A03056CF2DEDED2F00ED7014 /* AdyenCheckoutComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenCheckoutComponent.swift; sourceTree = "<group>"; };
+		A03056CF2DEDED2F00ED7014 /* CheckoutPaymentComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutPaymentComponent.swift; sourceTree = "<group>"; };
 		A03056D02DEDED2F00ED7014 /* AdyenCheckoutProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenCheckoutProtocol.swift; sourceTree = "<group>"; };
 		A03056D12DEDED2F00ED7014 /* CheckoutComponentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutComponentBuilder.swift; sourceTree = "<group>"; };
 		A03056D92DEF32FD00ED7014 /* AdyenCheckout+DelegateCallbacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdyenCheckout+DelegateCallbacks.swift"; sourceTree = "<group>"; };
@@ -2732,7 +2732,7 @@
 		F919DF9624E6E2810027976E /* StoredCardComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCardComponent.swift; sourceTree = "<group>"; };
 		F919DF9824EA64680027976E /* CardPublicKeyProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPublicKeyProviderTests.swift; sourceTree = "<group>"; };
 		F919DF9F24EABCC10027976E /* StoredCardComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCardComponentTests.swift; sourceTree = "<group>"; };
-		F919DFA124ED599D0027976E /* AdyenActionComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenActionComponentTests.swift; sourceTree = "<group>"; };
+		F919DFA124ED599D0027976E /* CheckoutActionComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutActionComponentTests.swift; sourceTree = "<group>"; };
 		F92326AC25A3669E002C5BC4 /* AdyenEncryption.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AdyenEncryption.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F92326AE25A3669E002C5BC4 /* AdyenEncryption.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AdyenEncryption.h; sourceTree = "<group>"; };
 		F92326AF25A3669E002C5BC4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2867,7 +2867,7 @@
 		F9789C6923F18057000B4B2B /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
 		F9789C6B23F18069000B4B2B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		F9789C6D23F18EBD000B4B2B /* WeChatPayActionComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeChatPayActionComponent.swift; sourceTree = "<group>"; };
-		F9789C6F23F1924B000B4B2B /* AdyenActionComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenActionComponent.swift; sourceTree = "<group>"; };
+		F9789C6F23F1924B000B4B2B /* CheckoutActionComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutActionComponent.swift; sourceTree = "<group>"; };
 		F9789C7223F1A5C1000B4B2B /* WeChatPaySDKAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeChatPaySDKAction.swift; sourceTree = "<group>"; };
 		F9789C7423F1A76D000B4B2B /* WeChatPayAdditionalDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeChatPayAdditionalDetails.swift; sourceTree = "<group>"; };
 		F97BC22B2667768B00F1D242 /* AppleWalletPassProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleWalletPassProvider.swift; sourceTree = "<group>"; };
@@ -4004,7 +4004,7 @@
 				A03056CE2DEDED2F00ED7014 /* AdyenCheckout.swift */,
 				A03056DB2DF07F7800ED7014 /* AdyenCheckoutProvider.swift */,
 				A03056D92DEF32FD00ED7014 /* AdyenCheckout+DelegateCallbacks.swift */,
-				A03056CF2DEDED2F00ED7014 /* AdyenCheckoutComponent.swift */,
+				A03056CF2DEDED2F00ED7014 /* CheckoutPaymentComponent.swift */,
 				A03056D12DEDED2F00ED7014 /* CheckoutComponentBuilder.swift */,
 				00262C8E2E828AB500DDDFA4 /* CheckoutConfiguration */,
 				A03056CC2DEDED2F00ED7014 /* AdyenCheckout.h */,
@@ -5656,7 +5656,7 @@
 		E7975F952880253400A12C40 /* ActionComponent */ = {
 			isa = PBXGroup;
 			children = (
-				F919DFA124ED599D0027976E /* AdyenActionComponentTests.swift */,
+				F919DFA124ED599D0027976E /* CheckoutActionComponentTests.swift */,
 				F9AC61C1243751A70062A00D /* ActionComponentDelegateMock.swift */,
 				81DA70862BDA6075006CE5D5 /* Twint */,
 			);
@@ -6128,7 +6128,7 @@
 				F9175FEF259499C100D653BE /* UI */,
 				F9175FC52594997F00D653BE /* Components */,
 				F9175F8E2594986900D653BE /* AdyenActions.h */,
-				F9789C6F23F1924B000B4B2B /* AdyenActionComponent.swift */,
+				F9789C6F23F1924B000B4B2B /* CheckoutActionComponent.swift */,
 				F9175F8F2594986900D653BE /* Info.plist */,
 			);
 			path = AdyenActions;
@@ -8341,7 +8341,7 @@
 				00600F332E7D9D6F00637477 /* CheckoutConfiguration.swift in Sources */,
 				00600F372E7D9FE600637477 /* CheckoutConfiguration+Callbacks.swift in Sources */,
 				A03056DC2DF07F8100ED7014 /* AdyenCheckoutProvider.swift in Sources */,
-				A03056D62DEDED2F00ED7014 /* AdyenCheckoutComponent.swift in Sources */,
+				A03056D62DEDED2F00ED7014 /* CheckoutPaymentComponent.swift in Sources */,
 				00262C8D2E8286E200DDDFA4 /* ConfigurationBuilder.swift in Sources */,
 				A03056D72DEDED2F00ED7014 /* AdyenCheckout.swift in Sources */,
 			);
@@ -8806,7 +8806,7 @@
 				F95B6D9025231880002C9062 /* PhoneNumberValidatorTests.swift in Sources */,
 				F9639B5224E29E340073F38A /* PresentationDelegateMock.swift in Sources */,
 				B6C4C6682ECF61E000500BCD /* FormLabelItemTests.swift in Sources */,
-				F919DFA224ED599D0027976E /* AdyenActionComponentTests.swift in Sources */,
+				F919DFA224ED599D0027976E /* CheckoutActionComponentTests.swift in Sources */,
 				81DA70912BDA6120006CE5D5 /* PaymentMethods+Equatable.swift in Sources */,
 				C927083927590B7900D15EA0 /* BACSInputPresenterProtocolMock.swift in Sources */,
 				8100F2BD2A4C3407008C09E7 /* FormValidatableItemViewTests.swift in Sources */,
@@ -9203,7 +9203,7 @@
 				C92960042E95402500BC97CF /* QRCodeView.swift in Sources */,
 				F95A78B925C4302A0032CF7E /* ShareableVoucherView.swift in Sources */,
 				F95A78CD25C43C4F0032CF7E /* VoucherSeparatorView.swift in Sources */,
-				E745256925C1C9E1006A941F /* AdyenActionComponent.swift in Sources */,
+				E745256925C1C9E1006A941F /* CheckoutActionComponent.swift in Sources */,
 				F917616F25A30B6A00D653BE /* ThreeDSActionHandlerResult.swift in Sources */,
 				21B3A71929CA780200F48386 /* DelegatedAuthenticationComponentStyle.swift in Sources */,
 				F97C850125C17CCD00D7F85C /* VoucherShareableViewProvider.swift in Sources */,

--- a/AdyenActions/CheckoutActionComponent.swift
+++ b/AdyenActions/CheckoutActionComponent.swift
@@ -11,11 +11,8 @@ import UIKit
 
 /**
  An action handler component to perform any supported action out of the box.
- 
- - SeeAlso:
- [Implementation Reference](https://github.com/Adyen/adyen-ios#handling-an-action)
  */
-public final class AdyenActionComponent: ActionComponent, ActionHandlingComponent {
+public final class CheckoutActionComponent: ActionComponent, ActionHandlingComponent {
     
     /// :nodoc:
     /// The context object for this component.
@@ -127,7 +124,7 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
         public init(
             localizationParameters: LocalizationParameters? = nil,
             style: ActionComponentStyle = .init(),
-            threeDS: AdyenActionComponent.Configuration.ThreeDS = .init(),
+            threeDS: CheckoutActionComponent.Configuration.ThreeDS = .init(),
             twint: Twint? = nil
         ) {
             self.localizationParameters = localizationParameters
@@ -141,7 +138,7 @@ public final class AdyenActionComponent: ActionComponent, ActionHandlingComponen
     
     internal var appLauncher: AnyAppLauncher = AppLauncher()
     
-    /// Initializes a new instance of `AdyenActionComponent`
+    /// Initializes a new instance of `CheckoutActionComponent`
     ///
     /// - Parameters:
     ///   - context: The context object.

--- a/AdyenCheckout/AdyenCheckout.swift
+++ b/AdyenCheckout/AdyenCheckout.swift
@@ -28,13 +28,13 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
     internal weak var presentationDelegate: PresentationDelegate?
     
     internal lazy var actionHandlingComponent: ActionHandlingComponent = {
-        let handler = AdyenActionComponent(
+        let handler = CheckoutActionComponent(
             context: configuration.context,
-            configuration: AdyenActionComponent.Configuration()
+            configuration: CheckoutActionComponent.Configuration()
         )
-        // TODO: create a way for CheckoutConfig to have AdyenActionComponent.Configuration
+        // TODO: create a way for CheckoutConfig to have CheckoutActionComponent.Configuration
         // and it should provided if they want to have action handling
-        // move AdyenActionComponent.Configuration to its own entity and make it public
+        // move CheckoutActionComponent.Configuration to its own entity and make it public
         handler.delegate = self
         handler.presentationDelegate = presentationDelegate
         return handler
@@ -112,17 +112,17 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
         )
     }
     
-    public func createComponent(with paymentMethod: any PaymentMethod) -> AdyenCheckoutComponent? {
+    public func createComponent(with paymentMethod: any PaymentMethod) -> CheckoutPaymentComponent? {
         // TODO: Add new v6 style here
-        AdyenCheckoutComponent(
+        CheckoutPaymentComponent(
             paymentMethod: paymentMethod,
             configuration: configuration,
             delegate: self
         )
     }
     
-    public func createComponent(with action: Action) -> AdyenCheckoutComponent? {
-        AdyenCheckoutComponent(
+    public func createComponent(with action: Action) -> CheckoutPaymentComponent? {
+        CheckoutPaymentComponent(
             action: action,
             configuration: configuration,
             delegate: self

--- a/AdyenCheckout/AdyenCheckoutProtocol.swift
+++ b/AdyenCheckout/AdyenCheckoutProtocol.swift
@@ -15,9 +15,9 @@ import AdyenNetworking
 
 internal protocol AdyenCheckoutProtocol {
     
-    func createComponent(with paymentMethod: PaymentMethod) -> AdyenCheckoutComponent?
+    func createComponent(with paymentMethod: PaymentMethod) -> CheckoutPaymentComponent?
     
-    func createComponent(with action: Action) -> AdyenCheckoutComponent?
+    func createComponent(with action: Action) -> CheckoutPaymentComponent?
     
     func createDropIn() -> DropInComponent?
 }

--- a/AdyenCheckout/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/CheckoutComponentBuilder.swift
@@ -58,9 +58,18 @@ internal enum CheckoutComponentBuilder {
         }
         
         // TODO: create real checkout errors
+        // TODO: for gift card, throw correct error code
         fatalError()
     }
     
+    internal static func build(
+        for storedPaymentMethod: StoredPaymentMethod,
+        configuration: CheckoutConfiguration
+    ) -> PaymentComponent {
+        fatalError()
+    }
+    
+    // TODO: this will be removed as CheckoutActionComponent already handles actions.
     internal static func build(
         for action: Action,
         configuration: CheckoutConfiguration

--- a/AdyenCheckout/CheckoutPaymentComponent.swift
+++ b/AdyenCheckout/CheckoutPaymentComponent.swift
@@ -10,7 +10,7 @@ import UIKit
 package typealias CheckoutComponentDelegate = (PaymentComponentDelegate & ActionComponentDelegate)
 
 // TODO: add description
-public final class AdyenCheckoutComponent {
+public final class CheckoutPaymentComponent {
     
     internal let paymentComponent: PaymentComponent?
     

--- a/AdyenDropIn/Models/DropInConfiguration.swift
+++ b/AdyenDropIn/Models/DropInConfiguration.swift
@@ -95,10 +95,10 @@ public extension DropInComponent {
         public init() { /* Empty initializer */ }
         
         /// Three DS configurations
-        public var threeDS: AdyenActionComponent.Configuration.ThreeDS = .init()
+        public var threeDS: CheckoutActionComponent.Configuration.ThreeDS = .init()
         
         /// Twint configurations
-        public var twint: AdyenActionComponent.Configuration.Twint?
+        public var twint: CheckoutActionComponent.Configuration.Twint?
     }
 
     /// Boleto component configuration.

--- a/AdyenDropIn/Modules/DropInFlowManager.swift
+++ b/AdyenDropIn/Modules/DropInFlowManager.swift
@@ -54,8 +54,8 @@ internal class DropInFlowManager: DropInFlowManaging {
 
     // MARK: - Private
 
-    private lazy var actionComponent: AdyenActionComponent = {
-        let actionComponent = AdyenActionComponent(context: context)
+    private lazy var actionComponent: CheckoutActionComponent = {
+        let actionComponent = CheckoutActionComponent(context: context)
         actionComponent.delegate = self
         actionComponent.presentationDelegate = self
         actionComponent.configuration.style = configuration.style.actionComponent

--- a/AdyenSession/AdyenSession.swift
+++ b/AdyenSession/AdyenSession.swift
@@ -43,13 +43,13 @@ public final class AdyenSession: AdyenSessionProtocol {
     }()
     
     internal lazy var actionHandlingComponent: ActionHandlingComponent = {
-        let handler = AdyenActionComponent(
+        let handler = CheckoutActionComponent(
             context: context,
-            configuration: AdyenActionComponent.Configuration()
+            configuration: CheckoutActionComponent.Configuration()
         )
-        // TODO: create a way for CheckoutConfig to have AdyenActionComponent.Configuration
+        // TODO: create a way for CheckoutConfig to have CheckoutActionComponent.Configuration
         // and it should provided if they want to have action handling
-        // move AdyenActionComponent.Configuration to its own entity and make it public
+        // move CheckoutActionComponent.Configuration to its own entity and make it public
         handler.delegate = self
         handler.presentationDelegate = presentationDelegate
         return handler

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/BLIKComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/BLIKComponentAdvancedFlowExample.swift
@@ -15,7 +15,7 @@ internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
     internal weak var presenter: PresenterExampleProtocol?
 
     private var adyenCheckout: AdyenCheckout?
-    private var adyenComponent: AdyenCheckoutComponent?
+    private var adyenComponent: CheckoutPaymentComponent?
 
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
 
@@ -42,7 +42,7 @@ internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
     }
 
     private func blikComponent(from paymentMethods: PaymentMethods) async throws
-        -> AdyenCheckoutComponent {
+        -> CheckoutPaymentComponent {
 
         let configuration = try CheckoutConfiguration(
             environment: ConfigurationConstants.componentsEnvironment,
@@ -153,7 +153,7 @@ internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
     }
 
     @MainActor
-    private func present(component: AdyenCheckoutComponent) {
+    private func present(component: CheckoutPaymentComponent) {
         presenter?.present(viewController: viewController(for: component), completion: nil)
     }
 
@@ -165,7 +165,7 @@ internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
         }
     }
 
-    private func viewController(for component: AdyenCheckoutComponent) -> UIViewController {
+    private func viewController(for component: CheckoutPaymentComponent) -> UIViewController {
         let navigation = UINavigationController(rootViewController: component.viewController!)
         component.viewController?.navigationItem.leftBarButtonItem = .init(
             barButtonSystemItem: .cancel,

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -15,7 +15,7 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
     internal weak var presenter: PresenterExampleProtocol?
 
     private var adyenCheckout: AdyenCheckout?
-    private var adyenComponent: AdyenCheckoutComponent?
+    private var adyenComponent: CheckoutPaymentComponent?
 
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
 
@@ -44,7 +44,7 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
     // MARK: - Presentation
     
     private func cardComponent(from paymentMethods: PaymentMethods) async throws
-        -> AdyenCheckoutComponent {
+        -> CheckoutPaymentComponent {
 
         let configuration = try CheckoutConfiguration(
             environment: ConfigurationConstants.componentsEnvironment,
@@ -171,7 +171,7 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
     }
 
     @MainActor
-    private func present(component: AdyenCheckoutComponent) {
+    private func present(component: CheckoutPaymentComponent) {
         presenter?.present(viewController: viewController(for: component), completion: nil)
     }
 
@@ -183,7 +183,7 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
         }
     }
 
-    private func viewController(for component: AdyenCheckoutComponent) -> UIViewController {
+    private func viewController(for component: CheckoutPaymentComponent) -> UIViewController {
         let navigation = UINavigationController(rootViewController: component.viewController!)
         component.viewController?.navigationItem.leftBarButtonItem = .init(
             barButtonSystemItem: .cancel,

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
@@ -24,8 +24,8 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
 
     // MARK: - Action Handling
 
-    private lazy var adyenActionComponent: AdyenActionComponent = {
-        let handler = AdyenActionComponent(context: context)
+    private lazy var actionComponent: CheckoutActionComponent = {
+        let handler = CheckoutActionComponent(context: context)
         handler.delegate = self
         handler.presentationDelegate = self
         return handler
@@ -83,7 +83,7 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
         switch result {
         case let .success(response):
             if let action = response.action {
-                adyenActionComponent.handle(action)
+                actionComponent.handle(action)
             } else {
                 finish(with: response)
             }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/IssuerListComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/IssuerListComponentAdvancedFlowExample.swift
@@ -22,8 +22,8 @@ internal final class IssuerListComponentAdvancedFlowExample: InitialDataAdvanced
 
     // MARK: - Action Handling
 
-    private lazy var adyenActionComponent: AdyenActionComponent = {
-        let handler = AdyenActionComponent(context: context)
+    private lazy var actionComponent: CheckoutActionComponent = {
+        let handler = CheckoutActionComponent(context: context)
         handler.delegate = self
         handler.presentationDelegate = self
         return handler
@@ -79,7 +79,7 @@ internal final class IssuerListComponentAdvancedFlowExample: InitialDataAdvanced
         switch result {
         case let .success(response):
             if let action = response.action {
-                adyenActionComponent.handle(action)
+                actionComponent.handle(action)
             } else {
                 finish(with: response)
             }

--- a/Demo/Common/IntegrationExamples/Session/Components/BLIKComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/BLIKComponentExample.swift
@@ -14,7 +14,7 @@ internal final class BLIKComponentExample: InitialDataFlowProtocol {
     internal weak var presenter: PresenterExampleProtocol?
     
     private var adyenCheckout: AdyenCheckout?
-    private var adyenComponent: AdyenCheckoutComponent?
+    private var adyenComponent: CheckoutPaymentComponent?
     
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
     
@@ -38,7 +38,7 @@ internal final class BLIKComponentExample: InitialDataFlowProtocol {
         }
     }
     
-    private func blikComponent(from sessionResponse: SessionResponse) async throws -> AdyenCheckoutComponent {
+    private func blikComponent(from sessionResponse: SessionResponse) async throws -> CheckoutPaymentComponent {
         
         let configuration = try CheckoutConfiguration(
             environment: ConfigurationConstants.componentsEnvironment,
@@ -93,7 +93,7 @@ internal final class BLIKComponentExample: InitialDataFlowProtocol {
     }
     
     @MainActor
-    private func present(component: AdyenCheckoutComponent) {
+    private func present(component: CheckoutPaymentComponent) {
         presenter?.present(viewController: viewController(for: component), completion: nil)
     }
     
@@ -105,7 +105,7 @@ internal final class BLIKComponentExample: InitialDataFlowProtocol {
         }
     }
     
-    private func viewController(for component: AdyenCheckoutComponent) -> UIViewController {
+    private func viewController(for component: CheckoutPaymentComponent) -> UIViewController {
         guard let viewController = component.viewController else { fatalError("Cannot find component's view controller") }
         
         let navigation = UINavigationController(rootViewController: viewController)

--- a/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
@@ -16,7 +16,7 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
     internal weak var presenter: PresenterExampleProtocol?
 
     private var adyenCheckout: AdyenCheckout?
-    private var adyenComponent: AdyenCheckoutComponent?
+    private var adyenComponent: CheckoutPaymentComponent?
     
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
     
@@ -45,7 +45,7 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
     
     // MARK: - Presentation
     
-    private func cardComponent(from sessionResponse: SessionResponse) async throws -> AdyenCheckoutComponent {
+    private func cardComponent(from sessionResponse: SessionResponse) async throws -> CheckoutPaymentComponent {
         let configuration = try CheckoutConfiguration(
             environment: ConfigurationConstants.componentsEnvironment,
             amount: ConfigurationConstants.current.amount,
@@ -124,7 +124,7 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
     }
     
     @MainActor
-    private func present(component: AdyenCheckoutComponent) {
+    private func present(component: CheckoutPaymentComponent) {
         presenter?.present(viewController: viewController(for: component), completion: nil)
     }
     
@@ -145,7 +145,7 @@ extension CardComponentExample: PresentationDelegate {
 
 private extension CardComponentExample {
     
-    func viewController(for component: AdyenCheckoutComponent) -> UIViewController {
+    func viewController(for component: CheckoutPaymentComponent) -> UIViewController {
         guard let viewController = component.viewController else { fatalError("Cannot find component's view controller") }
         
         let navigation = UINavigationController(rootViewController: viewController)

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/CheckoutActionComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/CheckoutActionComponentTests.swift
@@ -14,7 +14,7 @@ import XCTest
     import AdyenTwint
 #endif
 
-class AdyenActionComponentTests: XCTestCase {
+class CheckoutActionComponentTests: XCTestCase {
 
     let weChatActionResponse = """
     {
@@ -99,7 +99,7 @@ class AdyenActionComponentTests: XCTestCase {
     }
 
     func testRedirectToHttpWebLink() throws {
-        let sut = AdyenActionComponent(context: Dummy.context)
+        let sut = CheckoutActionComponent(context: Dummy.context)
         let delegate = ActionComponentDelegateMock()
         sut.presentationDelegate = try UIViewController.topPresenter()
         sut.delegate = delegate
@@ -115,7 +115,7 @@ class AdyenActionComponentTests: XCTestCase {
     }
 
     func testAwaitAction() throws {
-        let sut = AdyenActionComponent(context: Dummy.context)
+        let sut = CheckoutActionComponent(context: Dummy.context)
         sut.presentationDelegate = try UIViewController.topPresenter()
 
         let action = Action.await(AwaitAction(paymentData: "SOME_DATA", paymentMethodType: .blik))
@@ -146,7 +146,7 @@ class AdyenActionComponentTests: XCTestCase {
             completion?(true)
         }
         
-        let sut = AdyenActionComponent(context: Dummy.context)
+        let sut = CheckoutActionComponent(context: Dummy.context)
         sut.appLauncher = mockAppLauncher
         
         sut.presentationDelegate = try UIViewController.topPresenter()
@@ -175,7 +175,7 @@ class AdyenActionComponentTests: XCTestCase {
     }
 
     func testWeChatAction() throws {
-        let sut = AdyenActionComponent(context: Dummy.context)
+        let sut = CheckoutActionComponent(context: Dummy.context)
 
         let expectation = expectation(description: "Assertion Expectation")
 
@@ -192,7 +192,7 @@ class AdyenActionComponentTests: XCTestCase {
     }
 
     func test3DSAction() throws {
-        let sut = AdyenActionComponent(context: Dummy.context)
+        let sut = CheckoutActionComponent(context: Dummy.context)
         let action = try JSONDecoder().decode(ThreeDS2Action.self, from: threeDSFingerprintAction.data(using: .utf8)!)
         sut.handle(Action.threeDS2(action))
 
@@ -200,7 +200,7 @@ class AdyenActionComponentTests: XCTestCase {
     }
 
     func testVoucherAction() throws {
-        let sut = AdyenActionComponent(context: Dummy.context)
+        let sut = CheckoutActionComponent(context: Dummy.context)
         sut.presentationDelegate = try UIViewController.topPresenter()
         
         let action = try JSONDecoder().decode(VoucherAction.self, from: voucherAction.data(using: .utf8)!)
@@ -221,7 +221,7 @@ class AdyenActionComponentTests: XCTestCase {
     
     func testQRCodeAction() throws {
 
-        let sut = AdyenActionComponent(context: Dummy.context)
+        let sut = CheckoutActionComponent(context: Dummy.context)
         sut.presentationDelegate = try UIViewController.topPresenter()
         
         let action = try JSONDecoder().decode(QRCodeAction.self, from: qrAction.data(using: .utf8)!)
@@ -232,7 +232,7 @@ class AdyenActionComponentTests: XCTestCase {
     
     func testDocumentAction() throws {
         // DocumentAction
-        let sut = AdyenActionComponent(context: Dummy.context)
+        let sut = CheckoutActionComponent(context: Dummy.context)
         sut.presentationDelegate = try UIViewController.topPresenter()
         
         let action = try JSONDecoder().decode(DocumentAction.self, from: documentAction.data(using: .utf8)!)
@@ -244,7 +244,7 @@ class AdyenActionComponentTests: XCTestCase {
     
     func testTwintAction() throws {
         
-        let sut = AdyenActionComponent(context: Dummy.context)
+        let sut = CheckoutActionComponent(context: Dummy.context)
         sut.presentationDelegate = try UIViewController.topPresenter()
         
         let assertionExpectation = expectation(description: "Should Assert if no Twint configuration is provided")
@@ -287,7 +287,7 @@ class AdyenActionComponentTests: XCTestCase {
                 XCTFail("No assertion should have been raised")
             }
             
-            _ = AdyenActionComponent.Configuration.Twint(callbackAppScheme: scheme)
+            _ = CheckoutActionComponent.Configuration.Twint(callbackAppScheme: scheme)
         }
         
         // Invalid Configuration
@@ -297,7 +297,7 @@ class AdyenActionComponentTests: XCTestCase {
                 XCTAssertEqual(message, "Format of provided callbackAppScheme '\(scheme)' is incorrect.")
             }
             
-            _ = AdyenActionComponent.Configuration.Twint(callbackAppScheme: scheme)
+            _ = CheckoutActionComponent.Configuration.Twint(callbackAppScheme: scheme)
         }
     }
     
@@ -339,7 +339,7 @@ class AdyenActionComponentTests: XCTestCase {
     private func testEvent(for action: Action) {
         
         let analyticsProviderMock = AnalyticsProviderMock()
-        let sut = AdyenActionComponent(context: Dummy.context(with: analyticsProviderMock))
+        let sut = CheckoutActionComponent(context: Dummy.context(with: analyticsProviderMock))
         
         sut.handle(action)
         


### PR DESCRIPTION
# Summary [Required]
Part of adding standalone action/stored component support via Checkout. Renaming public classes align with Checkout keyword.

## Ticket [Optional]
<ticket>
COSDK-939
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
