### PR TITLE
Remove unnecessary available(iOS) checks below 15

### DIFF
--- a/Adyen/Helpers/TimeIntervalHelpers.swift
+++ b/Adyen/Helpers/TimeIntervalHelpers.swift
@@ -18,27 +18,6 @@ public extension AdyenScope where Base == TimeInterval {
     /// Transform `TimeInterval` to a `String` with either "MM:SS" or "HH:MM:SS" depending
     /// on whether number of full hours is bigger than 0
     func timeLeftString() -> String? {
-        if #available(iOS 13.0, *) {
-            return postIOS13TimeString()
-        } else {
-            return preIOS13TimeString()
-        }
-    }
-    
-    private func preIOS13TimeString() -> String {
-        let intValue = Int(base)
-        let seconds = intValue % 60
-        let minutes = (intValue / 60) % 60
-        let hours = intValue / 60 / 60
-        let format = "%02d"
-        
-        return [hours > 0 ? hours : nil, minutes, seconds]
-            .compactMap { $0 }
-            .map { String(format: format, $0) }
-            .joined(separator: ":")
-    }
-    
-    private func postIOS13TimeString() -> String? {
         let formatter = DateComponentsFormatter()
         formatter.zeroFormattingBehavior = [.dropLeading, .pad]
         formatter.allowedUnits = [.hour, .minute, .second]

--- a/Adyen/Helpers/UIApplicationHelpers.swift
+++ b/Adyen/Helpers/UIApplicationHelpers.swift
@@ -8,12 +8,8 @@ import UIKit
 
 public extension AdyenScope where Base: UIApplication {
     var mainKeyWindow: UIWindow? {
-        if #available(iOS 13, *) {
-            return base.connectedScenes
-                .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
-                .first { $0.isKeyWindow }
-        } else {
-            return base.keyWindow
-        }
+        base.connectedScenes
+            .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+            .first { $0.isKeyWindow }
     }
 }

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UIStackViewHelper.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UIStackViewHelper.swift
@@ -27,9 +27,7 @@ extension UIStackView {
         
         if withBackground {
             let subView = UIView(frame: view.bounds)
-            if #available(iOS 13.0, *) {
-                subView.backgroundColor = UIColor.secondarySystemBackground
-            }
+            subView.backgroundColor = UIColor.secondarySystemBackground
             subView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             self.insertSubview(subView, at: 0)
             subView.layer.cornerRadius = 10.0

--- a/AdyenCard/Components/Card/CardDetails.swift
+++ b/AdyenCard/Components/Card/CardDetails.swift
@@ -104,11 +104,7 @@ public struct CardDetails: PaymentMethodDetails, ShopperInformation {
     
     private static func createDelegatedAuthenticationData() -> DelegatedAuthenticationData? {
         #if canImport(AdyenAuthentication)
-            if #available(iOS 14.0, *) {
-                return (try? DeviceSupportChecker().checkSupport()).map { DelegatedAuthenticationData.sdkOutput($0) }
-            } else {
-                return nil
-            }
+            return (try? DeviceSupportChecker().checkSupport()).map { DelegatedAuthenticationData.sdkOutput($0) }
         #else
             return nil
         #endif

--- a/AdyenCard/Components/Card/CardScannerController.swift
+++ b/AdyenCard/Components/Card/CardScannerController.swift
@@ -117,8 +117,7 @@ internal protocol CardScannerControlling: CardScannerAvailability {
         }
 
         internal var isScannerAvailable: Bool {
-            guard #available(iOS 13.0, *) else { return false }
-            return availabilityProvider.isScannerAvailable
+            availabilityProvider.isScannerAvailable
         }
 
         internal func openCardScanner() {

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -32,7 +32,7 @@ internal class CardViewController: FormViewController {
     private let allowedCoBadgedCardTypes: [CardType] = [.carteBancaire, .bcmc, .dankort]
     private let cardScannerAnalyticsHandler: CardScannerAnalyticsHandler
     private lazy var cardScannerController: CardScannerControlling = {
-        let controller: CardScannerControlling = CardScannerController(presenter: self, analyticsHandler: cardScannerAnalyticsHandler)
+        var controller: CardScannerControlling = CardScannerController(presenter: self, analyticsHandler: cardScannerAnalyticsHandler)
         controller.title = localizedString(.cardScanYourCardButton, localizationParameters)
         controller.onScanComplete = { [weak self] result in
             self?.handleCardScanningResult(result)

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -32,7 +32,7 @@ internal class CardViewController: FormViewController {
     private let allowedCoBadgedCardTypes: [CardType] = [.carteBancaire, .bcmc, .dankort]
     private let cardScannerAnalyticsHandler: CardScannerAnalyticsHandler
     private lazy var cardScannerController: CardScannerControlling = {
-        var controller: CardScannerControlling = CardScannerController(presenter: self, analyticsHandler: cardScannerAnalyticsHandler)
+        let controller: CardScannerControlling = CardScannerController(presenter: self, analyticsHandler: cardScannerAnalyticsHandler)
         controller.title = localizedString(.cardScanYourCardButton, localizationParameters)
         controller.onScanComplete = { [weak self] result in
             self?.handleCardScanningResult(result)

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -32,12 +32,7 @@ internal class CardViewController: FormViewController {
     private let allowedCoBadgedCardTypes: [CardType] = [.carteBancaire, .bcmc, .dankort]
     private let cardScannerAnalyticsHandler: CardScannerAnalyticsHandler
     private lazy var cardScannerController: CardScannerControlling = {
-        var controller: CardScannerControlling
-        if #available(iOS 13.0, *) {
-            controller = CardScannerController(presenter: self, analyticsHandler: cardScannerAnalyticsHandler)
-        } else {
-            controller = DummyCardScannerController(presenter: self, analyticsHandler: cardScannerAnalyticsHandler)
-        }
+        var controller: CardScannerControlling = CardScannerController(presenter: self, analyticsHandler: cardScannerAnalyticsHandler)
         controller.title = localizedString(.cardScanYourCardButton, localizationParameters)
         controller.onScanComplete = { [weak self] result in
             self?.handleCardScanningResult(result)

--- a/AdyenCard/Form/FormCardNumberItemView+ScanCard.swift
+++ b/AdyenCard/Form/FormCardNumberItemView+ScanCard.swift
@@ -23,9 +23,7 @@ extension FormCardNumberItemView {
         scanButton.setTitle(title, for: .normal)
         scanButton.tintColor = .systemBlue
 
-        if #available(iOS 13.0, *) {
-            scanButton.setImage(UIImage(systemName: Constants.imageName), for: .normal)
-        }
+        scanButton.setImage(UIImage(systemName: Constants.imageName), for: .normal)
         
         scanButton.imageView?.contentMode = .scaleAspectFit
         scanButton.contentHorizontalAlignment = .center

--- a/AdyenCardScanner.podspec
+++ b/AdyenCardScanner.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/Adyen/adyen-ios.git', :tag => '5.20.0' }
   s.source_files = 'AdyenCardScanner/**/*.swift'
   s.framework = 'Foundation'
-  s.ios.deployment_target = '12.0'
-  s.swift_version = '5.7'
+  s.ios.deployment_target = '15.0'
+  s.swift_version = '5.9'
 
   s.pod_target_xcconfig = { 
     'DEFINES_MODULE' => 'YES',

--- a/AdyenCardScanner/Sources/CaptureSessionManager.swift
+++ b/AdyenCardScanner/Sources/CaptureSessionManager.swift
@@ -18,7 +18,6 @@ internal protocol CaptureSessionDelegate: AnyObject {
     func didCapture(image: CIImage?)
 }
 
-@available(iOS 13.0, *)
 internal protocol CaptureSessionManaging {
     var delegate: CaptureSessionDelegate? { get set }
     func requestCaptureAuthorization() async -> CaptureAuthorizationStatus
@@ -29,7 +28,6 @@ internal protocol CaptureSessionManaging {
     var videoPreviewLayer: AVCaptureVideoPreviewLayer { get }
 }
 
-@available(iOS 13.0, *)
 internal class CaptureSessionManager: NSObject, CaptureSessionManaging {
 
     private enum Constants {
@@ -175,7 +173,6 @@ internal class CaptureSessionManager: NSObject, CaptureSessionManaging {
     }
 }
 
-@available(iOS 13.0, *)
 extension CaptureSessionManager: AVCaptureVideoDataOutputSampleBufferDelegate {
 
     func captureOutput(

--- a/AdyenCardScanner/Sources/CardImageParser.swift
+++ b/AdyenCardScanner/Sources/CardImageParser.swift
@@ -15,7 +15,6 @@ internal protocol CardImageParsing {
     )
 }
 
-@available(iOS 13.0, *)
 internal class CardImageParser: CardImageParsing {
 
     private enum Constants {
@@ -162,7 +161,6 @@ private extension String {
     }
 }
 
-@available(iOS 13.0, *)
 private extension CIImage {
 
     func applyNoiseReductionFilter() -> CIImage? {

--- a/AdyenCardScanner/Sources/CardScanner.swift
+++ b/AdyenCardScanner/Sources/CardScanner.swift
@@ -15,8 +15,6 @@ public typealias CardScanDetails = (number: String?, expirationDate: Date?)
 /// Use `createCardScanner(localizationBundle:completion:)` to present the scanner and `isAvailable` to check device support.
 /// Ensure `NSCameraUsageDescription` is set in your `Info.plist`.
 ///
-/// - Availability: iOS 13.0+
-@available(iOS 13.0, *)
 public enum CardScanner {
 
     // MARK: - Properties

--- a/AdyenCardScanner/Sources/CardScannerAssembler.swift
+++ b/AdyenCardScanner/Sources/CardScannerAssembler.swift
@@ -15,7 +15,6 @@ internal protocol CardScannerAssembling {
     ) -> UIViewController?
 }
 
-@available(iOS 13.0, *)
 internal class CardScannerAssembler: CardScannerAssembling {
 
     // MARK: - Initializers

--- a/AdyenCardScanner/Sources/CardScannerOverlayView.swift
+++ b/AdyenCardScanner/Sources/CardScannerOverlayView.swift
@@ -6,7 +6,6 @@
 
 import UIKit
 
-@available(iOS 13.0, *)
 internal class CardScannerOverlayView: UIView {
 
     private enum Style {

--- a/AdyenCardScanner/Sources/CardScannerViewController.swift
+++ b/AdyenCardScanner/Sources/CardScannerViewController.swift
@@ -13,7 +13,6 @@ internal protocol CardScannerPresenting: AnyObject {
     func presentCameraAccessDeniedAlert()
 }
 
-@available(iOS 13.0, *)
 internal class CardScannerViewController: UIViewController, CardScannerPresenting {
 
     // MARK: - UI elements

--- a/AdyenCardScanner/Sources/CardScannerViewModel.swift
+++ b/AdyenCardScanner/Sources/CardScannerViewModel.swift
@@ -24,7 +24,6 @@ internal protocol CardScannerViewModelProtocol {
     var cameraAlertCancelButtonTitle: String { get }
 }
 
-@available(iOS 13.0, *)
 internal class CardScannerViewModel: CardScannerViewModelProtocol {
 
     // MARK: - Properties
@@ -173,7 +172,6 @@ internal class CardScannerViewModel: CardScannerViewModelProtocol {
 
 // MARK: - CaptureSessionDelegate
 
-@available(iOS 13.0, *)
 extension CardScannerViewModel: CaptureSessionDelegate {
 
     internal func didCapture(image: CIImage?) {
@@ -192,7 +190,6 @@ extension CardScannerViewModel: CaptureSessionDelegate {
 
 // MARK: - Localization
 
-@available(iOS 13.0, *)
 extension CardScannerViewModel {
 
     private enum LocalizationKey: String {

--- a/AdyenCardScanner/Sources/Protocols/AppOpener.swift
+++ b/AdyenCardScanner/Sources/Protocols/AppOpener.swift
@@ -8,11 +8,9 @@ import Foundation
 import UIKit
 
 internal protocol AppOpener {
-    @available(iOS 13.0, *)
     func openSettingsApp() async
 }
 
-@available(iOS 13.0, *)
 extension UIApplication: AppOpener {
     func openSettingsApp() async {
         guard let settingsAppURL = URL(string: UIApplication.openSettingsURLString) else {

--- a/AdyenComponents/Apple Pay/ApplePayComponentDelegate.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentDelegate.swift
@@ -25,7 +25,6 @@ public protocol ApplePayComponentDelegate: AnyObject {
     )
 
     /// Tells the delegate that the shopper entered or updated a coupon code.
-    @available(iOS 15.0, *)
     func didUpdate(
         couponCode: String,
         for summaryItems: [PKPaymentSummaryItem],

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -102,7 +102,6 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         }
     }
 
-    @available(iOS 15.0, *)
     public func paymentAuthorizationViewController(
         _ controller: PKPaymentAuthorizationViewController,
         didChangeCouponCode couponCode: String,

--- a/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
+++ b/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
@@ -257,23 +257,19 @@ extension ComponentManager: PaymentComponentBuilder {
                 )
                 return nil
             }
-            if #available(iOS 13.0, *) {
-                var cashAppPayConfiguration = CashAppPayConfiguration(
-                    redirectURL: cashAppPayDropInConfig.redirectURL,
-                    referenceId: cashAppPayDropInConfig.referenceId
-                )
-                cashAppPayConfiguration.showsStorePaymentMethodField = cashAppPayDropInConfig.showsStorePaymentMethodField
-                cashAppPayConfiguration.localizationParameters = configuration.localizationParameters
-                cashAppPayConfiguration.style = configuration.style.formComponent
-        
-                return CashAppPayComponent(
-                    paymentMethod: paymentMethod,
-                    context: context,
-                    configuration: cashAppPayConfiguration
-                )
-            } else {
-                return nil
-            }
+            var cashAppPayConfiguration = CashAppPayConfiguration(
+                redirectURL: cashAppPayDropInConfig.redirectURL,
+                referenceId: cashAppPayDropInConfig.referenceId
+            )
+            cashAppPayConfiguration.showsStorePaymentMethodField = cashAppPayDropInConfig.showsStorePaymentMethodField
+            cashAppPayConfiguration.localizationParameters = configuration.localizationParameters
+            cashAppPayConfiguration.style = configuration.style.formComponent
+    
+            return CashAppPayComponent(
+                paymentMethod: paymentMethod,
+                context: context,
+                configuration: cashAppPayConfiguration
+            )
         #else
             return nil
         #endif

--- a/AdyenDropIn/Views/PreApplePayView.swift
+++ b/AdyenDropIn/Views/PreApplePayView.swift
@@ -29,16 +29,7 @@ internal final class PreApplePayView: UIView, Localizable {
     
     /// Creates PKPaymentButtonStyle based on Dark or Light Mode.
     private var paymentButtonStyleAuto: PKPaymentButtonStyle {
-        if #available(iOS 14.0, *) {
-            return .automatic
-        }
-        
-        switch traitCollection.userInterfaceStyle {
-        case .dark:
-            return .white
-        default:
-            return .black
-        }
+        .automatic
     }
     
     internal init(model: Model) {

--- a/AdyenUI/UI/Helpers/UIViewRoundingHelpers.swift
+++ b/AdyenUI/UI/Helpers/UIViewRoundingHelpers.swift
@@ -52,9 +52,7 @@ public extension AdyenScope where Base: UIView {
     /// - Parameters:
     ///   - radius: The radius of each corner oval.
     func round(using rounding: CornerRounding) {
-        if #available(iOS 13.0, *) {
-            base.layer.cornerCurve = .continuous
-        }
+        base.layer.cornerCurve = .continuous
         
         switch rounding {
         case let .fixed(value):

--- a/AdyenUI/UI/List/ListCell.swift
+++ b/AdyenUI/UI/List/ListCell.swift
@@ -113,11 +113,7 @@ public final class ListCell: UITableViewCell {
     }
     
     private var activityIndicatorViewStyle: UIActivityIndicatorView.Style {
-        if #available(iOS 13.0, *) {
-            return .medium
-        } else {
-            return .gray
-        }
+        .medium
     }
     
     // MARK: - Item View

--- a/AdyenUI/UI/Styles/CoreColors.swift
+++ b/AdyenUI/UI/Styles/CoreColors.swift
@@ -17,67 +17,35 @@ extension UIColor {
         }
 
         public static var componentBackground: UIColor {
-            if #available(iOS 13.0, *) {
-                return .systemBackground
-            } else {
-                return .white
-            }
+            .systemBackground
         }
         
         public static var secondaryComponentBackground: UIColor {
-            if #available(iOS 13.0, *) {
-                return .secondarySystemBackground
-            } else {
-                return color(hex: 0xF8F9F9)
-            }
+            .secondarySystemBackground
         }
 
         public static var componentLabel: UIColor {
-            if #available(iOS 13.0, *) {
-                return .label
-            } else {
-                return .black
-            }
+            .label
         }
 
         public static var componentSecondaryLabel: UIColor {
-            if #available(iOS 13.0, *) {
-                return .secondaryLabel
-            } else {
-                return .darkGray
-            }
+            .secondaryLabel
         }
 
         public static var componentTertiaryLabel: UIColor {
-            if #available(iOS 13.0, *) {
-                return .tertiaryLabel
-            } else {
-                return .gray
-            }
+            .tertiaryLabel
         }
 
         public static var componentQuaternaryLabel: UIColor {
-            if #available(iOS 13.0, *) {
-                return .quaternaryLabel
-            } else {
-                return .lightGray
-            }
+            .quaternaryLabel
         }
 
         public static var componentPlaceholderText: UIColor {
-            if #available(iOS 13.0, *) {
-                return .placeholderText
-            } else {
-                return .gray
-            }
+            .placeholderText
         }
 
         public static var componentSeparator: UIColor {
-            if #available(iOS 13.0, *) {
-                return .separator
-            } else {
-                return UIColor(white: 0.0, alpha: 0.2)
-            }
+            .separator
         }
 
         public static var componentLoadingMessageColor: UIColor {

--- a/AdyenUI/UI/ToolBar/ModalToolbar.swift
+++ b/AdyenUI/UI/ToolBar/ModalToolbar.swift
@@ -175,12 +175,8 @@ public class ModalToolbar: UIView, AnyNavigationBar {
             button = UIButton(type: UIButton.ButtonType.custom)
             button.setImage(image, for: .normal)
         default:
-            if #available(iOS 13.0, *) {
-                button = UIButton(type: UIButton.ButtonType.close)
-                button.widthAnchor.constraint(equalTo: button.heightAnchor).isActive = true
-            } else {
-                return legacy()
-            }
+            button = UIButton(type: UIButton.ButtonType.close)
+            button.widthAnchor.constraint(equalTo: button.heightAnchor).isActive = true
         }
 
         return button

--- a/AdyenUI/UI/View Controllers/AddressLookup/Form/AddressInputFormViewController.swift
+++ b/AdyenUI/UI/View Controllers/AddressLookup/Form/AddressInputFormViewController.swift
@@ -24,9 +24,7 @@ public class AddressInputFormViewController: FormViewController {
         
         title = viewModel.title
         
-        if #available(iOS 13.0, *) {
-            isModalInPresentation = true
-        }
+        isModalInPresentation = true
         
         if viewModel.shouldShowSearch {
             append(searchButtonItem)

--- a/AdyenUI/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController.swift
+++ b/AdyenUI/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController.swift
@@ -39,9 +39,7 @@ internal class AddressLookupSearchViewController: SearchViewController {
             emptyView: emptyView
         )
         
-        if #available(iOS 13.0, *) {
-            isModalInPresentation = true
-        }
+        isModalInPresentation = true
         
         title = localizedString(.billingAddressSectionTitle, viewModel.localizationParameters)
         

--- a/AdyenUI/UI/Views/FormButton.swift
+++ b/AdyenUI/UI/Views/FormButton.swift
@@ -189,11 +189,7 @@ public final class FormButton: UIControl {
     }()
     
     private var activityIndicatorStyle: UIActivityIndicatorView.Style {
-        if #available(iOS 13.0, *) {
-            return .medium
-        } else {
-            return .white
-        }
+        .medium
     }
     
     // MARK: - Layout

--- a/AdyenUI/UI/Views/LoadingView.swift
+++ b/AdyenUI/UI/Views/LoadingView.swift
@@ -20,11 +20,7 @@ public final class LoadingView: UIControl {
     }()
     
     private var activityIndicatorStyle: UIActivityIndicatorView.Style {
-        if #available(iOS 13.0, *) {
-            return .large
-        } else {
-            return .whiteLarge
-        }
+        .large
     }
 
     private let contentView: UIView

--- a/Demo/Common/Configuration/AnalyticsSettingsView.swift
+++ b/Demo/Common/Configuration/AnalyticsSettingsView.swift
@@ -6,7 +6,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0.0, *)
 internal struct AnalyticsSettingsView: View {
     @ObservedObject internal var viewModel: ConfigurationViewModel
 

--- a/Demo/Common/Configuration/ApplePaySettingsView.swift
+++ b/Demo/Common/Configuration/ApplePaySettingsView.swift
@@ -6,7 +6,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0.0, *)
 internal struct ApplePaySettingsView: View {
     @ObservedObject internal var viewModel: ConfigurationViewModel
 

--- a/Demo/Common/Configuration/CardComponentSettingsView.swift
+++ b/Demo/Common/Configuration/CardComponentSettingsView.swift
@@ -8,7 +8,6 @@ import Adyen
 import AdyenCard
 import SwiftUI
 
-@available(iOS 13.0.0, *)
 internal struct CardSettingsView: View {
     @ObservedObject internal var viewModel: ConfigurationViewModel
     

--- a/Demo/Common/Configuration/ConfigurationView.swift
+++ b/Demo/Common/Configuration/ConfigurationView.swift
@@ -7,7 +7,6 @@
 import Adyen
 import SwiftUI
 
-@available(iOS 13.0.0, *)
 internal struct ConfigurationView: View {
     
     private enum ConfigurationSection: String, CaseIterable {
@@ -209,7 +208,6 @@ internal struct ConfigurationView: View {
     
 }
 
-@available(iOS 13.0.0, *)
 internal struct TextFieldItemView: View {
 
     internal let title: String
@@ -235,7 +233,6 @@ internal struct TextFieldItemView: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 private struct ListItemView<T: Hashable>: View {
     let viewModel: ViewModel<T>
     
@@ -253,7 +250,6 @@ private struct ListItemView<T: Hashable>: View {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension CountryDisplayInfo {
     fileprivate var toListItemViewModel: ListItemView<String>.ViewModel<String> {
         ListItemView.ViewModel(
@@ -276,7 +272,6 @@ extension CountryDisplayInfo {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension CurrencyDisplayInfo {
     fileprivate var toListItemViewModel: ListItemView<String>.ViewModel<String> {
         ListItemView.ViewModel(title: code, subtitle: symbol, tag: code)
@@ -288,7 +283,6 @@ extension CurrencyDisplayInfo {
     }
 }
 
-@available(iOS 13.0.0, *)
 extension Picker {
     @ViewBuilder
     fileprivate func navigationLinkStyle() -> some View {

--- a/Demo/Common/Configuration/ConfigurationViewModel.swift
+++ b/Demo/Common/Configuration/ConfigurationViewModel.swift
@@ -7,8 +7,6 @@
 import AdyenCard
 import SwiftUI
 
-@available(iOS 13.0.0, *)
-
 internal final class ConfigurationViewModel: ObservableObject {
     
     @Published internal var countryCode: String = ""

--- a/Demo/Common/Configuration/DropInSettingsView.swift
+++ b/Demo/Common/Configuration/DropInSettingsView.swift
@@ -8,7 +8,6 @@ import Adyen
 import AdyenCard
 import SwiftUI
 
-@available(iOS 13.0.0, *)
 internal struct DropInSettingsView: View {
     @ObservedObject internal var viewModel: ConfigurationViewModel
 

--- a/Demo/Common/Configuration/SearchBar.swift
+++ b/Demo/Common/Configuration/SearchBar.swift
@@ -6,7 +6,6 @@
 
 import SwiftUI
 
-@available(iOS 13.0.0, *)
 internal struct SearchBar: UIViewRepresentable {
 
     @Binding private var searchString: String

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
@@ -175,7 +175,6 @@ extension ApplePayComponentAdvancedFlowExample: ApplePayComponentDelegate {
         completion(.init(paymentSummaryItems: items))
     }
 
-    @available(iOS 15.0, *)
     func didUpdate(
         couponCode: String,
         for summaryItems: [PKPaymentSummaryItem],

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -359,9 +359,7 @@ internal extension PKPaymentRequest {
         paymentRequest.requiredShippingContactFields = [.postalAddress]
         paymentRequest.requiredBillingContactFields = [.postalAddress]
         paymentRequest.shippingMethods = ConfigurationConstants.shippingMethods
-        if #available(iOS 15.0, *) {
-            paymentRequest.supportsCouponCode = true
-        }
+        paymentRequest.supportsCouponCode = true
         return paymentRequest
     }
 }

--- a/Demo/UIKit/ComponentsView.swift
+++ b/Demo/UIKit/ComponentsView.swift
@@ -51,33 +51,17 @@ internal final class ComponentsView: UIView {
     // MARK: - Loading
     
     private lazy var activityIndicator: UIActivityIndicatorView = {
-        let activityIndicator: UIActivityIndicatorView
-        if #available(iOS 13.0, *) {
-            activityIndicator = UIActivityIndicatorView(style: .large)
-        } else {
-            activityIndicator = UIActivityIndicatorView(style: .whiteLarge)
-        }
+        let activityIndicator = UIActivityIndicatorView(style: .large)
         activityIndicator.hidesWhenStopped = true
-        
-        if #available(iOS 13.0, *) {
-            activityIndicator.color = .label
-            activityIndicator.backgroundColor = .systemGroupedBackground.withAlphaComponent(0.7)
-        } else {
-            activityIndicator.backgroundColor = .black.withAlphaComponent(0.3)
-        }
-        
+        activityIndicator.color = .label
+        activityIndicator.backgroundColor = .systemGroupedBackground.withAlphaComponent(0.7)
         return activityIndicator
     }()
     
     // MARK: - Table View
     
     private lazy var tableView: UITableView = {
-        var tableViewStyle = UITableView.Style.grouped
-        if #available(iOS 13.0, *) {
-            tableViewStyle = .insetGrouped
-        }
-        
-        let tableView = UITableView(frame: .zero, style: tableViewStyle)
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
         tableView.dataSource = self
         tableView.delegate = self
         tableView.rowHeight = 56.0
@@ -129,18 +113,7 @@ internal final class ComponentsView: UIView {
     }
     
     private func setUpApplePayCell(_ cell: UITableViewCell) {
-        let style: PKPaymentButtonStyle = {
-            if #available(iOS 14.0, *) {
-                return .automatic
-            }
-            
-            switch traitCollection.userInterfaceStyle {
-            case .dark:
-                return .white
-            default:
-                return .black
-            }
-        }()
+        let style: PKPaymentButtonStyle = .automatic
         
         let contentView = cell.contentView
         
@@ -182,9 +155,7 @@ extension ComponentsView: UITableViewDataSource {
             cell.textLabel?.text = item.title
             
             cell.detailTextLabel?.font = .preferredFont(forTextStyle: .caption1)
-            if #available(iOS 13.0, *) {
-                cell.detailTextLabel?.textColor = .secondaryLabel
-            }
+            cell.detailTextLabel?.textColor = .secondaryLabel
             cell.detailTextLabel?.adjustsFontForContentSizeCategory = true
             cell.detailTextLabel?.text = item.subtitle
         } else {

--- a/Demo/UIKit/ComponentsViewController.swift
+++ b/Demo/UIKit/ComponentsViewController.swift
@@ -125,9 +125,7 @@ internal final class ComponentsViewController: UIViewController {
             [ComponentsItem(title: "Apple Pay", selectionHandler: presentApplePayComponent)]
         ]
         
-        if #available(iOS 13.0.0, *) {
-            addConfigurationButton()
-        }
+        addConfigurationButton()
     }
     
     // MARK: - Private
@@ -253,9 +251,8 @@ extension UIViewController {
     }
 }
 
-// MARK: - Configuration, iOS13+
+// MARK: - Configuration
 
-@available(iOS 13.0.0, *)
 extension ComponentsViewController {
     
     private func addConfigurationButton() {

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/AuthenticationServiceMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/AuthenticationServiceMock.swift
@@ -8,7 +8,6 @@ import Foundation
 #if canImport(AdyenAuthentication)
     import AdyenAuthentication
 
-    @available(iOS 14.0, *)
     internal final class AuthenticationServiceMock: AuthenticationServiceProtocol {
         func registeredCredentials(withAuthenticationInput input: String) async throws -> [String] {
             []

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -36,11 +36,7 @@ class ApplePayComponentTest: XCTestCase {
             configuration: configuration
         )
         mockDelegate = PaymentComponentDelegateMock()
-        if #available(iOS 15.0, *) {
-            mockApplePayDelegate = ApplePayDelegateMockiOS15()
-        } else {
-            mockApplePayDelegate = ApplePayDelegateMockClassic()
-        }
+        mockApplePayDelegate = ApplePayDelegateMock()
         mockAuthorizationDelegate = ApplePayAuthorizationDelegateMock()
     }
 
@@ -291,13 +287,8 @@ class ApplePayComponentTest: XCTestCase {
     }
 
     func testApplePayCoupon() throws {
-        guard #available(iOS 15.0, *) else {
-            // XCTestCase does not respect @available so we have to skip the test like this
-            throw XCTSkip("Unsupported iOS version")
-        }
-
         sut.applePayDelegate = mockApplePayDelegate
-        (mockApplePayDelegate as! ApplePayDelegateMockiOS15).onCouponChange = { coupon, payment in
+        mockApplePayDelegate.onCouponChange = { coupon, payment in
             .init(paymentSummaryItems: [
                 PKPaymentSummaryItem(label: "New Item 1", amount: 1111),
                 PKPaymentSummaryItem(label: "New Item 2", amount: 2222)
@@ -388,12 +379,8 @@ class ApplePayComponentTest: XCTestCase {
     }
 
     func testApplePayCoupon_givenDelegateReturnsEmptyItems_shouldKeepOriginalItems() throws {
-        guard #available(iOS 15.0, *) else {
-            throw XCTSkip("Unsupported iOS version")
-        }
-
         sut.applePayDelegate = mockApplePayDelegate
-        (mockApplePayDelegate as! ApplePayDelegateMockiOS15).onCouponChange = { _, _ in
+        mockApplePayDelegate.onCouponChange = { _, _ in
             .init(paymentSummaryItems: [])
         }
 

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDelegateMock.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayDelegateMock.swift
@@ -7,44 +7,7 @@
 import AdyenComponents
 import PassKit
 
-protocol ApplePayDelegateMock: ApplePayComponentDelegate {
-    var contact: PKContact? { get }
-    var shippingMethod: PKShippingMethod? { get }
-    var couponCode: String? { get }
-
-    var onShippingContactChange: ((PKContact, [PKPaymentSummaryItem]) -> PKPaymentRequestShippingContactUpdate)? { get set }
-    var onShippingMethodChange: ((PKShippingMethod, [PKPaymentSummaryItem]) -> PKPaymentRequestShippingMethodUpdate)? { get set }
-}
-
-final class ApplePayDelegateMockClassic: ApplePayDelegateMock {
-
-    var contact: PKContact?
-    var shippingMethod: PKShippingMethod?
-    var couponCode: String?
-
-    var onShippingContactChange: ((PKContact, [PKPaymentSummaryItem]) -> PKPaymentRequestShippingContactUpdate)?
-    var onShippingMethodChange: ((PKShippingMethod, [PKPaymentSummaryItem]) -> PKPaymentRequestShippingMethodUpdate)?
-
-    func didUpdate(contact: PKContact, for summaryItems: [PKPaymentSummaryItem], completion: @escaping (PKPaymentRequestShippingContactUpdate) -> Void) {
-        self.contact = contact
-        let result = onShippingContactChange!(contact, summaryItems)
-        completion(result)
-    }
-
-    func didUpdate(shippingMethod: PKShippingMethod, for summaryItems: [PKPaymentSummaryItem], completion: @escaping (PKPaymentRequestShippingMethodUpdate) -> Void) {
-        self.shippingMethod = shippingMethod
-        let result = onShippingMethodChange!(shippingMethod, summaryItems)
-        completion(result)
-    }
-
-    @available(iOS 15.0, *)
-    func didUpdate(couponCode: String, for summaryItems: [PKPaymentSummaryItem], completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void) {
-        fatalError("Use ApplePayDelegateMockiOS15")
-    }
-}
-
-@available(iOS 15.0, *)
-final class ApplePayDelegateMockiOS15: ApplePayDelegateMock {
+final class ApplePayDelegateMock: ApplePayComponentDelegate {
 
     var contact: PKContact?
     var shippingMethod: PKShippingMethod?
@@ -67,7 +30,6 @@ final class ApplePayDelegateMockiOS15: ApplePayDelegateMock {
         completion(result)
     }
 
-    @available(iOS 15.0, *)
     func didUpdate(couponCode: String, for summaryItems: [PKPaymentSummaryItem], completion: @escaping (PKPaymentRequestCouponCodeUpdate) -> Void) {
         self.couponCode = couponCode
         let result = onCouponChange!(couponCode, summaryItems)


### PR DESCRIPTION
# Summary [Required]
Now that min version support is iOS 15, we are removing the `#available...` checks up to 15.

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
