### PR TITLE
Telemetry: align validation events funnel with web

### DIFF
--- a/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
@@ -272,9 +272,9 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
     /// Subclasses can override this method to stay notified when the text field resigns its first responder status.
     open func textFieldDidEndEditing(_ textField: UITextField) {
         isEditing = false
+        item.onDidEndEditing?()
         item.triggerValidation(.focusLost)
         updateBorderColor()
-        item.onDidEndEditing?()
     }
     
     /// This method hides validation accessories icons.

--- a/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItem.swift
+++ b/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItem.swift
@@ -46,7 +46,6 @@ open class FormValidatableValueItem<ValueType: Equatable>: FormValueItem<ValueTy
     /// Views observe this property to update their UI reactively.
     @AdyenUIObservable(.initial) package var validationState: ValidationState
     
-    
     /// Closure that is triggered when there is a validation error.
     public var onDidShowValidationError: ((ValidationError) -> Void)?
     
@@ -76,6 +75,20 @@ open class FormValidatableValueItem<ValueType: Equatable>: FormValueItem<ValueTy
         if trigger == .focusLost, isEmpty() {
             return
         }
-        validationState = isValid() ? .valid : .invalid(validationFailureMessage ?? "")
+        let newState: ValidationState = isValid() ? .valid : .invalid(validationFailureMessage ?? "")
+        validationState = newState
+
+        notifyOnValidationError(for: newState)
+    }
+
+    // MARK: - Private
+
+    private func notifyOnValidationError(for state: ValidationState) {
+        guard case .invalid = state,
+              let validationStatus = validationStatus(),
+              let error = validationStatus.validationError
+        else { return }
+        
+        onDidShowValidationError?(error)
     }
 }

--- a/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
@@ -51,6 +51,7 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
     package func onValidationStateChanged(state: ValidationState) {
         updateFooterDisplay(state: state, animated: true)
         updateAccessibility(state: state)
+        triggerValidationErrorCallbackIfNeeded()
     }
 
     private func updateFooterDisplay(state: ValidationState, animated: Bool) {
@@ -84,7 +85,6 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
     /// Called by form to trigger explicit validation (e.g., Pay button).
     public func showValidation() {
         item.triggerValidation(.explicit)
-        triggerValidationErrorCallbackIfNeeded()
     }
 
     /// Clears validation error state.

--- a/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
@@ -51,7 +51,6 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
     package func onValidationStateChanged(state: ValidationState) {
         updateFooterDisplay(state: state, animated: true)
         updateAccessibility(state: state)
-        triggerValidationErrorCallbackIfNeeded()
     }
 
     private func updateFooterDisplay(state: ValidationState, animated: Bool) {
@@ -101,14 +100,6 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
         } else {
             accessibilityLabelView?.accessibilityLabel = item.title
         }
-    }
-
-    private func triggerValidationErrorCallbackIfNeeded() {
-        guard item.validationState.shouldShowError,
-              let validationStatus = item.validationStatus(),
-              let error = validationStatus.validationError
-        else { return }
-        item.onDidShowValidationError?(error)
     }
 
     private func updateFooter(text: String?, color: UIColor, visible: Bool, animated: Bool) {

--- a/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
@@ -347,6 +347,64 @@ final class CardComponentEventTests: XCTestCase {
         )
     }
 
