### PR TITLE
Main actor adoption: PaymentComponents 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,7 @@ excluded:
   - DerivedData
   - TempProject
   - Scripts
+  - build
 
 line_length:
   ignores_function_declarations: true

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -465,8 +465,6 @@
 		A01DFBBF2BA887BF00205881 /* ThreadSafeAnalyticsEventDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01DFBBE2BA887BF00205881 /* ThreadSafeAnalyticsEventDataSource.swift */; };
 		A01DFBC52BB6F9FA00205881 /* ValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01DFBC42BB6F9FA00205881 /* ValidationError.swift */; };
 		A01DFBC72BB6FBF800205881 /* CardValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01DFBC62BB6FBF800205881 /* CardValidationError.swift */; };
-		A020EC4829E6EC4B0050B2FE /* AdyenCashAppPay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A04F8C1E29E5950100F3F62B /* AdyenCashAppPay.framework */; };
-		A020EC4929E6EC4B0050B2FE /* AdyenCashAppPay.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A04F8C1E29E5950100F3F62B /* AdyenCashAppPay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A020EC4F29E6ECBD0050B2FE /* PayKit in Frameworks */ = {isa = PBXBuildFile; productRef = A020EC4E29E6ECBD0050B2FE /* PayKit */; };
 		A020EC5A29ED33F90050B2FE /* CashAppPayComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A020EC5929ED33F90050B2FE /* CashAppPayComponentTests.swift */; };
 		A023A9B428103C2D004FDCA4 /* session_response.json in Resources */ = {isa = PBXBuildFile; fileRef = A023A9B328103C2D004FDCA4 /* session_response.json */; };
@@ -513,6 +511,8 @@
 		A03056E82E016D9A00ED7014 /* CheckoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03056E72E016D9A00ED7014 /* CheckoutTests.swift */; };
 		A03056EA2E1284ED00ED7014 /* SessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03056E92E1284E500ED7014 /* SessionProtocol.swift */; };
 		A03056EB2E016DA000ED7014 /* CheckoutAttemptIdProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03056EC2E016DA000ED7014 /* CheckoutAttemptIdProviderTests.swift */; };
+		A03EBF3F2F605803008AE601 /* AdyenCashAppPay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A04F8C1E29E5950100F3F62B /* AdyenCashAppPay.framework */; };
+		A03EBF402F605803008AE601 /* AdyenCashAppPay.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A04F8C1E29E5950100F3F62B /* AdyenCashAppPay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A03EE72F2760A2E300470561 /* DocumentActionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03EE72E2760A2E300470561 /* DocumentActionViewModel.swift */; };
 		A03EE7312761297800470561 /* DocumentComponentStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03EE7302761297800470561 /* DocumentComponentStyle.swift */; };
 		A03EE73327612BF300470561 /* DocumentActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03EE73227612BF300470561 /* DocumentActionView.swift */; };
@@ -1834,6 +1834,7 @@
 			files = (
 				F9175EEF2593955D00D653BE /* AdyenComponents.framework in Embed Frameworks */,
 				F92327C525A46EF0002C5BC4 /* AdyenEncryption.framework in Embed Frameworks */,
+				A03EBF402F605803008AE601 /* AdyenCashAppPay.framework in Embed Frameworks */,
 				E72375D927AABF400020DCF9 /* AdyenWeChatPay.framework in Embed Frameworks */,
 				F973A91A2791C3B0005AA753 /* AdyenActions.framework in Embed Frameworks */,
 				E2C0E099220B0827008616F6 /* Adyen.framework in Embed Frameworks */,
@@ -1844,7 +1845,6 @@
 				A0F749972D958B3000014A05 /* AdyenCheckout.framework in Embed Frameworks */,
 				E2C0E0AE220B0840008616F6 /* AdyenCard.framework in Embed Frameworks */,
 				F92980AD27CE2B33000CA5CA /* AdyenSession.framework in Embed Frameworks */,
-				A020EC4929E6EC4B0050B2FE /* AdyenCashAppPay.framework in Embed Frameworks */,
 				003BDD222E15200A009177E0 /* AdyenUI.framework in Embed Frameworks */,
 				B605AC122D8D988D0084D583 /* AdyenCardScanner.framework in Embed Frameworks */,
 			);
@@ -3175,10 +3175,10 @@
 				81A91AC22BEC12A2001E00C8 /* TwintSDK.xcframework in Frameworks */,
 				F9A2D01225DBF104008944BE /* PassKit.framework in Frameworks */,
 				F973A9192791C3B0005AA753 /* AdyenActions.framework in Frameworks */,
+				A03EBF3F2F605803008AE601 /* AdyenCashAppPay.framework in Frameworks */,
 				E2C0E098220B0827008616F6 /* Adyen.framework in Frameworks */,
 				F92980AC27CE2B33000CA5CA /* AdyenSession.framework in Frameworks */,
 				F94D65E72B036A450095D61E /* AdyenDelegatedAuthentication.framework in Frameworks */,
-				A020EC4829E6EC4B0050B2FE /* AdyenCashAppPay.framework in Frameworks */,
 				A0F749962D958B3000014A05 /* AdyenCheckout.framework in Frameworks */,
 				81BDD6CE2B21CE6C0022250E /* AdyenAuthentication in Frameworks */,
 				E9B36CB22243B2FF00EAA368 /* AdyenDropIn.framework in Frameworks */,
@@ -10379,7 +10379,7 @@
 				CODE_SIGN_ENTITLEMENTS = Demo/Shared.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 8GDUWCHDXJ;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Demo/UIKit/Info.plist;

--- a/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
+++ b/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
@@ -8,6 +8,7 @@ import Foundation
 import UIKit
 
 /// A component that wraps any `Component` to make it a `PresentableComponent`.
+@MainActor
 package final class PresentableComponentWrapper: PresentableComponent,
     Cancellable,
     FinalizableComponent,
@@ -34,7 +35,7 @@ package final class PresentableComponentWrapper: PresentableComponent,
     /// - Parameter component: The wrapped component.
     /// - Parameter viewController: The `ViewController` used as the UI of the `PresentableComponent`.
     /// - Parameter navBarType: Type of the navigation bar to use.
