### PR TITLE
Pass prefetched public key to components

### DIFF
--- a/Adyen/Core/Components/ComponentFactory.swift
+++ b/Adyen/Core/Components/ComponentFactory.swift
@@ -33,7 +33,7 @@ package protocol PaymentComponentFactory {
         with paymentMethod: Method,
         context: AdyenContext,
         configuration: Configuration,
-        publicKey: String
+        publicKey: PublicKeyFetchingProgramFlow
     ) -> Component
     
     /// Creates the default configuration for the component.

--- a/Adyen/Core/Components/ComponentFactory.swift
+++ b/Adyen/Core/Components/ComponentFactory.swift
@@ -32,7 +32,8 @@ package protocol PaymentComponentFactory {
     func create(
         with paymentMethod: Method,
         context: AdyenContext,
-        configuration: Configuration
+        configuration: Configuration,
+        publicKey: String
     ) -> Component
     
     /// Creates the default configuration for the component.

--- a/Adyen/Core/Payment Methods/Abstract/PaymentMethods.swift
+++ b/Adyen/Core/Payment Methods/Abstract/PaymentMethods.swift
@@ -6,6 +6,14 @@
 
 import Foundation
 
+/// A temporary type to ensure both the prefetched and the later fetched versions of the Components work.
+/// This will help us gradually migrate all flows to using the prefetched flow. So when notFetched is not used, this type can go.
+/// TODO: This type has to be deleted before release of v6.
+public enum PublicKeyFetchingProgramFlow {
+    case prefetched(String)
+    case notFetched
+}
+
 /**
  A collection of available payment methods.
 

--- a/Adyen/Utilities/PublicKeyProvider/PublicKeyConsumer.swift
+++ b/Adyen/Utilities/PublicKeyProvider/PublicKeyConsumer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 @_spi(AdyenInternal)
 public protocol PublicKeyConsumer {
+    
+    var publicKey: PublicKeyFetchingProgramFlow { get }
 
     /// Provider for fetching the public key.
     var publicKeyProvider: AnyPublicKeyProvider { get }

--- a/AdyenCard/Components/BCMC/BCMCComponent.swift
+++ b/AdyenCard/Components/BCMC/BCMCComponent.swift
@@ -20,13 +20,14 @@ public final class BCMCComponent: CardComponent {
     public init(
         paymentMethod: BCMCPaymentMethod,
         context: AdyenContext,
-        publicKey: String,
+        publicKey: PublicKeyFetchingProgramFlow,
         configuration: CardComponentConfiguration = .init()
     ) {
         let configuration = configuration.bcmcConfiguration()
-        
+        let publicKeyProvider = PublicKeyProvider(apiContext: context.apiContext)
         let binInfoProvider = BinInfoProvider(
             apiClient: APIClient(apiContext: context.apiContext),
+            publicKeyProvider: publicKeyProvider,
             publicKey: publicKey,
             minBinLength: Constant.thresholdBINLength,
             binLookupType: configuration.binLookupType
@@ -35,6 +36,7 @@ public final class BCMCComponent: CardComponent {
             paymentMethod: paymentMethod,
             context: context,
             configuration: configuration,
+            publicKeyProvider: publicKeyProvider,
             publicKey: publicKey,
             binProvider: binInfoProvider
         )
@@ -44,7 +46,8 @@ public final class BCMCComponent: CardComponent {
         paymentMethod: AnyCardPaymentMethod,
         context: AdyenContext,
         configuration: CardComponentConfiguration,
-        publicKey: String,
+        publicKeyProvider: AnyPublicKeyProvider,
+        publicKey: PublicKeyFetchingProgramFlow,
         binProvider: AnyBinInfoProvider
     ) {
         let configuration = configuration.bcmcConfiguration()
@@ -52,6 +55,7 @@ public final class BCMCComponent: CardComponent {
             paymentMethod: paymentMethod,
             context: context,
             configuration: configuration,
+            publicKeyProvider: publicKeyProvider,
             publicKey: publicKey,
             binProvider: binProvider
         )

--- a/AdyenCard/Components/BCMC/BCMCComponent.swift
+++ b/AdyenCard/Components/BCMC/BCMCComponent.swift
@@ -20,14 +20,14 @@ public final class BCMCComponent: CardComponent {
     public init(
         paymentMethod: BCMCPaymentMethod,
         context: AdyenContext,
+        publicKey: String,
         configuration: CardComponentConfiguration = .init()
     ) {
         let configuration = configuration.bcmcConfiguration()
         
-        let publicKeyProvider = PublicKeyProvider(apiContext: context.apiContext)
         let binInfoProvider = BinInfoProvider(
             apiClient: APIClient(apiContext: context.apiContext),
-            publicKeyProvider: publicKeyProvider,
+            publicKey: publicKey,
             minBinLength: Constant.thresholdBINLength,
             binLookupType: configuration.binLookupType
         )
@@ -35,7 +35,7 @@ public final class BCMCComponent: CardComponent {
             paymentMethod: paymentMethod,
             context: context,
             configuration: configuration,
-            publicKeyProvider: publicKeyProvider,
+            publicKey: publicKey,
             binProvider: binInfoProvider
         )
     }
@@ -44,7 +44,7 @@ public final class BCMCComponent: CardComponent {
         paymentMethod: AnyCardPaymentMethod,
         context: AdyenContext,
         configuration: CardComponentConfiguration,
-        publicKeyProvider: AnyPublicKeyProvider,
+        publicKey: String,
         binProvider: AnyBinInfoProvider
     ) {
         let configuration = configuration.bcmcConfiguration()
@@ -52,7 +52,7 @@ public final class BCMCComponent: CardComponent {
             paymentMethod: paymentMethod,
             context: context,
             configuration: configuration,
-            publicKeyProvider: publicKeyProvider,
+            publicKey: publicKey,
             binProvider: binProvider
         )
     }

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -36,7 +36,7 @@ public class CardComponent: PresentableComponent,
 
     internal let cardPaymentMethod: AnyCardPaymentMethod
 
-    internal let publicKey: PublicKeyFetchingProgramFlow
+    public let publicKey: PublicKeyFetchingProgramFlow
 
     @_spi(AdyenInternal)
     public let publicKeyProvider: AnyPublicKeyProvider
@@ -164,7 +164,7 @@ public class CardComponent: PresentableComponent,
         }
         // TODO: FIX StoredCard UI
         if configuration.stored.showsSecurityCodeField {
-            let storedComponent = StoredCardComponent(storedCardPaymentMethod: paymentMethod, context: context)
+            let storedComponent = StoredCardComponent(storedCardPaymentMethod: paymentMethod, context: context, publicKey: publicKey)
             storedComponent.localizationParameters = configuration.localizationParameters
             return storedComponent
         } else {

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -36,8 +36,7 @@ public class CardComponent: PresentableComponent,
 
     internal let cardPaymentMethod: AnyCardPaymentMethod
 
-    @_spi(AdyenInternal)
-    public let publicKeyProvider: AnyPublicKeyProvider
+    internal let publicKey: String
 
     internal let binInfoProvider: AnyBinInfoProvider
 
@@ -90,12 +89,12 @@ public class CardComponent: PresentableComponent,
     public convenience init(
         paymentMethod: AnyCardPaymentMethod,
         context: AdyenContext,
+        publicKey: String,
         configuration: CardComponentConfiguration = .init()
     ) {
-        let publicKeyProvider = PublicKeyProvider(apiContext: context.apiContext)
         let binInfoProvider = BinInfoProvider(
             apiClient: APIClient(apiContext: context.apiContext),
-            publicKeyProvider: publicKeyProvider,
+            publicKey: publicKey,
             minBinLength: Constant.thresholdBINLength,
             binLookupType: configuration.binLookupType
         )
@@ -103,7 +102,7 @@ public class CardComponent: PresentableComponent,
             paymentMethod: paymentMethod,
             context: context,
             configuration: configuration,
-            publicKeyProvider: publicKeyProvider,
+            publicKey: publicKey,
             binProvider: binInfoProvider
         )
     }
@@ -120,15 +119,14 @@ public class CardComponent: PresentableComponent,
         paymentMethod: AnyCardPaymentMethod,
         context: AdyenContext,
         configuration: CardComponentConfiguration,
-        publicKeyProvider: AnyPublicKeyProvider,
+        publicKey: String,
         binProvider: AnyBinInfoProvider
     ) {
         self.cardPaymentMethod = paymentMethod
         self.context = context
         self.configuration = configuration
-        self.publicKeyProvider = publicKeyProvider
         self.binInfoProvider = binProvider
-
+        self.publicKey = publicKey
         self.supportedCardTypes = configuration.allowedCardTypes ?? paymentMethod.brands
     }
 
@@ -261,9 +259,6 @@ extension CardComponent: CardViewControllerDelegate {
         }
     }
 }
-
-@_spi(AdyenInternal)
-extension CardComponent: PublicKeyConsumer {}
 
 private extension CardComponent {
 

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -36,7 +36,10 @@ public class CardComponent: PresentableComponent,
 
     internal let cardPaymentMethod: AnyCardPaymentMethod
 
-    internal let publicKey: String
+    internal let publicKey: PublicKeyFetchingProgramFlow
+
+    @_spi(AdyenInternal)
+    public let publicKeyProvider: AnyPublicKeyProvider
 
     internal let binInfoProvider: AnyBinInfoProvider
 
@@ -89,11 +92,13 @@ public class CardComponent: PresentableComponent,
     public convenience init(
         paymentMethod: AnyCardPaymentMethod,
         context: AdyenContext,
-        publicKey: String,
+        publicKey: PublicKeyFetchingProgramFlow,
         configuration: CardComponentConfiguration = .init()
     ) {
+        let publicKeyProvider = PublicKeyProvider(apiContext: context.apiContext)
         let binInfoProvider = BinInfoProvider(
             apiClient: APIClient(apiContext: context.apiContext),
+            publicKeyProvider: publicKeyProvider,
             publicKey: publicKey,
             minBinLength: Constant.thresholdBINLength,
             binLookupType: configuration.binLookupType
@@ -102,6 +107,7 @@ public class CardComponent: PresentableComponent,
             paymentMethod: paymentMethod,
             context: context,
             configuration: configuration,
+            publicKeyProvider: publicKeyProvider,
             publicKey: publicKey,
             binProvider: binInfoProvider
         )
@@ -119,7 +125,8 @@ public class CardComponent: PresentableComponent,
         paymentMethod: AnyCardPaymentMethod,
         context: AdyenContext,
         configuration: CardComponentConfiguration,
-        publicKey: String,
+        publicKeyProvider: AnyPublicKeyProvider,
+        publicKey: PublicKeyFetchingProgramFlow,
         binProvider: AnyBinInfoProvider
     ) {
         self.cardPaymentMethod = paymentMethod
@@ -127,6 +134,7 @@ public class CardComponent: PresentableComponent,
         self.configuration = configuration
         self.binInfoProvider = binProvider
         self.publicKey = publicKey
+        self.publicKeyProvider = publicKeyProvider
         self.supportedCardTypes = configuration.allowedCardTypes ?? paymentMethod.brands
     }
 
@@ -259,6 +267,9 @@ extension CardComponent: CardViewControllerDelegate {
         }
     }
 }
+
+@_spi(AdyenInternal)
+extension CardComponent: PublicKeyConsumer {}
 
 private extension CardComponent {
 

--- a/AdyenCard/Components/Card/CardComponentExtensions.swift
+++ b/AdyenCard/Components/Card/CardComponentExtensions.swift
@@ -21,8 +21,14 @@ extension CardComponent {
         }
         
         cardViewController.startLoading()
-        submitEncryptedCardData(cardPublicKey: publicKey)
-
+        switch publicKey {
+        case .notFetched:
+            fetchCardPublicKey(notifyingDelegateOnFailure: true) { [weak self] in
+                self?.submitEncryptedCardData(cardPublicKey: $0)
+            }
+        case let .prefetched(publicKey):
+            submitEncryptedCardData(cardPublicKey: publicKey)
+        }
     }
     
     private func submitEncryptedCardData(cardPublicKey: String) {
@@ -90,8 +96,13 @@ extension CardComponent: ViewControllerDelegate {
     public func viewDidLoad(viewController: UIViewController) {
         sendInitialAnalytics()
         sendDidLoadEvent()
-        // just cache the public key value
-        // fetchCardPublicKey(notifyingDelegateOnFailure: false)
+        switch publicKey {
+        case .notFetched:
+            // just cache the public key value
+            fetchCardPublicKey(notifyingDelegateOnFailure: false)
+        case .prefetched:
+            break
+        }
     }
 }
 

--- a/AdyenCard/Components/Card/CardComponentExtensions.swift
+++ b/AdyenCard/Components/Card/CardComponentExtensions.swift
@@ -21,10 +21,8 @@ extension CardComponent {
         }
         
         cardViewController.startLoading()
+        submitEncryptedCardData(cardPublicKey: publicKey)
 
-        fetchCardPublicKey(notifyingDelegateOnFailure: true) { [weak self] in
-            self?.submitEncryptedCardData(cardPublicKey: $0)
-        }
     }
     
     private func submitEncryptedCardData(cardPublicKey: String) {
@@ -93,7 +91,7 @@ extension CardComponent: ViewControllerDelegate {
         sendInitialAnalytics()
         sendDidLoadEvent()
         // just cache the public key value
-        fetchCardPublicKey(notifyingDelegateOnFailure: false)
+        // fetchCardPublicKey(notifyingDelegateOnFailure: false)
     }
 }
 

--- a/AdyenCard/Components/Card/CardComponentFactory.swift
+++ b/AdyenCard/Components/Card/CardComponentFactory.swift
@@ -34,6 +34,7 @@ package struct CardComponentFactory<CardMethod: AnyCardPaymentMethod>: PaymentCo
         CardComponent(
             paymentMethod: paymentMethod,
             context: context,
+            publicKey: "BOB",
             configuration: configuration
         )
     }

--- a/AdyenCard/Components/Card/CardComponentFactory.swift
+++ b/AdyenCard/Components/Card/CardComponentFactory.swift
@@ -30,7 +30,7 @@ package struct CardComponentFactory<CardMethod: AnyCardPaymentMethod>: PaymentCo
         with paymentMethod: CardMethod,
         context: AdyenContext,
         configuration: CardComponentConfiguration,
-        publicKey: String
+        publicKey: PublicKeyFetchingProgramFlow
     ) -> CardComponent {
         CardComponent(
             paymentMethod: paymentMethod,

--- a/AdyenCard/Components/Card/CardComponentFactory.swift
+++ b/AdyenCard/Components/Card/CardComponentFactory.swift
@@ -29,12 +29,13 @@ package struct CardComponentFactory<CardMethod: AnyCardPaymentMethod>: PaymentCo
     package func create(
         with paymentMethod: CardMethod,
         context: AdyenContext,
-        configuration: CardComponentConfiguration
+        configuration: CardComponentConfiguration,
+        publicKey: String
     ) -> CardComponent {
         CardComponent(
             paymentMethod: paymentMethod,
             context: context,
-            publicKey: "BOB",
+            publicKey: publicKey,
             configuration: configuration
         )
     }

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent+Extensions.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent+Extensions.swift
@@ -16,8 +16,13 @@ extension GiftCardComponent: ViewControllerDelegate {
     public func viewDidLoad(viewController: UIViewController) {
         sendInitialAnalytics()
         sendDidLoadEvent()
-        // just cache the public key value
-        fetchCardPublicKey(notifyingDelegateOnFailure: false)
+        switch publicKey {
+        case .notFetched:
+            // just cache the public key value
+            fetchCardPublicKey(notifyingDelegateOnFailure: false)
+        case .prefetched:
+            break
+        }
     }
 }
 

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -44,6 +44,8 @@ public final class GiftCardComponent: PresentableComponent,
     @_spi(AdyenInternal)
     public let publicKeyProvider: AnyPublicKeyProvider
 
+    public let publicKey: PublicKeyFetchingProgramFlow
+
     /// The gift card payment method.
     public var paymentMethod: PaymentMethod {
         partialPaymentMethodType.partialPaymentMethod
@@ -86,6 +88,7 @@ public final class GiftCardComponent: PresentableComponent,
         amount: Amount,
         style: FormComponentStyle = FormComponentStyle(),
         showsSubmitButton: Bool = true,
+        publicKey: PublicKeyFetchingProgramFlow,
         showsSecurityCodeField: Bool = true
     ) {
         self.init(
@@ -95,6 +98,7 @@ public final class GiftCardComponent: PresentableComponent,
             style: style,
             showsSubmitButton: showsSubmitButton,
             showsSecurityCodeField: showsSecurityCodeField,
+            publicKey: publicKey,
             publicKeyProvider: PublicKeyProvider(apiContext: context.apiContext)
         )
     }
@@ -114,6 +118,7 @@ public final class GiftCardComponent: PresentableComponent,
         context: AdyenContext,
         amount: Amount,
         style: FormComponentStyle = FormComponentStyle(),
+        publicKey: PublicKeyFetchingProgramFlow,
         showsSubmitButton: Bool = true,
         showsSecurityCodeField: Bool = true
     ) {
@@ -124,6 +129,7 @@ public final class GiftCardComponent: PresentableComponent,
             style: style,
             showsSubmitButton: showsSubmitButton,
             showsSecurityCodeField: showsSecurityCodeField,
+            publicKey: publicKey,
             publicKeyProvider: PublicKeyProvider(apiContext: context.apiContext)
         )
     }
@@ -135,11 +141,13 @@ public final class GiftCardComponent: PresentableComponent,
         style: FormComponentStyle = FormComponentStyle(),
         showsSubmitButton: Bool = true,
         showsSecurityCodeField: Bool = true,
+        publicKey: PublicKeyFetchingProgramFlow,
         publicKeyProvider: AnyPublicKeyProvider
     ) {
         self.partialPaymentMethodType = partialPaymentMethodType
         self.context = context
         self.style = style
+        self.publicKey = publicKey
         self.showsSubmitButton = showsSubmitButton
         self.showsSecurityCodeField = showsSecurityCodeField
         self.publicKeyProvider = publicKeyProvider
@@ -284,12 +292,22 @@ extension GiftCardComponent {
         }
 
         startLoading()
+        switch publicKey {
+        case .notFetched:
+            fetchCardPublicKey(notifyingDelegateOnFailure: true) { [weak self] cardPublicKey in
+                guard let self else { return }
+                self.createPaymentData(
+                    order: self.order,
+                    cardPublicKey: cardPublicKey
+                )
+                .mapError(Error.otherError)
+                .handle(success: self.startFlow(with:), failure: self.handle(error:))
+            }
 
-        fetchCardPublicKey(notifyingDelegateOnFailure: true) { [weak self] cardPublicKey in
-            guard let self else { return }
+        case let .prefetched(publicKey):
             self.createPaymentData(
                 order: self.order,
-                cardPublicKey: cardPublicKey
+                cardPublicKey: publicKey
             )
             .mapError(Error.otherError)
             .handle(success: self.startFlow(with:), failure: self.handle(error:))

--- a/AdyenCard/Components/Stored Card/StoredCardAlertManager.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardAlertManager.swift
@@ -15,7 +15,7 @@ internal final class StoredCardAlertManager: NSObject, UITextFieldDelegate, Adye
     internal let context: AdyenContext
     private let paymentMethod: StoredCardPaymentMethod
     private let amount: Amount?
-
+    private let publicKey: PublicKeyFetchingProgramFlow
     internal var publicKeyProvider: AnyPublicKeyProvider
     internal var completionHandler: Completion<Result<CardDetails, Error>>?
     internal var localizationParameters: LocalizationParameters?
@@ -23,12 +23,13 @@ internal final class StoredCardAlertManager: NSObject, UITextFieldDelegate, Adye
     internal init(
         paymentMethod: StoredCardPaymentMethod,
         context: AdyenContext,
+        publicKey: PublicKeyFetchingProgramFlow,
         amount: Amount?
     ) {
         self.context = context
         self.paymentMethod = paymentMethod
         self.amount = amount
-        
+        self.publicKey = publicKey
         self.publicKeyProvider = PublicKeyProvider(apiContext: context.apiContext)
     }
 
@@ -80,10 +81,15 @@ internal final class StoredCardAlertManager: NSObject, UITextFieldDelegate, Adye
         guard let textField = alertController.textFields?.first, let securityCode = textField.text else {
             return
         }
-        
-        fetchCardPublicKey { [weak self] in
-            self?.submit(securityCode: securityCode, cardPublicKey: $0)
-            self?.resetAlertFields()
+        switch publicKey {
+        case let .prefetched(publicKey):
+            submit(securityCode: securityCode, cardPublicKey: publicKey)
+            resetAlertFields()
+        case .notFetched:
+            fetchCardPublicKey { [weak self] in
+                self?.submit(securityCode: securityCode, cardPublicKey: $0)
+                self?.resetAlertFields()
+            }
         }
     }
     

--- a/AdyenCard/Components/Stored Card/StoredCardComponent.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardComponent.swift
@@ -25,13 +25,16 @@ package final class StoredCardComponent: StoredPaymentComponent, PaymentAware, L
     package var localizationParameters: LocalizationParameters?
         
     private let storedCardPaymentMethod: StoredCardPaymentMethod
-    
+    private let publicKey: PublicKeyFetchingProgramFlow
+
     package init(
         storedCardPaymentMethod: StoredCardPaymentMethod,
-        context: AdyenContext
+        context: AdyenContext,
+        publicKey: PublicKeyFetchingProgramFlow
     ) {
         self.storedCardPaymentMethod = storedCardPaymentMethod
         self.context = context
+        self.publicKey = publicKey
     }
     
     package var viewController: UIViewController {
@@ -45,6 +48,7 @@ package final class StoredCardComponent: StoredPaymentComponent, PaymentAware, L
         let manager = StoredCardAlertManager(
             paymentMethod: storedCardPaymentMethod,
             context: context,
+            publicKey: publicKey,
             amount: payment?.amount
         )
         

--- a/AdyenCard/Utilities/CardType/BinInfoProvider.swift
+++ b/AdyenCard/Utilities/CardType/BinInfoProvider.swift
@@ -21,7 +21,7 @@ internal final class BinInfoProvider: AnyBinInfoProvider {
 
     private var binLookupService: AnyBinLookupService?
     
-    private let publicKeyProvider: AnyPublicKeyProvider
+    private let publicKey: String
 
     private let fallbackCardTypeProvider: AnyBinInfoProvider
     
@@ -34,13 +34,13 @@ internal final class BinInfoProvider: AnyBinInfoProvider {
     ///   if API not available or BIN too short.
     internal init(
         apiClient: APIClientProtocol,
-        publicKeyProvider: AnyPublicKeyProvider,
+        publicKey: String,
         fallbackCardTypeProvider: AnyBinInfoProvider = FallbackBinInfoProvider(),
         minBinLength: Int,
         binLookupType: BinLookupRequestType
     ) {
         self.apiClient = apiClient
-        self.publicKeyProvider = publicKeyProvider
+        self.publicKey = publicKey
         self.fallbackCardTypeProvider = fallbackCardTypeProvider
         self.minBinLength = minBinLength
         self.binLookupType = binLookupType
@@ -79,17 +79,9 @@ internal final class BinInfoProvider: AnyBinInfoProvider {
         if let service = binLookupService {
             useService(service)
         } else {
-            publicKeyProvider.fetch { [weak self] result in
-                guard let self else { return }
-                switch result {
-                case let .success(publicKey):
-                    let service = BinLookupService(publicKey: publicKey, apiClient: self.apiClient, binLookupType: self.binLookupType)
-                    self.binLookupService = service
-                    useService(service)
-                case .failure:
-                    fallback()
-                }
-            }
+            let service = BinLookupService(publicKey: publicKey, apiClient: self.apiClient, binLookupType: self.binLookupType)
+            self.binLookupService = service
+            useService(service)
         }
     }
 

--- a/AdyenCard/Utilities/CardType/BinInfoProvider.swift
+++ b/AdyenCard/Utilities/CardType/BinInfoProvider.swift
@@ -20,8 +20,9 @@ internal final class BinInfoProvider: AnyBinInfoProvider {
     private let apiClient: APIClientProtocol
 
     private var binLookupService: AnyBinLookupService?
-    
-    private let publicKey: String
+
+    private let publicKeyProvider: AnyPublicKeyProvider
+    private let publicKey: PublicKeyFetchingProgramFlow
 
     private let fallbackCardTypeProvider: AnyBinInfoProvider
     
@@ -34,12 +35,14 @@ internal final class BinInfoProvider: AnyBinInfoProvider {
     ///   if API not available or BIN too short.
     internal init(
         apiClient: APIClientProtocol,
-        publicKey: String,
+        publicKeyProvider: AnyPublicKeyProvider,
+        publicKey: PublicKeyFetchingProgramFlow,
         fallbackCardTypeProvider: AnyBinInfoProvider = FallbackBinInfoProvider(),
         minBinLength: Int,
         binLookupType: BinLookupRequestType
     ) {
         self.apiClient = apiClient
+        self.publicKeyProvider = publicKeyProvider
         self.publicKey = publicKey
         self.fallbackCardTypeProvider = fallbackCardTypeProvider
         self.minBinLength = minBinLength
@@ -79,9 +82,24 @@ internal final class BinInfoProvider: AnyBinInfoProvider {
         if let service = binLookupService {
             useService(service)
         } else {
-            let service = BinLookupService(publicKey: publicKey, apiClient: self.apiClient, binLookupType: self.binLookupType)
-            self.binLookupService = service
-            useService(service)
+            switch publicKey {
+            case let .prefetched(publicKey):
+                let service = BinLookupService(publicKey: publicKey, apiClient: self.apiClient, binLookupType: self.binLookupType)
+                self.binLookupService = service
+                useService(service)
+            case .notFetched:
+                publicKeyProvider.fetch { [weak self] result in
+                    guard let self else { return }
+                    switch result {
+                    case let .success(publicKey):
+                        let service = BinLookupService(publicKey: publicKey, apiClient: self.apiClient, binLookupType: self.binLookupType)
+                        self.binLookupService = service
+                        useService(service)
+                    case .failure:
+                        fallback()
+                    }
+                }
+            }
         }
     }
 

--- a/AdyenCheckout/Checkout.swift
+++ b/AdyenCheckout/Checkout.swift
@@ -62,7 +62,7 @@ public final class Checkout: CheckoutProtocol {
 
     // TODO: Robert: The next task in public key fetching is to ensure that components are passed with this publicKey. and they don't fetch the key themselves.
     /// The client public key used for encrypting sensitive payment data.
-    internal let publicKey: String
+    internal let publicKey: PublicKeyFetchingProgramFlow
 
     internal let configuration: CheckoutConfiguration
     internal weak var presentationDelegate: PresentationDelegate?
@@ -166,7 +166,7 @@ public final class Checkout: CheckoutProtocol {
         session: SessionProtocol? = nil,
         paymentMethods: PaymentMethods? = nil,
         checkoutAttemptId: String?,
-        publicKey: String,
+        publicKey: PublicKeyFetchingProgramFlow,
         presentationDelegate: PresentationDelegate?
     ) {
         self.configuration = configuration

--- a/AdyenCheckout/Checkout.swift
+++ b/AdyenCheckout/Checkout.swift
@@ -62,7 +62,7 @@ public final class Checkout: CheckoutProtocol {
 
     // TODO: Robert: The next task in public key fetching is to ensure that components are passed with this publicKey. and they don't fetch the key themselves.
     /// The client public key used for encrypting sensitive payment data.
-    internal let publicKey: String?
+    internal let publicKey: String
 
     internal let configuration: CheckoutConfiguration
     internal weak var presentationDelegate: PresentationDelegate?
@@ -166,7 +166,7 @@ public final class Checkout: CheckoutProtocol {
         session: SessionProtocol? = nil,
         paymentMethods: PaymentMethods? = nil,
         checkoutAttemptId: String?,
-        publicKey: String? = nil,
+        publicKey: String,
         presentationDelegate: PresentationDelegate?
     ) {
         self.configuration = configuration
@@ -203,6 +203,7 @@ public extension Checkout {
         return CheckoutPaymentComponent(
             paymentMethod: paymentMethod,
             configuration: configuration,
+            publicKey: publicKey,
             delegate: self
         )
     }
@@ -232,6 +233,7 @@ public extension Checkout {
         return CheckoutPaymentComponent(
             storedPaymentMethod: storedPaymentMethod,
             configuration: configuration,
+            publicKey: publicKey,
             delegate: self
         )
     }

--- a/AdyenCheckout/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/CheckoutComponentBuilder.swift
@@ -20,7 +20,7 @@ internal enum CheckoutComponentBuilder {
     internal static func build(
         for paymentMethod: PaymentMethod,
         configuration: CheckoutConfiguration,
-        publicKey: String
+        publicKey: PublicKeyFetchingProgramFlow
     ) -> PaymentComponent {
         
         // Assembly layer
@@ -107,7 +107,7 @@ internal enum CheckoutComponentBuilder {
         using factory: Factory,
         paymentMethod: Factory.Method,
         configuration: CheckoutConfiguration,
-        publicKey: String
+        publicKey: PublicKeyFetchingProgramFlow
     ) -> PaymentComponent where Factory.Configuration: CheckoutComponentConfiguration {
         
         var componentConfiguration = configuration.configuration(

--- a/AdyenCheckout/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/CheckoutComponentBuilder.swift
@@ -19,7 +19,8 @@ internal enum CheckoutComponentBuilder {
     
     internal static func build(
         for paymentMethod: PaymentMethod,
-        configuration: CheckoutConfiguration
+        configuration: CheckoutConfiguration,
+        publicKey: String
     ) -> PaymentComponent {
         
         // Assembly layer
@@ -31,14 +32,16 @@ internal enum CheckoutComponentBuilder {
                 return createComponent(
                     using: BLIKComponentFactory(),
                     paymentMethod: blikPaymentMethod,
-                    configuration: configuration
+                    configuration: configuration,
+                    publicKey: publicKey
                 )
             
             case let achPaymentMethod as ACHDirectDebitPaymentMethod:
                 return createComponent(
                     using: ACHDirectDebitComponentFactory(),
                     paymentMethod: achPaymentMethod,
-                    configuration: configuration
+                    configuration: configuration,
+                    publicKey: publicKey
                 )
         #endif
             
@@ -48,7 +51,8 @@ internal enum CheckoutComponentBuilder {
                 return createComponent(
                     using: CardComponentFactory(),
                     paymentMethod: cardPaymentMethod,
-                    configuration: configuration
+                    configuration: configuration,
+                    publicKey: publicKey
                 )
                 // TODO: add other card methods like stored or write a generic one.
             
@@ -102,7 +106,8 @@ internal enum CheckoutComponentBuilder {
     private static func createComponent<Factory: PaymentComponentFactory>(
         using factory: Factory,
         paymentMethod: Factory.Method,
-        configuration: CheckoutConfiguration
+        configuration: CheckoutConfiguration,
+        publicKey: String
     ) -> PaymentComponent where Factory.Configuration: CheckoutComponentConfiguration {
         
         var componentConfiguration = configuration.configuration(
@@ -116,7 +121,8 @@ internal enum CheckoutComponentBuilder {
         return factory.create(
             with: paymentMethod,
             context: configuration.context,
-            configuration: componentConfiguration
+            configuration: componentConfiguration,
+            publicKey: publicKey
         )
     }
 }

--- a/AdyenCheckout/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/CheckoutComponentBuilder.swift
@@ -69,7 +69,8 @@ internal enum CheckoutComponentBuilder {
     /// Builds stored payment components.
     internal static func build(
         for storedPaymentMethod: StoredPaymentMethod,
-        configuration: CheckoutConfiguration
+        configuration: CheckoutConfiguration,
+        publicKey: PublicKeyFetchingProgramFlow
     ) -> PaymentComponent {
         
         // TODO: stored components requires no configuration
@@ -81,7 +82,8 @@ internal enum CheckoutComponentBuilder {
             case let storedCard as StoredCardPaymentMethod:
                 StoredCardComponent(
                     storedCardPaymentMethod: storedCard,
-                    context: configuration.context
+                    context: configuration.context,
+                    publicKey: publicKey
                 )
         #endif
             

--- a/AdyenCheckout/CheckoutPaymentComponent.swift
+++ b/AdyenCheckout/CheckoutPaymentComponent.swift
@@ -29,7 +29,9 @@ public final class CheckoutPaymentComponent {
     private var configuration: CheckoutConfiguration
     
     internal weak var delegate: PaymentComponentDelegate?
-    
+
+    private var publicKey: String
+
     /// The view controller of the component.
     public var viewController: UIViewController? {
         guard let presentableComponent = paymentComponent as? PresentableComponent else {
@@ -41,24 +43,28 @@ public final class CheckoutPaymentComponent {
     package init(
         paymentMethod: PaymentMethod,
         configuration: CheckoutConfiguration,
+        publicKey: String,
         delegate: PaymentComponentDelegate?
     ) {
         self.configuration = configuration
         self.delegate = delegate
+        self.publicKey = publicKey
         // TODO: Add new v6 style here
-        self.paymentComponent = CheckoutComponentBuilder.build(for: paymentMethod, configuration: configuration)
+        self.paymentComponent = CheckoutComponentBuilder.build(for: paymentMethod, configuration: configuration, publicKey: publicKey)
         self.paymentComponent?.delegate = delegate
     }
     
     package init(
         storedPaymentMethod: StoredPaymentMethod,
         configuration: CheckoutConfiguration,
+        publicKey: String,
         delegate: PaymentComponentDelegate?
     ) {
         self.configuration = configuration
         self.delegate = delegate
+        self.publicKey = publicKey
         // TODO: Add new v6 style here
-        self.paymentComponent = CheckoutComponentBuilder.build(for: storedPaymentMethod, configuration: configuration)
+        self.paymentComponent = CheckoutComponentBuilder.build(for: storedPaymentMethod, configuration: configuration, publicKey: publicKey)
         self.paymentComponent?.delegate = delegate
     }
 }

--- a/AdyenCheckout/CheckoutPaymentComponent.swift
+++ b/AdyenCheckout/CheckoutPaymentComponent.swift
@@ -30,7 +30,7 @@ public final class CheckoutPaymentComponent {
     
     internal weak var delegate: PaymentComponentDelegate?
 
-    private var publicKey: String
+    private var publicKey: PublicKeyFetchingProgramFlow
 
     /// The view controller of the component.
     public var viewController: UIViewController? {
@@ -43,7 +43,7 @@ public final class CheckoutPaymentComponent {
     package init(
         paymentMethod: PaymentMethod,
         configuration: CheckoutConfiguration,
-        publicKey: String,
+        publicKey: PublicKeyFetchingProgramFlow,
         delegate: PaymentComponentDelegate?
     ) {
         self.configuration = configuration
@@ -57,7 +57,7 @@ public final class CheckoutPaymentComponent {
     package init(
         storedPaymentMethod: StoredPaymentMethod,
         configuration: CheckoutConfiguration,
-        publicKey: String,
+        publicKey: PublicKeyFetchingProgramFlow,
         delegate: PaymentComponentDelegate?
     ) {
         self.configuration = configuration

--- a/AdyenCheckout/CheckoutProvider.swift
+++ b/AdyenCheckout/CheckoutProvider.swift
@@ -60,7 +60,7 @@ internal class CheckoutProvider: CheckoutProviding {
             configuration: configuration,
             session: session,
             checkoutAttemptId: checkoutAttemptId,
-            publicKey: publicKey,
+            publicKey: .prefetched(publicKey),
             presentationDelegate: presentationDelegate
         )
     }
@@ -93,7 +93,7 @@ internal class CheckoutProvider: CheckoutProviding {
             configuration: configuration,
             paymentMethods: paymentMethods,
             checkoutAttemptId: checkoutAttemptId,
-            publicKey: publicKey,
+            publicKey: .prefetched(publicKey),
             presentationDelegate: presentationDelegate
         )
     }
@@ -121,7 +121,7 @@ internal class CheckoutProvider: CheckoutProviding {
         return try await Checkout(
             configuration: configuration,
             checkoutAttemptId: checkoutAttemptId,
-            publicKey: publicKey,
+            publicKey: .prefetched(publicKey),
             presentationDelegate: presentationDelegate
         )
     }

--- a/AdyenCheckout/CheckoutProvider.swift
+++ b/AdyenCheckout/CheckoutProvider.swift
@@ -49,7 +49,7 @@ internal class CheckoutProvider: CheckoutProviding {
         )
 
         // TODO: Robert: Note here we are using try? do we already want to fail here if in the 0.0001% of the change that there is a failure. (I assume yes?)
-        async let publicKey = try? await publicKeyProvider.fetchPublicKey(
+        async let publicKey = try await publicKeyProvider.fetchPublicKey(
             apiClient: apiClient,
             clientKey: configuration.context.apiContext.clientKey
         )
@@ -84,12 +84,12 @@ internal class CheckoutProvider: CheckoutProviding {
 
         let apiClient = APIClient(apiContext: configuration.context.apiContext)
 
-        async let publicKey = try? await publicKeyProvider.fetchPublicKey(
+        async let publicKey = try await publicKeyProvider.fetchPublicKey(
             apiClient: apiClient,
             clientKey: configuration.context.apiContext.clientKey
         )
 
-        return await Checkout(
+        return try await Checkout(
             configuration: configuration,
             paymentMethods: paymentMethods,
             checkoutAttemptId: checkoutAttemptId,
@@ -113,12 +113,12 @@ internal class CheckoutProvider: CheckoutProviding {
         
         let apiClient = APIClient(apiContext: configuration.context.apiContext)
 
-        async let publicKey = try? await publicKeyProvider.fetchPublicKey(
+        async let publicKey = try await publicKeyProvider.fetchPublicKey(
             apiClient: apiClient,
             clientKey: configuration.context.apiContext.clientKey
         )
 
-        return await Checkout(
+        return try await Checkout(
             configuration: configuration,
             checkoutAttemptId: checkoutAttemptId,
             publicKey: publicKey,

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -31,7 +31,7 @@ package final class ACHDirectDebitComponent: PaymentComponent,
     
     /// The context object for this component.
     package let context: AdyenContext
-    
+
     package var paymentMethod: PaymentMethod {
         achDirectDebitPaymentMethod
     }
@@ -54,7 +54,9 @@ package final class ACHDirectDebitComponent: PaymentComponent,
     )
     
     package let publicKeyProvider: AnyPublicKeyProvider
-    
+
+    package let publicKey: PublicKeyFetchingProgramFlow
+
     private var defaultCountryCode: String {
         payment?.countryCode ?? configuration.billingAddressCountryCodes.first ?? "US"
     }
@@ -71,12 +73,14 @@ package final class ACHDirectDebitComponent: PaymentComponent,
     package convenience init(
         paymentMethod: ACHDirectDebitPaymentMethod,
         context: AdyenContext,
+        publicKey: PublicKeyFetchingProgramFlow,
         configuration: ACHDirectDebitComponentConfiguration = .init()
     ) {
         self.init(
             paymentMethod: paymentMethod,
             context: context,
             configuration: configuration,
+            publicKey: publicKey,
             publicKeyProvider: PublicKeyProvider(apiContext: context.apiContext)
         )
     }
@@ -85,11 +89,13 @@ package final class ACHDirectDebitComponent: PaymentComponent,
         paymentMethod: ACHDirectDebitPaymentMethod,
         context: AdyenContext,
         configuration: ACHDirectDebitComponentConfiguration = .init(),
+        publicKey: PublicKeyFetchingProgramFlow,
         publicKeyProvider: AnyPublicKeyProvider
     ) {
         self.configuration = configuration
         self.achDirectDebitPaymentMethod = paymentMethod
         self.context = context
+        self.publicKey = publicKey
         self.configuration = configuration
         self.publicKeyProvider = publicKeyProvider
     }
@@ -108,9 +114,14 @@ package final class ACHDirectDebitComponent: PaymentComponent,
         guard validate() else { return }
         
         startLoading()
-        
-        fetchCardPublicKey(notifyingDelegateOnFailure: true) { [weak self] publicKey in
-            self?.submitEncryptedData(publicKey: publicKey)
+        switch publicKey {
+        case let .prefetched(publicKey):
+            submitEncryptedData(publicKey: publicKey)
+
+        case .notFetched:
+            fetchCardPublicKey(notifyingDelegateOnFailure: true) { [weak self] publicKey in
+                self?.submitEncryptedData(publicKey: publicKey)
+            }
         }
     }
     
@@ -326,8 +337,13 @@ extension ACHDirectDebitComponent: ViewControllerDelegate {
     package func viewDidLoad(viewController: UIViewController) {
         sendInitialAnalytics()
         sendDidLoadEvent()
-        // just cache the public key value
-        fetchCardPublicKey(notifyingDelegateOnFailure: false)
+        switch publicKey {
+        case .prefetched:
+            break
+        case .notFetched:
+            // just cache the public key value
+            fetchCardPublicKey(notifyingDelegateOnFailure: false)
+        }
     }
 }
 

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponentFactory.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponentFactory.swift
@@ -33,6 +33,7 @@ package struct ACHDirectDebitComponentFactory: PaymentComponentFactory {
         ACHDirectDebitComponent(
             paymentMethod: paymentMethod,
             context: context,
+            publicKey: .notFetched,
             configuration: configuration
         )
     }

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponentFactory.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponentFactory.swift
@@ -27,7 +27,8 @@ package struct ACHDirectDebitComponentFactory: PaymentComponentFactory {
     package func create(
         with paymentMethod: ACHDirectDebitPaymentMethod,
         context: AdyenContext,
-        configuration: ACHDirectDebitComponentConfiguration
+        configuration: ACHDirectDebitComponentConfiguration,
+        publicKey: String
     ) -> ACHDirectDebitComponent {
         ACHDirectDebitComponent(
             paymentMethod: paymentMethod,

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponentFactory.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponentFactory.swift
@@ -28,7 +28,7 @@ package struct ACHDirectDebitComponentFactory: PaymentComponentFactory {
         with paymentMethod: ACHDirectDebitPaymentMethod,
         context: AdyenContext,
         configuration: ACHDirectDebitComponentConfiguration,
-        publicKey: String
+        publicKey: PublicKeyFetchingProgramFlow
     ) -> ACHDirectDebitComponent {
         ACHDirectDebitComponent(
             paymentMethod: paymentMethod,

--- a/AdyenComponents/BLIK/BLIKComponentFactory.swift
+++ b/AdyenComponents/BLIK/BLIKComponentFactory.swift
@@ -27,7 +27,8 @@ package struct BLIKComponentFactory: PaymentComponentFactory {
     package func create(
         with paymentMethod: BLIKPaymentMethod,
         context: AdyenContext,
-        configuration: BLIKComponentConfiguration
+        configuration: BLIKComponentConfiguration,
+        publicKey: String
     ) -> BLIKComponent {
         BLIKComponent(
             paymentMethod: paymentMethod,

--- a/AdyenComponents/BLIK/BLIKComponentFactory.swift
+++ b/AdyenComponents/BLIK/BLIKComponentFactory.swift
@@ -28,7 +28,7 @@ package struct BLIKComponentFactory: PaymentComponentFactory {
         with paymentMethod: BLIKPaymentMethod,
         context: AdyenContext,
         configuration: BLIKComponentConfiguration,
-        publicKey: String
+        publicKey: PublicKeyFetchingProgramFlow
     ) -> BLIKComponent {
         BLIKComponent(
             paymentMethod: paymentMethod,

--- a/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
+++ b/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
@@ -317,7 +317,7 @@ private extension ComponentManager {
         return CardComponent(
             paymentMethod: paymentMethod,
             context: context,
-            publicKey: "BOB",
+            publicKey: .notFetched,
             configuration: cardConfiguration
         )
     }
@@ -331,7 +331,7 @@ private extension ComponentManager {
         return BCMCComponent(
             paymentMethod: paymentMethod,
             context: context,
-            publicKey: "BOB",
+            publicKey: .notFetched,
             configuration: cardConfiguration
         )
     }

--- a/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
+++ b/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
@@ -317,6 +317,7 @@ private extension ComponentManager {
         return CardComponent(
             paymentMethod: paymentMethod,
             context: context,
+            publicKey: "BOB",
             configuration: cardConfiguration
         )
     }
@@ -330,6 +331,7 @@ private extension ComponentManager {
         return BCMCComponent(
             paymentMethod: paymentMethod,
             context: context,
+            publicKey: "BOB",
             configuration: cardConfiguration
         )
     }

--- a/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
+++ b/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
@@ -164,6 +164,7 @@ extension ComponentManager: PaymentComponentBuilder {
             context: context,
             amount: amount,
             style: configuration.style.formComponent,
+            publicKey: .notFetched,
             showsSecurityCodeField: configuration.giftCard.showsSecurityCodeField
         )
     }
@@ -175,6 +176,7 @@ extension ComponentManager: PaymentComponentBuilder {
             context: context,
             amount: amount,
             style: configuration.style.formComponent,
+            publicKey: .notFetched,
             showsSecurityCodeField: configuration.giftCard.showsSecurityCodeField
         )
     }
@@ -408,6 +410,7 @@ private extension ComponentManager {
         return ACHDirectDebitComponent(
             paymentMethod: paymentMethod,
             context: context,
+            publicKey: .notFetched,
             configuration: config
         )
     }


### PR DESCRIPTION
**Problem:** 
So in V6 public key is fetched during the initialization/building. 
1. This needs to be passed down to the components
2. Many components are initiated in flows withtout the Checkout root object. So the public key will not available in that flow. 

**Approach**
To ensure that Drop in flow still works.
Created a temporary type `PublicKeyProgramFlow` which has 2 states, `fetched` & `prefetched`.
`fetched` - from the flow using the v6 code. i.e. `Checkout`
`notFetched` - a flow where the public key is not available during creation eg: Dropin flow. 

**Future**
Once all code is migrated to being constructed using the Checkout root object. Then `notFetched` will not be used anymore in the code and then we can remove `PublicKeyProvider`, `PublicKeyConsumer` and remove the need of this enum `PublicKeyProgramFlow`.

TODO: I haven't updated the tests, if this approach seems acceptable then i'll update the tests accordingly. 