+    // MARK: - Focus loss with invalid input validation events
+
+    // EVT-UC5: Focus Loss with Invalid Input - Send Both Unfocus and Validation Error Events
+    func test_cardNumber_onFocusLossWithInvalidValue_shouldSendUnfocusAndValidationErrorEvents()
+        throws {
+        let analyticsProviderMock = AnalyticsProviderMock()
+        let sut = makeSUT(analyticsProviderMock: analyticsProviderMock)
+
+        let cardNumberItemView: FormTextItemView<FormCardNumberItem> = try XCTUnwrap(
+            sut.cardViewController.view.findView(
+                with: "AdyenCard.FormCardNumberContainerItem.numberItem"
+            )
+        )
+
+        testFocusLossValidationErrorEvent(
+            for: cardNumberItemView,
+            target: .cardNumber,
+            invalidValue: "123",
+            analyticsProviderMock: analyticsProviderMock
+        )
+    }
+
+    // EVT-UC5: Focus Loss with Invalid Input - Send Both Unfocus and Validation Error Events
+    func test_expiryDate_onFocusLossWithInvalidValue_shouldSendUnfocusAndValidationErrorEvents()
+        throws {
+        let analyticsProviderMock = AnalyticsProviderMock()
+        let sut = makeSUT(analyticsProviderMock: analyticsProviderMock)
+
+        let expiryDateItemView: FormTextInputItemView = try XCTUnwrap(
+            sut.cardViewController.view.findView(with: "AdyenCard.CardComponent.expiryDateItem")
+        )
+
+        testFocusLossValidationErrorEvent(
+            for: expiryDateItemView,
+            target: .expiryDate,
+            invalidValue: "1",
+            analyticsProviderMock: analyticsProviderMock
+        )
+    }
+
+    // EVT-UC5: Focus Loss with Invalid Input - Send Both Unfocus and Validation Error Events
+    func test_securityCode_onFocusLossWithInvalidValue_shouldSendUnfocusAndValidationErrorEvents()
+        throws {
+        let analyticsProviderMock = AnalyticsProviderMock()
+        let sut = makeSUT(analyticsProviderMock: analyticsProviderMock)
+
+        let securityCodeItemView: FormCardSecurityCodeItemView = try XCTUnwrap(
+            sut.cardViewController.view.findView(with: "AdyenCard.CardComponent.securityCodeItem")
+        )
+
+        testFocusLossValidationErrorEvent(
+            for: securityCodeItemView,
+            target: .securityCode,
+            invalidValue: "1",
+            analyticsProviderMock: analyticsProviderMock
+        )
+    }
+
     // EVT-UC4: Explicit Validation Success - No Validation Error Event
     func test_cardNumber_withValidValue_shouldNotSendValidationErrorEvent() throws {
         let analyticsProviderMock = AnalyticsProviderMock()
@@ -432,6 +490,45 @@ final class CardComponentEventTests: XCTestCase {
         )
         XCTAssertNotNil(
             validationEvent?.validationErrorMessage, "Validation error should include error message"
+        )
+    }
+
+    private func testFocusLossValidationErrorEvent(
+        for field: FormTextItemView<some FormTextItem>,
+        target: AnalyticsEventTarget,
+        invalidValue: String,
+        analyticsProviderMock: AnalyticsProviderMock
+    ) {
+        analyticsProviderMock.clearAll()
+
+        field.item.value = invalidValue
+        field.textFieldDidBeginEditing(field.textField)
+        field.textFieldDidEndEditing(field.textField)
+
+        XCTAssertEqual(
+            analyticsProviderMock.infos.count,
+            3,
+            "Expected focus, unfocus, and validation error events"
+        )
+
+        let focusEvent = analyticsProviderMock.infos[0]
+        XCTAssertEqual(focusEvent.type, .focus)
+        XCTAssertEqual(focusEvent.target, target)
+
+        let unfocusEvent = analyticsProviderMock.infos[1]
+        XCTAssertEqual(unfocusEvent.type, .unfocus)
+        XCTAssertEqual(unfocusEvent.target, target)
+
+        let validationEvent = analyticsProviderMock.infos[2]
+        XCTAssertEqual(validationEvent.type, .validationError)
+        XCTAssertEqual(validationEvent.target, target)
+        XCTAssertNotNil(
+            validationEvent.validationErrorCode,
+            "Validation error should include error code"
+        )
+        XCTAssertNotNil(
+            validationEvent.validationErrorMessage,
+            "Validation error should include error message"
         )
     }
 

--- a/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
@@ -4,11 +4,10 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
-
 @_spi(AdyenInternal) @testable import Adyen
 @_spi(AdyenInternal) @testable import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
