### PR TITLE
Specify ref in prepare release workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -30,6 +30,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        ref: ${{ github.ref }}
     
     # Update Version
     - name: Updating Version Number


### PR DESCRIPTION
# Summary [Required]

The prepare release was referencing `develop` by default instead of the specified branch. This fix address it.

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
