### PR TITLE
Fix: Switching to Dark mode doesn't trigger inputs border color update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ Demo/Secrets.*.xcconfig
 /.gemini
 /.windsurf
 /openspec
+.factory

--- a/AdyenUI/UI/Form/FormViewController.swift
+++ b/AdyenUI/UI/Form/FormViewController.swift
@@ -128,17 +128,12 @@ open class FormViewController: UIViewController, AdyenObserver {
     override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        guard let previousTraitCollection else { return }
-
-        if #available(iOS 13.0, *) {
-            guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) else { return }
-        } else {
-            guard previousTraitCollection.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }
-        }
+        guard let previousTraitCollection,
+              traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) else { return }
 
         itemManager.flatItemViews
             .compactMap { $0 as? AppearanceChangeRefreshable }
-            .forEach { $0.appearanceRefresher?(traitCollection) }
+            .forEach { $0.refreshAppearance(with: traitCollection) }
     }
 
     override public var preferredContentSize: CGSize {

--- a/AdyenUI/UI/Form/FormViewController.swift
+++ b/AdyenUI/UI/Form/FormViewController.swift
@@ -125,6 +125,22 @@ open class FormViewController: UIViewController, AdyenObserver {
         resignFirstResponder()
     }
 
+    override open func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        guard let previousTraitCollection else { return }
+
+        if #available(iOS 13.0, *) {
+            guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) else { return }
+        } else {
+            guard previousTraitCollection.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }
+        }
+
+        itemManager.flatItemViews
+            .compactMap { $0 as? AppearanceChangeRefreshable }
+            .forEach { $0.appearanceRefresher?(traitCollection) }
+    }
+
     override public var preferredContentSize: CGSize {
         get { formView.intrinsicContentSize }
 

--- a/AdyenUI/UI/Form/Items/FormItemView.swift
+++ b/AdyenUI/UI/Form/Items/FormItemView.swift
@@ -57,14 +57,7 @@ public protocol AnyFormItemView: UIView {
 
 @_spi(AdyenInternal)
 public protocol AppearanceChangeRefreshable: AnyObject {
-    var appearanceRefresher: ((UITraitCollection) -> Void)? { get }
-}
-
-@_spi(AdyenInternal)
-public extension AppearanceChangeRefreshable {
-    var appearanceRefresher: ((UITraitCollection) -> Void)? {
-        nil
-    }
+    func refreshAppearance(with traitCollection: UITraitCollection)
 }
 
 @_spi(AdyenInternal)

--- a/AdyenUI/UI/Form/Items/FormItemView.swift
+++ b/AdyenUI/UI/Form/Items/FormItemView.swift
@@ -14,7 +14,8 @@ open class FormItemView<ItemType: FormItem>: UIView, AnyFormItemView, AdyenObser
     /// The item represented by the view.
     public let item: ItemType
     
-    /// The primary view within this item designated for accessibility label updates, used for both descriptive text and validation messages.
+    /// The primary view within this item designated for accessibility label updates,
+    /// used for both descriptive text and validation messages.
     internal var accessibilityLabelView: UIView? {
         AdyenAssertion.assertionFailure(message: "'\(#function)' needs to be implemented on '\(String(describing: Self.self))'")
         return nil
@@ -52,6 +53,18 @@ public protocol AnyFormItemView: UIView {
     
     /// The array of item views embedded in the current item view.
     var childItemViews: [AnyFormItemView] { get }
+}
+
+@_spi(AdyenInternal)
+public protocol AppearanceChangeRefreshable: AnyObject {
+    var appearanceRefresher: ((UITraitCollection) -> Void)? { get }
+}
+
+@_spi(AdyenInternal)
+public extension AppearanceChangeRefreshable {
+    var appearanceRefresher: ((UITraitCollection) -> Void)? {
+        nil
+    }
 }
 
 @_spi(AdyenInternal)

--- a/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
@@ -35,7 +35,8 @@ public protocol AnyFormTextItemView: AnyFormItemView {
 @_spi(AdyenInternal)
 open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemView<String, ItemType>,
     UITextFieldDelegate,
-    AnyFormTextItemView {
+    AnyFormTextItemView,
+    AppearanceChangeRefreshable {
     
     override public var accessibilityLabelView: UIView? {
         textField
@@ -336,7 +337,10 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         updateBorderColor(state: item.validationState)
     }
 
-    private func updateBorderColor(state: ValidationState) {
+    private func updateBorderColor(
+        state: ValidationState,
+        resolvingWith traitCollection: UITraitCollection? = nil
+    ) {
         let style = theme.elements.textField
         let borderColor: UIColor
         if isEditing {
@@ -346,7 +350,13 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         } else {
             borderColor = style.borderColor
         }
-        entryTextStackView.layer.borderColor = borderColor.cgColor
+        adyen.applyLayerBorderColor(borderColor, on: entryTextStackView.layer, resolvingWith: traitCollection)
+    }
+
+    public var appearanceRefresher: ((UITraitCollection) -> Void)? {
+        { [weak self] traitCollection in
+            self?.updateBorderColor(state: self?.item.validationState ?? .valid, resolvingWith: traitCollection)
+        }
     }
 }
 

--- a/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
@@ -353,10 +353,8 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
         adyen.applyLayerBorderColor(borderColor, on: entryTextStackView.layer, resolvingWith: traitCollection)
     }
 
-    public var appearanceRefresher: ((UITraitCollection) -> Void)? {
-        { [weak self] traitCollection in
-            self?.updateBorderColor(state: self?.item.validationState ?? .valid, resolvingWith: traitCollection)
-        }
+    public func refreshAppearance(with traitCollection: UITraitCollection) {
+        updateBorderColor(state: item.validationState, resolvingWith: traitCollection)
     }
 }
 

--- a/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 package class FormSelectableValueItemView<ValueType, ItemType: FormSelectableValueItem<ValueType?>>:
-    FormValidatableValueItemView<ValueType?, ItemType> {
+    FormValidatableValueItemView<ValueType?, ItemType>,
+    AppearanceChangeRefreshable {
 
     internal var numberOfLines: Int = 1 {
         didSet {
@@ -126,7 +127,7 @@ package class FormSelectableValueItemView<ValueType, ItemType: FormSelectableVal
 
         containerView.backgroundColor = style.containerColor
         containerView.layer.borderWidth = style.borderWidth
-        containerView.layer.borderColor = style.borderColor.cgColor
+        adyen.applyLayerBorderColor(style.borderColor, on: containerView.layer)
 
         switch style.cornerRadius {
         case let .fixed(radius):
@@ -139,10 +140,22 @@ package class FormSelectableValueItemView<ValueType, ItemType: FormSelectableVal
         valueLabel.apply(theme.elements.labels.body)
     }
 
-    private func updateContainerBorderColor(isValid: Bool) {
+    private func updateContainerBorderColor(
+        isValid: Bool,
+        resolvingWith traitCollection: UITraitCollection? = nil
+    ) {
         let style = theme.elements.textField
         let borderColor = isValid ? style.borderColor : style.errorColor
-        containerView.layer.borderColor = borderColor.cgColor
+        adyen.applyLayerBorderColor(borderColor, on: containerView.layer, resolvingWith: traitCollection)
+    }
+
+    package var appearanceRefresher: ((UITraitCollection) -> Void)? {
+        { [weak self] traitCollection in
+            self?.updateContainerBorderColor(
+                isValid: !(self?.item.validationState.shouldShowError ?? false),
+                resolvingWith: traitCollection
+            )
+        }
     }
 
     // MARK: - Convenience

--- a/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Selectable/FormSelectableValueItemView.swift
@@ -149,13 +149,11 @@ package class FormSelectableValueItemView<ValueType, ItemType: FormSelectableVal
         adyen.applyLayerBorderColor(borderColor, on: containerView.layer, resolvingWith: traitCollection)
     }
 
-    package var appearanceRefresher: ((UITraitCollection) -> Void)? {
-        { [weak self] traitCollection in
-            self?.updateContainerBorderColor(
-                isValid: !(self?.item.validationState.shouldShowError ?? false),
-                resolvingWith: traitCollection
-            )
-        }
+    package func refreshAppearance(with traitCollection: UITraitCollection) {
+        updateContainerBorderColor(
+            isValid: !item.validationState.shouldShowError,
+            resolvingWith: traitCollection
+        )
     }
 
     // MARK: - Convenience

--- a/AdyenUI/UI/Helpers/UIViewHelpers.swift
+++ b/AdyenUI/UI/Helpers/UIViewHelpers.swift
@@ -101,4 +101,14 @@ extension AdyenScope where Base: UIView {
             verticalFittingPriority: .fittingSizeLevel
         )
     }
+
+    public func applyLayerBorderColor(
+        _ color: UIColor?,
+        on layer: CALayer? = nil,
+        resolvingWith traitCollection: UITraitCollection? = nil
+    ) {
+        let targetLayer = layer ?? base.layer
+        let resolvedTraitCollection = traitCollection ?? base.traitCollection
+        targetLayer.borderColor = color?.resolvedColor(with: resolvedTraitCollection).cgColor
+    }
 }

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -214,6 +214,51 @@ class CardComponentTests: XCTestCase {
         XCTAssertNotNil(storeDetailsToggle, "Store details toggle should be present when configured")
     }
 
+    func test_cardViewController_whenInterfaceStyleChanges_shouldRefreshHolderNameBorderColor() throws {
+        // Given
+        let expectedBorderColor = dynamicColor(light: .systemGreen, dark: .systemBlue)
+        let expectedActiveBorderColor = dynamicColor(light: .orange, dark: .purple)
+
+        var configuration = CardComponentConfiguration()
+        configuration.showsHolderNameField = true
+        configuration.theme = AdyenTheme(
+            colors: AdyenColors(
+                containerOutline: expectedBorderColor,
+                primary: expectedActiveBorderColor
+            )
+        )
+
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: Dummy.context(with: nil),
+            configuration: configuration,
+            publicKeyProvider: PublicKeyProviderMock(),
+            binProvider: BinInfoProviderMock()
+        )
+
+        setupRootViewController(sut.cardViewController)
+
+        let holderNameItemView: FormTextInputItemView = try XCTUnwrap(
+            sut.cardViewController.view.findView(with: CardViewIdentifier.holdername)
+        )
+        let holderNameContainer: UIView = try XCTUnwrap(
+            sut.cardViewController.view.findView(with: "\(CardViewIdentifier.holdername).entryTextStackView")
+        )
+
+        // When / Then
+        setInterfaceStyle(.light)
+        XCTAssertEqual(holderNameContainer.layer.borderColor, resolvedBorderColor(for: expectedBorderColor, interfaceStyle: .light))
+
+        triggerEditing(on: holderNameItemView, isEditing: true)
+        XCTAssertEqual(holderNameContainer.layer.borderColor, resolvedBorderColor(for: expectedActiveBorderColor, interfaceStyle: .light))
+
+        setInterfaceStyle(.dark)
+        XCTAssertEqual(holderNameContainer.layer.borderColor, resolvedBorderColor(for: expectedActiveBorderColor, interfaceStyle: .dark))
+
+        triggerEditing(on: holderNameItemView, isEditing: false)
+        XCTAssertEqual(holderNameContainer.layer.borderColor, resolvedBorderColor(for: expectedBorderColor, interfaceStyle: .dark))
+    }
+
     func test_viewController_shouldNotShowBigTitle() {
 
         let sut = CardComponent(
@@ -2425,6 +2470,29 @@ extension CardComponentTests {
         populate(textItemView: cardNumberItemView!, with: card.number ?? "")
         populate(textItemView: expiryDateItemView!, with: "\(card.expiryMonth ?? "") \(card.expiryYear ?? "")")
         populate(textItemView: securityCodeItemView!, with: card.securityCode ?? "")
+    }
+
+    func triggerEditing(on itemView: FormTextInputItemView, isEditing: Bool) {
+        if isEditing {
+            itemView.textField.delegate?.textFieldDidBeginEditing?(itemView.textField)
+        } else {
+            itemView.textField.delegate?.textFieldDidEndEditing?(itemView.textField)
+        }
+    }
+
+    func setInterfaceStyle(_ style: UIUserInterfaceStyle) {
+        UIApplication.shared.adyen.mainKeyWindow?.overrideUserInterfaceStyle = style
+        wait(for: .aMoment)
+    }
+
+    func dynamicColor(light: UIColor, dark: UIColor) -> UIColor {
+        UIColor { traitCollection in
+            traitCollection.userInterfaceStyle == .dark ? dark : light
+        }
+    }
+
+    func resolvedBorderColor(for color: UIColor, interfaceStyle: UIUserInterfaceStyle) -> CGColor {
+        color.resolvedColor(with: UITraitCollection(userInterfaceStyle: interfaceStyle)).cgColor
     }
 
     func tapSubmitButton(on view: UIView) {

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -228,13 +228,7 @@ class CardComponentTests: XCTestCase {
             )
         )
 
-        let sut = CardComponent(
-            paymentMethod: method,
-            context: Dummy.context(with: nil),
-            configuration: configuration,
-            publicKeyProvider: PublicKeyProviderMock(),
-            binProvider: BinInfoProviderMock()
-        )
+        let sut = makeSUT(configuration: configuration)
 
         setupRootViewController(sut.cardViewController)
 
@@ -271,13 +265,7 @@ class CardComponentTests: XCTestCase {
             )
         )
 
-        let sut = CardComponent(
-            paymentMethod: method,
-            context: Dummy.context(with: nil),
-            configuration: configuration,
-            publicKeyProvider: PublicKeyProviderMock(),
-            binProvider: BinInfoProviderMock()
-        )
+        let sut = makeSUT(configuration: configuration)
 
         setupRootViewController(sut.cardViewController)
 
@@ -2495,6 +2483,16 @@ extension UIView {
 }
 
 extension CardComponentTests {
+
+    private func makeSUT(configuration: CardComponentConfiguration) -> CardComponent {
+        CardComponent(
+            paymentMethod: method,
+            context: Dummy.context(with: nil),
+            configuration: configuration,
+            publicKeyProvider: PublicKeyProviderMock(),
+            binProvider: BinInfoProviderMock()
+        )
+    }
 
     func fillCard(on view: UIView, with card: Card) {
         let cardNumberItemView: FormTextItemView<FormCardNumberItem>? = view.findView(with: "AdyenCard.FormCardNumberContainerItem.numberItem")

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -259,6 +259,40 @@ class CardComponentTests: XCTestCase {
         XCTAssertEqual(holderNameContainer.layer.borderColor, resolvedBorderColor(for: expectedBorderColor, interfaceStyle: .dark))
     }
 
+    func test_cardViewController_whenInterfaceStyleChanges_shouldRefreshBillingAddressBorderColor() throws {
+        // Given
+        let expectedBorderColor = dynamicColor(light: .systemGreen, dark: .systemBlue)
+
+        var configuration = CardComponentConfiguration()
+        configuration.billingAddress.mode = .lookup(onAddressLookup: { _ in [] })
+        configuration.theme = AdyenTheme(
+            colors: AdyenColors(
+                containerOutline: expectedBorderColor
+            )
+        )
+
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: Dummy.context(with: nil),
+            configuration: configuration,
+            publicKeyProvider: PublicKeyProviderMock(),
+            binProvider: BinInfoProviderMock()
+        )
+
+        setupRootViewController(sut.cardViewController)
+
+        let billingAddressView: FormAddressPickerItemView = try XCTUnwrap(
+            sut.cardViewController.view.findView(by: CardViewIdentifier.billingAddress)
+        )
+
+        // When / Then
+        setInterfaceStyle(.light)
+        XCTAssertEqual(billingAddressView.containerView.layer.borderColor, resolvedBorderColor(for: expectedBorderColor, interfaceStyle: .light))
+
+        setInterfaceStyle(.dark)
+        XCTAssertEqual(billingAddressView.containerView.layer.borderColor, resolvedBorderColor(for: expectedBorderColor, interfaceStyle: .dark))
+    }
+
     func test_viewController_shouldNotShowBigTitle() {
 
         let sut = CardComponent(


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

This fixes the bug when switching between light/dark modes on the fly caused input border colors to stale. 
The root cause - these colors are set via `CALayer.borderColor` that is not a part of UIKit and doesn't support dynamic colors and dynamic updates.

In order to make it work, we have to leverage one of the UIViewController lifecycle methods and according to the best practices, it should be `traitCollectionDidChange`. 
However, this approach doesn't scale well as it requires tons of overrides, so I tried to create a thin abstraction to remove this logic from the views.

I am not 100% happy with this one, please treat this as an idea/poc/first iteration. Any feedback on how to make it more elegant is welcome.

# Demo [Required for UI changes]
<!-- Add screenshots or link to screen recording demonstrating the changes -->
<!-- Include both light/dark mode and different device sizes if it matters -->

| 🐛 Before fix | ✅  After fix |
|--------|--------|
| <img width="500" height="947" alt="image" src="https://github.com/user-attachments/assets/fa2ca901-24cd-4126-a8e5-abf0e36a2618" /> | <img width="500" height="947" alt="image" src="https://github.com/user-attachments/assets/fb4b896c-b80e-42d9-bb61-b04aeaab2b67" /> |

## Ticket [Optional]
<ticket>
COSDK-1048
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