+import XCTest
 
 final class CardComponentEventTests: XCTestCase {
 
@@ -209,6 +208,7 @@ final class CardComponentEventTests: XCTestCase {
             for: cardNumberItemView,
             target: .cardNumber,
             invalidValue: "123",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.cardNumberPartial,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -226,6 +226,7 @@ final class CardComponentEventTests: XCTestCase {
             for: expiryDateItemView,
             target: .expiryDate,
             invalidValue: "13/20",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.expiryDatePartial,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -243,6 +244,7 @@ final class CardComponentEventTests: XCTestCase {
             for: securityCodeItemView,
             target: .securityCode,
             invalidValue: "12",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.securityCodePartial,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -262,6 +264,7 @@ final class CardComponentEventTests: XCTestCase {
             for: holderNameItemView,
             target: .holderName,
             invalidValue: "",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.holderNameEmpty,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -283,6 +286,7 @@ final class CardComponentEventTests: XCTestCase {
             for: kcpItemView,
             target: .taxNumber,
             invalidValue: "123",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.kcpFieldPartial,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -304,6 +308,7 @@ final class CardComponentEventTests: XCTestCase {
             for: kcpPasswordItemView,
             target: .authPassWord,
             invalidValue: "1",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.kcpPasswordPartial,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -325,6 +330,7 @@ final class CardComponentEventTests: XCTestCase {
             for: socialSecurityItemView,
             target: .boletoSocialSecurityNumber,
             invalidValue: "123",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.brazilSSNPartial,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -344,6 +350,7 @@ final class CardComponentEventTests: XCTestCase {
             for: postalCodeItemView,
             target: .addressPostalCode,
             invalidValue: "1",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.postalCodePartial,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -366,6 +373,7 @@ final class CardComponentEventTests: XCTestCase {
             for: cardNumberItemView,
             target: .cardNumber,
             invalidValue: "123",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.cardNumberPartial,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -384,6 +392,7 @@ final class CardComponentEventTests: XCTestCase {
             for: expiryDateItemView,
             target: .expiryDate,
             invalidValue: "1",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.expiryDatePartial,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -402,6 +411,7 @@ final class CardComponentEventTests: XCTestCase {
             for: securityCodeItemView,
             target: .securityCode,
             invalidValue: "1",
+            expectedErrorCode: AnalyticsConstants.ValidationErrorCodes.securityCodePartial,
             analyticsProviderMock: analyticsProviderMock
         )
     }
@@ -472,6 +482,7 @@ final class CardComponentEventTests: XCTestCase {
         for field: FormTextItemView<some FormTextItem>,
         target: AnalyticsEventTarget,
         invalidValue: String,
+        expectedErrorCode: Int,
         analyticsProviderMock: AnalyticsProviderMock
     ) {
         analyticsProviderMock.clearAll()
@@ -486,8 +497,10 @@ final class CardComponentEventTests: XCTestCase {
         let validationEvent = analyticsProviderMock.infos.first
         XCTAssertEqual(validationEvent?.type, .validationError)
         XCTAssertEqual(validationEvent?.target, target)
-        XCTAssertNotNil(
-            validationEvent?.validationErrorCode, "Validation error should include error code"
+        XCTAssertEqual(
+            validationEvent?.validationErrorCode,
+            String(expectedErrorCode),
+            "Expected error code \(expectedErrorCode) for \(target)"
         )
         XCTAssertNotNil(
             validationEvent?.validationErrorMessage, "Validation error should include error message"
@@ -498,6 +511,7 @@ final class CardComponentEventTests: XCTestCase {
         for field: FormTextItemView<some FormTextItem>,
         target: AnalyticsEventTarget,
         invalidValue: String,
+        expectedErrorCode: Int,
         analyticsProviderMock: AnalyticsProviderMock
     ) {
         analyticsProviderMock.clearAll()
@@ -523,9 +537,10 @@ final class CardComponentEventTests: XCTestCase {
         let validationEvent = analyticsProviderMock.infos[2]
         XCTAssertEqual(validationEvent.type, .validationError)
         XCTAssertEqual(validationEvent.target, target)
-        XCTAssertNotNil(
+        XCTAssertEqual(
             validationEvent.validationErrorCode,
-            "Validation error should include error code"
+            String(expectedErrorCode),
+            "Expected error code \(expectedErrorCode) for \(target)"
         )
         XCTAssertNotNil(
             validationEvent.validationErrorMessage,

--- a/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
@@ -4,10 +4,11 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
 import XCTest
-@testable @_spi(AdyenInternal) import AdyenCard
-@testable @_spi(AdyenInternal) import AdyenUI
+
+@_spi(AdyenInternal) @testable import Adyen
+@_spi(AdyenInternal) @testable import AdyenCard
+@_spi(AdyenInternal) @testable import AdyenUI
 
 final class CardComponentEventTests: XCTestCase {
 


### PR DESCRIPTION
# Summary
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

This change bridges the gap between iOS and Web. iOS SDK needs to start sending validation error events on both "focus loss" and "forced" validation.

[Reasoning](https://github.com/Adyen/adyen-checkout-sdk-meta/pull/23)

## Checklist 
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against [acceptance criteria](https://github.com/Adyen/adyen-checkout-sdk-meta/blob/c5594ef41fd6c7a91ead8bdd2b1dc62ef65353bc/specs/FORM_VALIDATION_EVENTS_USE_CASES.md)
