### PR TITLE
Foundation for standalone stored components

### DIFF
--- a/AdyenActions/CheckoutActionComponent.swift
+++ b/AdyenActions/CheckoutActionComponent.swift
@@ -12,6 +12,7 @@ import UIKit
 /**
  An action handler component to perform any supported action out of the box.
  */
+// TODO: make package
 public final class CheckoutActionComponent: ActionComponent, ActionHandlingComponent {
     
     /// :nodoc:

--- a/AdyenCard/Components/Stored Card/StoredCardComponent.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardComponent.swift
@@ -9,24 +9,24 @@ import Foundation
 import UIKit
 
 /// A component that provides a form for stored card payments.
-internal final class StoredCardComponent: PaymentComponent, PaymentAware, PresentableComponent, Localizable {
+package final class StoredCardComponent: PaymentComponent, PaymentAware, PresentableComponent, Localizable {
     
     /// The context object for this component.
-    internal let context: AdyenContext
+    package let context: AdyenContext
     
     /// The card payment method.
-    internal var paymentMethod: PaymentMethod { storedCardPaymentMethod }
+    package var paymentMethod: PaymentMethod { storedCardPaymentMethod }
     
     /// The delegate of the component.
-    internal weak var delegate: PaymentComponentDelegate?
+    package weak var delegate: PaymentComponentDelegate?
     
-    internal var localizationParameters: LocalizationParameters?
+    package var localizationParameters: LocalizationParameters?
     
-    internal var requiresModalPresentation: Bool = false
+    package var requiresModalPresentation: Bool = false
     
     private let storedCardPaymentMethod: StoredCardPaymentMethod
     
-    internal init(
+    package init(
         storedCardPaymentMethod: StoredCardPaymentMethod,
         context: AdyenContext
     ) {
@@ -34,7 +34,7 @@ internal final class StoredCardComponent: PaymentComponent, PaymentAware, Presen
         self.context = context
     }
     
-    internal var viewController: UIViewController {
+    package var viewController: UIViewController {
         storedCardAlertManager.alertController
     }
     

--- a/AdyenCheckout/AdyenCheckout.swift
+++ b/AdyenCheckout/AdyenCheckout.swift
@@ -112,18 +112,56 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
         )
     }
     
-    public func createComponent(with paymentMethod: any PaymentMethod) -> CheckoutPaymentComponent? {
+    /// Creates a payment component for the specified payment method type.
+    ///
+    /// Use this method to create a component for regular (non-stored) payment methods.
+    ///
+    /// - Parameter type: The type of payment method to create a component for (e.g., `.scheme` for cards, `.ideal` for iDEAL).
+    /// - Returns: A configured payment component, or `nil` if the payment method is not available
+    ///   in the current payment methods.
+    ///
+    /// ## Example
+    /// ```swift
+    /// if let cardComponent = checkout.createPaymentComponent(for: .scheme) {
+    ///     present(cardComponent.viewController, animated: true)
+    /// }
+    /// ```
+    public func createPaymentComponent(for type: PaymentMethodType) -> CheckoutPaymentComponent? {
+        guard let paymentMethod = paymentMethods?.paymentMethod(ofType: type) else { return nil }
+        
         // TODO: Add new v6 style here
-        CheckoutPaymentComponent(
+        return CheckoutPaymentComponent(
             paymentMethod: paymentMethod,
             configuration: configuration,
             delegate: self
         )
     }
     
-    public func createComponent(with action: Action) -> CheckoutPaymentComponent? {
-        CheckoutPaymentComponent(
-            action: action,
+    /// Creates a payment component for a stored payment method.
+    ///
+    /// Use this method to create a component for previously saved payment methods,
+    /// such as stored cards or saved bank accounts. The identifier uniquely identifies
+    /// the stored payment method from the shopper's saved payment methods.
+    ///
+    /// - Parameter identifier: The unique identifier of the stored payment method.
+    ///   This value comes from `StoredPaymentMethod.identifier` in `paymentMethods.stored`.
+    /// - Returns: A configured payment component, or `nil` if no stored payment method
+    ///   with the given identifier exists.
+    ///
+    /// ## Example
+    /// ```swift
+    ///
+    /// // Create component for selected stored method
+    /// if let storedComponent = checkout.createPaymentComponent(for: selectedMethod.identifier) {
+    ///     present(storedComponent.viewController, animated: true)
+    /// }
+    /// ```
+    public func createPaymentComponent(for identifier: String) -> CheckoutPaymentComponent? {
+        guard let storedPaymentMethod = paymentMethods?.stored.first(where: { $0.identifier == identifier }) else { return nil }
+        
+        // TODO: Add new v6 style here
+        return CheckoutPaymentComponent(
+            storedPaymentMethod: storedPaymentMethod,
             configuration: configuration,
             delegate: self
         )

--- a/AdyenCheckout/AdyenCheckout.swift
+++ b/AdyenCheckout/AdyenCheckout.swift
@@ -144,7 +144,7 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
     /// the stored payment method from the shopper's saved payment methods.
     ///
     /// - Parameter identifier: The unique identifier of the stored payment method.
-    ///   This value comes from `StoredPaymentMethod.identifier` in `paymentMethods.stored`.
+    ///   This value comes from `paymentMethods.stored`.
     /// - Returns: A configured payment component, or `nil` if no stored payment method
     ///   with the given identifier exists.
     ///

--- a/AdyenCheckout/AdyenCheckout.swift
+++ b/AdyenCheckout/AdyenCheckout.swift
@@ -17,10 +17,35 @@
 import AdyenNetworking
 import Foundation
 
-/// `AdyenCheckout` is the entry point to the Checkout flow. You initialize it through its static methods for your chosen flow
-/// and it prepares all the required data asynchronously and returns an `AdyenCheckout` instance ready to be used.
+/// The entry point for the Adyen Checkout SDK.
+///
+/// Use `AdyenCheckout` to create payment components and handle actions.
+/// Initialize using one of the static `setup` methods.
+///
+/// ## Session Flow
+/// ```swift
+/// let checkout = try await AdyenCheckout.setup(
+///     with: sessionId,
+///     sessionData: sessionData,
+///     configuration: config
+/// )
+/// ```
+///
+/// ## Advanced Flow
+/// ```swift
+/// let checkout = try await AdyenCheckout.setup(
+///     with: paymentMethods,
+///     configuration: config
+/// )
+/// ```
+///
+/// ## Creating Components
+/// ```swift
+/// let component = checkout.createPaymentComponent(for: .scheme)
+/// ```
 public final class AdyenCheckout: AdyenCheckoutProtocol {
     
+    /// The available payment methods for this checkout session.
     public let paymentMethods: PaymentMethods?
     internal let session: AdyenSessionProtocol?
     internal let checkoutAttemptId: String?
@@ -40,15 +65,20 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
         return handler
     }()
     
+    // MARK: - Public
+    
     // TODO: should we replace sessionId/sessionData params with a struct to future proof session init?
-    /// Sets up the checkout object for the default flow
-    /// with the values from your backend's `/session` call.
+    /// Sets up checkout for the session flow.
+    ///
+    /// Use this method when integrating with the `/sessions` endpoint.
+    ///
     /// - Parameters:
-    ///   - sessionId: sessionId from the `/session` call response.
-    ///   - sessionData: session data from the `/session` call response.
-    ///   - configuration: The `CheckoutConfiguration` instance.
-    ///   - presentationDelegate: A delegate in order to handle presentation logic if needed.
-    ///   - completion: A closure that is called when the setup is complete, containing the checkout object.
+    ///   - sessionId: The session ID from the `/sessions` response.
+    ///   - sessionData: The session data from the `/sessions` response.
+    ///   - configuration: The checkout configuration.
+    ///   - presentationDelegate: Optional delegate for handling UI presentation.
+    /// - Returns: An `AdyenCheckout` instance.
+    /// - Throws: An error if setup fails.
     public static func setup(
         with sessionId: String,
         sessionData: String,
@@ -64,28 +94,16 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
         )
     }
     
-    internal static func setup(
-        with sessionId: String,
-        sessionData: String,
-        configuration: CheckoutConfiguration,
-        presentationDelegate: PresentationDelegate? = nil,
-        provider: AdyenCheckoutProviding = AdyenCheckoutProvider.default
-    ) async throws -> AdyenCheckout {
-        try await provider.setup(
-            with: sessionId,
-            sessionData: sessionData,
-            configuration: configuration,
-            presentationDelegate: presentationDelegate
-        )
-    }
-    
-    /// Sets up the checkout object for the advanced flow
-    /// with the values from your backend's `/paymentMethods` call.
+    /// Sets up checkout for the advanced flow.
+    ///
+    /// Use this method when you handle `/payments` and `/payments/details` calls yourself.
+    ///
     /// - Parameters:
-    ///   - paymentMethods: The `PaymentMethods` response from the `/paymentMethods` call.
-    ///   - configuration: The `CheckoutConfiguration` instance.
-    ///   - presentationDelegate: A delegate in order to handle presentation logic if needed.
-    ///   - completion: A closure that is called when the setup is complete, containing the checkout object.
+    ///   - paymentMethods: The payment methods from the `/paymentMethods` response.
+    ///   - configuration: The checkout configuration.
+    ///   - presentationDelegate: Optional delegate for handling UI presentation.
+    /// - Returns: An `AdyenCheckout` instance.
+    /// - Throws: An error if setup fails.
     public static func setup(
         with paymentMethods: PaymentMethods,
         configuration: CheckoutConfiguration,
@@ -99,18 +117,27 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
         )
     }
     
-    internal static func setup(
-        with paymentMethods: PaymentMethods,
+    // MARK: Internal
+
+    internal init(
         configuration: CheckoutConfiguration,
-        presentationDelegate: PresentationDelegate? = nil,
-        provider: AdyenCheckoutProviding = AdyenCheckoutProvider.default
-    ) async throws -> AdyenCheckout {
-        try await provider.setup(
-            with: paymentMethods,
-            configuration: configuration,
-            presentationDelegate: presentationDelegate
-        )
+        session: AdyenSessionProtocol? = nil,
+        paymentMethods: PaymentMethods? = nil,
+        checkoutAttemptId: String?,
+        presentationDelegate: PresentationDelegate?
+    ) {
+        self.configuration = configuration
+        self.session = session
+        self.paymentMethods = paymentMethods ?? session?.state.paymentMethods
+        self.checkoutAttemptId = checkoutAttemptId
+        self.presentationDelegate = presentationDelegate
+        
+        self.session?.delegate = self
+        self.session?.presentationDelegate = presentationDelegate
     }
+}
+
+public extension AdyenCheckout {
     
     /// Creates a payment component for the specified payment method type.
     ///
@@ -126,7 +153,7 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
     ///     present(cardComponent.viewController, animated: true)
     /// }
     /// ```
-    public func createPaymentComponent(for type: PaymentMethodType) -> CheckoutPaymentComponent? {
+    func createPaymentComponent(for type: PaymentMethodType) -> CheckoutPaymentComponent? {
         guard let paymentMethod = paymentMethods?.paymentMethod(ofType: type) else { return nil }
         
         // TODO: Add new v6 style here
@@ -156,7 +183,7 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
     ///     present(storedComponent.viewController, animated: true)
     /// }
     /// ```
-    public func createPaymentComponent(for identifier: String) -> CheckoutPaymentComponent? {
+    func createPaymentComponent(for identifier: String) -> CheckoutPaymentComponent? {
         guard let storedPaymentMethod = paymentMethods?.stored.first(where: { $0.identifier == identifier }) else { return nil }
         
         // TODO: Add new v6 style here
@@ -167,27 +194,52 @@ public final class AdyenCheckout: AdyenCheckoutProtocol {
         )
     }
     
-    public func createDropIn() -> DropInComponent? {
+    /// Creates a Drop-in component with all available payment methods.
+    ///
+    /// - Returns: A configured Drop-in component, or `nil` if unavailable.
+    func createDropIn() -> DropInComponent? {
         // TODO: dropin creation discussion with new changes
         nil
     }
     
-    // MARK: Internal
+    /// Handles an action received from the `/payments` or `/payments/details` response.
+    ///
+    /// Some actions require showing UI (e.g., 3DS challenges, vouchers, QR codes).
+    /// The `presentationDelegate` provided on setup is used to handle such cases.
+    ///
+    /// - Parameter action: The action to handle.
+    func handle(action: Action) {
+        actionHandlingComponent.handle(action)
+    }
+}
 
-    internal init(
+internal extension AdyenCheckout {
+    
+    static func setup(
+        with sessionId: String,
+        sessionData: String,
         configuration: CheckoutConfiguration,
-        session: AdyenSessionProtocol? = nil,
-        paymentMethods: PaymentMethods? = nil,
-        checkoutAttemptId: String?,
-        presentationDelegate: PresentationDelegate?
-    ) {
-        self.configuration = configuration
-        self.session = session
-        self.paymentMethods = paymentMethods ?? session?.state.paymentMethods
-        self.checkoutAttemptId = checkoutAttemptId
-        self.presentationDelegate = presentationDelegate
-        
-        self.session?.delegate = self
-        self.session?.presentationDelegate = presentationDelegate
+        presentationDelegate: PresentationDelegate? = nil,
+        provider: AdyenCheckoutProviding = AdyenCheckoutProvider.default
+    ) async throws -> AdyenCheckout {
+        try await provider.setup(
+            with: sessionId,
+            sessionData: sessionData,
+            configuration: configuration,
+            presentationDelegate: presentationDelegate
+        )
+    }
+    
+    static func setup(
+        with paymentMethods: PaymentMethods,
+        configuration: CheckoutConfiguration,
+        presentationDelegate: PresentationDelegate? = nil,
+        provider: AdyenCheckoutProviding = AdyenCheckoutProvider.default
+    ) async throws -> AdyenCheckout {
+        try await provider.setup(
+            with: paymentMethods,
+            configuration: configuration,
+            presentationDelegate: presentationDelegate
+        )
     }
 }

--- a/AdyenCheckout/AdyenCheckoutProtocol.swift
+++ b/AdyenCheckout/AdyenCheckoutProtocol.swift
@@ -15,9 +15,9 @@ import AdyenNetworking
 
 internal protocol AdyenCheckoutProtocol {
     
-    func createComponent(with paymentMethod: PaymentMethod) -> CheckoutPaymentComponent?
+    func createPaymentComponent(for type: PaymentMethodType) -> CheckoutPaymentComponent?
     
-    func createComponent(with action: Action) -> CheckoutPaymentComponent?
+    func createPaymentComponent(for identifier: String) -> CheckoutPaymentComponent?
     
     func createDropIn() -> DropInComponent?
 }

--- a/AdyenCheckout/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/CheckoutComponentBuilder.swift
@@ -62,21 +62,33 @@ internal enum CheckoutComponentBuilder {
         fatalError()
     }
     
+    /// Builds stored payment components.
     internal static func build(
         for storedPaymentMethod: StoredPaymentMethod,
         configuration: CheckoutConfiguration
     ) -> PaymentComponent {
-        fatalError()
+        
+        // TODO: stored components requires no configuration
+        // (when new localization is implemented, see if this needs to updated
+        
+        switch storedPaymentMethod {
+            
+        #if canImport(AdyenCard)
+            case let storedCard as StoredCardPaymentMethod:
+                StoredCardComponent(
+                    storedCardPaymentMethod: storedCard,
+                    context: configuration.context
+                )
+        #endif
+            
+        default:
+            StoredPaymentMethodComponent(
+                paymentMethod: storedPaymentMethod,
+                context: configuration.context
+            )
+        }
     }
-    
-    // TODO: this will be removed as CheckoutActionComponent already handles actions.
-    internal static func build(
-        for action: Action,
-        configuration: CheckoutConfiguration
-    ) -> ActionComponent {
-        fatalError()
-    }
-    
+
     /// Creates a component using the provided factory for standard payment methods.
     ///
     /// This works for all components whose configurations conform to

--- a/AdyenCheckout/CheckoutPaymentComponent.swift
+++ b/AdyenCheckout/CheckoutPaymentComponent.swift
@@ -7,17 +7,30 @@
 @_spi(AdyenInternal) import Adyen
 import UIKit
 
-package typealias CheckoutComponentDelegate = (PaymentComponentDelegate & ActionComponentDelegate)
-
-// TODO: add description
+/// A component that handles payment method UI and data collection.
+///
+/// Create instances using `AdyenCheckout.createPaymentComponent(for:)`.
+///
+/// ```swift
+/// let component = checkout.createPaymentComponent(for: .scheme)
+/// ```
+///
+/// ## Custom Pay Button
+/// If you opted to use your own pay button, call
+/// ``submit()`` when the shopper taps your button.
+///
+/// ```swift
+/// component.submit()
+/// ```
 public final class CheckoutPaymentComponent {
     
     internal let paymentComponent: PaymentComponent?
     
     private var configuration: CheckoutConfiguration
     
-    internal weak var delegate: CheckoutComponentDelegate?
+    internal weak var delegate: PaymentComponentDelegate?
     
+    /// The view controller of the component.
     public var viewController: UIViewController? {
         guard let presentableComponent = paymentComponent as? PresentableComponent else {
             return nil
@@ -28,7 +41,7 @@ public final class CheckoutPaymentComponent {
     package init(
         paymentMethod: PaymentMethod,
         configuration: CheckoutConfiguration,
-        delegate: CheckoutComponentDelegate?
+        delegate: PaymentComponentDelegate?
     ) {
         self.configuration = configuration
         self.delegate = delegate
@@ -40,7 +53,7 @@ public final class CheckoutPaymentComponent {
     package init(
         storedPaymentMethod: StoredPaymentMethod,
         configuration: CheckoutConfiguration,
-        delegate: CheckoutComponentDelegate?
+        delegate: PaymentComponentDelegate?
     ) {
         self.configuration = configuration
         self.delegate = delegate

--- a/AdyenCheckout/CheckoutPaymentComponent.swift
+++ b/AdyenCheckout/CheckoutPaymentComponent.swift
@@ -14,8 +14,6 @@ public final class CheckoutPaymentComponent {
     
     internal let paymentComponent: PaymentComponent?
     
-    private let actionComponent: ActionComponent?
-    
     private var configuration: CheckoutConfiguration
     
     internal weak var delegate: CheckoutComponentDelegate?
@@ -37,18 +35,17 @@ public final class CheckoutPaymentComponent {
         // TODO: Add new v6 style here
         self.paymentComponent = CheckoutComponentBuilder.build(for: paymentMethod, configuration: configuration)
         self.paymentComponent?.delegate = delegate
-        self.actionComponent = nil
     }
     
     package init(
-        action: Action,
+        storedPaymentMethod: StoredPaymentMethod,
         configuration: CheckoutConfiguration,
         delegate: CheckoutComponentDelegate?
     ) {
         self.configuration = configuration
         self.delegate = delegate
-        self.actionComponent = CheckoutComponentBuilder.build(for: action, configuration: configuration)
-        self.actionComponent?.delegate = delegate
-        self.paymentComponent = nil
+        // TODO: Add new v6 style here
+        self.paymentComponent = CheckoutComponentBuilder.build(for: storedPaymentMethod, configuration: configuration)
+        self.paymentComponent?.delegate = delegate
     }
 }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/BLIKComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/BLIKComponentAdvancedFlowExample.swift
@@ -89,9 +89,7 @@ internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
 
         self.adyenCheckout = checkout
 
-        guard let blikPaymentMethod = paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self),
-              let component = checkout.createComponent(with: blikPaymentMethod)
-        else {
+        guard let component = checkout.createPaymentComponent(for: .blik) else {
             throw IntegrationError.paymentMethodNotAvailable(paymentMethod: BLIKPaymentMethod.self)
         }
 

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -107,9 +107,7 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
 
         self.adyenCheckout = checkout
 
-        guard let cardPaymentMethod = paymentMethods.paymentMethod(ofType: CardPaymentMethod.self),
-              let component = checkout.createComponent(with: cardPaymentMethod)
-        else {
+        guard let component = checkout.createPaymentComponent(for: .scheme) else {
             throw IntegrationError.paymentMethodNotAvailable(paymentMethod: CardPaymentMethod.self)
         }
 

--- a/Demo/Common/IntegrationExamples/Session/Components/BLIKComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/BLIKComponentExample.swift
@@ -69,9 +69,7 @@ internal final class BLIKComponentExample: InitialDataFlowProtocol {
         
         self.adyenCheckout = checkout
         
-        guard let paymentMethods = checkout.paymentMethods,
-              let blikPaymentMethod = paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self),
-              let component = checkout.createComponent(with: blikPaymentMethod) else {
+        guard let component = checkout.createPaymentComponent(for: .blik) else {
             throw IntegrationError.paymentMethodNotAvailable(paymentMethod: BLIKPaymentMethod.self)
         }
         

--- a/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
@@ -100,9 +100,7 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
         
         self.adyenCheckout = checkout
         
-        guard let paymentMethods = checkout.paymentMethods,
-              let blikPaymentMethod = paymentMethods.paymentMethod(ofType: CardPaymentMethod.self),
-              let component = checkout.createComponent(with: blikPaymentMethod) else {
+        guard let component = checkout.createPaymentComponent(for: .scheme) else {
             throw IntegrationError.paymentMethodNotAvailable(paymentMethod: CardPaymentMethod.self)
         }
         

--- a/Tests/UnitTests/AdyenCheckout/AdyenCheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/AdyenCheckoutTests.swift
@@ -214,6 +214,147 @@ final class AdyenCheckoutTests: XCTestCase {
         XCTAssertTrue(didCallSubmit)
     }
     
+    // MARK: - createPaymentComponent(for type:) Tests
+    
+    func test_createPaymentComponent_forType_returnsComponent_whenPaymentMethodExists() {
+        // Given
+        let sut = AdyenCheckout(
+            configuration: configuration,
+            paymentMethods: paymentMethods,
+            checkoutAttemptId: "attemptId",
+            presentationDelegate: nil
+        )
+        
+        // When
+        let component = sut.createPaymentComponent(for: .blik)
+        
+        // Then
+        XCTAssertNotNil(component)
+        XCTAssertNotNil(component?.viewController)
+    }
+    
+    func test_createPaymentComponent_forType_returnsNil_whenPaymentMethodDoesNotExist() {
+        // Given
+        let sut = AdyenCheckout(
+            configuration: configuration,
+            paymentMethods: paymentMethods,
+            checkoutAttemptId: "attemptId",
+            presentationDelegate: nil
+        )
+        
+        // When
+        let component = sut.createPaymentComponent(for: .ideal)
+        
+        // Then
+        XCTAssertNil(component)
+    }
+    
+    func test_createPaymentComponent_forType_returnsNil_whenPaymentMethodsIsNil() {
+        // Given
+        let sut = AdyenCheckout(
+            configuration: configuration,
+            paymentMethods: nil,
+            checkoutAttemptId: "attemptId",
+            presentationDelegate: nil
+        )
+        
+        // When
+        let component = sut.createPaymentComponent(for: .scheme)
+        
+        // Then
+        XCTAssertNil(component)
+    }
+    
+    func test_createPaymentComponent_forScheme_returnsCardComponent() {
+        // Given
+        let sut = AdyenCheckout(
+            configuration: configuration,
+            paymentMethods: paymentMethods,
+            checkoutAttemptId: "attemptId",
+            presentationDelegate: nil
+        )
+        
+        // When
+        let component = sut.createPaymentComponent(for: .scheme)
+        
+        // Then
+        XCTAssertNotNil(component)
+        XCTAssertNotNil(component?.viewController)
+    }
+    
+    // MARK: - createPaymentComponent(for identifier:) Tests
+    
+    func test_createPaymentComponent_forIdentifier_returnsComponent_whenStoredMethodExists() {
+        // Given
+        let sut = AdyenCheckout(
+            configuration: configuration,
+            paymentMethods: paymentMethods,
+            checkoutAttemptId: "attemptId",
+            presentationDelegate: nil
+        )
+        let storedMethodIdentifier = paymentMethods.stored.first!.identifier
+        
+        // When
+        let component = sut.createPaymentComponent(for: storedMethodIdentifier)
+        
+        // Then
+        XCTAssertNotNil(component)
+    }
+    
+    func test_createPaymentComponent_forIdentifier_returnsNil_whenStoredMethodDoesNotExist() {
+        // Given
+        let sut = AdyenCheckout(
+            configuration: configuration,
+            paymentMethods: paymentMethods,
+            checkoutAttemptId: "attemptId",
+            presentationDelegate: nil
+        )
+        
+        // When
+        let component = sut.createPaymentComponent(for: "non-existent-identifier")
+        
+        // Then
+        XCTAssertNil(component)
+    }
+    
+    func test_createPaymentComponent_forIdentifier_returnsNil_whenPaymentMethodsIsNil() {
+        // Given
+        let sut = AdyenCheckout(
+            configuration: configuration,
+            paymentMethods: nil,
+            checkoutAttemptId: "attemptId",
+            presentationDelegate: nil
+        )
+        
+        // When
+        let component = sut.createPaymentComponent(for: "any-identifier")
+        
+        // Then
+        XCTAssertNil(component)
+    }
+    
+    func test_createPaymentComponent_forIdentifier_returnsCorrectStoredMethod() {
+        // Given
+        let sut = AdyenCheckout(
+            configuration: configuration,
+            paymentMethods: paymentMethods,
+            checkoutAttemptId: "attemptId",
+            presentationDelegate: nil
+        )
+        
+        // Get the first stored card identifier
+        guard let storedCard = paymentMethods.stored.first(where: { $0 is StoredCardPaymentMethod }) else {
+            XCTFail("Expected stored card payment method in test data")
+            return
+        }
+        
+        // When
+        let component = sut.createPaymentComponent(for: storedCard.identifier)
+        
+        // Then
+        XCTAssertNotNil(component)
+    }
+    
 }
 
 struct TestError: Error {}

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -5,6 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
+@_spi(AdyenInternal) @testable import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenCheckout
 @_spi(AdyenInternal) @testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
@@ -263,7 +264,7 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         // Given
         let paymentMethod = try XCTUnwrap(createACHPaymentMethod())
         let customTheme = AdyenTheme()
-            .colors(AdyenColors(primary: .systemPink))
+            .colors(AdyenColors(primary: .yellow))
 
         checkoutConfiguration = CheckoutConfiguration(context: context)
         checkoutConfiguration.theme = customTheme
@@ -281,7 +282,7 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         }
         XCTAssertEqual(
             achComponent.configuration.theme.colors.primary,
-            UIColor.systemPink,
+            UIColor.yellow,
             "Theme should be propagated from CheckoutConfiguration to component"
         )
     }
@@ -290,7 +291,7 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         // Given
         let paymentMethod = try XCTUnwrap(createBLIKPaymentMethod())
         let customTheme = AdyenTheme()
-            .colors(AdyenColors(primary: .systemPink))
+            .colors(AdyenColors(primary: .yellow))
 
         checkoutConfiguration = CheckoutConfiguration(context: context)
         checkoutConfiguration.theme = customTheme
@@ -308,11 +309,81 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         }
         XCTAssertEqual(
             blikComponent.configuration.theme.colors.primary,
-            UIColor.systemPink,
+            UIColor.yellow,
             "Theme should be propagated from CheckoutConfiguration to component"
         )
     }
 
+    // MARK: - Stored Payment Method Tests
+    
+    func test_build_withStoredCardPaymentMethod_returnsStoredCardComponent() throws {
+        // Given
+        let storedPaymentMethod = try XCTUnwrap(createStoredCardPaymentMethod())
+        
+        // When
+        let component = CheckoutComponentBuilder.build(
+            for: storedPaymentMethod,
+            configuration: checkoutConfiguration
+        )
+        
+        // Then
+        XCTAssertEqual(component.paymentMethod.type, .scheme)
+        XCTAssertTrue(component is StoredCardComponent, "Component should be StoredCardComponent")
+    }
+    
+    func test_build_withStoredCardPaymentMethod_passesCorrectContext() throws {
+        // Given
+        let customAmount = Amount(value: 1000, currencyCode: "EUR")
+        let customContext = AdyenContext(
+            apiContext: Dummy.apiContext,
+            payment: Payment(amount: customAmount, countryCode: "NL"),
+            amount: customAmount
+        )
+        checkoutConfiguration = CheckoutConfiguration(context: customContext)
+        let storedPaymentMethod = try XCTUnwrap(createStoredCardPaymentMethod())
+        
+        // When
+        let component = CheckoutComponentBuilder.build(
+            for: storedPaymentMethod,
+            configuration: checkoutConfiguration
+        )
+        
+        // Then
+        XCTAssertEqual(component.context.amount.value, 1000)
+        XCTAssertEqual(component.context.amount.currencyCode, "EUR")
+    }
+    
+    func test_build_withGenericStoredPaymentMethod_returnsStoredPaymentMethodComponent() throws {
+        // Given
+        let storedPaymentMethod = try XCTUnwrap(createStoredPayPalPaymentMethod())
+        
+        // When
+        let component = CheckoutComponentBuilder.build(
+            for: storedPaymentMethod,
+            configuration: checkoutConfiguration
+        )
+        
+        // Then
+        XCTAssertEqual(component.paymentMethod.type, .payPal)
+        XCTAssertTrue(component is StoredPaymentMethodComponent, "Component should be StoredPaymentMethodComponent")
+    }
+    
+    func test_build_withStoredBCMCPaymentMethod_returnsStoredPaymentMethodComponent() throws {
+        // Given
+        let storedPaymentMethod = try XCTUnwrap(createStoredBCMCPaymentMethod())
+        
+        // When
+        let component = CheckoutComponentBuilder.build(
+            for: storedPaymentMethod,
+            configuration: checkoutConfiguration
+        )
+        
+        // Then
+        XCTAssertEqual(component.paymentMethod.type, .bcmc)
+        // StoredBCMC falls through to generic StoredPaymentMethodComponent
+        XCTAssertTrue(component is StoredPaymentMethodComponent, "Component should be StoredPaymentMethodComponent")
+    }
+    
     // MARK: - Helper Methods
     
     private func createBLIKPaymentMethod() -> BLIKPaymentMethod? {
@@ -329,5 +400,55 @@ final class CheckoutComponentBuilderTests: XCTestCase {
             "name": "ACH Direct Debit"
         ]
         return try? AdyenCoder.decode(dict) as ACHDirectDebitPaymentMethod
+    }
+    
+    private func createStoredCardPaymentMethod() -> StoredCardPaymentMethod? {
+        let dict: [String: Any] = [
+            "type": "scheme",
+            "id": "9314881977134903",
+            "name": "VISA",
+            "brand": "visa",
+            "lastFour": "1111",
+            "expiryMonth": "08",
+            "expiryYear": "2018",
+            "holderName": "test",
+            "fundingSource": "credit",
+            "supportedShopperInteractions": [
+                "Ecommerce",
+                "ContAuth"
+            ]
+        ]
+        return try? AdyenCoder.decode(dict) as StoredCardPaymentMethod
+    }
+    
+    private func createStoredPayPalPaymentMethod() -> StoredPayPalPaymentMethod? {
+        let dict: [String: Any] = [
+            "type": "paypal",
+            "id": "9314881977134903",
+            "name": "PayPal",
+            "shopperEmail": "example@shopper.com",
+            "supportedShopperInteractions": [
+                "Ecommerce",
+                "ContAuth"
+            ]
+        ]
+        return try? AdyenCoder.decode(dict) as StoredPayPalPaymentMethod
+    }
+    
+    private func createStoredBCMCPaymentMethod() -> StoredBCMCPaymentMethod? {
+        let dict: [String: Any] = [
+            "expiryMonth": "10",
+            "expiryYear": "2020",
+            "id": "8415736344108917",
+            "supportedShopperInteractions": [
+                "Ecommerce"
+            ],
+            "lastFour": "4449",
+            "brand": "bcmc",
+            "type": "scheme",
+            "holderName": "Checkout Shopper PlaceHolder",
+            "name": "Maestro"
+        ]
+        return try? AdyenCoder.decode(dict) as StoredBCMCPaymentMethod
     }
 }


### PR DESCRIPTION
# Summary [Required]
Updates `AdyenCheckout` and `CheckoutComponentBuilder` to create standalone payment and stored payment components as `CheckoutPaymentComponent`, while also simplifying the creation via `PaymentMethodType` instead of the whole `PaymentMethod` object.


## Ticket [Optional]
<ticket>
COSDK-939
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
