### PR TITLE
Add installments to PaymentsRequest for sessions

### DIFF
--- a/AdyenSession/API/Payments/PaymentsRequest.swift
+++ b/AdyenSession/API/Payments/PaymentsRequest.swift
@@ -57,6 +57,7 @@ internal struct PaymentsRequest: APIRequest {
         try container.encodeIfPresent(data.socialSecurityNumber, forKey: .socialSecurityNumber)
         try container.encodeIfPresent(data.browserInfo, forKey: .browserInfo)
         try container.encodeIfPresent(data.order?.compactOrder, forKey: .order)
+        try container.encodeIfPresent(data.installments, forKey: .installments)
     }
     
     private enum CodingKeys: String, CodingKey {
@@ -72,6 +73,7 @@ internal struct PaymentsRequest: APIRequest {
         case socialSecurityNumber
         case order
         case delegatedAuthenticationData
+        case installments
     }
 }
 

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -10,6 +10,7 @@ import XCTest
 @_spi(AdyenInternal) @testable import AdyenActions
 import AdyenComponents
 import AdyenDropIn
+import AdyenEncryption
 import AdyenNetworking
 
 class SessionTests: XCTestCase {
@@ -1134,7 +1135,55 @@ class SessionTests: XCTestCase {
         XCTAssertNil(cardComponent.viewController.view.findView(with: "AdyenCard.CardComponent.storeDetailsItem"))
         XCTAssertFalse(cardComponent.configuration.showsStorePaymentMethodField)
     }
-    
+
+    func testPaymentsRequestEncodesInstallments() throws {
+        let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular[1] as? CardPaymentMethod)
+        let encryptedCard = EncryptedCard(number: "number", securityCode: "code", expiryMonth: "month", expiryYear: "year")
+        let cardDetails = CardDetails(paymentMethod: paymentMethod, encryptedCard: encryptedCard)
+        let installments = Installments(totalMonths: 3, plan: .regular)
+        let data = PaymentComponentData(
+            paymentMethodDetails: cardDetails,
+            amount: nil,
+            order: nil,
+            installments: installments
+        )
+
+        let request = PaymentsRequest(
+            sessionId: "session_id",
+            sessionData: "session_data",
+            data: data
+        )
+
+        let encodedData = try JSONEncoder().encode(request)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedData) as? [String: Any])
+
+        let installmentsJson = try XCTUnwrap(json["installments"] as? [String: Any])
+        XCTAssertEqual(installmentsJson["value"] as? Int, 3)
+        XCTAssertEqual(installmentsJson["plan"] as? String, "regular")
+    }
+
+    func testPaymentsRequestOmitsInstallmentsWhenNil() throws {
+        let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular[1] as? CardPaymentMethod)
+        let encryptedCard = EncryptedCard(number: "number", securityCode: "code", expiryMonth: "month", expiryYear: "year")
+        let cardDetails = CardDetails(paymentMethod: paymentMethod, encryptedCard: encryptedCard)
+        let data = PaymentComponentData(
+            paymentMethodDetails: cardDetails,
+            amount: nil,
+            order: nil
+        )
+
+        let request = PaymentsRequest(
+            sessionId: "session_id",
+            sessionData: "session_data",
+            data: data
+        )
+
+        let encodedData = try JSONEncoder().encode(request)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encodedData) as? [String: Any])
+
+        XCTAssertNil(json["installments"])
+    }
+
     private func initializeSession(
         expectedPaymentMethods: PaymentMethods,
         delegate: AdyenSessionDelegate = SessionDelegateMock(),

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -10,7 +10,7 @@ import XCTest
 @_spi(AdyenInternal) @testable import AdyenActions
 import AdyenComponents
 import AdyenDropIn
-import AdyenEncryption
+@testable import AdyenEncryption
 import AdyenNetworking
 
 class SessionTests: XCTestCase {
@@ -1137,7 +1137,7 @@ class SessionTests: XCTestCase {
     }
 
     func testPaymentsRequestEncodesInstallments() throws {
-        let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular[1] as? CardPaymentMethod)
+        let paymentMethod = CardPaymentMethodMock(fundingSource: .credit, type: .other("test_type"), name: "test name", brands: [.visa, .bcmc])
         let encryptedCard = EncryptedCard(number: "number", securityCode: "code", expiryMonth: "month", expiryYear: "year")
         let cardDetails = CardDetails(paymentMethod: paymentMethod, encryptedCard: encryptedCard)
         let installments = Installments(totalMonths: 3, plan: .regular)
@@ -1163,7 +1163,7 @@ class SessionTests: XCTestCase {
     }
 
     func testPaymentsRequestOmitsInstallmentsWhenNil() throws {
-        let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular[1] as? CardPaymentMethod)
+        let paymentMethod = CardPaymentMethodMock(fundingSource: .credit, type: .other("test_type"), name: "test name", brands: [.visa, .bcmc])
         let encryptedCard = EncryptedCard(number: "number", securityCode: "code", expiryMonth: "month", expiryYear: "year")
         let cardDetails = CardDetails(paymentMethod: paymentMethod, encryptedCard: encryptedCard)
         let data = PaymentComponentData(


### PR DESCRIPTION
# Summary 
Update `PaymentsRequest` to encode the `installments` property from `PaymentComponentData`.
Add unit tests to verify that installments are correctly serialized in the request body.

## Release Notes

<new>
- Added ability for installments on the sessions flow.
</new>

## Ticket 
<ticket>
COSDK-991
</ticket>

## Checklist
- [X] Tested changes locally
- [X] Added/updated unit tests
- [X] Verified against acceptance criteria
