### PR TITLE
Fix cashapp flag being ignored

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,6 +20,7 @@ excluded:
   - Carthage
   - TempProject
   - Scripts
+  - build
 
 line_length:
   ignores_function_declarations: true

--- a/AdyenCashAppPay/CashAppPayComponent.swift
+++ b/AdyenCashAppPay/CashAppPayComponent.swift
@@ -61,8 +61,10 @@ public final class CashAppPayComponent: PaymentComponent,
 
     private let cashAppPayPaymentMethod: CashAppPayPaymentMethod
 
-    private var storePayment: Bool? {
-        configuration.showsStorePaymentMethodField ? storeDetailsItem.value : nil
+    private var shouldStorePayment: Bool {
+        // if the toggle is visible, check its value
+        // if it's hidden, check the second flag's value
+        configuration.showsStorePaymentMethodField ? storeDetailsItem.value : configuration.storePaymentMethod
     }
 
     private lazy var cashAppPay: CashAppPay = {
@@ -175,7 +177,8 @@ public final class CashAppPayComponent: PaymentComponent,
             actions.append(oneTimeAction)
         }
     
-        if storePayment == true {
+        // onFile action is needed for /payments to tokenize the payment
+        if shouldStorePayment {
             let onFileAction = PaymentAction.onFilePayment(
                 scopeID: cashAppPayPaymentMethod.scopeId,
                 accountReferenceID: nil
@@ -214,7 +217,7 @@ public final class CashAppPayComponent: PaymentComponent,
                 paymentMethodDetails: details,
                 amount: payment?.amount,
                 order: order,
-                storePaymentMethod: storePayment
+                storePaymentMethod: shouldStorePayment
             ))
         } catch {
             fail(with: error, message: error.localizedDescription)

--- a/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
+++ b/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
@@ -257,6 +257,7 @@ extension ComponentManager: PaymentComponentBuilder {
                     referenceId: cashAppPayDropInConfig.referenceId
                 )
                 cashAppPayConfiguration.showsStorePaymentMethodField = cashAppPayDropInConfig.showsStorePaymentMethodField
+                cashAppPayConfiguration.storePaymentMethod = cashAppPayDropInConfig.storePaymentMethod
                 cashAppPayConfiguration.localizationParameters = configuration.localizationParameters
                 cashAppPayConfiguration.style = configuration.style.formComponent
         

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
@@ -70,6 +70,8 @@ internal final class DropInAdvancedFlowExample: InitialDataAdvancedFlowProtocol 
         configuration.actionComponent.threeDS.delegateAuthentication = ConfigurationConstants.delegatedAuthenticationConfigurations
         configuration.actionComponent.threeDS.requestorAppURL = ConfigurationConstants.returnUrl
         configuration.card = ConfigurationConstants.current.cardDropInConfiguration
+        configuration.cashAppPay?.storePaymentMethod = true
+        configuration.cashAppPay?.showsStorePaymentMethodField = false
         return configuration
     }
 

--- a/Demo/Common/Networking/SessionRequest.swift
+++ b/Demo/Common/Networking/SessionRequest.swift
@@ -58,7 +58,7 @@ internal struct SessionRequest: APIRequest {
                 message: "API version should be v70 or above to apply card component's store payment method field",
                 condition: ConfigurationConstants.current.apiVersion < 70
             )
-            try container.encode("enabled", forKey: .storePaymentMethodMode)
+            try container.encode("askForConsent", forKey: .storePaymentMethodMode)
             try container.encode(ConfigurationConstants.recurringProcessingModel, forKey: .recurringProcessingModel)
         }
         


### PR DESCRIPTION

# Summary [Required]
Fixes `storePaymentMethod` flag in cashapp configuration being ignored to determine whether the payment should be stored if the toggle is hidden via `showsStorePaymentMethodField`.

<fixed>
- Fixed an issue preventing to tokenize a CashAppPay payment if the toggle to store it was hidden. 
</fixed>


## Ticket [Optional]
<ticket>
COSDK-1096
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