-    package init(
+    package nonisolated init(
         component: Component,
         viewController: UIViewController,
         navBarType: NavigationBarType = .regular

--- a/Adyen/Core/Components/ComponentFactory.swift
+++ b/Adyen/Core/Components/ComponentFactory.swift
@@ -11,6 +11,7 @@ import Foundation
 /// Each factory is responsible for creating a single type of payment component
 /// with its corresponding configuration.
 ///
+@MainActor
 package protocol PaymentComponentFactory {
     
     /// The configuration type required by this factory to create components.

--- a/Adyen/Core/Components/InstantPaymentComponent.swift
+++ b/Adyen/Core/Components/InstantPaymentComponent.swift
@@ -6,12 +6,14 @@
 
 import Foundation
 
+@MainActor
 public protocol InitiablePaymentComponent: PaymentComponent {
     /// Initiate the payment flow
     func initiatePayment(delegate: PaymentComponentDelegate)
 }
 
 /// A component that handles payment methods that don't need any payment detail to be filled.
+@MainActor
 public final class InstantPaymentComponent: InitiablePaymentComponent {
 
     /// The context object for this component.

--- a/Adyen/Core/Components/StoredPaymentMethodComponent.swift
+++ b/Adyen/Core/Components/StoredPaymentMethodComponent.swift
@@ -9,6 +9,7 @@ import UIKit
 
 // TODO: Fix Stored PM UI
 ///  A component that handle stored payment methods.
+@MainActor
 public final class StoredPaymentMethodComponent: StoredPaymentComponent {
 
     package var localizationParameters: LocalizationParameters?

--- a/Adyen/Core/Configuration/CheckoutBaseCallbacks.swift
+++ b/Adyen/Core/Configuration/CheckoutBaseCallbacks.swift
@@ -10,8 +10,6 @@ import Foundation
 public typealias PaymentsResponseHandler = (_ response: CheckoutPaymentsResponse) -> Void
 public typealias SubmitHandler = (_ data: PaymentComponentData, _ handler: PaymentsResponseHandler?) -> Void
 public typealias AdditionalDetailsHandler = (_ data: ActionComponentData, _ handler: PaymentsResponseHandler?) -> Void
-// TODO: Have a checkout error object?
-// add component as parameter to callbacks?
 public typealias CheckoutErrorHandler = (_ error: Error) -> Void
 public typealias CheckoutSuccessHandler = (_ result: CheckoutResult) -> Void
 

--- a/Adyen/Core/Core Protocols/DropInComponentDelegate.swift
+++ b/Adyen/Core/Core Protocols/DropInComponentDelegate.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 /// Defines the methods a delegate of the drop in component should implement.
+@MainActor
 public protocol DropInComponentDelegate: AnyObject {
     
     /// Invoked when a payment method is selected and the initial details have been filled.

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -24,6 +24,7 @@ public enum PaymentComponentType {
 }
 
 /// A component that handles the initial phase of getting payment details to initiate a payment.
+@MainActor
 public protocol PaymentComponent: Component, PartialPaymentOrderAware, PaymentMethodAware {
     
     /// The delegate of the payment component.
@@ -97,6 +98,7 @@ extension PaymentComponent {
 }
 
 /// Describes the methods a delegate of the payment component needs to implement.
+@MainActor
 public protocol PaymentComponentDelegate: AnyObject {
     
     /// Invoked when the shopper submits the data needed for the payments call.

--- a/Adyen/Core/Core Protocols/PresentableComponent.swift
+++ b/Adyen/Core/Core Protocols/PresentableComponent.swift
@@ -35,6 +35,7 @@ public enum NavigationBarType {
 }
 
 /// A component that provides a view controller for the shopper to fill payment details.
+@MainActor
 public protocol PresentableComponent: Component {
     
     /// Returns a view controller that presents the payment details for the shopper to fill.

--- a/Adyen/Core/Core Protocols/ReadyToSubmitPaymentComponentDelegate.swift
+++ b/Adyen/Core/Core Protocols/ReadyToSubmitPaymentComponentDelegate.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 /// The delegate that handles shopper confirmation UI when the balance of the gift card is sufficient to pay.
+@MainActor
 public protocol ReadyToSubmitPaymentComponentDelegate: AnyObject {
 
     /// Called when the payment component is ready to submit shopper details,

--- a/Adyen/Utilities/PublicKeyProvider/PublicKeyConsumer.swift
+++ b/Adyen/Utilities/PublicKeyProvider/PublicKeyConsumer.swift
@@ -32,7 +32,10 @@ extension PublicKeyConsumer where Self: PaymentComponent {
                 successHandler?(key)
             case let .failure(error):
                 if notifyingDelegateOnFailure {
-                    self.delegate?.didFail(with: error, from: self)
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        self.delegate?.didFail(with: error, from: self)
+                    }
                 }
             }
         }

--- a/AdyenActions/Components/Redirect/BrowserComponent.swift
+++ b/AdyenActions/Components/Redirect/BrowserComponent.swift
@@ -14,6 +14,7 @@ internal protocol BrowserComponentDelegate: AnyObject {
 }
 
 /// A component that opens a URL in web browsed and presents it.
+@MainActor
 internal final class BrowserComponent: NSObject, PresentableComponent {
 
     /// :nodoc
@@ -38,7 +39,7 @@ internal final class BrowserComponent: NSObject, PresentableComponent {
         return safariViewController
     }()
     
-    internal weak var delegate: BrowserComponentDelegate?
+    internal nonisolated(unsafe) weak var delegate: BrowserComponentDelegate?
     
     @AdyenDependency(\.openAppDetector) private var openAppDetector
     
@@ -47,7 +48,7 @@ internal final class BrowserComponent: NSObject, PresentableComponent {
     /// - Parameter url: The URL to where the user should be redirected
     /// - Parameter context: The context object for this component.
     /// - Parameter style: The component's UI style.
-    internal init(
+    internal nonisolated init(
         url: URL,
         context: AdyenContext,
         style: RedirectComponentStyle? = nil

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -18,6 +18,7 @@ import UIKit
  - SeeAlso:
  [Implementation guidelines](https://docs.adyen.com/payment-methods/cards/ios-component)
  */
+@MainActor
 public class CardComponent: PresentableComponent,
     PaymentMethodAware,
     LoadingComponent {

--- a/AdyenCard/Components/Card/CardComponentFactory.swift
+++ b/AdyenCard/Components/Card/CardComponentFactory.swift
@@ -11,6 +11,7 @@
 ///
 /// This factory is generic over any payment method that conforms to `AnyCardPaymentMethod`,
 /// allowing it to handle regular cards, stored cards, and BCMC payments.
+@MainActor
 package struct CardComponentFactory<CardMethod: AnyCardPaymentMethod>: PaymentComponentFactory {
     
     package typealias Method = CardMethod

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -14,6 +14,7 @@
 import UIKit
 
 /// A component that provides a form for gift card payments.
+@MainActor
 public final class GiftCardComponent: PresentableComponent,
     Localizable,
     LoadingComponent,

--- a/AdyenCard/Components/Stored Card/StoredCardComponent.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardComponent.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 
 /// A component that provides a form for stored card payments.
+@MainActor
 package final class StoredCardComponent: StoredPaymentComponent, Localizable {
 
     /// The context object for this component.

--- a/AdyenCashAppPay/CashAppPayComponent.swift
+++ b/AdyenCashAppPay/CashAppPayComponent.swift
@@ -13,6 +13,7 @@ import PayKitUI
 import UIKit
 
 /// A component that handles a Cash App Pay payment.
+@MainActor
 public final class CashAppPayComponent: PaymentComponent,
     PresentableComponent,
     LoadingComponent {

--- a/AdyenCheckout/Checkout.swift
+++ b/AdyenCheckout/Checkout.swift
@@ -51,6 +51,7 @@ import Foundation
 /// ```swift
 /// let component = checkout.createPaymentComponent(for: .scheme)
 /// ```
+@MainActor
 public final class Checkout: CheckoutProtocol {
     
     /// The available payment methods for this checkout session.

--- a/AdyenCheckout/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/CheckoutComponentBuilder.swift
@@ -17,6 +17,7 @@
 
 internal enum CheckoutComponentBuilder {
     
+    @MainActor
     internal static func build(
         for paymentMethod: PaymentMethod,
         configuration: CheckoutConfiguration,
@@ -35,7 +36,6 @@ internal enum CheckoutComponentBuilder {
                     configuration: configuration,
                     context: context
                 )
-            
             case let achPaymentMethod as ACHDirectDebitPaymentMethod:
                 return createComponent(
                     using: ACHDirectDebitComponentFactory(),
@@ -67,6 +67,7 @@ internal enum CheckoutComponentBuilder {
     }
     
     /// Builds stored payment components.
+    @MainActor
     internal static func build(
         for storedPaymentMethod: StoredPaymentMethod,
         configuration: CheckoutConfiguration,
@@ -104,6 +105,7 @@ internal enum CheckoutComponentBuilder {
     ///   - paymentMethod: The payment method to create a component for.
     ///   - configuration: The checkout configuration.
     /// - Returns: A configured payment component.
+    @MainActor
     private static func createComponent<Factory: PaymentComponentFactory>(
         using factory: Factory,
         paymentMethod: Factory.Method,

--- a/AdyenCheckout/CheckoutPaymentComponent.swift
+++ b/AdyenCheckout/CheckoutPaymentComponent.swift
@@ -22,6 +22,7 @@ import UIKit
 /// ```swift
 /// component.submit()
 /// ```
+@MainActor
 public final class CheckoutPaymentComponent {
     
     internal let paymentComponent: PaymentComponent?

--- a/AdyenCheckout/CheckoutProtocol.swift
+++ b/AdyenCheckout/CheckoutProtocol.swift
@@ -13,6 +13,7 @@
 #endif
 import AdyenNetworking
 
+@MainActor
 internal protocol CheckoutProtocol {
     
     func createPaymentComponent(for type: PaymentMethodType) -> CheckoutPaymentComponent?

--- a/AdyenCheckout/CheckoutProvider.swift
+++ b/AdyenCheckout/CheckoutProvider.swift
@@ -70,7 +70,7 @@ internal class CheckoutProvider: CheckoutProviding {
 
         let adyenContext = try await setupAdyenContext(configuration: configuration, apiClient: apiClient)
 
-        return Checkout(
+        return await Checkout(
             configuration: configuration,
             paymentMethods: paymentMethods,
             adyenContext: adyenContext,
@@ -91,7 +91,7 @@ internal class CheckoutProvider: CheckoutProviding {
 
         let adyenContext = try await setupAdyenContext(configuration: configuration, apiClient: apiClient)
 
-        return Checkout(
+        return await Checkout(
             configuration: configuration,
             adyenContext: adyenContext,
             presentationDelegate: presentationDelegate

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -14,6 +14,7 @@
 import UIKit
 
 /// A component that provides a form for ACH Direct Debit payment.
+@MainActor
 package final class ACHDirectDebitComponent: PaymentComponent,
     PresentableComponent,
     LoadingComponent {

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponentFactory.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponentFactory.swift
@@ -10,6 +10,7 @@
 ///
 /// This factory creates `ACHDirectDebitComponent` instances configured with the
 /// provided ACH payment method and component configuration.
+@MainActor
 package struct ACHDirectDebitComponentFactory: PaymentComponentFactory {
     package typealias Configuration = ACHDirectDebitComponentConfiguration
     package typealias Method = ACHDirectDebitPaymentMethod

--- a/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
+++ b/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
@@ -12,6 +12,7 @@ import UIKit
 
 /// An abstract class that needs to be subclassed to abstract away any component
 /// who's form consists of a combination of personal information pieces like first name, last name, phone, email, and billing address.
+@MainActor
 open class AbstractPersonalInformationComponent: PaymentComponent, PresentableComponent {
 
     public typealias Configuration = PersonalInformationConfiguration
@@ -287,6 +288,7 @@ extension AbstractPersonalInformationComponent: ViewControllerPresenter {
 
 @_spi(AdyenInternal)
 extension AbstractPersonalInformationComponent: ViewControllerDelegate {
+
     // MARK: - ViewControllerDelegate
 
     public func viewWillAppear(viewController: UIViewController) {

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -9,6 +9,7 @@ import Foundation
 import PassKit
 
 /// A component that handles Apple Pay payments.
+@MainActor
 public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent, FinalizableComponent {
 
     internal let paymentRequest: PKPaymentRequest

--- a/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
+++ b/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
@@ -16,6 +16,7 @@ internal protocol BACSDirectDebitRouterProtocol: AnyObject {
 }
 
 /// A component that provides a form for BACS Direct Debit payments.
+@MainActor
 public final class BACSDirectDebitComponent: PaymentComponent, PresentableComponent {
 
     /// Configuration for BACS Direct Debit Component.

--- a/AdyenComponents/BLIK/BLIKComponent.swift
+++ b/AdyenComponents/BLIK/BLIKComponent.swift
@@ -12,6 +12,7 @@ import UIKit
 #endif
 
 /// A component that provides a form for BLIK payments.
+@MainActor
 public final class BLIKComponent: PaymentComponent, PresentableComponent, LoadingComponent {
     
     /// The context object for this component.

--- a/AdyenComponents/BLIK/BLIKComponentFactory.swift
+++ b/AdyenComponents/BLIK/BLIKComponentFactory.swift
@@ -10,6 +10,7 @@
 ///
 /// This factory creates `BLIKComponent` instances configured with the
 /// provided BLIK payment method and component configuration.
+@MainActor
 package struct BLIKComponentFactory: PaymentComponentFactory {
     package typealias Configuration = BLIKComponentConfiguration
     package typealias Method = BLIKPaymentMethod

--- a/AdyenComponents/Boleto/BoletoComponent.swift
+++ b/AdyenComponents/Boleto/BoletoComponent.swift
@@ -12,6 +12,7 @@ import Foundation
 import UIKit
 
 /// A component that provides a form for Boleto payment.
+@MainActor
 public final class BoletoComponent: PaymentComponent,
     LoadingComponent,
     PresentableComponent,

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -13,6 +13,7 @@ import UIKit
 
 /// A generic component for "issuer-based" payment methods, such as MOLPay.
 /// This component will provide a list in which the user can select their issuer.
+@MainActor
 public final class IssuerListComponent: PaymentComponent, PresentableComponent, LoadingComponent {
     
     private enum Constants {

--- a/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
+++ b/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
@@ -11,6 +11,7 @@
 import UIKit
 
 /// A component that provides a form for Online Banking payment.
+@MainActor
 public final class OnlineBankingComponent: PaymentComponent,
     PresentableComponent,
     LoadingComponent {

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent.swift
@@ -12,6 +12,7 @@ import Foundation
 import UIKit
 
 /// A component that handles a Pay by Bank US payment.
+@MainActor
 public final class PayByBankUSComponent: PaymentComponent, PresentableComponent {
 
     /// The context object for this component.

--- a/AdyenComponents/PayTo/PayToComponent.swift
+++ b/AdyenComponents/PayTo/PayToComponent.swift
@@ -11,6 +11,7 @@
 import UIKit
 
 /// A component that provides PayTo flows for PayTo component.
+@MainActor
 public final class PayToComponent: PaymentComponent, PresentableComponent, AdyenObserver, LoadingComponent {
 
     /// Configuration for PayTo Component.

--- a/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
+++ b/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
@@ -12,6 +12,7 @@ import UIKit
 #endif
 
 /// A component that provides a form for SEPA Direct Debit payments.
+@MainActor
 public final class SEPADirectDebitComponent: PaymentComponent, PresentableComponent, LoadingComponent {
     
     /// Configuration for SEPA Direct Debit Component

--- a/AdyenComponents/UPI/UPIComponent.swift
+++ b/AdyenComponents/UPI/UPIComponent.swift
@@ -11,6 +11,7 @@
 import UIKit
 
 /// A component that provides a upi flows for UPI component.
+@MainActor
 public final class UPIComponent: PaymentComponent,
     PresentableComponent,
     LoadingComponent {

--- a/AdyenDropIn/Modules/Common/Protocols/Router.swift
+++ b/AdyenDropIn/Modules/Common/Protocols/Router.swift
@@ -8,6 +8,7 @@ import Foundation
 import UIKit
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol Router: AnyObject {
     var childRouter: Router? { get }
     var rootViewController: UIViewController { get }

--- a/AdyenDropIn/Modules/Common/Utilities/ActionPresentationHelper.swift
+++ b/AdyenDropIn/Modules/Common/Utilities/ActionPresentationHelper.swift
@@ -10,6 +10,7 @@ import SafariServices
 
 /// A centralized helper to prepare an action `PresentableComponent` for presentation.
 /// Wraps the action component in `ActionWrapperViewController` only if needed.
+@MainActor
 internal enum ActionPresentationHelper {
 
     internal static func viewController(

--- a/AdyenDropIn/Modules/ComponentContainer/ComponentContainerAssembler.swift
+++ b/AdyenDropIn/Modules/ComponentContainer/ComponentContainerAssembler.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol ComponentContainerAssemblerProtocol {
     func resolveComponentContainerRouter(
         for component: PresentableComponent,
@@ -17,6 +18,7 @@ internal protocol ComponentContainerAssemblerProtocol {
     ) -> Router
 }
 
+@MainActor
 internal struct ComponentContainerAssembler: ComponentContainerAssemblerProtocol {
 
     // MARK: - Properties

--- a/AdyenDropIn/Modules/ComponentContainer/ComponentContainerRouter.swift
+++ b/AdyenDropIn/Modules/ComponentContainer/ComponentContainerRouter.swift
@@ -9,17 +9,20 @@ import Foundation
 import UIKit
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol ComponentContainerRouterListener: AnyObject {
     func didDismissComponentContainer(completion: (() -> Void)?)
 }
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol ComponentContainerRouting: AnyObject {
     func present(paymentComponent: PresentableComponent)
     func present(actionComponent: PresentableComponent, onCancel: (() -> Void)?)
     func dismiss(completion: (() -> Void)?)
 }
 
+@MainActor
 internal class ComponentContainerRouter: Router, ComponentContainerRouting {
 
     // MARK: - Properties

--- a/AdyenDropIn/Modules/ComponentContainer/ComponentContainerViewModel.swift
+++ b/AdyenDropIn/Modules/ComponentContainer/ComponentContainerViewModel.swift
@@ -9,11 +9,13 @@ import Foundation
 import UIKit
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol ComponentContainerViewModelProtocol {
     var componentViewController: UIViewController { get }
     func cancel()
 }
 
+@MainActor
 internal class ComponentContainerViewModel: ComponentContainerViewModelProtocol {
 
     // MARK: - Properties

--- a/AdyenDropIn/Modules/DropInFlowManager.swift
+++ b/AdyenDropIn/Modules/DropInFlowManager.swift
@@ -11,12 +11,14 @@
 import Foundation
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol ActionPresenter: AnyObject {
     func present(actionComponent: PresentableComponent)
     func didCancel(actionComponent: ActionComponent)
 }
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol DropInFlowManaging {
     func submit(
         _ data: PaymentComponentData,
@@ -28,6 +30,7 @@ internal protocol DropInFlowManaging {
     func handle(action: Action)
 }
 
+@MainActor
 internal class DropInFlowManager: DropInFlowManaging {
 
     // MARK: - Properties

--- a/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListAssembler.swift
+++ b/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListAssembler.swift
@@ -8,10 +8,12 @@ import Adyen
 import Foundation
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol PaymentMethodListAssemblerProtocol {
     func resolvePaymentMethodListRouter(delegate: PaymentMethodListRouterListener?) -> Router
 }
 
+@MainActor
 internal struct PaymentMethodListAssembler: PaymentMethodListAssemblerProtocol {
 
     // MARK: - Properties

--- a/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListRouter.swift
+++ b/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListRouter.swift
@@ -9,17 +9,20 @@ import Foundation
 import UIKit
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol PaymentMethodListRouterListener: AnyObject {
     func didDismissPaymentMethodList(completion: (() -> Void)?)
 }
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol PaymentMethodListRouting: AnyObject {
     func present(component: PaymentComponent, onCancel: @escaping () -> Void)
     func present(actionComponent: any PresentableComponent, onCancel: (() -> Void)?)
     func dismiss(completion: (() -> Void)?)
 }
 
+@MainActor
 internal class PaymentMethodListRouter: Router, PaymentMethodListRouting {
 
     // MARK: - Properties

--- a/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListViewModel.swift
+++ b/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListViewModel.swift
@@ -17,6 +17,7 @@ internal enum PaymentMethodListState {
 }
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol PaymentMethodListViewModelProtocol {
     var context: AdyenContext { get }
     var title: String { get }
@@ -27,6 +28,7 @@ internal protocol PaymentMethodListViewModelProtocol {
     func listItemIdentifier(for paymentMethod: PaymentMethod) -> String
 }
 
+@MainActor
 internal class PaymentMethodListViewModel: PaymentMethodListViewModelProtocol {
 
     // MARK: - Properties

--- a/AdyenDropIn/Modules/PreApplePay/PreApplePayComponent.swift
+++ b/AdyenDropIn/Modules/PreApplePay/PreApplePayComponent.swift
@@ -14,6 +14,7 @@ import UIKit
     @_spi(AdyenInternal) import AdyenComponents
 #endif
 
+@MainActor
 internal final class PreApplePayComponent: PresentableComponent,
     FinalizableComponent,
     PaymentComponent,

--- a/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodAssembler.swift
+++ b/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodAssembler.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol PreselectedPaymentMethodAssemblerProtocol {
     func resolvePreselectedPaymentMethodRouter(
         delegate: PreselectedPaymentMethodRouterListener?,
@@ -17,6 +18,7 @@ internal protocol PreselectedPaymentMethodAssemblerProtocol {
     ) -> Router
 }
 
+@MainActor
 internal struct PreselectedPaymentMethodAssembler: PreselectedPaymentMethodAssemblerProtocol {
     
     // MARK: - Properties

--- a/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodRouter.swift
+++ b/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodRouter.swift
@@ -8,11 +8,13 @@ import Adyen
 import Foundation
 import UIKit
 
+@MainActor
 internal protocol PreselectedPaymentMethodRouterListener: AnyObject {
     func didDismissPreselectedPaymentMethod(completion: (() -> Void)?)
 }
 
 // sourcery:AutoMockable
+@MainActor
 internal protocol PreselectedPaymentMethodRouting: AnyObject {
     func presentPaymentMethodList()
     func present(component: PaymentComponent, onCancel: @escaping () -> Void)
@@ -20,6 +22,7 @@ internal protocol PreselectedPaymentMethodRouting: AnyObject {
     func dismiss(completion: (() -> Void)?)
 }
 
+@MainActor
 internal class PreselectedPaymentMethodRouter: Router, PreselectedPaymentMethodRouting {
 
     // MARK: - Properties

--- a/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodViewModel.swift
+++ b/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodViewModel.swift
@@ -12,6 +12,7 @@ import UIKit
     @_spi(AdyenInternal) import AdyenUI
 #endif
 
+@MainActor
 internal protocol PreselectedPaymentMethodViewModelProtocol: AnyObject {
 
     // To Retrieve what to be displayed
@@ -35,6 +36,7 @@ internal protocol PreselectedPaymentMethodViewModelProtocol: AnyObject {
     func viewDidLoad()
 }
 
+@MainActor
 internal final class PreselectedPaymentMethodViewModel: PreselectedPaymentMethodViewModelProtocol {
 
     private enum Constants {

--- a/AdyenDropIn/Modules/Root/DropInAssembler.swift
+++ b/AdyenDropIn/Modules/Root/DropInAssembler.swift
@@ -9,6 +9,7 @@ import AdyenNetworking
 import Foundation
 import UIKit
 
+@MainActor
 internal struct DropInAssembler {
 
     // MARK: - Properties

--- a/AdyenDropIn/Modules/Root/DropInRouter.swift
+++ b/AdyenDropIn/Modules/Root/DropInRouter.swift
@@ -12,6 +12,7 @@ import UIKit
 
 internal protocol DropInRouting: Router, AnyObject {}
 
+@MainActor
 internal class DropInRouter: DropInRouting {
     
     // MARK: - Properties

--- a/AdyenDropIn/Modules/Root/DropInViewModel.swift
+++ b/AdyenDropIn/Modules/Root/DropInViewModel.swift
@@ -11,11 +11,13 @@ import Foundation
     @_spi(AdyenInternal) import AdyenActions
 #endif
 
+@MainActor
 internal protocol DropInViewModelProtocol {
     var root: DropInRoot { get }
     var title: String { get }
 }
 
+@MainActor
 internal class DropInViewModel: DropInViewModelProtocol {
 
     // MARK: - Properties

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -19,12 +19,14 @@
 #endif
 import Foundation
 
+@MainActor
 internal protocol ComponentManaging {
     var sections: [PaymentMethodsSection] { get }
     func buildComponent(for paymentMethod: PaymentMethod) -> PaymentComponent?
 }
 
 // TODO: - The ComponentManager should use the factories that Eren introduced in components.
+@MainActor
 internal final class ComponentManager: ComponentManaging {
 
     // MARK: - Properties

--- a/AdyenSession/Session+ActionComponentDelegate.swift
+++ b/AdyenSession/Session+ActionComponentDelegate.swift
@@ -51,7 +51,9 @@ extension Session {
         from component: ActionComponent,
         dropInComponent: AnyDropInComponent?
     ) {
-        (component as? PresentableComponent)?.viewController.view.isUserInteractionEnabled = false
+        MainActor.assumeIsolated {
+            (component as? PresentableComponent)?.viewController.view.isUserInteractionEnabled = false
+        }
         let request = PaymentDetailsRequest(
             sessionId: state.identifier,
             sessionData: state.data,

--- a/AdyenSession/Session+PaymentComponentDelegate.swift
+++ b/AdyenSession/Session+PaymentComponentDelegate.swift
@@ -145,19 +145,22 @@ extension Session {
         let localizationParameters = (dropInComponent as? Localizable)?.localizationParameters
         let title = localizedString(.errorTitle, localizationParameters)
         let message = localizedString(.paymentRefusedMessage, localizationParameters)
-        let alertController = UIAlertController(
-            title: title,
-            message: message,
-            preferredStyle: .alert
-        )
         
-        let doneTitle = localizedString(.dismissButton, localizationParameters)
-        let doneAction = UIAlertAction(title: doneTitle, style: .default) { _ in
-            completion()
+        Task { @MainActor in
+            let alertController = UIAlertController(
+                title: title,
+                message: message,
+                preferredStyle: .alert
+            )
+            
+            let doneTitle = localizedString(.dismissButton, localizationParameters)
+            let doneAction = UIAlertAction(title: doneTitle, style: .default) { _ in
+                completion()
+            }
+            alertController.addAction(doneAction)
+            
+            dropInComponent.viewController.present(alertController, animated: true)
         }
-        alertController.addAction(doneAction)
-        
-        dropInComponent.viewController.present(alertController, animated: true)
     }
     
     private func updateDropIn(_ dropInComponent: AnyDropInComponent, with order: PartialPaymentOrder, currentComponent: Component) {

--- a/AdyenSession/Session+StoredPaymentMethodsDelegate.swift
+++ b/AdyenSession/Session+StoredPaymentMethodsDelegate.swift
@@ -38,16 +38,18 @@ extension Session: SessionStoredPaymentMethodsDelegate {
         let message = localizedString(.errorUnknown, localizationParameters)
         let doneTitle = localizedString(.dismissButton, localizationParameters)
         
-        let alertController = UIAlertController(
-            title: title,
-            message: message,
-            preferredStyle: .alert
-        )
-        
-        let doneAction = UIAlertAction(title: doneTitle, style: .default)
-        alertController.addAction(doneAction)
-        
-        dropIn.viewController.present(alertController, animated: true)
+        Task { @MainActor in
+            let alertController = UIAlertController(
+                title: title,
+                message: message,
+                preferredStyle: .alert
+            )
+            
+            let doneAction = UIAlertAction(title: doneTitle, style: .default)
+            alertController.addAction(doneAction)
+            
+            dropIn.viewController.present(alertController, animated: true)
+        }
     }
     
     /// empty implementation of the old method

--- a/AdyenTwint/TwintComponent.swift
+++ b/AdyenTwint/TwintComponent.swift
@@ -11,6 +11,7 @@
 import TwintSDK
 
 /// A component that handles a Twint payment.
+@MainActor
 public final class TwintComponent: InitiablePaymentComponent {
 
     /// Configuration for Twint Component.

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/BLIKComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/BLIKComponentAdvancedFlowExample.swift
@@ -10,6 +10,7 @@ import AdyenCheckout
 import AdyenComponents
 import AdyenUI
 
+@MainActor
 internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowProtocol {
 
     internal weak var presenter: PresenterExampleProtocol?
@@ -32,11 +33,11 @@ internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
                 let paymentMethods = try await requestPaymentMethods(order: nil)
                 let component = try await blikComponent(from: paymentMethods)
                 self.adyenComponent = component
-                await hideLoading()
-                await present(component: component)
+                hideLoading()
+                present(component: component)
             } catch {
-                await hideLoading()
-                await handleError(error)
+                hideLoading()
+                handleError(error)
             }
         }
     }
@@ -142,17 +143,14 @@ internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
         presenter?.showLoadingIndicator()
     }
 
-    @MainActor
     private func handleError(_ error: Error) {
         presenter?.presentAlert(withTitle: "Error", message: error.localizedDescription)
     }
 
-    @MainActor
     private func hideLoading() {
         presenter?.hideLoadingIndicator()
     }
 
-    @MainActor
     private func present(component: CheckoutPaymentComponent) {
         presenter?.present(viewController: viewController(for: component), completion: nil)
     }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -10,6 +10,7 @@ import AdyenCheckout
 import AdyenUI
 import PassKit
 
+@MainActor
 internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowProtocol {
 
     internal weak var presenter: PresenterExampleProtocol?
@@ -32,11 +33,11 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
                 let paymentMethods = try await requestPaymentMethods(order: nil)
                 let component = try await cardComponent(from: paymentMethods)
                 self.adyenComponent = component
-                await hideLoading()
-                await present(component: component)
+                hideLoading()
+                present(component: component)
             } catch {
-                await hideLoading()
-                await handleError(error)
+                hideLoading()
+                handleError(error)
             }
         }
     }
@@ -161,17 +162,14 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
         presenter?.showLoadingIndicator()
     }
 
-    @MainActor
     private func handleError(_ error: Error) {
         presenter?.presentAlert(withTitle: "Error", message: error.localizedDescription)
     }
 
-    @MainActor
     private func hideLoading() {
         presenter?.hideLoadingIndicator()
     }
 
-    @MainActor
     private func present(component: CheckoutPaymentComponent) {
         presenter?.present(viewController: viewController(for: component), completion: nil)
     }

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataAdvancedFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataAdvancedFlowProtocol.swift
@@ -9,6 +9,7 @@ import struct AdyenCheckout.CheckoutConfiguration
 import AdyenNetworking
 import AdyenSession
 
+@MainActor
 internal protocol InitialDataAdvancedFlowProtocol: AnyObject {
     var context: AdyenContext { get }
     var apiClient: APIClientProtocol { get }

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
@@ -9,6 +9,7 @@ import struct AdyenCheckout.CheckoutConfiguration
 import AdyenNetworking
 import AdyenSession
 
+@MainActor
 internal protocol InitialDataFlowProtocol: AnyObject {
     var context: AdyenContext { get }
     var apiClient: APIClientProtocol { get }

--- a/Demo/Common/IntegrationExamples/Session/Components/BLIKComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/BLIKComponentExample.swift
@@ -8,6 +8,7 @@ import Adyen
 import AdyenCheckout
 import AdyenComponents
 
+@MainActor
 internal final class BLIKComponentExample: InitialDataFlowProtocol {
     
     internal weak var presenter: PresenterExampleProtocol?
@@ -28,11 +29,11 @@ internal final class BLIKComponentExample: InitialDataFlowProtocol {
                 let sessionResponse = try await requestSessionInitialInfo()
                 let component = try await self.blikComponent(from: sessionResponse)
                 self.adyenComponent = component
-                await hideLoading()
-                await present(component: component)
+                hideLoading()
+                present(component: component)
             } catch {
-                await hideLoading()
-                await handleError(error)
+                hideLoading()
+                handleError(error)
             }
         }
     }

--- a/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
@@ -10,6 +10,7 @@ import AdyenCard
 import AdyenCheckout
 import AdyenComponents
 
+@MainActor
 internal final class CardComponentExample: InitialDataFlowProtocol {
 
     // MARK: - Properties
@@ -35,11 +36,11 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
                 let sessionResponse = try await requestSessionInitialInfo()
                 let component = try await self.cardComponent(from: sessionResponse)
                 self.adyenComponent = component
-                await hideLoading()
-                await present(component: component)
+                hideLoading()
+                present(component: component)
             } catch {
-                await hideLoading()
-                await handleError(error)
+                hideLoading()
+                handleError(error)
             }
         }
     }
@@ -56,28 +57,12 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
             )
         ) {
             ConfigurationConstants.current.cardConfiguration
-                .installmentConfiguration(
-                    InstallmentConfiguration(
-                        defaultOptions: .init(
-                            monthValues: [3, 5, 7],
-                            includesRevolving: false
-                        )
-                    )
-                )
-                .billingAddressMode(
-                    .lookup(
-                        onAddressLookup: { searchTerm in
-                            await MapkitAddressLookupProvider().searchAsync(searchTerm)
-                        }
-                    )
-                )
                 .onBinChange { bin in
                     print("Here is the bin \(bin)")
                 }
                 .onBinLookup { brands in
                     print("Bin lookup response \(brands)")
                 }
-                .showsSecurityCodeField(false)
             ThreeDS2ActionConfiguration()
                 .requestorAppURL(ConfigurationConstants.returnUrl)
         }

--- a/Demo/Common/IntegrationExamples/Session/Components/IssuerListComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/IssuerListComponentExample.swift
@@ -8,6 +8,7 @@ import Adyen
 import AdyenComponents
 import AdyenSession
 
+@MainActor
 internal final class IssuerListComponentExample: InitialDataFlowProtocol {
 
     // MARK: - Properties

--- a/Demo/Common/PresentationDelegates/BACSDirectDebitPresentationDelegate.swift
+++ b/Demo/Common/PresentationDelegates/BACSDirectDebitPresentationDelegate.swift
@@ -8,6 +8,7 @@ import Adyen
 import AdyenComponents
 import Foundation
 
+@MainActor
 internal class BACSDirectDebitPresentationDelegate: PresentationDelegate {
 
     // MARK: - Properties

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests.swift
@@ -13,7 +13,7 @@ import XCTest
 #endif
 
 #if canImport(TwintSDK)
-
+    @MainActor
     final class TwintSDKActionTests: XCTestCase {
 
         override func tearDownWithError() throws {

--- a/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
@@ -51,6 +51,7 @@ extension AwaitAction: Equatable {
     }
 }
 
+@MainActor
 class AwaitComponentTests: XCTestCase {
 
     func testLocalizationWithCustomTableName() {

--- a/Tests/IntegrationTests/Actions Tests/Redirect/RedirectComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Redirect/RedirectComponentTests.swift
@@ -10,6 +10,7 @@ import AdyenNetworking
 import SafariServices
 import XCTest
 
+@MainActor
 class RedirectComponentTests: XCTestCase {
     
     override func setUp(completion: @escaping (Error?) -> Void) {

--- a/Tests/IntegrationTests/Actions Tests/Voucher/VoucherComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/VoucherComponentTests.swift
@@ -9,6 +9,7 @@
 import UIKit
 import XCTest
 
+@MainActor
 class VoucherComponentTests: XCTestCase {
 
     var sut: VoucherComponent!

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
@@ -12,6 +12,7 @@ import Adyen3DS2
 @_spi(AdyenInternal) import AdyenUI
 
 @available(iOS 16.0, *)
+@MainActor
 class ThreeDS2ComponentTests: XCTestCase {
 
     func testFullFlowRedirectSuccess() throws {

--- a/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
@@ -11,6 +11,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class BCMCComponentTests: XCTestCase {
 
     var analyticsProviderMock: AnalyticsProviderMock!

--- a/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 final class CardComponentEventTests: XCTestCase {
 
     // EVT-UC9: Component Rendered - Send Initial Event

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -11,6 +11,7 @@
 @testable import AdyenEncryption
 import XCTest
 
+@MainActor
 class CardComponentTests: XCTestCase {
 
     var context: AdyenContext {

--- a/Tests/IntegrationTests/Card Tests/CardComponentValidationTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentValidationTests.swift
@@ -11,6 +11,7 @@ import XCTest
 @testable import AdyenDropIn
 @testable import AdyenEncryption
 
+@MainActor
 class CardComponentValidationTests: XCTestCase {
 
     var context: AdyenContext {

--- a/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
@@ -8,6 +8,7 @@
 @testable @_spi(AdyenInternal) import AdyenCard
 import XCTest
 
+@MainActor
 class StoredCardComponentTests: XCTestCase {
 
     private var context = Dummy.context

--- a/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -10,6 +10,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class ACHDirectDebitComponentTests: XCTestCase {
 
     var context: AdyenContext!

--- a/Tests/IntegrationTests/Components Tests/Affirm/AffirmComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Affirm/AffirmComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class AffirmComponentTests: XCTestCase {
 
     private var paymentMethod: PaymentMethod {

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -10,6 +10,7 @@ import Contacts
 import PassKit
 import XCTest
 
+@MainActor
 class ApplePayComponentTest: XCTestCase {
 
     var mockDelegate: PaymentComponentDelegateMock!

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/PreApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/PreApplePayComponentTests.swift
@@ -11,6 +11,7 @@
 import PassKit
 import XCTest
 
+@MainActor
 class PreApplePayComponentTests: XCTestCase {
 
     var analyticsProviderMock: AnalyticsProviderMock!

--- a/Tests/IntegrationTests/Components Tests/Atome/AtomeComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Atome/AtomeComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class AtomeComponentTests: XCTestCase {
 
     private var context: AdyenContext!

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/BACSDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/BACSDirectDebitComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class BACSDirectDebitComponentTests: XCTestCase {
 
     var inputPresenter: BACSInputPresenterProtocolMock!

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/DocumentComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/DocumentComponentTests.swift
@@ -10,6 +10,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class DocumentComponentTests: XCTestCase {
     
     let action: DocumentAction = .init(downloadUrl: URL(string: "www.adyen.com")!, paymentMethodType: .bacs)

--- a/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class BLIKComponentTests: XCTestCase {
 
     lazy var paymentMethod = BLIKPaymentMethod(type: .blik, name: "test_name")

--- a/Tests/IntegrationTests/Components Tests/Boleto/BoletoComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Boleto/BoletoComponentTests.swift
@@ -10,6 +10,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class BoletoComponentTests: XCTestCase {
 
     private var method = BoletoPaymentMethod(type: .boletoBancarioSantander, name: "Boleto Bancario")

--- a/Tests/IntegrationTests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
@@ -14,6 +14,7 @@ import XCTest
     @testable import PayKit
     import UIKit
 
+    @MainActor
     final class CashAppPayComponentTests: XCTestCase {
         
         private enum ErrorOption {

--- a/Tests/IntegrationTests/Components Tests/Doku/DokuComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Doku/DokuComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class DokuComponentTests: XCTestCase {
 
     private var context: AdyenContext!

--- a/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class GiftCardComponentTests: XCTestCase {
 
     var partialPaymentDelegate: PartialPaymentDelegateMock!

--- a/Tests/IntegrationTests/Components Tests/Instant Payment/InstantPaymentComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Instant Payment/InstantPaymentComponentTests.swift
@@ -8,6 +8,7 @@
 @testable @_spi(AdyenInternal) import AdyenCard
 import XCTest
 
+@MainActor
 class InstantPaymentComponentTests: XCTestCase {
 
     private var paymentMethod: GiftCardPaymentMethod!

--- a/Tests/IntegrationTests/Components Tests/IssuerList/IssuerListComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/IssuerList/IssuerListComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class IssuerListComponentTests: XCTestCase {
 
     private var context: AdyenContext!

--- a/Tests/IntegrationTests/Components Tests/MB Way/MBWayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/MB Way/MBWayComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class MBWayComponentTests: XCTestCase {
 
     private var context: AdyenContext!

--- a/Tests/IntegrationTests/Components Tests/Online Banking/OnlineBankingComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Online Banking/OnlineBankingComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class OnlineBankingComponentTests: XCTestCase {
 
     private var context: AdyenContext!

--- a/Tests/IntegrationTests/Components Tests/PayByBankUSComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayByBankUSComponentTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable @_spi(AdyenInternal) import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
 
+@MainActor
 class PayByBankUSComponentTests: XCTestCase {
     
     let context = Dummy.context

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class PayToComponentTests: XCTestCase {
 
     var sut: PayToComponent!

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -8,6 +8,7 @@ import XCTest
 @_spi(AdyenInternal) @testable import Adyen
 @_spi(AdyenInternal) @testable import AdyenComponents
 
+@MainActor
 class PaymentComponentSubjectTests: XCTestCase {
 
     var analyticsProviderMock: AnalyticsProviderMock!

--- a/Tests/IntegrationTests/Components Tests/QRCode/QRCodeActionComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/QRCode/QRCodeActionComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class QRCodeActionComponentTests: XCTestCase {
     
     var context: AdyenContext!

--- a/Tests/IntegrationTests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class QiwiWalletComponentTests: XCTestCase {
 
     var context: AdyenContext!

--- a/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
@@ -10,6 +10,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class SEPADirectDebitComponentTests: XCTestCase {
 
     var context: AdyenContext!

--- a/Tests/IntegrationTests/Components Tests/Seven Eleven Component/BasicPersonalInfoFormComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Seven Eleven Component/BasicPersonalInfoFormComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class BasicPersonalInfoFormComponentTests: XCTestCase {
 
     lazy var paymentMethod = SevenElevenPaymentMethod(type: .econtextSevenEleven, name: "test_name")

--- a/Tests/IntegrationTests/Components Tests/Twint/TwintComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Twint/TwintComponentTests.swift
@@ -9,6 +9,7 @@
 @testable @_spi(AdyenInternal) import AdyenTwint
 import XCTest
 
+@MainActor
 class TwintComponentTests: XCTestCase {
 
     private var paymentMethod: TwintPaymentMethod!

--- a/Tests/IntegrationTests/Components Tests/UPIComponent/UPIComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/UPIComponent/UPIComponentTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class UPIComponentTests: XCTestCase {
     
     func test_init_withApps() throws {

--- a/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentMethod/PreselectedPaymentMethodIntegrationTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentMethod/PreselectedPaymentMethodIntegrationTests.swift
@@ -15,6 +15,7 @@ import UIKit
 
 @MainActor
 struct PreselectedPaymentMethodIntegrationTests {
+
     // MARK: - UI Display Tests
 
     @Test("PaymentComponent - UI fields", arguments: PaymentComponentTestData.allCases)
@@ -263,6 +264,7 @@ struct PreselectedPaymentMethodIntegrationTests {
         /// PaymentInitiable
         case initiableBCMC
 
+        @MainActor
         var paymentComponent: PaymentComponent {
             switch self {
             case .visa:

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -13,6 +13,7 @@ import AdyenComponents
 @testable import AdyenDropIn
 import AdyenNetworking
 
+@MainActor
 class SessionTests: XCTestCase {
 
     var analyticsProviderMock: AnalyticsProviderMock!

--- a/Tests/SnapshotTests/Components/AffirmComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/AffirmComponentUITests.swift
@@ -9,6 +9,7 @@ import XCTest
 @_spi(AdyenInternal) @testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
 
+@MainActor
 class AffirmComponentUITests: XCTestCase {
     
     private var paymentMethod: PaymentMethod {

--- a/Tests/SnapshotTests/Components/AtomeComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/AtomeComponentUITests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
 
+@MainActor
 class AtomeComponentUITests: XCTestCase {
 
     private var paymentMethod: PaymentMethod!

--- a/Tests/SnapshotTests/Components/BLIKComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/BLIKComponentUITests.swift
@@ -10,6 +10,7 @@ import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 final class BLIKComponentUITests: XCTestCase {
 
     private var paymentMethod: BLIKPaymentMethod {

--- a/Tests/SnapshotTests/Components/BoletoComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/BoletoComponentUITests.swift
@@ -10,6 +10,7 @@ import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 final class BoletoComponentUITests: XCTestCase {
 
     private var context: AdyenContext {

--- a/Tests/SnapshotTests/Components/CardComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/CardComponentUITests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import AdyenCard
 @testable import AdyenComponents
 
+@MainActor
 class CardComponentUITests: XCTestCase {
     
     let paymentMethod = CardPaymentMethod(

--- a/Tests/SnapshotTests/Components/DokuComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/DokuComponentUITests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 final class DokuComponentUITests: XCTestCase {
 
     private var context: AdyenContext!

--- a/Tests/SnapshotTests/Components/GiftCardComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/GiftCardComponentUITests.swift
@@ -11,6 +11,7 @@ import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class GiftCardUITests: XCTestCase {
     
     func test_checkBalance_failure() throws {

--- a/Tests/SnapshotTests/Components/IssuerListComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/IssuerListComponentUITests.swift
@@ -10,6 +10,7 @@
 import SnapshotTesting
 import XCTest
 
+@MainActor
 final class IssuerListComponentUITests: XCTestCase {
 
     private var context: AdyenContext {

--- a/Tests/SnapshotTests/Components/MBWayComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/MBWayComponentUITests.swift
@@ -10,6 +10,7 @@ import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 final class MBWayComponentUITests: XCTestCase {
 
     private var paymentMethod: MBWayPaymentMethod!

--- a/Tests/SnapshotTests/Components/OnlineBankingComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/OnlineBankingComponentUITests.swift
@@ -10,6 +10,7 @@ import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class OnlineBankingComponentUITests: XCTestCase {
 
     private var paymentMethod: OnlineBankingPaymentMethod!

--- a/Tests/SnapshotTests/Components/PayToComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/PayToComponentUITests.swift
@@ -10,6 +10,7 @@ import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class PayToComponentUITests: XCTestCase {
 
     private lazy var paymentMethod: PayToPaymentMethod = .init(

--- a/Tests/SnapshotTests/Components/QRCodeActionComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/QRCodeActionComponentUITests.swift
@@ -10,6 +10,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class QRCodeActionComponentUITests: XCTestCase {
 
     override func run() {

--- a/Tests/SnapshotTests/Components/UPIComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/UPIComponentUITests.swift
@@ -10,6 +10,7 @@ import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class UPIComponentUITests: XCTestCase {
 
     private lazy var paymentMethod: UPIPaymentMethod = .init(

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -11,6 +11,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 final class CheckoutComponentBuilderTests: XCTestCase {
     
     var checkoutConfiguration: CheckoutConfiguration!

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -41,7 +41,7 @@ final class CheckoutTests: XCTestCase {
         paymentMethods = try! AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
     }
 
-    func testSetupWithSession_Success() async throws {
+    @MainActor func testSetupWithSession_Success() async throws {
         let expectedSession = AdyenSessionMock(state: .init(
             data: "test_session_data",
             identifier: "test_session_id",
@@ -79,7 +79,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertTrue(mockProvider.setupSessionCalled)
     }
 
-    func testSetupWithSession_Failure() async {
+    @MainActor func testSetupWithSession_Failure() async {
         mockProvider.setupWithSessionResult = .failure(TestError())
         
         do {
@@ -98,7 +98,7 @@ final class CheckoutTests: XCTestCase {
         }
     }
 
-    func testSetupWithPaymentMethods_Success() async throws {
+    @MainActor func testSetupWithPaymentMethods_Success() async throws {
         let expectedCheckout = Checkout(
             configuration: configuration,
             paymentMethods: paymentMethods,
@@ -120,7 +120,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertTrue(mockProvider.setupPaymentMethodsCalled)
     }
 
-    func testSetupWithPaymentMethods_Failure() async {
+    @MainActor func testSetupWithPaymentMethods_Failure() async {
         mockProvider.setupWithPaymentMethodsResult = .failure(TestError())
         
         do {
@@ -136,7 +136,7 @@ final class CheckoutTests: XCTestCase {
         }
     }
     
-    func testSetupSessionProtocolCall() async {
+    @MainActor func testSetupSessionProtocolCall() async {
         let sessionMock = AdyenSessionMock(state: .init(
             data: "test_data",
             identifier: "test_id",
@@ -166,7 +166,7 @@ final class CheckoutTests: XCTestCase {
     
     // MARK: - payment component delegate
     
-    func test_didSubmit_callsOnSubmit_whenSet() throws {
+    @MainActor func test_didSubmit_callsOnSubmit_whenSet() throws {
         let expectation = expectation(description: "onSubmit called")
         var didCallSubmit = false
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
@@ -204,7 +204,7 @@ final class CheckoutTests: XCTestCase {
     
     // MARK: - createPaymentComponent(for type:) Tests
     
-    func test_createPaymentComponent_forType_returnsComponent_whenPaymentMethodExists() {
+    @MainActor func test_createPaymentComponent_forType_returnsComponent_whenPaymentMethodExists() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -221,7 +221,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNotNil(component?.viewController)
     }
     
-    func test_createPaymentComponent_forType_returnsNil_whenPaymentMethodDoesNotExist() {
+    @MainActor func test_createPaymentComponent_forType_returnsNil_whenPaymentMethodDoesNotExist() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -237,7 +237,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(component)
     }
     
-    func test_createPaymentComponent_forType_returnsNil_whenPaymentMethodsIsNil() {
+    @MainActor func test_createPaymentComponent_forType_returnsNil_whenPaymentMethodsIsNil() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -252,7 +252,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(component)
     }
     
-    func test_createPaymentComponent_forScheme_returnsCardComponent() {
+    @MainActor func test_createPaymentComponent_forScheme_returnsCardComponent() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -271,7 +271,7 @@ final class CheckoutTests: XCTestCase {
     
     // MARK: - createPaymentComponent(for identifier:) Tests
     
-    func test_createPaymentComponent_forIdentifier_returnsComponent_whenStoredMethodExists() throws {
+    @MainActor func test_createPaymentComponent_forIdentifier_returnsComponent_whenStoredMethodExists() throws {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -288,7 +288,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNotNil(component)
     }
     
-    func test_createPaymentComponent_forIdentifier_returnsNil_whenStoredMethodDoesNotExist() {
+    @MainActor func test_createPaymentComponent_forIdentifier_returnsNil_whenStoredMethodDoesNotExist() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -304,7 +304,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(component)
     }
     
-    func test_createPaymentComponent_forIdentifier_returnsNil_whenPaymentMethodsIsNil() {
+    @MainActor func test_createPaymentComponent_forIdentifier_returnsNil_whenPaymentMethodsIsNil() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -319,7 +319,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(component)
     }
     
-    func test_createPaymentComponent_forIdentifier_returnsCorrectStoredMethod() {
+    @MainActor func test_createPaymentComponent_forIdentifier_returnsCorrectStoredMethod() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -343,7 +343,7 @@ final class CheckoutTests: XCTestCase {
     
     // MARK: - Action-Only Setup Tests
     
-    func testSetupActionOnly_Success() async throws {
+    @MainActor func testSetupActionOnly_Success() async throws {
         // Given
         let expectedCheckout = Checkout(
             configuration: configuration,
@@ -365,7 +365,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertTrue(mockProvider.setupActionOnlyCalled)
     }
     
-    func testSetupActionOnly_Failure() async {
+    @MainActor func testSetupActionOnly_Failure() async {
         // Given
         mockProvider.setupActionOnlyResult = .failure(TestError())
         
@@ -382,7 +382,7 @@ final class CheckoutTests: XCTestCase {
         }
     }
     
-    func testSetupActionOnly_createPaymentComponent_returnsNil() async throws {
+    @MainActor func testSetupActionOnly_createPaymentComponent_returnsNil() async throws {
         // Given
         let expectedCheckout = Checkout(
             configuration: configuration,

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -12,6 +12,7 @@
 @_spi(AdyenInternal) @testable import AdyenActions
 import XCTest
 
+@MainActor
 final class CheckoutTests: XCTestCase {
     var mockProvider: CheckoutProviderMock!
     var configuration: CheckoutConfiguration!
@@ -41,7 +42,7 @@ final class CheckoutTests: XCTestCase {
         paymentMethods = try! AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
     }
 
-    @MainActor func testSetupWithSession_Success() async throws {
+    func testSetupWithSession_Success() async throws {
         let expectedSession = AdyenSessionMock(state: .init(
             data: "test_session_data",
             identifier: "test_session_id",
@@ -79,7 +80,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertTrue(mockProvider.setupSessionCalled)
     }
 
-    @MainActor func testSetupWithSession_Failure() async {
+    func testSetupWithSession_Failure() async {
         mockProvider.setupWithSessionResult = .failure(TestError())
         
         do {
@@ -98,7 +99,7 @@ final class CheckoutTests: XCTestCase {
         }
     }
 
-    @MainActor func testSetupWithPaymentMethods_Success() async throws {
+    func testSetupWithPaymentMethods_Success() async throws {
         let expectedCheckout = Checkout(
             configuration: configuration,
             paymentMethods: paymentMethods,
@@ -120,7 +121,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertTrue(mockProvider.setupPaymentMethodsCalled)
     }
 
-    @MainActor func testSetupWithPaymentMethods_Failure() async {
+    func testSetupWithPaymentMethods_Failure() async {
         mockProvider.setupWithPaymentMethodsResult = .failure(TestError())
         
         do {
@@ -136,7 +137,7 @@ final class CheckoutTests: XCTestCase {
         }
     }
     
-    @MainActor func testSetupSessionProtocolCall() async {
+    func testSetupSessionProtocolCall() async {
         let sessionMock = AdyenSessionMock(state: .init(
             data: "test_data",
             identifier: "test_id",
@@ -166,7 +167,7 @@ final class CheckoutTests: XCTestCase {
     
     // MARK: - payment component delegate
     
-    @MainActor func test_didSubmit_callsOnSubmit_whenSet() throws {
+    func test_didSubmit_callsOnSubmit_whenSet() throws {
         let expectation = expectation(description: "onSubmit called")
         var didCallSubmit = false
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
@@ -204,7 +205,7 @@ final class CheckoutTests: XCTestCase {
     
     // MARK: - createPaymentComponent(for type:) Tests
     
-    @MainActor func test_createPaymentComponent_forType_returnsComponent_whenPaymentMethodExists() {
+    func test_createPaymentComponent_forType_returnsComponent_whenPaymentMethodExists() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -221,7 +222,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNotNil(component?.viewController)
     }
     
-    @MainActor func test_createPaymentComponent_forType_returnsNil_whenPaymentMethodDoesNotExist() {
+    func test_createPaymentComponent_forType_returnsNil_whenPaymentMethodDoesNotExist() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -237,7 +238,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(component)
     }
     
-    @MainActor func test_createPaymentComponent_forType_returnsNil_whenPaymentMethodsIsNil() {
+    func test_createPaymentComponent_forType_returnsNil_whenPaymentMethodsIsNil() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -252,7 +253,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(component)
     }
     
-    @MainActor func test_createPaymentComponent_forScheme_returnsCardComponent() {
+    func test_createPaymentComponent_forScheme_returnsCardComponent() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -271,7 +272,7 @@ final class CheckoutTests: XCTestCase {
     
     // MARK: - createPaymentComponent(for identifier:) Tests
     
-    @MainActor func test_createPaymentComponent_forIdentifier_returnsComponent_whenStoredMethodExists() throws {
+    func test_createPaymentComponent_forIdentifier_returnsComponent_whenStoredMethodExists() throws {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -288,7 +289,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNotNil(component)
     }
     
-    @MainActor func test_createPaymentComponent_forIdentifier_returnsNil_whenStoredMethodDoesNotExist() {
+    func test_createPaymentComponent_forIdentifier_returnsNil_whenStoredMethodDoesNotExist() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -304,7 +305,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(component)
     }
     
-    @MainActor func test_createPaymentComponent_forIdentifier_returnsNil_whenPaymentMethodsIsNil() {
+    func test_createPaymentComponent_forIdentifier_returnsNil_whenPaymentMethodsIsNil() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -319,7 +320,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(component)
     }
     
-    @MainActor func test_createPaymentComponent_forIdentifier_returnsCorrectStoredMethod() {
+    func test_createPaymentComponent_forIdentifier_returnsCorrectStoredMethod() {
         // Given
         let sut = Checkout(
             configuration: configuration,
@@ -343,7 +344,7 @@ final class CheckoutTests: XCTestCase {
     
     // MARK: - Action-Only Setup Tests
     
-    @MainActor func testSetupActionOnly_Success() async throws {
+    func testSetupActionOnly_Success() async throws {
         // Given
         let expectedCheckout = Checkout(
             configuration: configuration,
@@ -365,7 +366,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertTrue(mockProvider.setupActionOnlyCalled)
     }
     
-    @MainActor func testSetupActionOnly_Failure() async {
+    func testSetupActionOnly_Failure() async {
         // Given
         mockProvider.setupActionOnlyResult = .failure(TestError())
         
@@ -382,7 +383,7 @@ final class CheckoutTests: XCTestCase {
         }
     }
     
-    @MainActor func testSetupActionOnly_createPaymentComponent_returnsNil() async throws {
+    func testSetupActionOnly_createPaymentComponent_returnsNil() async throws {
         // Given
         let expectedCheckout = Checkout(
             configuration: configuration,

--- a/Tests/UnitTests/AdyenCheckout/Component Factory Tests/BLIKComponentFactoryTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/Component Factory Tests/BLIKComponentFactoryTests.swift
@@ -9,6 +9,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 final class BLIKComponentFactoryTests: XCTestCase {
     
     var factory: BLIKComponentFactory!

--- a/Tests/UnitTests/AdyenDropIn/ComponentManagerTests.swift
+++ b/Tests/UnitTests/AdyenDropIn/ComponentManagerTests.swift
@@ -18,6 +18,7 @@
 import PassKit
 import XCTest
 
+@MainActor
 class ComponentManagerTests: XCTestCase {
 
     var paymentMethods: PaymentMethods {

--- a/Tests/UnitTests/Core/PaymentComponentFactoryProtocolTests.swift
+++ b/Tests/UnitTests/Core/PaymentComponentFactoryProtocolTests.swift
@@ -15,6 +15,7 @@
 @_spi(AdyenInternal) @testable import Adyen
 import XCTest
 
+@MainActor
 final class PaymentComponentFactoryProtocolTests: XCTestCase {
     
     // MARK: - Mock Types for Testing

--- a/spell-check-word-allow-list.yaml
+++ b/spell-check-word-allow-list.yaml
@@ -222,3 +222,4 @@ whiteList:
   - xcconfig
   - adhoc
   - sourcery
+  - nonisolated


### PR DESCRIPTION
# Summary [Required]
In preparation for a safer code and a better v6 structure and also easier adoption of Swift 6, we start adopting MainActor.

First candidate is **PaymentComponent** and all its connected entities.

- All payment components
- Checkout
- CheckoutProtocol
- Router
- All Dropin related UI entities 
and more

**Next Step: Action Components and co.**

## Ticket [Optional]
<ticket>
COSDK-1050
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [ ] Tested changes locally
- [ ] Added/updated unit tests
- [ ] Verified against acceptance criteria
