### PR TITLE
Main Actor Adoption: Action Components

### DIFF
--- a/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
+++ b/Adyen/Core/Components/Base/PresentableComponentWrapper.swift
@@ -35,7 +35,7 @@ package final class PresentableComponentWrapper: PresentableComponent,
     /// - Parameter component: The wrapped component.
     /// - Parameter viewController: The `ViewController` used as the UI of the `PresentableComponent`.
     /// - Parameter navBarType: Type of the navigation bar to use.
-    package nonisolated init(
+    package init(
         component: Component,
         viewController: UIViewController,
         navBarType: NavigationBarType = .regular

--- a/Adyen/Core/Core Protocols/ActionComponent.swift
+++ b/Adyen/Core/Core Protocols/ActionComponent.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 /// A component that handles an action to complete a payment.
+@MainActor
 public protocol ActionComponent: Component {
     
     /// The delegate of the action component.
@@ -15,6 +16,7 @@ public protocol ActionComponent: Component {
 }
 
 /// Describes the methods a delegate of the action component needs to implement.
+@MainActor
 public protocol ActionComponentDelegate: AnyObject {
     
     /// Invoked when the action component opens a third party application outside the scope of the Adyen checkout,

--- a/Adyen/Core/Core Protocols/PartialPaymentDelegate.swift
+++ b/Adyen/Core/Core Protocols/PartialPaymentDelegate.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 /// Describes the methods a delegate of the partial payment component needs to implement.
+@MainActor
 public protocol PartialPaymentDelegate: AnyObject {
 
     /// Invoked when the payment component needs a balance check call to be done by the merchant.

--- a/Adyen/Core/Core Protocols/PresentationDelegate.swift
+++ b/Adyen/Core/Core Protocols/PresentationDelegate.swift
@@ -7,6 +7,7 @@
 import Foundation
 
 /// Delegates `ViewController`'s presentation.
+@MainActor
 public protocol PresentationDelegate: AnyObject {
     
     /// Asks the delegate to present a `PresentableComponent` as the `delegate` sees fit.

--- a/Adyen/Core/Core Protocols/StoredPaymentMethodsDelegate.swift
+++ b/Adyen/Core/Core Protocols/StoredPaymentMethodsDelegate.swift
@@ -8,6 +8,7 @@ import Foundation
 import UIKit
 
 /// Describes the methods a delegate of stored payment methods needs to implement.
+@MainActor
 public protocol StoredPaymentMethodsDelegate: AnyObject {
 
     /// Invoked when shopper wants to delete a stored payment method.

--- a/AdyenActions/CheckoutActionComponent.swift
+++ b/AdyenActions/CheckoutActionComponent.swift
@@ -13,6 +13,7 @@ import UIKit
 /**
  An action handler component to perform any supported action out of the box.
  */
+@MainActor
 public final class CheckoutActionComponent: ActionComponent, ActionHandlingComponent {
     
     /// :nodoc:

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -29,6 +29,7 @@ internal protocol AnyThreeDS2CoreActionHandler: Component {
 internal typealias ThreeDSService = ThreeDSConfigurable & ThreeDSServiceable
 
 /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
+@MainActor
 internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
     private enum Constants {
         static let transStatusWhenError = "U"

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
@@ -17,6 +17,7 @@ internal typealias VoidHandler = () -> Void
     
     /// Handles the 3D Secure 2 fingerprint and challenge actions separately + Delegated Authentication.
     @available(iOS 16.0, *)
+    @MainActor
     // swiftlint:disable:next type_body_length
     internal class ThreeDS2PlusDACoreActionHandler: ThreeDS2CoreActionHandler {
         internal var delegatedAuthenticationState: DelegatedAuthenticationState = .init()

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDAScreenPresenter.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDAScreenPresenter.swift
@@ -42,6 +42,7 @@ internal protocol ThreeDS2PlusDAScreenPresenterProtocol {
 
 /// This type handles the presenting of the Delegate authentication screens of Register and Approval.
 @available(iOS 16.0, *)
+@MainActor
 internal final class ThreeDS2PlusDAScreenPresenter: ThreeDS2PlusDAScreenPresenterProtocol {
     private let style: DelegatedAuthenticationComponentStyle
     private let localizedParameters: LocalizationParameters?

--- a/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -52,6 +52,7 @@ extension ComponentWrapper {
     }
 }
 
+@MainActor
 internal func createDefaultThreeDS2CoreActionHandler(
     context: AdyenContext,
     service: ThreeDSService,

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
@@ -9,6 +9,7 @@ import Adyen3DS2
 import Foundation
 
 /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
+@MainActor
 internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, ComponentWrapper {
     
     internal let context: AdyenContext

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
@@ -9,6 +9,7 @@ import Adyen3DS2
 import Foundation
 
 /// Handles the 3D Secure 2 fingerprint and challenge in one call using a `fingerprintSubmitter`.
+@MainActor
 internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, ComponentWrapper {
     
     // MARK: - Private

--- a/AdyenActions/Components/3DS2/ThreeDS2Component.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2Component.swift
@@ -13,6 +13,7 @@ internal protocol AnyRedirectComponent: ActionComponent {
 }
 
 /// Handles the 3D Secure 2 fingerprint and challenge.
+@MainActor
 public final class ThreeDS2Component: ActionComponent {
     
     /// The context object for this component.

--- a/AdyenActions/Components/Await/AwaitComponent.swift
+++ b/AdyenActions/Components/Await/AwaitComponent.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 /// A component that handles Await action's.
+@MainActor
 public final class AwaitComponent: ActionComponent, Cancellable {
     
     /// The context object for this component.

--- a/AdyenActions/Components/Await/PollingComponent.swift
+++ b/AdyenActions/Components/Await/PollingComponent.swift
@@ -9,6 +9,7 @@ import AdyenNetworking
 import Foundation
 
 /// A specific await component thats keeps polling the `/status` endpoint to check the payment status.
+@MainActor
 internal final class PollingComponent: AnyPollingHandler {
     
     private let maxErrorNumber = 1

--- a/AdyenActions/Components/Await/PollingHandlerProvider.swift
+++ b/AdyenActions/Components/Await/PollingHandlerProvider.swift
@@ -20,6 +20,7 @@ internal protocol AnyPollingHandlerProvider {
     func handler(for qrPaymentMethodType: QRCodePaymentMethod) -> AnyPollingHandler
 }
 
+@MainActor
 internal struct PollingHandlerProvider: AnyPollingHandlerProvider {
 
     private let context: AdyenContext

--- a/AdyenActions/Components/Document/DocumentComponent.swift
+++ b/AdyenActions/Components/Document/DocumentComponent.swift
@@ -12,6 +12,7 @@ import AdyenNetworking
 import UIKit
 
 /// A component that handles document actions.
+@MainActor
 public final class DocumentComponent: ActionComponent, ShareableComponent {
 
     /// The context object for this component.

--- a/AdyenActions/Components/QRCode/QRCodeActionComponent.swift
+++ b/AdyenActions/Components/QRCode/QRCodeActionComponent.swift
@@ -21,6 +21,7 @@ internal enum QRCodeComponentError: LocalizedError {
 }
 
 /// A component  for QRCode action.
+@MainActor
 public final class QRCodeActionComponent: ActionComponent, Cancellable, ShareableComponent {
     
     /// The context object for this component.

--- a/AdyenActions/Components/Redirect/BrowserComponent.swift
+++ b/AdyenActions/Components/Redirect/BrowserComponent.swift
@@ -39,7 +39,7 @@ internal final class BrowserComponent: NSObject, PresentableComponent {
         return safariViewController
     }()
     
-    internal nonisolated(unsafe) weak var delegate: BrowserComponentDelegate?
+    internal weak var delegate: BrowserComponentDelegate?
     
     @AdyenDependency(\.openAppDetector) private var openAppDetector
     
@@ -48,7 +48,7 @@ internal final class BrowserComponent: NSObject, PresentableComponent {
     /// - Parameter url: The URL to where the user should be redirected
     /// - Parameter context: The context object for this component.
     /// - Parameter style: The component's UI style.
-    internal nonisolated init(
+    internal init(
         url: URL,
         context: AdyenContext,
         style: RedirectComponentStyle? = nil

--- a/AdyenActions/Components/Redirect/RedirectComponent.swift
+++ b/AdyenActions/Components/Redirect/RedirectComponent.swift
@@ -11,6 +11,7 @@ import UIKit
 extension RedirectComponent: AnyRedirectComponent {}
 
 /// Handles any redirect Url whether its a web url, an App custom scheme url, or an app universal link.
+@MainActor
 public final class RedirectComponent: ActionComponent {
     
     /// Describes the types of errors that can be returned by the component.

--- a/AdyenActions/Components/Redirect/RedirectComponent.swift
+++ b/AdyenActions/Components/Redirect/RedirectComponent.swift
@@ -60,8 +60,8 @@ public final class RedirectComponent: ActionComponent {
     
     internal var appLauncher: AnyAppLauncher = AppLauncher()
     
-    internal lazy var apiClient: AnyRetryAPIClient = {
-        APIClient(apiContext: context.apiContext).retryAPIClient(with: SimpleScheduler(maximumCount: 2))
+    internal lazy var apiClient: APIClientProtocol = {
+        APIClient(apiContext: context.apiContext)
     }()
     
     private var browserComponent: BrowserComponent?
@@ -81,15 +81,6 @@ public final class RedirectComponent: ActionComponent {
     ) {
         self.context = context
         self.configuration = configuration
-    }
-    
-    internal convenience init(
-        context: AdyenContext,
-        configuration: Configuration = Configuration(),
-        apiClient: AnyRetryAPIClient
-    ) {
-        self.init(context: context, configuration: configuration)
-        self.apiClient = apiClient
     }
     
     /// Handles a redirect action.

--- a/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
+++ b/AdyenActions/Components/SDK/TwintSDKActionComponent.swift
@@ -12,6 +12,7 @@ import Foundation
 
 #if canImport(TwintSDK)
     /// A component that handles Twint SDK action's.
+    @MainActor
     public final class TwintSDKActionComponent: ActionComponent {
 
         /// The context object for this component.

--- a/AdyenActions/Components/Voucher/VoucherComponent.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponent.swift
@@ -18,6 +18,7 @@ internal protocol AnyVoucherActionHandler: ActionComponent, Cancellable {
 }
 
 /// A component that handles voucher action.
+@MainActor
 public final class VoucherComponent: AnyVoucherActionHandler, ShareableComponent {
 
     /// The context object for this component.

--- a/AdyenActions/Protocols/ActionHandlingComponent.swift
+++ b/AdyenActions/Protocols/ActionHandlingComponent.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 /// Any component that can handle an `Action` object.
+@MainActor
 public protocol ActionHandlingComponent: Component {
     
     /// Handles an action object.

--- a/AdyenSession/Session+ActionComponentDelegate.swift
+++ b/AdyenSession/Session+ActionComponentDelegate.swift
@@ -20,6 +20,7 @@ extension Session: ActionComponentDelegate {
         didComplete(currentComponent: component)
     }
     
+    @MainActor
     internal func didComplete(currentComponent: Component) {
         guard let resultCode = state.resultCode else {
             AdyenAssertion.assertionFailure(message: "Missing resultCode.")
@@ -40,20 +41,21 @@ extension Session: ActionComponentDelegate {
         didOpenExternalApplication(actionComponent: component)
     }
     
+    @MainActor
     internal func didOpenExternalApplication(actionComponent: ActionComponent) {
         delegate?.didOpenExternalApplication(component: actionComponent, session: self)
     }
 }
 
 extension Session {
+    
+    @MainActor
     package func didProvide(
         _ actionComponentData: ActionComponentData,
         from component: ActionComponent,
         dropInComponent: AnyDropInComponent?
     ) {
-        MainActor.assumeIsolated {
-            (component as? PresentableComponent)?.viewController.view.isUserInteractionEnabled = false
-        }
+        (component as? PresentableComponent)?.viewController.view.isUserInteractionEnabled = false
         let request = PaymentDetailsRequest(
             sessionId: state.identifier,
             sessionData: state.data,

--- a/AdyenSession/Session+ActionComponentDelegate.swift
+++ b/AdyenSession/Session+ActionComponentDelegate.swift
@@ -60,7 +60,7 @@ extension Session {
             paymentData: actionComponentData.paymentData,
             details: actionComponentData.details
         )
-        apiClient.perform(request) { [weak self] in
+        apiClient.perform(request) { @MainActor [weak self] in
             self?.handle(paymentResponseResult: $0, for: component)
         }
     }

--- a/AdyenSession/Session+PaymentComponentDelegate.swift
+++ b/AdyenSession/Session+PaymentComponentDelegate.swift
@@ -13,10 +13,16 @@ import UIKit
 
 @_spi(AdyenInternal)
 extension Session: PaymentComponentDelegate {
+    
     public func didSubmit(_ data: PaymentComponentData, from component: PaymentComponent) {
         didSubmit(data, from: component, dropInComponent: nil)
     }
     
+    public func didFail(with error: Error, from component: PaymentComponent) {
+        failWithError(error, component)
+    }
+    
+    @MainActor
     internal func finish(with result: CheckoutResult, component: Component) {
         let success = result.resultCode == .authorised
             || result.resultCode == .received
@@ -27,18 +33,17 @@ extension Session: PaymentComponentDelegate {
         }
     }
     
+    @MainActor
     internal func finish(with error: Error, component: Component) {
         failWithError(error, component)
     }
-
-    public func didFail(with error: Error, from component: PaymentComponent) {
-        failWithError(error, component)
-    }
     
+    @MainActor
     internal func didFail(with error: Error, currentComponent: Component) {
         failWithError(error, currentComponent)
     }
 
+    @MainActor
     internal func failWithError(_ error: Error, _ component: Component) {
         component.finalizeIfNeeded(with: false) { [weak self] in
             guard let self else { return }
@@ -48,6 +53,8 @@ extension Session: PaymentComponentDelegate {
 }
 
 extension Session {
+    
+    @MainActor
     package func didSubmit(
         _ paymentComponentData: PaymentComponentData,
         from component: PaymentComponent,
@@ -126,6 +133,7 @@ extension Session {
         }
     }
     
+    @MainActor
     private func handle(
         order: PartialPaymentOrder,
         resultCode: CheckoutResultCode,
@@ -144,28 +152,28 @@ extension Session {
         }
     }
     
+    @MainActor
     private func showPaymentFailedAlert(on dropInComponent: AnyDropInComponent, completion: @escaping (() -> Void)) {
         let localizationParameters = (dropInComponent as? Localizable)?.localizationParameters
         let title = localizedString(.errorTitle, localizationParameters)
         let message = localizedString(.paymentRefusedMessage, localizationParameters)
         
-        Task { @MainActor in
-            let alertController = UIAlertController(
-                title: title,
-                message: message,
-                preferredStyle: .alert
-            )
-            
-            let doneTitle = localizedString(.dismissButton, localizationParameters)
-            let doneAction = UIAlertAction(title: doneTitle, style: .default) { _ in
-                completion()
-            }
-            alertController.addAction(doneAction)
-            
-            dropInComponent.viewController.present(alertController, animated: true)
+        let alertController = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert
+        )
+        
+        let doneTitle = localizedString(.dismissButton, localizationParameters)
+        let doneAction = UIAlertAction(title: doneTitle, style: .default) { _ in
+            completion()
         }
+        alertController.addAction(doneAction)
+        
+        dropInComponent.viewController.present(alertController, animated: true)
     }
     
+    @MainActor
     private func updateDropIn(_ dropInComponent: AnyDropInComponent, with order: PartialPaymentOrder, currentComponent: Component) {
         let initialInfo = SessionResponse(
             id: state.identifier,
@@ -193,6 +201,7 @@ extension Session {
         }
     }
     
+    @MainActor
     private func reload(
         dropInComponent: AnyDropInComponent,
         with order: PartialPaymentOrder,

--- a/AdyenSession/Session+PaymentComponentDelegate.swift
+++ b/AdyenSession/Session+PaymentComponentDelegate.swift
@@ -58,11 +58,12 @@ extension Session {
             sessionData: state.data,
             data: paymentComponentData
         )
-        apiClient.perform(request) { [weak self] in
+        apiClient.perform(request) { @MainActor [weak self] in
             self?.handle(paymentResponseResult: $0, for: component, in: dropInComponent)
         }
     }
     
+    @MainActor
     internal func handle(
         paymentResponseResult: Result<PaymentsResponse, Error>,
         for currentComponent: Component,
@@ -76,6 +77,7 @@ extension Session {
         }
     }
     
+    @MainActor
     private func handle(
         paymentResponse response: PaymentsResponse,
         for currentComponent: Component,
@@ -111,6 +113,7 @@ extension Session {
         }
     }
     
+    @MainActor
     private func handle(
         action: Action,
         for currentComponent: Component,

--- a/AdyenSession/Session+StoredPaymentMethodsDelegate.swift
+++ b/AdyenSession/Session+StoredPaymentMethodsDelegate.swift
@@ -21,7 +21,7 @@ extension Session: SessionStoredPaymentMethodsDelegate {
             sessionData: state.data,
             storedPaymentMethodId: storedPaymentMethod.identifier
         )
-        apiClient.perform(request) { [weak self] result in
+        apiClient.perform(request) { @MainActor [weak self] result in
             switch result {
             case .success:
                 completion(true)
@@ -32,24 +32,23 @@ extension Session: SessionStoredPaymentMethodsDelegate {
         }
     }
     
+    @MainActor
     private func showAlert(with error: Error?, on dropIn: AnyDropInComponent) {
         let localizationParameters = (dropIn as? Localizable)?.localizationParameters
         let title = localizedString(.errorTitle, localizationParameters)
         let message = localizedString(.errorUnknown, localizationParameters)
         let doneTitle = localizedString(.dismissButton, localizationParameters)
         
-        Task { @MainActor in
-            let alertController = UIAlertController(
-                title: title,
-                message: message,
-                preferredStyle: .alert
-            )
-            
-            let doneAction = UIAlertAction(title: doneTitle, style: .default)
-            alertController.addAction(doneAction)
-            
-            dropIn.viewController.present(alertController, animated: true)
-        }
+        let alertController = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert
+        )
+        
+        let doneAction = UIAlertAction(title: doneTitle, style: .default)
+        alertController.addAction(doneAction)
+        
+        dropIn.viewController.present(alertController, animated: true)
     }
     
     /// empty implementation of the old method

--- a/AdyenSession/Session.swift
+++ b/AdyenSession/Session.swift
@@ -42,6 +42,7 @@ public final class Session: SessionProtocol {
         )
     }()
     
+    @MainActor
     internal lazy var actionHandlingComponent: ActionHandlingComponent = {
         let handler = CheckoutActionComponent(
             context: context,

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/CheckoutActionComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/CheckoutActionComponentTests.swift
@@ -14,6 +14,7 @@ import XCTest
     import AdyenTwint
 #endif
 
+@MainActor
 class CheckoutActionComponentTests: XCTestCase {
 
     let weChatActionResponse = """

--- a/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
@@ -31,6 +31,7 @@ final class PollingHandlerMock: AnyPollingHandler {
     }
 }
 
+@MainActor
 struct AwaitActionHandlerProviderMock: AnyPollingHandlerProvider {
 
     var onAwaitHandler: ((_ paymentMethodType: AwaitPaymentMethod) -> AnyPollingHandler)?

--- a/Tests/IntegrationTests/Actions Tests/Await/PollingComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Await/PollingComponentTests.swift
@@ -9,6 +9,7 @@
 import AdyenNetworking
 import XCTest
 
+@MainActor
 class PollingComponentTests: XCTestCase {
 
     func testRetryWhenResultIsReceived() {

--- a/Tests/IntegrationTests/Actions Tests/Redirect/RedirectComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Redirect/RedirectComponentTests.swift
@@ -277,7 +277,8 @@ class RedirectComponentTests: XCTestCase {
     
     func testNativeRedirectHappyScenario() throws {
         let apiClient = APIClientMock()
-        let sut = RedirectComponent(context: Dummy.context, apiClient: apiClient.retryAPIClient(with: SimpleScheduler(maximumCount: 2)))
+        let sut = RedirectComponent(context: Dummy.context)
+        sut.apiClient = apiClient
         apiClient.mockedResults = try [.success(RedirectDetails(returnURL: XCTUnwrap(URL(string: "url://?redirectResult=test_redirectResult"))))]
         
         let appLauncher = AppLauncherMock()
@@ -347,10 +348,8 @@ class RedirectComponentTests: XCTestCase {
     func testNativeRedirectEndpointCallFails() throws {
         let apiClient = APIClientMock()
         let analyticsProviderMock = AnalyticsProviderMock()
-        let sut = RedirectComponent(
-            context: Dummy.context(with: analyticsProviderMock),
-            apiClient: apiClient.retryAPIClient(with: SimpleScheduler(maximumCount: 2))
-        )
+        let sut = RedirectComponent(context: Dummy.context(with: analyticsProviderMock))
+        sut.apiClient = apiClient
         apiClient.mockedResults = [.failure(Dummy.error)]
         
         let appLauncher = AppLauncherMock()
@@ -395,7 +394,8 @@ class RedirectComponentTests: XCTestCase {
     func testNativeRedirectWithNativeRedirectDataNilShouldPerformNativeRedirectResultRequest() throws {
         // Given
         let apiClient = APIClientMock()
-        let sut = RedirectComponent(context: Dummy.context, apiClient: apiClient.retryAPIClient(with: SimpleScheduler(maximumCount: 2)))
+        let sut = RedirectComponent(context: Dummy.context)
+        sut.apiClient = apiClient
         apiClient.mockedResults = try [.success(RedirectDetails(returnURL: XCTUnwrap(URL(string: "url://?redirectResult=test_redirectResult"))))]
 
         let appLauncher = AppLauncherMock()

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
@@ -10,6 +10,7 @@ import Adyen3DS2
 @testable @_spi(AdyenInternal) import AdyenCard
 import XCTest
 
+@MainActor
 class ThreeDS2ClassicActionHandlerTests: XCTestCase {
 
     var authenticationRequestParameters: AnyAuthenticationRequestParameters!

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
@@ -10,6 +10,7 @@ import Adyen3DS2
 @testable @_spi(AdyenInternal) import AdyenCard
 import XCTest
 
+@MainActor
 class ThreeDS2CompactActionHandlerTests: XCTestCase {
 
     var authenticationRequestParameters: AnyAuthenticationRequestParameters!

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -15,6 +15,7 @@ import XCTest
     import UIKit
 
     @available(iOS 16.0, *)
+    @MainActor
     final class ThreeDS2PlusDACoreActionHandlerTests: XCTestCase {
         var authenticationRequestParameters: AnyAuthenticationRequestParameters!
 

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -292,6 +292,10 @@ class SessionTests: XCTestCase {
         sut.didSubmit(data, from: component, in: dropInComponent)
         wait(for: [apiCallsExpectation], timeout: 1)
 
+        let stateUpdatedExpectation = expectation(description: "Expect state to be updated")
+        stateUpdatedExpectation.isInverted = true
+        wait(for: [stateUpdatedExpectation], timeout: 0.5)
+
         XCTAssertEqual(sut.state.amount, expectedAmount)
         XCTAssertEqual(sut.state.countryCode, "EG")
         XCTAssertEqual(sut.state.shopperLocale, "EG")

--- a/Tests/UnitTests/Utilities/AssertsTests.swift
+++ b/Tests/UnitTests/Utilities/AssertsTests.swift
@@ -10,6 +10,7 @@
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
+@MainActor
 class AssertsTests: XCTestCase {
 
     var context: AdyenContext!


### PR DESCRIPTION
# Summary [Required]
Part 2 of MainActor adoption, ActionComponents and all connected entities. 

This also clears up some code (e.g. `nonisolated`, `MainActor.assumeIsolated` etc) that was added on the previous step to preserve build safety which now became redundant when the connecting parts are also made MainActor.

## Ticket [Optional]
<ticket>
COSDK-1055
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
