### PR TITLE
Threeds2Component theme migration - AdyenTheme to ADYAppearanceConfiguration

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -3663,6 +3663,7 @@
 			children = (
 				21C7110C2D67F86700A08111 /* ThreeDSServiceLegacy.swift */,
 				21C7111F2D6D388700A08111 /* AnyADYTransaction.swift */,
+				21ED843A2F72C34000568BDE /* ADYAppearanceConfigurationBuilder.swift */,
 				21C7111D2D6D386F00A08111 /* ADYServiceAdapter.swift */,
 			);
 			path = LegacySDK;
@@ -5001,7 +5002,6 @@
 				F957A9F825514ED30099AD73 /* Fingerprint Submitter */,
 				F957A9E125514A590099AD73 /* API */,
 				E2345C01229BCC7D000F2C94 /* ThreeDS2Component.swift */,
-				21ED843A2F72C34000568BDE /* ADYAppearanceConfigurationBuilder.swift */,
 				A0CB497C2F336B6E00372021 /* ThreeDS2ActionConfiguration.swift */,
 				E2345C05229BDA3C000F2C94 /* ThreeDS2ComponentFingerprintToken.swift */,
 				21CBEF4E2D88CA1600178809 /* ThreeDS2ComponentThreeDSConfiguration.swift */,

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 		21CBEF662D8B6B3A00178809 /* ThreeDSServiceProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21CBEF652D8B6B2F00178809 /* ThreeDSServiceProviderTests.swift */; };
 		21D6FC1B2F236EED003811A8 /* AdyenUI.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 21D6FC1A2F236EED003811A8 /* AdyenUI.xcassets */; };
 		21E641B72F3F65910087253F /* PublicKeyFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E641B62F3F65910087253F /* PublicKeyFetcherTests.swift */; };
+		21ED843B2F72C34000568BDE /* ADYAppearanceConfigurationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21ED843A2F72C34000568BDE /* ADYAppearanceConfigurationBuilder.swift */; };
 		4D6ACC5A19457F96B7013F0E /* FormAddressPickerItemViewStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A944D9CA552D7C8E2063601 /* FormAddressPickerItemViewStyleTests.swift */; };
 		5A15D589264BB0BD00A8E3C7 /* BoletoComponentExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A15D588264BB0BD00A8E3C7 /* BoletoComponentExtensions.swift */; };
 		5A15D5A1264BE1E500A8E3C7 /* PrefilledShopperInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A15D5A0264BE1E500A8E3C7 /* PrefilledShopperInformation.swift */; };
@@ -442,6 +443,7 @@
 		81FC2C8F2BB18F0F007F1316 /* ImageLoaderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FC2C8C2BB18D0A007F1316 /* ImageLoaderMock.swift */; };
 		81FC2C982BB1BB68007F1316 /* URLProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FC2C962BB1B9F3007F1316 /* URLProtocolMock.swift */; };
 		81FC2C992BB1BB69007F1316 /* URLProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FC2C962BB1B9F3007F1316 /* URLProtocolMock.swift */; };
+		867E3058D1CC3D00964901B6 /* DemoAPIClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1B74F41FC86BF6808193FD /* DemoAPIClientMock.swift */; };
 		A001297C2C0DF2E0009EF80C /* StoredPaymentMethodsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A001297B2C0DF2E0009EF80C /* StoredPaymentMethodsDelegate.swift */; };
 		A001676A2BC9567B0099A6AE /* AnalyticsValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00167692BC9567B0099A6AE /* AnalyticsValidationError.swift */; };
 		A001676C2BD120400099A6AE /* CardHolderNameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A001676B2BD120400099A6AE /* CardHolderNameValidator.swift */; };
@@ -739,8 +741,6 @@
 		B6D808452BCD2B0600F3F5EB /* RSAOAEP256AlgorithmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F1A99326CD39740005CB1D /* RSAOAEP256AlgorithmTests.swift */; };
 		B6EE0F382BBE9C4500B9810D /* APIClientHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C560525EE8C8D00B57758 /* APIClientHelper.swift */; };
 		B6EE0F392BBE9C4500B9810D /* APIClientHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E73C560525EE8C8D00B57758 /* APIClientHelper.swift */; };
-		B6EE0F3A2BBEA2A800B9810D /* APIClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E757F02525D2ED4C007C813D /* APIClientMock.swift */; };
-		867E3058D1CC3D00964901B6 /* DemoAPIClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F1B74F41FC86BF6808193FD /* DemoAPIClientMock.swift */; };
 		B6EE0F3B2BBEA2A800B9810D /* APIClientMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E757F02525D2ED4C007C813D /* APIClientMock.swift */; };
 		B6EE0F3C2BBEAB4900B9810D /* AnalyticsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C0005B280468E100CE2EEC /* AnalyticsProviderMock.swift */; };
 		B6EE0F3D2BBEBF5100B9810D /* AnalyticsProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C0005B280468E100CE2EEC /* AnalyticsProviderMock.swift */; };
@@ -1990,6 +1990,7 @@
 		21CBEF652D8B6B2F00178809 /* ThreeDSServiceProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSServiceProviderTests.swift; sourceTree = "<group>"; };
 		21D6FC1A2F236EED003811A8 /* AdyenUI.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AdyenUI.xcassets; sourceTree = "<group>"; };
 		21E641B62F3F65910087253F /* PublicKeyFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKeyFetcherTests.swift; sourceTree = "<group>"; };
+		21ED843A2F72C34000568BDE /* ADYAppearanceConfigurationBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ADYAppearanceConfigurationBuilder.swift; sourceTree = "<group>"; };
 		3A944D9CA552D7C8E2063601 /* FormAddressPickerItemViewStyleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormAddressPickerItemViewStyleTests.swift; sourceTree = "<group>"; };
 		5A1315C826296B100092366D /* ProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewStyle.swift; sourceTree = "<group>"; };
 		5A15D588264BB0BD00A8E3C7 /* BoletoComponentExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoletoComponentExtensions.swift; sourceTree = "<group>"; };
@@ -2027,6 +2028,7 @@
 		5AD755DA268E11DA0040B919 /* VoucherComponentExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoucherComponentExtensions.swift; sourceTree = "<group>"; };
 		5AF730E92667C3F10091C573 /* APIContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIContextTests.swift; sourceTree = "<group>"; };
 		5AF8CD4C26691D3A00102339 /* Dummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dummy.swift; sourceTree = "<group>"; };
+		6F1B74F41FC86BF6808193FD /* DemoAPIClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAPIClientMock.swift; sourceTree = "<group>"; };
 		8100F2BC2A4C3407008C09E7 /* FormValidatableItemViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormValidatableItemViewTests.swift; sourceTree = "<group>"; };
 		8100F2BF2A4C37E3008C09E7 /* FormSelectableItemViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormSelectableItemViewTests.swift; sourceTree = "<group>"; };
 		8107F4832BB1CE8A007745FC /* String+UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+UIImage.swift"; sourceTree = "<group>"; };
@@ -2582,7 +2584,6 @@
 		E7388D9523E08BF9008E62B8 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E73C54E325EBD2DC00B57758 /* BrowserComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BrowserComponent.swift; sourceTree = "<group>"; };
 		E73C560525EE8C8D00B57758 /* APIClientHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientHelper.swift; sourceTree = "<group>"; };
-		6F1B74F41FC86BF6808193FD /* DemoAPIClientMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAPIClientMock.swift; sourceTree = "<group>"; };
 		E73C567E25EFCC4200B57758 /* IssuerListComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssuerListComponentTests.swift; sourceTree = "<group>"; };
 		E745175425FB6A59000BDCCF /* CardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewController.swift; sourceTree = "<group>"; };
 		E745179825FB8340000BDCCF /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
@@ -4996,6 +4997,7 @@
 				F957A9F825514ED30099AD73 /* Fingerprint Submitter */,
 				F957A9E125514A590099AD73 /* API */,
 				E2345C01229BCC7D000F2C94 /* ThreeDS2Component.swift */,
+				21ED843A2F72C34000568BDE /* ADYAppearanceConfigurationBuilder.swift */,
 				A0CB497C2F336B6E00372021 /* ThreeDS2ActionConfiguration.swift */,
 				E2345C05229BDA3C000F2C94 /* ThreeDS2ComponentFingerprintToken.swift */,
 				21CBEF4E2D88CA1600178809 /* ThreeDS2ComponentThreeDSConfiguration.swift */,
@@ -9185,6 +9187,7 @@
 				F9175FD02594999600D653BE /* RedirectDetails.swift in Sources */,
 				81A6B4E32AD53E3300A089A1 /* OpenExternalAppDetector.swift in Sources */,
 				F917613625A30B5700D653BE /* ThreeDS2ComponentChallengeToken.swift in Sources */,
+				21ED843B2F72C34000568BDE /* ADYAppearanceConfigurationBuilder.swift in Sources */,
 				0058691928B6451000B65A19 /* QRCodeViewModel.swift in Sources */,
 				0042EBC32B8364ED001B1F6C /* TwintSDKActionComponent.swift in Sources */,
 				F93E534C289A86A800BB6580 /* NativeRedirectResultRequest.swift in Sources */,

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -256,6 +256,8 @@
 		21B3A71529CA720C00F48386 /* DARegistrationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B3A71429CA720C00F48386 /* DARegistrationViewController.swift */; };
 		21B3A71729CA721F00F48386 /* DAApprovalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B3A71629CA721F00F48386 /* DAApprovalViewController.swift */; };
 		21B3A71929CA780200F48386 /* DelegatedAuthenticationComponentStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21B3A71829CA780200F48386 /* DelegatedAuthenticationComponentStyle.swift */; };
+		21BF4C202F73E2D80063B13C /* ExampleAppThemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BF4C1F2F73E2D80063B13C /* ExampleAppThemes.swift */; };
+		21BF4C212F73E2D80063B13C /* ExampleAppThemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21BF4C1F2F73E2D80063B13C /* ExampleAppThemes.swift */; };
 		21C7110E2D67F86700A08111 /* ThreeDSServiceLegacy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7110C2D67F86700A08111 /* ThreeDSServiceLegacy.swift */; };
 		21C7110F2D67F86700A08111 /* ThreeDSServiceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C7110D2D67F86700A08111 /* ThreeDSServiceable.swift */; };
 		21C711112D67FE6B00A08111 /* ThreeDSServiceChallengeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C711102D67FE6B00A08111 /* ThreeDSServiceChallengeError.swift */; };
@@ -1973,6 +1975,7 @@
 		21B3A71429CA720C00F48386 /* DARegistrationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DARegistrationViewController.swift; sourceTree = "<group>"; };
 		21B3A71629CA721F00F48386 /* DAApprovalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DAApprovalViewController.swift; sourceTree = "<group>"; };
 		21B3A71829CA780200F48386 /* DelegatedAuthenticationComponentStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegatedAuthenticationComponentStyle.swift; sourceTree = "<group>"; };
+		21BF4C1F2F73E2D80063B13C /* ExampleAppThemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleAppThemes.swift; sourceTree = "<group>"; };
 		21C7110C2D67F86700A08111 /* ThreeDSServiceLegacy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSServiceLegacy.swift; sourceTree = "<group>"; };
 		21C7110D2D67F86700A08111 /* ThreeDSServiceable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSServiceable.swift; sourceTree = "<group>"; };
 		21C711102D67FE6B00A08111 /* ThreeDSServiceChallengeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSServiceChallengeError.swift; sourceTree = "<group>"; };
@@ -3715,6 +3718,7 @@
 		5A67461E264262CF00E9184D /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				21BF4C1F2F73E2D80063B13C /* ExampleAppThemes.swift */,
 				5A67461F264262F000E9184D /* ConfigurationView.swift */,
 				00D5B8652A4C63FE003CFCD0 /* CardComponentSettingsView.swift */,
 				001BFF412A6E74BD007B2A46 /* DropInSettingsView.swift */,
@@ -9041,6 +9045,7 @@
 				B67D1F682E4615390000C37F /* ApplePayComponentAdvancedFlowExample.swift in Sources */,
 				B67D1F692E4615390000C37F /* InstantPaymentComponentAdvancedFlowExample.swift in Sources */,
 				B67D1F6A2E4615390000C37F /* ApplePayComponentExample.swift in Sources */,
+				21BF4C212F73E2D80063B13C /* ExampleAppThemes.swift in Sources */,
 				B67D1F6B2E4615390000C37F /* IssuerListComponentExample.swift in Sources */,
 				B67D1F6C2E4615390000C37F /* CardComponentAdvancedFlowExample.swift in Sources */,
 				F9A53C442549887F009000A7 /* DefaultAPIClient.swift in Sources */,
@@ -9381,6 +9386,7 @@
 				B67D1F702E4615390000C37F /* CardComponentExample.swift in Sources */,
 				B67D1F712E4615390000C37F /* InstantPaymentComponentExample.swift in Sources */,
 				B67D1F722E4615390000C37F /* ApplePayComponentAdvancedFlowExample.swift in Sources */,
+				21BF4C202F73E2D80063B13C /* ExampleAppThemes.swift in Sources */,
 				B67D1F732E4615390000C37F /* InstantPaymentComponentAdvancedFlowExample.swift in Sources */,
 				B67D1F742E4615390000C37F /* ApplePayComponentExample.swift in Sources */,
 				B67D1F752E4615390000C37F /* IssuerListComponentExample.swift in Sources */,

--- a/AdyenActions/CheckoutActionComponent.swift
+++ b/AdyenActions/CheckoutActionComponent.swift
@@ -5,7 +5,6 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
 import Foundation
 import UIKit
 

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/FingerprintServiceParameters.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/FingerprintServiceParameters.swift
@@ -4,7 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import AdyenUI
+#if canImport(AdyenUI)
+    import AdyenUI
+#endif
 import Foundation
 
 internal struct FingerprintServiceParameters {

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/FingerprintServiceParameters.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/FingerprintServiceParameters.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import class Adyen3DS2.ADYAppearanceConfiguration
+import AdyenUI
 import Foundation
 
 internal struct FingerprintServiceParameters {
@@ -12,6 +12,6 @@ internal struct FingerprintServiceParameters {
     internal let directoryServerPublicKey: String
     internal let directoryServerRootCertificates: String
     internal let deviceExcludedParameters: [String: Any]?
-    internal let appearanceConfiguration: Adyen3DS2.ADYAppearanceConfiguration
+    internal let theme: AdyenTheme
     internal let threeDSMessageVersion: String
 }

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ADYAppearanceConfigurationBuilder.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ADYAppearanceConfigurationBuilder.swift
@@ -5,7 +5,9 @@
 //
 
 import Adyen3DS2
-import AdyenUI
+#if canImport(AdyenUI)
+    @_spi(AdyenInternal) import AdyenUI
+#endif
 import Foundation
 
 /// Builds an `Adyen3DS2.ADYAppearanceConfiguration` from an `AdyenTheme`.
@@ -24,7 +26,6 @@ internal struct ADYAppearanceConfigurationBuilder {
         configureTextFieldAppearance(config.textFieldAppearance)
         configureButtonAppearances(config)
         configureSwitchAppearance(config.switchAppearance)
-        configureNavigationBarAppearance(config.navigationBarAppearance)
         configureSelectAppearance(config.selectAppearance)
         configureInfoAppearance(config.infoAppearance)
         return config
@@ -106,14 +107,7 @@ internal struct ADYAppearanceConfigurationBuilder {
             switchAppearance.switchTintColor = tintColor
         }
     }
-    
-    // MARK: - Navigation Bar Appearance
-    
-    private func configureNavigationBarAppearance(_ navigationBarAppearance: ADYNavigationBarAppearance) {
-//        let colors = theme.colors
-//        navigationBarAppearance.textColor = colors.
-    }
-    
+        
     // MARK: - Select Appearance
     
     private func configureSelectAppearance(_ selectAppearance: ADYSelectAppearance) {

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ADYAppearanceConfigurationBuilder.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ADYAppearanceConfigurationBuilder.swift
@@ -6,7 +6,7 @@
 
 import Adyen3DS2
 #if canImport(AdyenUI)
-    @_spi(AdyenInternal) import AdyenUI
+    import AdyenUI
 #endif
 import Foundation
 

--- a/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ThreeDSServiceLegacy.swift
+++ b/AdyenActions/Components/3DS2/3DS2 SDK Adapters/LegacySDK/ThreeDSServiceLegacy.swift
@@ -32,7 +32,7 @@ internal final class ThreeDSServiceLegacy: ThreeDSServiceable {
         )
         service.service(
             with: serviceParameters,
-            appearanceConfiguration: parameters.appearanceConfiguration
+            appearanceConfiguration: ADYAppearanceConfigurationBuilder(theme: parameters.theme).build()
         ) { [weak self] service in
             guard let self else { return }
             do {

--- a/AdyenActions/Components/3DS2/ADYAppearanceConfigurationBuilder.swift
+++ b/AdyenActions/Components/3DS2/ADYAppearanceConfigurationBuilder.swift
@@ -1,0 +1,225 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen3DS2
+import AdyenUI
+import Foundation
+
+/// Builds an `ADYAppearanceConfiguration` from an `AdyenTheme`.
+///
+/// This struct transforms the Adyen SDK's theming system into the 3DS2 SDK's appearance configuration,
+/// mapping colors, fonts, and styles from `AdyenTheme` to the corresponding `ADYAppearanceConfiguration` properties.
+internal struct ADYAppearanceConfigurationBuilder {
+    
+    private let theme: AdyenTheme
+    
+    internal init(theme: AdyenTheme) {
+        self.theme = theme
+    }
+    
+    /// Builds and returns an `ADYAppearanceConfiguration` based on the provided `AdyenTheme`.
+    internal func build() -> ADYAppearanceConfiguration {
+        let config = ADYAppearanceConfiguration()
+        
+        configureGlobalColors(config)
+        configureLabelAppearance(config.labelAppearance)
+        configureTextFieldAppearance(config.textFieldAppearance)
+        configureButtonAppearances(config)
+        configureSwitchAppearance(config.switchAppearance)
+        configureNavigationBarAppearance(config.navigationBarAppearance)
+        configureSelectAppearance(config.selectAppearance)
+        configureInfoAppearance(config.infoAppearance)
+        
+        // TODO: config.statusBarStyle - no direct mapping in AdyenTheme (system-level setting)
+        // TODO: config.modalPresentationStyle - no direct mapping in AdyenTheme (presentation-level setting)
+        
+        return config
+    }
+    
+    // MARK: - Global Colors
+    
+    private func configureGlobalColors(_ config: ADYAppearanceConfiguration) {
+        let colors = theme.colors
+        
+        config.backgroundColor = colors.background
+        config.textColor = colors.text
+        config.borderColor = colors.containerOutline
+        config.tintColor = colors.primary
+    }
+    
+    // MARK: - Label Appearance
+    
+    private func configureLabelAppearance(_ labelAppearance: ADYLabelAppearance) {
+        let labels = theme.elements.labels
+        let colors = theme.colors
+        
+        // ADYAppearance base properties (inherited)
+        labelAppearance.font = labels.body.font
+        labelAppearance.textColor = labels.body.color
+        
+        // ADYLabelAppearance specific properties
+        labelAppearance.headingFont = labels.title.font
+        labelAppearance.headingTextColor = labels.title.color
+        labelAppearance.subheadingFont = labels.subtitle.font
+        labelAppearance.subheadingTextColor = labels.subtitle.color
+        labelAppearance.errorTextColor = colors.destructive
+        
+        // TODO: labelAppearance.headingLineHeight - no direct mapping in AdyenTheme (line height not exposed)
+        // TODO: labelAppearance.lineHeight - no direct mapping in AdyenTheme (line height not exposed)
+    }
+    
+    // MARK: - Text Field Appearance
+    
+    private func configureTextFieldAppearance(_ textFieldAppearance: ADYTextFieldAppearance) {
+        let textField = theme.elements.textField
+        
+        // ADYAppearance base properties (inherited)
+        textFieldAppearance.font = textField.text.font
+        textFieldAppearance.textColor = textField.text.color
+        
+        // ADYTextFieldAppearance specific properties
+        textFieldAppearance.borderWidth = textField.borderWidth
+        textFieldAppearance.borderColor = textField.borderColor
+        textFieldAppearance.cornerRadius = textField.cornerRadius.cgFloatValue
+        
+        // TODO: textFieldAppearance.keyboardAppearance - no direct mapping in AdyenTheme (keyboard style not exposed)
+    }
+    
+    // MARK: - Button Appearances
+    
+    private func configureButtonAppearances(_ config: ADYAppearanceConfiguration) {
+        let buttons = theme.elements.buttons
+        let defaultCornerRadius = theme.attributes.cornerRadius
+        
+        // Submit, Continue, Next, OOB buttons use primary style
+        let primaryButtonTypes: [ADYAppearanceButtonType] = [.submit, .continue, .next, .OOB]
+        for buttonType in primaryButtonTypes {
+            configureButtonAppearance(
+                config.buttonAppearance(for: buttonType),
+                with: buttons.primary,
+                defaultCornerRadius: defaultCornerRadius
+            )
+        }
+        
+        // Cancel button uses destructive style
+        configureButtonAppearance(
+            config.buttonAppearance(for: .cancel),
+            with: buttons.destructive,
+            defaultCornerRadius: defaultCornerRadius
+        )
+        
+        // Resend button uses secondary style
+        configureButtonAppearance(
+            config.buttonAppearance(for: .resend),
+            with: buttons.secondary,
+            defaultCornerRadius: defaultCornerRadius
+        )
+    }
+    
+    private func configureButtonAppearance(
+        _ buttonAppearance: ADYButtonAppearance,
+        with style: AdyenButtonStyle,
+        defaultCornerRadius: CGFloat
+    ) {
+        // ADYAppearance base properties (inherited)
+        // TODO: buttonAppearance.font - no direct mapping in AdyenTheme (AdyenButtonStyle doesn't expose font)
+        // TODO: buttonAppearance.textColor is set below as ADYButtonAppearance overrides it
+        
+        // ADYButtonAppearance specific properties
+        buttonAppearance.backgroundColor = style.backgroundColor
+        buttonAppearance.textColor = style.textColor
+        buttonAppearance.disabledBackgroundColor = style.disabledBackgroundColor
+        buttonAppearance.disabledTextColor = style.disabledTextColor
+        buttonAppearance.cornerRadius = style.cornerRadius?.cgFloatValue ?? defaultCornerRadius
+        
+        // TODO: buttonAppearance.highlightedBackgroundColor - no direct mapping in AdyenTheme (highlighted state not exposed)
+        // TODO: buttonAppearance.textTransform - no direct mapping in AdyenTheme (text transform not exposed)
+    }
+    
+    // MARK: - Switch Appearance
+    
+    private func configureSwitchAppearance(_ switchAppearance: ADYSwitchAppearance) {
+        let switchStyle = theme.elements.switch
+        
+        // ADYAppearance base properties (inherited)
+        switchAppearance.font = switchStyle.title.font
+        switchAppearance.textColor = switchStyle.title.color
+        
+        // ADYSwitchAppearance specific properties
+        if let tintColor = switchStyle.tintColor {
+            switchAppearance.switchTintColor = tintColor
+        }
+    }
+    
+    // MARK: - Navigation Bar Appearance
+    
+    private func configureNavigationBarAppearance(_ navigationBarAppearance: ADYNavigationBarAppearance) {
+        let labels = theme.elements.labels
+        let colors = theme.colors
+        
+        // ADYAppearance base properties (inherited)
+        navigationBarAppearance.font = labels.subtitle.font
+        navigationBarAppearance.textColor = colors.text
+        
+        // ADYNavigationBarAppearance specific properties
+        // TODO: navigationBarAppearance.title - no direct mapping in AdyenTheme (app-specific, set by merchant)
+        // TODO: navigationBarAppearance.cancelButtonTitle - no direct mapping in AdyenTheme (app-specific, set by merchant)
+        // Note: navigationBarAppearance.backgroundColor is deprecated for iOS 26+
+    }
+    
+    // MARK: - Select Appearance
+    
+    private func configureSelectAppearance(_ selectAppearance: ADYSelectAppearance) {
+        let colors = theme.colors
+        let labels = theme.elements.labels
+        
+        // ADYAppearance base properties (inherited)
+        selectAppearance.font = labels.body.font
+        selectAppearance.textColor = labels.body.color
+        
+        // ADYSelectAppearance specific properties
+        selectAppearance.borderColor = colors.containerOutline
+        selectAppearance.selectionIndicatorTintColor = colors.primary
+        
+        // TODO: selectAppearance.highlightedBackgroundColor - no direct mapping in AdyenTheme (highlighted state not exposed)
+    }
+    
+    // MARK: - Info Appearance
+    
+    private func configureInfoAppearance(_ infoAppearance: ADYInfoAppearance) {
+        let colors = theme.colors
+        let labels = theme.elements.labels
+        
+        // ADYAppearance base properties (inherited)
+        infoAppearance.font = labels.body.font
+        infoAppearance.textColor = labels.body.color
+        
+        // ADYInfoAppearance specific properties
+        infoAppearance.headingFont = labels.title.font
+        infoAppearance.headingTextColor = labels.title.color
+        infoAppearance.borderColor = colors.containerOutline
+        infoAppearance.selectionIndicatorTintColor = colors.primary
+    }
+}
+
+// MARK: - CornerRounding Extension
+
+private extension CornerRounding {
+    /// Converts the `CornerRounding` enum to a `CGFloat` value suitable for the 3DS2 SDK.
+    var cgFloatValue: CGFloat {
+        switch self {
+        case .none:
+            return 0
+        case let .fixed(value):
+            return value
+        case let .percent(value):
+            // For percent-based rounding, use a reasonable default since we don't have view dimensions.
+            // The 3DS2 SDK expects a fixed CGFloat value.
+            // Using a multiplier to approximate a reasonable corner radius.
+            return value * 100
+        }
+    }
+}

--- a/AdyenActions/Components/3DS2/ADYAppearanceConfigurationBuilder.swift
+++ b/AdyenActions/Components/3DS2/ADYAppearanceConfigurationBuilder.swift
@@ -8,10 +8,7 @@ import Adyen3DS2
 import AdyenUI
 import Foundation
 
-/// Builds an `ADYAppearanceConfiguration` from an `AdyenTheme`.
-///
-/// This struct transforms the Adyen SDK's theming system into the 3DS2 SDK's appearance configuration,
-/// mapping colors, fonts, and styles from `AdyenTheme` to the corresponding `ADYAppearanceConfiguration` properties.
+/// Builds an `Adyen3DS2.ADYAppearanceConfiguration` from an `AdyenTheme`.
 internal struct ADYAppearanceConfigurationBuilder {
     
     private let theme: AdyenTheme
@@ -20,7 +17,6 @@ internal struct ADYAppearanceConfigurationBuilder {
         self.theme = theme
     }
     
-    /// Builds and returns an `ADYAppearanceConfiguration` based on the provided `AdyenTheme`.
     internal func build() -> ADYAppearanceConfiguration {
         let config = ADYAppearanceConfiguration()
         
@@ -32,10 +28,6 @@ internal struct ADYAppearanceConfigurationBuilder {
         configureNavigationBarAppearance(config.navigationBarAppearance)
         configureSelectAppearance(config.selectAppearance)
         configureInfoAppearance(config.infoAppearance)
-        
-        // TODO: config.statusBarStyle - no direct mapping in AdyenTheme (system-level setting)
-        // TODO: config.modalPresentationStyle - no direct mapping in AdyenTheme (presentation-level setting)
-        
         return config
     }
     
@@ -43,11 +35,7 @@ internal struct ADYAppearanceConfigurationBuilder {
     
     private func configureGlobalColors(_ config: ADYAppearanceConfiguration) {
         let colors = theme.colors
-        
         config.backgroundColor = colors.background
-        config.textColor = colors.text
-        config.borderColor = colors.containerOutline
-        config.tintColor = colors.primary
     }
     
     // MARK: - Label Appearance
@@ -55,37 +43,19 @@ internal struct ADYAppearanceConfigurationBuilder {
     private func configureLabelAppearance(_ labelAppearance: ADYLabelAppearance) {
         let labels = theme.elements.labels
         let colors = theme.colors
-        
-        // ADYAppearance base properties (inherited)
-        labelAppearance.font = labels.body.font
         labelAppearance.textColor = labels.body.color
-        
-        // ADYLabelAppearance specific properties
-        labelAppearance.headingFont = labels.title.font
         labelAppearance.headingTextColor = labels.title.color
-        labelAppearance.subheadingFont = labels.subtitle.font
         labelAppearance.subheadingTextColor = labels.subtitle.color
-        labelAppearance.errorTextColor = colors.destructive
-        
-        // TODO: labelAppearance.headingLineHeight - no direct mapping in AdyenTheme (line height not exposed)
-        // TODO: labelAppearance.lineHeight - no direct mapping in AdyenTheme (line height not exposed)
     }
     
     // MARK: - Text Field Appearance
     
     private func configureTextFieldAppearance(_ textFieldAppearance: ADYTextFieldAppearance) {
         let textField = theme.elements.textField
-        
-        // ADYAppearance base properties (inherited)
-        textFieldAppearance.font = textField.text.font
         textFieldAppearance.textColor = textField.text.color
-        
-        // ADYTextFieldAppearance specific properties
         textFieldAppearance.borderWidth = textField.borderWidth
         textFieldAppearance.borderColor = textField.borderColor
         textFieldAppearance.cornerRadius = textField.cornerRadius.cgFloatValue
-        
-        // TODO: textFieldAppearance.keyboardAppearance - no direct mapping in AdyenTheme (keyboard style not exposed)
     }
     
     // MARK: - Button Appearances
@@ -93,9 +63,8 @@ internal struct ADYAppearanceConfigurationBuilder {
     private func configureButtonAppearances(_ config: ADYAppearanceConfiguration) {
         let buttons = theme.elements.buttons
         let defaultCornerRadius = theme.attributes.cornerRadius
-        
-        // Submit, Continue, Next, OOB buttons use primary style
-        let primaryButtonTypes: [ADYAppearanceButtonType] = [.submit, .continue, .next, .OOB]
+
+        let primaryButtonTypes: [ADYAppearanceButtonType] = [.submit, .continue, .next]
         for buttonType in primaryButtonTypes {
             configureButtonAppearance(
                 config.buttonAppearance(for: buttonType),
@@ -103,20 +72,15 @@ internal struct ADYAppearanceConfigurationBuilder {
                 defaultCornerRadius: defaultCornerRadius
             )
         }
-        
-        // Cancel button uses destructive style
-        configureButtonAppearance(
-            config.buttonAppearance(for: .cancel),
-            with: buttons.destructive,
-            defaultCornerRadius: defaultCornerRadius
-        )
-        
-        // Resend button uses secondary style
-        configureButtonAppearance(
-            config.buttonAppearance(for: .resend),
-            with: buttons.secondary,
-            defaultCornerRadius: defaultCornerRadius
-        )
+
+        let secondaryButtonTypes: [ADYAppearanceButtonType] = [.OOB, .cancel, .resend]
+        for buttonType in secondaryButtonTypes {
+            configureButtonAppearance(
+                config.buttonAppearance(for: buttonType),
+                with: buttons.secondary,
+                defaultCornerRadius: defaultCornerRadius
+            )
+        }
     }
     
     private func configureButtonAppearance(
@@ -124,31 +88,19 @@ internal struct ADYAppearanceConfigurationBuilder {
         with style: AdyenButtonStyle,
         defaultCornerRadius: CGFloat
     ) {
-        // ADYAppearance base properties (inherited)
-        // TODO: buttonAppearance.font - no direct mapping in AdyenTheme (AdyenButtonStyle doesn't expose font)
-        // TODO: buttonAppearance.textColor is set below as ADYButtonAppearance overrides it
-        
-        // ADYButtonAppearance specific properties
         buttonAppearance.backgroundColor = style.backgroundColor
         buttonAppearance.textColor = style.textColor
         buttonAppearance.disabledBackgroundColor = style.disabledBackgroundColor
         buttonAppearance.disabledTextColor = style.disabledTextColor
         buttonAppearance.cornerRadius = style.cornerRadius?.cgFloatValue ?? defaultCornerRadius
-        
-        // TODO: buttonAppearance.highlightedBackgroundColor - no direct mapping in AdyenTheme (highlighted state not exposed)
-        // TODO: buttonAppearance.textTransform - no direct mapping in AdyenTheme (text transform not exposed)
     }
     
     // MARK: - Switch Appearance
     
     private func configureSwitchAppearance(_ switchAppearance: ADYSwitchAppearance) {
         let switchStyle = theme.elements.switch
-        
-        // ADYAppearance base properties (inherited)
         switchAppearance.font = switchStyle.title.font
         switchAppearance.textColor = switchStyle.title.color
-        
-        // ADYSwitchAppearance specific properties
         if let tintColor = switchStyle.tintColor {
             switchAppearance.switchTintColor = tintColor
         }
@@ -159,15 +111,7 @@ internal struct ADYAppearanceConfigurationBuilder {
     private func configureNavigationBarAppearance(_ navigationBarAppearance: ADYNavigationBarAppearance) {
         let labels = theme.elements.labels
         let colors = theme.colors
-        
-        // ADYAppearance base properties (inherited)
-        navigationBarAppearance.font = labels.subtitle.font
-        navigationBarAppearance.textColor = colors.text
-        
-        // ADYNavigationBarAppearance specific properties
-        // TODO: navigationBarAppearance.title - no direct mapping in AdyenTheme (app-specific, set by merchant)
-        // TODO: navigationBarAppearance.cancelButtonTitle - no direct mapping in AdyenTheme (app-specific, set by merchant)
-        // Note: navigationBarAppearance.backgroundColor is deprecated for iOS 26+
+        navigationBarAppearance.textColor = colors.text // All platforms map this
     }
     
     // MARK: - Select Appearance
@@ -175,16 +119,9 @@ internal struct ADYAppearanceConfigurationBuilder {
     private func configureSelectAppearance(_ selectAppearance: ADYSelectAppearance) {
         let colors = theme.colors
         let labels = theme.elements.labels
-        
-        // ADYAppearance base properties (inherited)
-        selectAppearance.font = labels.body.font
         selectAppearance.textColor = labels.body.color
-        
-        // ADYSelectAppearance specific properties
-        selectAppearance.borderColor = colors.containerOutline
+        selectAppearance.borderColor = colors.separator
         selectAppearance.selectionIndicatorTintColor = colors.primary
-        
-        // TODO: selectAppearance.highlightedBackgroundColor - no direct mapping in AdyenTheme (highlighted state not exposed)
     }
     
     // MARK: - Info Appearance
@@ -192,15 +129,10 @@ internal struct ADYAppearanceConfigurationBuilder {
     private func configureInfoAppearance(_ infoAppearance: ADYInfoAppearance) {
         let colors = theme.colors
         let labels = theme.elements.labels
-        
-        // ADYAppearance base properties (inherited)
-        infoAppearance.font = labels.body.font
+
         infoAppearance.textColor = labels.body.color
-        
-        // ADYInfoAppearance specific properties
-        infoAppearance.headingFont = labels.body.font
-        infoAppearance.headingTextColor = labels.body.color
-        infoAppearance.borderColor = colors.containerOutline
+        infoAppearance.headingTextColor = theme.colors.textSecondary
+        infoAppearance.borderColor = colors.separator
         infoAppearance.selectionIndicatorTintColor = colors.primary
     }
 }
@@ -208,7 +140,6 @@ internal struct ADYAppearanceConfigurationBuilder {
 // MARK: - CornerRounding Extension
 
 private extension CornerRounding {
-    /// Converts the `CornerRounding` enum to a `CGFloat` value suitable for the 3DS2 SDK.
     var cgFloatValue: CGFloat {
         switch self {
         case .none:
@@ -216,9 +147,8 @@ private extension CornerRounding {
         case let .fixed(value):
             return value
         case let .percent(value):
-            // For percent-based rounding, use a reasonable default since we don't have view dimensions.
-            // The 3DS2 SDK expects a fixed CGFloat value.
             // Using a multiplier to approximate a reasonable corner radius.
+            // TODO: Robert: What is a percent CornerRounding? How does it translate to something that is static.
             return value * 100
         }
     }

--- a/AdyenActions/Components/3DS2/ADYAppearanceConfigurationBuilder.swift
+++ b/AdyenActions/Components/3DS2/ADYAppearanceConfigurationBuilder.swift
@@ -71,7 +71,7 @@ internal struct ADYAppearanceConfigurationBuilder {
             )
         }
 
-        let secondaryButtonTypes: [ADYAppearanceButtonType] = [.OOB, .cancel, .resend]
+        let secondaryButtonTypes: [ADYAppearanceButtonType] = [.OOB, .resend]
         for buttonType in secondaryButtonTypes {
             configureButtonAppearance(
                 config.buttonAppearance(for: buttonType),
@@ -79,6 +79,9 @@ internal struct ADYAppearanceConfigurationBuilder {
                 defaultCornerRadius: defaultCornerRadius
             )
         }
+
+        let cancelButtonAppearance = config.buttonAppearance(for: .cancel)
+        cancelButtonAppearance.textColor = theme.colors.primary
     }
     
     private func configureButtonAppearance(
@@ -107,8 +110,8 @@ internal struct ADYAppearanceConfigurationBuilder {
     // MARK: - Navigation Bar Appearance
     
     private func configureNavigationBarAppearance(_ navigationBarAppearance: ADYNavigationBarAppearance) {
-        let colors = theme.colors
-        navigationBarAppearance.textColor = colors.text
+//        let colors = theme.colors
+//        navigationBarAppearance.textColor = colors.
     }
     
     // MARK: - Select Appearance

--- a/AdyenActions/Components/3DS2/ADYAppearanceConfigurationBuilder.swift
+++ b/AdyenActions/Components/3DS2/ADYAppearanceConfigurationBuilder.swift
@@ -198,8 +198,8 @@ internal struct ADYAppearanceConfigurationBuilder {
         infoAppearance.textColor = labels.body.color
         
         // ADYInfoAppearance specific properties
-        infoAppearance.headingFont = labels.title.font
-        infoAppearance.headingTextColor = labels.title.color
+        infoAppearance.headingFont = labels.body.font
+        infoAppearance.headingTextColor = labels.body.color
         infoAppearance.borderColor = colors.containerOutline
         infoAppearance.selectionIndicatorTintColor = colors.primary
     }

--- a/AdyenActions/Components/3DS2/ADYAppearanceConfigurationBuilder.swift
+++ b/AdyenActions/Components/3DS2/ADYAppearanceConfigurationBuilder.swift
@@ -19,7 +19,6 @@ internal struct ADYAppearanceConfigurationBuilder {
     
     internal func build() -> ADYAppearanceConfiguration {
         let config = ADYAppearanceConfiguration()
-        
         configureGlobalColors(config)
         configureLabelAppearance(config.labelAppearance)
         configureTextFieldAppearance(config.textFieldAppearance)
@@ -42,7 +41,6 @@ internal struct ADYAppearanceConfigurationBuilder {
     
     private func configureLabelAppearance(_ labelAppearance: ADYLabelAppearance) {
         let labels = theme.elements.labels
-        let colors = theme.colors
         labelAppearance.textColor = labels.body.color
         labelAppearance.headingTextColor = labels.title.color
         labelAppearance.subheadingTextColor = labels.subtitle.color
@@ -109,9 +107,8 @@ internal struct ADYAppearanceConfigurationBuilder {
     // MARK: - Navigation Bar Appearance
     
     private func configureNavigationBarAppearance(_ navigationBarAppearance: ADYNavigationBarAppearance) {
-        let labels = theme.elements.labels
         let colors = theme.colors
-        navigationBarAppearance.textColor = colors.text // All platforms map this
+        navigationBarAppearance.textColor = colors.text
     }
     
     // MARK: - Select Appearance

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -5,7 +5,9 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import AdyenUI
+#if canImport(AdyenUI)
+    import AdyenUI
+#endif
 import Foundation
 
 internal protocol AnyThreeDS2CoreActionHandler: Component {

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -5,7 +5,6 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
 import AdyenUI
 import Foundation
 
@@ -28,10 +27,6 @@ internal protocol AnyThreeDS2CoreActionHandler: Component {
 }
 
 internal typealias ThreeDSService = ThreeDSConfigurable & ThreeDSServiceable
-
-func appearanceConfigurationFromAdyenTheme(adyenTheme: AdyenTheme) -> ADYAppearanceConfiguration {
-    ADYAppearanceConfiguration()
-}
 
 /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
 @MainActor
@@ -90,7 +85,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
                 directoryServerPublicKey: token.directoryServerPublicKey,
                 directoryServerRootCertificates: token.directoryServerRootCertificates,
                 deviceExcludedParameters: nil,
-                appearanceConfiguration: appearanceConfigurationFromAdyenTheme(adyenTheme: theme),
+                theme: theme,
                 threeDSMessageVersion: token.threeDSMessageVersion
             )
             service.configuration = token.configuration

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2 Without Delegated Authentication/ThreeDS2CoreActionHandler.swift
@@ -6,6 +6,7 @@
 
 @_spi(AdyenInternal) import Adyen
 import Adyen3DS2
+import AdyenUI
 import Foundation
 
 internal protocol AnyThreeDS2CoreActionHandler: Component {
@@ -28,6 +29,10 @@ internal protocol AnyThreeDS2CoreActionHandler: Component {
 
 internal typealias ThreeDSService = ThreeDSConfigurable & ThreeDSServiceable
 
+func appearanceConfigurationFromAdyenTheme(adyenTheme: AdyenTheme) -> ADYAppearanceConfiguration {
+    ADYAppearanceConfiguration()
+}
+
 /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
 @MainActor
 internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
@@ -39,9 +44,8 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
     
     internal let context: AdyenContext
 
-    /// The appearance configuration of the 3D Secure 2 challenge UI.
-    internal let appearanceConfiguration: ADYAppearanceConfiguration
-    
+    internal let theme: AdyenTheme
+
     private var service: ThreeDSService
     
     internal weak var presentationDelegate: PresentationDelegate?
@@ -57,10 +61,10 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
     internal init(
         context: AdyenContext,
         service: ThreeDSService,
-        appearanceConfiguration: ADYAppearanceConfiguration = ADYAppearanceConfiguration()
+        theme: AdyenTheme
     ) {
         self.context = context
-        self.appearanceConfiguration = appearanceConfiguration
+        self.theme = theme
         self.service = service
     }
 
@@ -86,7 +90,7 @@ internal class ThreeDS2CoreActionHandler: AnyThreeDS2CoreActionHandler {
                 directoryServerPublicKey: token.directoryServerPublicKey,
                 directoryServerRootCertificates: token.directoryServerRootCertificates,
                 deviceExcludedParameters: nil,
-                appearanceConfiguration: appearanceConfiguration,
+                appearanceConfiguration: appearanceConfigurationFromAdyenTheme(adyenTheme: theme),
                 threeDSMessageVersion: token.threeDSMessageVersion
             )
             service.configuration = token.configuration

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
@@ -12,6 +12,7 @@ internal typealias VoidHandler = () -> Void
     @_spi(AdyenInternal) import Adyen
     import Adyen3DS2
     import AdyenAuthentication
+    import AdyenUI
     import Foundation
     import UIKit
     
@@ -44,7 +45,7 @@ internal typealias VoidHandler = () -> Void
         internal convenience init(
             context: AdyenContext,
             service: ThreeDSService,
-            appearanceConfiguration: ADYAppearanceConfiguration,
+            theme: AdyenTheme,
             delegatedAuthenticationConfiguration: ThreeDS2ActionConfiguration.DelegatedAuthentication
         ) {
             self.init(
@@ -55,7 +56,7 @@ internal typealias VoidHandler = () -> Void
                     localizedParameters: delegatedAuthenticationConfiguration.localizationParameters,
                     context: context
                 ),
-                appearanceConfiguration: appearanceConfiguration,
+                theme: theme,
                 style: delegatedAuthenticationConfiguration.style,
                 delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
             )
@@ -74,7 +75,7 @@ internal typealias VoidHandler = () -> Void
             context: AdyenContext,
             service: ThreeDSService,
             presenter: ThreeDS2PlusDAScreenPresenterProtocol,
-            appearanceConfiguration: ADYAppearanceConfiguration = .init(),
+            theme: AdyenTheme,
             style: DelegatedAuthenticationComponentStyle = .init(),
             delegatedAuthenticationConfiguration: ThreeDS2ActionConfiguration.DelegatedAuthentication,
             delegatedAuthenticationService: AuthenticationServiceProtocol? = nil,
@@ -84,7 +85,7 @@ internal typealias VoidHandler = () -> Void
             self.deviceSupportCheckerService = deviceSupportCheckerService
             self.presenter = presenter
             self.delegatedAuthenticationService = delegatedAuthenticationService
-            super.init(context: context, service: service, appearanceConfiguration: appearanceConfiguration)
+            super.init(context: context, service: service, theme: theme)
             self.presenter.presentationDelegate = self
         }
         

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
@@ -10,7 +10,6 @@ internal typealias VoidHandler = () -> Void
 
 #if canImport(AdyenAuthentication)
     @_spi(AdyenInternal) import Adyen
-    import Adyen3DS2
     import AdyenAuthentication
     #if canImport(AdyenUI)
         import AdyenUI

--- a/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDACoreActionHandler.swift
@@ -12,7 +12,9 @@ internal typealias VoidHandler = () -> Void
     @_spi(AdyenInternal) import Adyen
     import Adyen3DS2
     import AdyenAuthentication
-    import AdyenUI
+    #if canImport(AdyenUI)
+        import AdyenUI
+    #endif
     import Foundation
     import UIKit
     

--- a/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -5,7 +5,9 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import AdyenUI
+#if canImport(AdyenUI)
+    import AdyenUI
+#endif
 import Foundation
 
 internal protocol AnyThreeDS2ActionHandler {

--- a/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
+import AdyenUI
 import Foundation
 
 internal protocol AnyThreeDS2ActionHandler {
@@ -56,7 +56,7 @@ extension ComponentWrapper {
 internal func createDefaultThreeDS2CoreActionHandler(
     context: AdyenContext,
     service: ThreeDSService,
-    appearanceConfiguration: ADYAppearanceConfiguration,
+    theme: AdyenTheme,
     delegatedAuthenticationConfiguration: ThreeDS2ActionConfiguration.DelegatedAuthentication?
 ) -> AnyThreeDS2CoreActionHandler {
     #if canImport(AdyenAuthentication)
@@ -64,21 +64,21 @@ internal func createDefaultThreeDS2CoreActionHandler(
             return ThreeDS2PlusDACoreActionHandler(
                 context: context,
                 service: service,
-                appearanceConfiguration: appearanceConfiguration,
+                theme: theme,
                 delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
             )
         } else {
             return ThreeDS2CoreActionHandler(
                 context: context,
                 service: service,
-                appearanceConfiguration: appearanceConfiguration
+                theme: theme
             )
         }
     #else
         return ThreeDS2CoreActionHandler(
             context: context,
             service: service,
-            appearanceConfiguration: appearanceConfiguration
+            theme: theme
         )
     #endif
 }

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler+Initializers.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler+Initializers.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
+import AdyenUI
 import Foundation
 #if canImport(AdyenAuthentication)
     import AdyenAuthentication
@@ -17,18 +17,18 @@ extension ThreeDS2ClassicActionHandler {
     internal convenience init(
         context: AdyenContext,
         service: ThreeDSService,
-        appearanceConfiguration: ADYAppearanceConfiguration,
+        theme: AdyenTheme,
         delegatedAuthenticationConfiguration: ThreeDS2ActionConfiguration.DelegatedAuthentication?
     ) {
         let defaultHandler = createDefaultThreeDS2CoreActionHandler(
             context: context,
             service: service,
-            appearanceConfiguration: appearanceConfiguration,
+            theme: theme,
             delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
         )
         self.init(
             context: context,
-            appearanceConfiguration: appearanceConfiguration,
+            theme: theme,
             service: service,
             coreActionHandler: defaultHandler,
             delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler+Initializers.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler+Initializers.swift
@@ -5,7 +5,9 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import AdyenUI
+#if canImport(AdyenUI)
+    import AdyenUI
+#endif
 import Foundation
 #if canImport(AdyenAuthentication)
     import AdyenAuthentication

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
@@ -5,7 +5,6 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
 import AdyenUI
 import Foundation
 

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
@@ -5,7 +5,9 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import AdyenUI
+#if canImport(AdyenUI)
+    import AdyenUI
+#endif
 import Foundation
 
 /// Handles the 3D Secure 2 fingerprint and challenge actions separately.

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2ClassicActionHandler.swift
@@ -6,6 +6,7 @@
 
 @_spi(AdyenInternal) import Adyen
 import Adyen3DS2
+import AdyenUI
 import Foundation
 
 /// Handles the 3D Secure 2 fingerprint and challenge actions separately.
@@ -39,7 +40,7 @@ internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, Component
     
     internal init(
         context: AdyenContext,
-        appearanceConfiguration: ADYAppearanceConfiguration,
+        theme: AdyenTheme,
         service: ThreeDSService,
         coreActionHandler: AnyThreeDS2CoreActionHandler? = nil,
         delegatedAuthenticationConfiguration: ThreeDS2ActionConfiguration.DelegatedAuthentication? = nil
@@ -47,7 +48,7 @@ internal class ThreeDS2ClassicActionHandler: AnyThreeDS2ActionHandler, Component
         self.coreActionHandler = coreActionHandler ?? createDefaultThreeDS2CoreActionHandler(
             context: context,
             service: service,
-            appearanceConfiguration: appearanceConfiguration,
+            theme: theme,
             delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
         )
         self.context = context

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler+Initializers.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler+Initializers.swift
@@ -5,7 +5,9 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import AdyenUI
+#if canImport(AdyenUI)
+    import AdyenUI
+#endif
 import Foundation
 #if canImport(AdyenAuthentication)
     import AdyenAuthentication

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler+Initializers.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler+Initializers.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
+import AdyenUI
 import Foundation
 #if canImport(AdyenAuthentication)
     import AdyenAuthentication
@@ -17,7 +17,7 @@ extension ThreeDS2CompactActionHandler {
     internal convenience init(
         context: AdyenContext,
         service: ThreeDSService,
-        appearanceConfiguration: ADYAppearanceConfiguration,
+        theme: AdyenTheme,
         delegatedAuthenticationConfiguration: ThreeDS2ActionConfiguration.DelegatedAuthentication?
     ) {
         
@@ -25,12 +25,12 @@ extension ThreeDS2CompactActionHandler {
         self.init(
             context: context,
             fingerprintSubmitter: fingerprintSubmitter,
-            appearanceConfiguration: appearanceConfiguration,
+            theme: theme,
             service: service,
             coreActionHandler: createDefaultThreeDS2CoreActionHandler(
                 context: context,
                 service: service,
-                appearanceConfiguration: appearanceConfiguration,
+                theme: theme,
                 delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
             ),
             delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
@@ -5,7 +5,9 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import AdyenUI
+#if canImport(AdyenUI)
+    import AdyenUI
+#endif
 import Foundation
 
 /// Handles the 3D Secure 2 fingerprint and challenge in one call using a `fingerprintSubmitter`.

--- a/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
+++ b/AdyenActions/Components/3DS2/Action handlers/ThreeDS2CompactActionHandler.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
+import AdyenUI
 import Foundation
 
 /// Handles the 3D Secure 2 fingerprint and challenge in one call using a `fingerprintSubmitter`.
@@ -55,7 +55,7 @@ internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, Com
     internal init(
         context: AdyenContext,
         fingerprintSubmitter: AnyThreeDS2FingerprintSubmitter? = nil,
-        appearanceConfiguration: ADYAppearanceConfiguration,
+        theme: AdyenTheme,
         service: ThreeDSService,
         coreActionHandler: AnyThreeDS2CoreActionHandler? = nil,
         delegatedAuthenticationConfiguration: ThreeDS2ActionConfiguration.DelegatedAuthentication? = nil
@@ -64,7 +64,7 @@ internal final class ThreeDS2CompactActionHandler: AnyThreeDS2ActionHandler, Com
         self.coreActionHandler = coreActionHandler ?? createDefaultThreeDS2CoreActionHandler(
             context: context,
             service: service,
-            appearanceConfiguration: appearanceConfiguration,
+            theme: theme,
             delegatedAuthenticationConfiguration: delegatedAuthenticationConfiguration
         )
         self.fingerprintSubmitter = fingerprintSubmitter ?? ThreeDS2FingerprintSubmitter(context: context)

--- a/AdyenActions/Components/3DS2/ThreeDS2ActionConfiguration.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ActionConfiguration.swift
@@ -6,7 +6,7 @@
 
 @_spi(AdyenInternal) import Adyen
 #if canImport(AdyenUI)
-    @_spi(AdyenInternal) import AdyenUI
+    import AdyenUI
 #endif
 import Adyen3DS2
 

--- a/AdyenActions/Components/3DS2/ThreeDS2ActionConfiguration.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ActionConfiguration.swift
@@ -8,6 +8,7 @@
 #if canImport(AdyenUI)
     import AdyenUI
 #endif
+import Foundation
 
 /// Configuration for 3D Secure 2 action handling.
 public struct ThreeDS2ActionConfiguration: CheckoutComponentConfiguration {

--- a/AdyenActions/Components/3DS2/ThreeDS2ActionConfiguration.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ActionConfiguration.swift
@@ -54,8 +54,8 @@ public struct ThreeDS2ActionConfiguration: CheckoutComponentConfiguration {
     }
     
     /// Initializes a new instance of ThreeDS2ActionConfiguration
-    public init() {
-        self.theme = .default
+    public init(theme: AdyenTheme = .default) {
+        self.theme = theme
         self.showsSubmitButton = false
     }
 }

--- a/AdyenActions/Components/3DS2/ThreeDS2ActionConfiguration.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ActionConfiguration.swift
@@ -28,10 +28,7 @@ public struct ThreeDS2ActionConfiguration: CheckoutComponentConfiguration {
     
     /// The configuration for Delegated Authentication.
     package var delegatedAuthentication: DelegatedAuthentication?
-    
-    /// ThreeDS2Component UI configuration.
-    package var appearanceConfiguration: ADYAppearanceConfiguration
-    
+
     /// Configuration for Delegated Authentication in 3D Secure 2.
     public struct DelegatedAuthentication {
         
@@ -60,7 +57,6 @@ public struct ThreeDS2ActionConfiguration: CheckoutComponentConfiguration {
     public init() {
         self.theme = .default
         self.showsSubmitButton = false
-        self.appearanceConfiguration = .init()
     }
 }
 

--- a/AdyenActions/Components/3DS2/ThreeDS2ActionConfiguration.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ActionConfiguration.swift
@@ -8,7 +8,6 @@
 #if canImport(AdyenUI)
     import AdyenUI
 #endif
-import Adyen3DS2
 
 /// Configuration for 3D Secure 2 action handling.
 public struct ThreeDS2ActionConfiguration: CheckoutComponentConfiguration {

--- a/AdyenActions/Components/3DS2/ThreeDS2Component.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2Component.swift
@@ -167,7 +167,7 @@ public final class ThreeDS2Component: ActionComponent {
         let handler = ThreeDS2CompactActionHandler(
             context: context,
             service: ThreeDSServiceProvider(),
-            appearanceConfiguration: configuration.appearanceConfiguration,
+            theme: configuration.theme,
             delegatedAuthenticationConfiguration: configuration.delegatedAuthentication
         )
         handler.presentationDelegate = presentationDelegate
@@ -181,7 +181,7 @@ public final class ThreeDS2Component: ActionComponent {
         let handler = ThreeDS2ClassicActionHandler(
             context: context,
             service: ThreeDSServiceProvider(),
-            appearanceConfiguration: configuration.appearanceConfiguration,
+            theme: configuration.theme,
             delegatedAuthenticationConfiguration: configuration.delegatedAuthentication
         )
         handler.presentationDelegate = presentationDelegate

--- a/AdyenActions/Components/3DS2/ThreeDS2Component.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2Component.swift
@@ -5,7 +5,6 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
 import Foundation
 
 internal protocol AnyRedirectComponent: ActionComponent {

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentChallengeToken.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentChallengeToken.swift
@@ -5,7 +5,6 @@
 //
 
 import Adyen
-import Adyen3DS2
 import Foundation
 
 internal extension ThreeDS2Component {
@@ -32,24 +31,6 @@ internal extension ThreeDS2Component {
             case paymentInfo
         }
         
-    }
-    
-}
-
-internal extension ADYChallengeParameters {
-    
-    // swiftlint:disable:next explicit_acl
-    convenience init(
-        challengeToken: ThreeDS2Component.ChallengeToken,
-        threeDSRequestorAppURL: URL?
-    ) {
-        self.init(
-            serverTransactionIdentifier: challengeToken.serverTransactionIdentifier,
-            threeDSRequestorAppURL: threeDSRequestorAppURL,
-            acsTransactionIdentifier: challengeToken.acsTransactionIdentifier,
-            acsReferenceNumber: challengeToken.acsReferenceNumber,
-            acsSignedContent: challengeToken.acsSignedContent
-        )
     }
     
 }

--- a/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprint.swift
+++ b/AdyenActions/Components/3DS2/ThreeDS2ComponentFingerprint.swift
@@ -5,7 +5,6 @@
 //
 
 import Adyen
-import Adyen3DS2
 import Foundation
 
 internal extension ThreeDS2Component {

--- a/AdyenCheckout/Checkout.swift
+++ b/AdyenCheckout/Checkout.swift
@@ -65,7 +65,7 @@ public final class Checkout: CheckoutProtocol {
     internal lazy var actionHandlingComponent: ActionHandlingComponent = {
         let threeDS2Config: ThreeDS2ActionConfiguration = configuration.configuration(
             for: .threeDS2,
-            defaultValue: ThreeDS2ActionConfiguration()
+            defaultValue: ThreeDS2ActionConfiguration(theme: configuration.theme)
         )
         
         let twintConfig: TwintActionConfiguration? = configuration.configuration(for: .twint)

--- a/AdyenUI/AdyenTheme.swift
+++ b/AdyenUI/AdyenTheme.swift
@@ -139,7 +139,8 @@ extension AdyenTheme {
             attributes: attributes
         )
     }
-    
+
+    // TODO: Robert: AdyenTheme: Do we need to expose something like secondaryButton? similar to textSecondary
     /// Customizes the destructive button style using UIKit primitives.
     ///
     /// All parameters are optional and use smart merging - only the specified values are changed,

--- a/Demo/Common/Configuration/ConfigurationView.swift
+++ b/Demo/Common/Configuration/ConfigurationView.swift
@@ -17,6 +17,7 @@ internal struct ConfigurationView: View {
         case components = "Components"
         case authentication = "Authentication"
         case dropIn = "DropIn"
+        case themes = "Themes"
     }
     
     @ObservedObject internal var viewModel: ConfigurationViewModel
@@ -52,6 +53,7 @@ internal struct ConfigurationView: View {
                 wrapInSection(view: dropInSection, section: .dropIn)
                 wrapInSection(view: componentsSection, section: .components)
                 wrapInSection(view: authenticationSection, section: .authentication)
+                wrapInSection(view: themesSection, section: .themes)
             }.navigationBarTitle("Configuration", displayMode: .inline)
                 .navigationBarItems(
                     leading: Button("Default", action: viewModel.defaultTapped),
@@ -180,6 +182,14 @@ internal struct ConfigurationView: View {
                 Text("Analytics")
             }
         }
+    }
+    
+    private var themesSection: some View {
+        Picker("Theme", selection: $viewModel.selectedTheme) {
+            ForEach(ExampleAppTheme.allCases, id: \.self) { theme in
+                Text(theme.rawValue).tag(theme)
+            }
+        }.navigationLinkStyle()
     }
 
     private func pickerWithSearchBar<T: Hashable>(

--- a/Demo/Common/Configuration/ConfigurationViewModel.swift
+++ b/Demo/Common/Configuration/ConfigurationViewModel.swift
@@ -34,6 +34,7 @@ internal final class ConfigurationViewModel: ObservableObject {
     @Published internal var analyticsIsEnabled: Bool = true
     @Published internal var installmentsEnabled: Bool = false
     @Published internal var showInstallmentAmount: Bool = false
+    @Published internal var selectedTheme: ExampleAppTheme = .defaultTheme
 
     private let onDone: (DemoAppSettings) -> Void
     private let configuration: DemoAppSettings
@@ -71,6 +72,7 @@ internal final class ConfigurationViewModel: ObservableObject {
         self.analyticsIsEnabled = configuration.analyticsSettings.isEnabled
         self.installmentsEnabled = configuration.cardSettings.enableInstallments
         self.showInstallmentAmount = configuration.cardSettings.showsInstallmentAmount
+        self.selectedTheme = configuration.themeSettings.theme
     }
     
     internal func doneTapped() {
@@ -112,7 +114,8 @@ internal final class ConfigurationViewModel: ObservableObject {
                 allowOnboarding: allowOnboarding,
                 didAuthorizeSuccessful: applePayDidAuthorizeSuccessful
             ),
-            analyticsSettings: AnalyticsSettings(isEnabled: analyticsIsEnabled)
+            analyticsSettings: AnalyticsSettings(isEnabled: analyticsIsEnabled),
+            themeSettings: ThemeSettings(selectedTheme: selectedTheme.rawValue)
         )
     }
 

--- a/Demo/Common/Configuration/ExampleAppThemes.swift
+++ b/Demo/Common/Configuration/ExampleAppThemes.swift
@@ -1,0 +1,408 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import AdyenUI
+import UIKit
+
+/// Example themes demonstrating the full range of AdyenTheme configuration options.
+/// Each theme showcases different aspects of the theming system.
+internal enum ExampleAppTheme: String, CaseIterable {
+    case defaultTheme = "Default"
+    case ocean = "Ocean"
+    case forest = "Forest"
+    case sunset = "Sunset"
+    case midnight = "Midnight"
+    case minimal = "Minimal"
+    case rounded = "Rounded"
+    case corporate = "Corporate"
+    case playful = "Playful"
+    
+    internal static let defaultOption = ExampleAppTheme.defaultTheme
+    
+    /// Returns the corresponding AdyenTheme for this appearance style.
+    internal var theme: AdyenTheme {
+        switch self {
+        case .defaultTheme:
+            return defaultAppTheme
+        case .ocean:
+            return oceanTheme
+        case .forest:
+            return forestTheme
+        case .sunset:
+            return sunsetTheme
+        case .midnight:
+            return midnightTheme
+        case .minimal:
+            return minimalTheme
+        case .rounded:
+            return roundedTheme
+        case .corporate:
+            return corporateTheme
+        case .playful:
+            return playfulTheme
+        }
+    }
+    
+    // MARK: - Theme Definitions
+    
+    /// Default theme - SDK defaults with Adyen green accent
+    /// Demonstrates: Basic primary button customization
+    private var defaultAppTheme: AdyenTheme {
+        let adyenGreen = UIColor(red: 0.04, green: 0.75, blue: 0.33, alpha: 1.0) // #0ABF53
+        
+        return AdyenTheme.default
+            .primaryButton(backgroundColor: adyenGreen)
+    }
+    
+    /// Ocean theme - Deep blue color scheme
+    /// Demonstrates: Full color palette customization with AdyenColors
+    private var oceanTheme: AdyenTheme {
+        let deepBlue = UIColor(red: 0.02, green: 0.216, blue: 0.494, alpha: 1.0) // #053779
+        let lightBlue = UIColor(red: 0.0, green: 0.631, blue: 0.894, alpha: 1.0) // #00A1E4
+        let oceanBackground = UIColor(red: 0.95, green: 0.97, blue: 1.0, alpha: 1.0) // Light blue tint
+        let containerColor = UIColor(red: 0.90, green: 0.95, blue: 1.0, alpha: 1.0)
+        
+        return AdyenTheme(
+            colors: AdyenColors(
+                background: oceanBackground,
+                container: containerColor,
+                containerOutline: lightBlue.withAlphaComponent(0.3),
+                primary: deepBlue,
+                textOnPrimary: .white,
+                highlight: lightBlue,
+                destructive: UIColor(red: 0.8, green: 0.2, blue: 0.2, alpha: 1.0),
+                text: deepBlue,
+                textSecondary: deepBlue.withAlphaComponent(0.6)
+            )
+        )
+        .primaryButton(
+            backgroundColor: deepBlue,
+            textColor: .white,
+            disabledBackgroundColor: deepBlue.withAlphaComponent(0.4),
+            disabledTextColor: .white.withAlphaComponent(0.6),
+            cornerRadius: 8.0
+        )
+        .destructiveButton(
+            backgroundColor: .clear,
+            textColor: UIColor(red: 0.8, green: 0.2, blue: 0.2, alpha: 1.0),
+            cornerRadius: 8.0
+        )
+        .bodyLabel(
+            color: deepBlue,
+            textAlignment: .left
+        )
+        .cornerRadius(8.0)
+    }
+    
+    /// Forest theme - Natural green tones
+    /// Demonstrates: Custom fonts with body label styling
+    private var forestTheme: AdyenTheme {
+        let forestGreen = UIColor(red: 0.13, green: 0.55, blue: 0.13, alpha: 1.0) // #228B22
+        let darkGreen = UIColor(red: 0.0, green: 0.39, blue: 0.0, alpha: 1.0) // #006400
+        let leafGreen = UIColor(red: 0.20, green: 0.80, blue: 0.20, alpha: 1.0) // #33CC33
+        
+        let bodyFont = UIFont.systemFont(ofSize: 16.0, weight: .regular)
+        let emphasizedFont = UIFont.systemFont(ofSize: 16.0, weight: .semibold)
+        
+        return AdyenTheme(
+            colors: AdyenColors(
+                background: UIColor(red: 0.97, green: 0.99, blue: 0.97, alpha: 1.0),
+                container: UIColor(red: 0.94, green: 0.98, blue: 0.94, alpha: 1.0),
+                containerOutline: forestGreen.withAlphaComponent(0.3),
+                primary: forestGreen,
+                textOnPrimary: .white,
+                highlight: leafGreen,
+                destructive: UIColor(red: 0.7, green: 0.1, blue: 0.1, alpha: 1.0),
+                success: leafGreen,
+                text: darkGreen,
+                textSecondary: forestGreen.withAlphaComponent(0.7)
+            )
+        )
+        .primaryButton(
+            backgroundColor: forestGreen,
+            textColor: .white,
+            disabledBackgroundColor: forestGreen.withAlphaComponent(0.3),
+            disabledTextColor: .white.withAlphaComponent(0.5),
+            cornerRadius: 12.0
+        )
+        .bodyLabel(
+            font: bodyFont,
+            color: darkGreen,
+            disabledColor: darkGreen.withAlphaComponent(0.4),
+            textAlignment: .left
+        )
+        .cornerRadius(12.0)
+    }
+    
+    /// Sunset theme - Warm orange and red tones
+    /// Demonstrates: Gradient-like warm color scheme with custom disabled states
+    private var sunsetTheme: AdyenTheme {
+        let sunsetOrange = UIColor(red: 1.0, green: 0.45, blue: 0.0, alpha: 1.0) // #FF7300
+        let warmRed = UIColor(red: 0.9, green: 0.25, blue: 0.2, alpha: 1.0) // #E64033
+        let goldenYellow = UIColor(red: 1.0, green: 0.84, blue: 0.0, alpha: 1.0) // #FFD700
+        let darkBrown = UIColor(red: 0.36, green: 0.20, blue: 0.09, alpha: 1.0) // #5C3317
+        
+        return AdyenTheme(
+            colors: AdyenColors(
+                background: UIColor(red: 1.0, green: 0.98, blue: 0.95, alpha: 1.0),
+                container: UIColor(red: 1.0, green: 0.96, blue: 0.90, alpha: 1.0),
+                containerOutline: sunsetOrange.withAlphaComponent(0.3),
+                primary: sunsetOrange,
+                textOnPrimary: .white,
+                highlight: goldenYellow,
+                destructive: warmRed,
+                textOnDestructive: .white,
+                disabled: UIColor(red: 0.9, green: 0.85, blue: 0.8, alpha: 1.0),
+                textOnDisabled: UIColor(red: 0.6, green: 0.5, blue: 0.4, alpha: 1.0),
+                separator: sunsetOrange.withAlphaComponent(0.2),
+                text: darkBrown,
+                textSecondary: darkBrown.withAlphaComponent(0.6)
+            )
+        )
+        .primaryButton(
+            backgroundColor: sunsetOrange,
+            textColor: .white,
+            disabledBackgroundColor: sunsetOrange.withAlphaComponent(0.3),
+            disabledTextColor: .white.withAlphaComponent(0.5),
+            cornerRadius: 6.0
+        )
+        .destructiveButton(
+            backgroundColor: warmRed,
+            textColor: .white,
+            disabledBackgroundColor: warmRed.withAlphaComponent(0.3),
+            disabledTextColor: .white.withAlphaComponent(0.5),
+            cornerRadius: 6.0
+        )
+        .bodyLabel(color: darkBrown)
+        .cornerRadius(6.0)
+    }
+    
+    /// Midnight theme - Dark mode with accent colors
+    /// Demonstrates: Full dark mode color scheme with all color properties
+    private var midnightTheme: AdyenTheme {
+        let accentPurple = UIColor(red: 0.6, green: 0.4, blue: 0.9, alpha: 1.0) // #9966E6
+        let darkBackground = UIColor(red: 0.08, green: 0.08, blue: 0.12, alpha: 1.0) // #14141F
+        let containerDark = UIColor(red: 0.12, green: 0.12, blue: 0.18, alpha: 1.0) // #1F1F2E
+        let lightText = UIColor(red: 0.93, green: 0.93, blue: 0.95, alpha: 1.0) // #EDEDED
+        let mutedText = UIColor(red: 0.6, green: 0.6, blue: 0.65, alpha: 1.0) // #9999A6
+        
+        return AdyenTheme(
+            colors: AdyenColors(
+                background: darkBackground,
+                container: containerDark,
+                containerOutline: UIColor(white: 1.0, alpha: 0.15),
+                primary: accentPurple,
+                textOnPrimary: .white,
+                highlight: accentPurple,
+                destructive: UIColor(red: 0.95, green: 0.3, blue: 0.3, alpha: 1.0),
+                success: UIColor(red: 0.3, green: 0.85, blue: 0.5, alpha: 1.0),
+                textOnDestructive: .white,
+                disabled: UIColor(white: 0.25, alpha: 1.0),
+                textOnDisabled: UIColor(white: 0.5, alpha: 1.0),
+                separator: UIColor(white: 1.0, alpha: 0.1),
+                text: lightText,
+                textSecondary: mutedText,
+                supportShadow: UIColor.black.withAlphaComponent(0.5)
+            )
+        )
+        .primaryButton(
+            backgroundColor: accentPurple,
+            textColor: .white,
+            disabledBackgroundColor: accentPurple.withAlphaComponent(0.3),
+            disabledTextColor: .white.withAlphaComponent(0.4),
+            cornerRadius: 8.0
+        )
+        .destructiveButton(
+            backgroundColor: .clear,
+            textColor: UIColor(red: 0.95, green: 0.3, blue: 0.3, alpha: 1.0),
+            cornerRadius: 8.0
+        )
+        .bodyLabel(
+            color: lightText,
+            disabledColor: mutedText
+        )
+        .cornerRadius(8.0)
+    }
+    
+    /// Minimal theme - Clean black and white design
+    /// Demonstrates: Sharp corners (0 radius) and monochrome styling
+    private var minimalTheme: AdyenTheme {
+        let pureBlack = UIColor.black
+        let pureWhite = UIColor.white
+        let mediumGray = UIColor(white: 0.5, alpha: 1.0)
+        let lightGray = UIColor(white: 0.95, alpha: 1.0)
+        
+        return AdyenTheme(
+            colors: AdyenColors(
+                background: pureWhite,
+                container: lightGray,
+                containerOutline: UIColor(white: 0.8, alpha: 1.0),
+                primary: pureBlack,
+                textOnPrimary: pureWhite,
+                highlight: pureBlack,
+                destructive: pureBlack,
+                textOnDestructive: pureWhite,
+                disabled: UIColor(white: 0.9, alpha: 1.0),
+                textOnDisabled: mediumGray,
+                separator: UIColor(white: 0.85, alpha: 1.0),
+                text: pureBlack,
+                textSecondary: mediumGray
+            )
+        )
+        .primaryButton(
+            backgroundColor: pureBlack,
+            textColor: pureWhite,
+            disabledBackgroundColor: UIColor(white: 0.7, alpha: 1.0),
+            disabledTextColor: pureWhite,
+            cornerRadius: 0.0
+        )
+        .destructiveButton(
+            backgroundColor: .clear,
+            textColor: pureBlack,
+            cornerRadius: 0.0
+        )
+        .bodyLabel(
+            font: UIFont.systemFont(ofSize: 15.0, weight: .light),
+            color: pureBlack
+        )
+        .cornerRadius(0.0)
+    }
+    
+    /// Rounded theme - Soft, pill-shaped buttons
+    /// Demonstrates: Large corner radius for pill-shaped elements
+    private var roundedTheme: AdyenTheme {
+        let softBlue = UIColor(red: 0.0, green: 0.48, blue: 1.0, alpha: 1.0) // #007AFF (iOS blue)
+        let softPink = UIColor(red: 1.0, green: 0.4, blue: 0.6, alpha: 1.0) // #FF6699
+        
+        return AdyenTheme(
+            colors: AdyenColors(
+                background: UIColor(red: 0.98, green: 0.98, blue: 1.0, alpha: 1.0),
+                container: .white,
+                containerOutline: softBlue.withAlphaComponent(0.2),
+                primary: softBlue,
+                textOnPrimary: .white,
+                highlight: softBlue,
+                destructive: softPink,
+                textOnDestructive: .white,
+                text: UIColor(red: 0.1, green: 0.1, blue: 0.2, alpha: 1.0),
+                textSecondary: UIColor(red: 0.4, green: 0.4, blue: 0.5, alpha: 1.0)
+            )
+        )
+        .primaryButton(
+            backgroundColor: softBlue,
+            textColor: .white,
+            disabledBackgroundColor: softBlue.withAlphaComponent(0.3),
+            disabledTextColor: .white.withAlphaComponent(0.6),
+            cornerRadius: 24.0
+        )
+        .destructiveButton(
+            backgroundColor: softPink,
+            textColor: .white,
+            cornerRadius: 24.0
+        )
+        .bodyLabel(
+            font: UIFont.systemFont(ofSize: 16.0, weight: .medium),
+            textAlignment: .center
+        )
+        .cornerRadius(16.0)
+    }
+    
+    /// Corporate theme - Professional blue-gray scheme
+    /// Demonstrates: Subtle, professional color palette with custom text styling
+    private var corporateTheme: AdyenTheme {
+        let corporateBlue = UIColor(red: 0.15, green: 0.25, blue: 0.45, alpha: 1.0) // #263D73
+        let steelGray = UIColor(red: 0.45, green: 0.50, blue: 0.55, alpha: 1.0) // #73808C
+        let lightSteelBg = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.0)
+        
+        let professionalFont = UIFont.systemFont(ofSize: 15.0, weight: .regular)
+        
+        return AdyenTheme(
+            colors: AdyenColors(
+                background: lightSteelBg,
+                container: .white,
+                containerOutline: UIColor(red: 0.85, green: 0.87, blue: 0.90, alpha: 1.0),
+                primary: corporateBlue,
+                textOnPrimary: .white,
+                highlight: UIColor(red: 0.2, green: 0.4, blue: 0.7, alpha: 1.0),
+                destructive: UIColor(red: 0.75, green: 0.15, blue: 0.15, alpha: 1.0),
+                success: UIColor(red: 0.15, green: 0.55, blue: 0.25, alpha: 1.0),
+                textOnDestructive: .white,
+                disabled: UIColor(red: 0.88, green: 0.90, blue: 0.92, alpha: 1.0),
+                textOnDisabled: steelGray,
+                separator: UIColor(red: 0.88, green: 0.90, blue: 0.92, alpha: 1.0),
+                text: corporateBlue,
+                textSecondary: steelGray
+            )
+        )
+        .primaryButton(
+            backgroundColor: corporateBlue,
+            textColor: .white,
+            disabledBackgroundColor: corporateBlue.withAlphaComponent(0.4),
+            disabledTextColor: .white.withAlphaComponent(0.7),
+            cornerRadius: 4.0
+        )
+        .destructiveButton(
+            backgroundColor: .clear,
+            textColor: UIColor(red: 0.75, green: 0.15, blue: 0.15, alpha: 1.0),
+            cornerRadius: 4.0
+        )
+        .bodyLabel(
+            font: professionalFont,
+            color: corporateBlue,
+            disabledColor: steelGray,
+            textAlignment: .left
+        )
+        .cornerRadius(4.0)
+    }
+    
+    /// Playful theme - Vibrant, fun colors
+    /// Demonstrates: Bold, vibrant colors with medium corner radius
+    private var playfulTheme: AdyenTheme {
+        let vibrantPink = UIColor(red: 1.0, green: 0.2, blue: 0.5, alpha: 1.0) // #FF3380
+        let electricBlue = UIColor(red: 0.0, green: 0.8, blue: 1.0, alpha: 1.0) // #00CCFF
+        let sunnyYellow = UIColor(red: 1.0, green: 0.9, blue: 0.0, alpha: 1.0) // #FFE600
+        let darkPurple = UIColor(red: 0.3, green: 0.1, blue: 0.4, alpha: 1.0) // #4D1A66
+        
+        let funFont = UIFont.systemFont(ofSize: 17.0, weight: .bold)
+        
+        return AdyenTheme(
+            colors: AdyenColors(
+                background: UIColor(red: 1.0, green: 0.98, blue: 0.98, alpha: 1.0),
+                container: .white,
+                containerOutline: vibrantPink.withAlphaComponent(0.2),
+                primary: vibrantPink,
+                textOnPrimary: .white,
+                highlight: electricBlue,
+                destructive: UIColor(red: 0.9, green: 0.1, blue: 0.1, alpha: 1.0),
+                success: UIColor(red: 0.2, green: 0.9, blue: 0.4, alpha: 1.0),
+                textOnDestructive: .white,
+                disabled: UIColor(red: 0.95, green: 0.9, blue: 0.92, alpha: 1.0),
+                textOnDisabled: UIColor(red: 0.7, green: 0.6, blue: 0.65, alpha: 1.0),
+                separator: vibrantPink.withAlphaComponent(0.15),
+                text: darkPurple,
+                textSecondary: darkPurple.withAlphaComponent(0.6)
+            )
+        )
+        .primaryButton(
+            backgroundColor: vibrantPink,
+            textColor: .white,
+            disabledBackgroundColor: vibrantPink.withAlphaComponent(0.3),
+            disabledTextColor: .white.withAlphaComponent(0.5),
+            cornerRadius: 14.0
+        )
+        .destructiveButton(
+            backgroundColor: UIColor(red: 0.9, green: 0.1, blue: 0.1, alpha: 1.0),
+            textColor: .white,
+            cornerRadius: 14.0
+        )
+        .bodyLabel(
+            font: funFont,
+            color: darkPurple,
+            textAlignment: .center
+        )
+        .cornerRadius(14.0)
+    }
+}

--- a/Demo/Common/Configuration/ExampleAppThemes.swift
+++ b/Demo/Common/Configuration/ExampleAppThemes.swift
@@ -124,7 +124,7 @@ internal enum ExampleAppTheme: String, CaseIterable {
                 disabled: ExampleColors.gray,
                 textOnDisabled: ExampleColors.gray2,
                 separator: ExampleColors.white.withAlphaComponent(0.1),
-                text: ExampleColors.white,
+                text: ExampleColors.purple,
                 textSecondary: ExampleColors.gray
             )
         )
@@ -158,7 +158,7 @@ internal enum ExampleAppTheme: String, CaseIterable {
                 disabled: ExampleColors.gray2,
                 textOnDisabled: ExampleColors.gray,
                 separator: ExampleColors.orange.withAlphaComponent(0.2),
-                text: ExampleColors.darkBackground,
+                text: ExampleColors.orange,
                 textSecondary: ExampleColors.gray
             )
         )

--- a/Demo/Common/Configuration/ExampleAppThemes.swift
+++ b/Demo/Common/Configuration/ExampleAppThemes.swift
@@ -7,18 +7,83 @@
 import AdyenUI
 import UIKit
 
-/// Example themes demonstrating the full range of AdyenTheme configuration options.
-/// Each theme showcases different aspects of the theming system.
+// MARK: - ExampleColors
+
+internal enum ExampleColors {
+    
+    // MARK: - Dynamic Colors (adapt to light/dark mode)
+    
+    /// Purple accent - Light: #9966E6, Dark: #B794F6
+    static let purple = UIColor { traitCollection in
+        traitCollection.userInterfaceStyle == .dark
+            ? UIColor(red: 0.72, green: 0.58, blue: 0.96, alpha: 1.0)
+            : UIColor(red: 0.6, green: 0.4, blue: 0.9, alpha: 1.0)
+    }
+    
+    /// Orange accent - Light: #FF7300, Dark: #FF9933
+    static let orange = UIColor { traitCollection in
+        traitCollection.userInterfaceStyle == .dark
+            ? UIColor(red: 1.0, green: 0.60, blue: 0.20, alpha: 1.0)
+            : UIColor(red: 1.0, green: 0.45, blue: 0.0, alpha: 1.0)
+    }
+    
+    /// Gold/yellow - Light: #FFD700, Dark: #FFE44D
+    static let gold = UIColor { traitCollection in
+        traitCollection.userInterfaceStyle == .dark
+            ? UIColor(red: 1.0, green: 0.89, blue: 0.30, alpha: 1.0)
+            : UIColor(red: 1.0, green: 0.84, blue: 0.0, alpha: 1.0)
+    }
+    
+    /// Coral red - Light: #E64033, Dark: #FF6B5B
+    static let coral = UIColor { traitCollection in
+        traitCollection.userInterfaceStyle == .dark
+            ? UIColor(red: 1.0, green: 0.42, blue: 0.36, alpha: 1.0)
+            : UIColor(red: 0.9, green: 0.25, blue: 0.2, alpha: 1.0)
+    }
+    
+    /// Dark background - Light: #F5F5F7, Dark: #14141F
+    static let darkBackground = UIColor { traitCollection in
+        traitCollection.userInterfaceStyle == .dark
+            ? UIColor(red: 0.08, green: 0.08, blue: 0.12, alpha: 1.0)
+            : UIColor(red: 0.96, green: 0.96, blue: 0.97, alpha: 1.0)
+    }
+    
+    /// Dark container - Light: #FFFFFF, Dark: #1F1F2E
+    static let darkContainer = UIColor { traitCollection in
+        traitCollection.userInterfaceStyle == .dark
+            ? UIColor(red: 0.12, green: 0.12, blue: 0.18, alpha: 1.0)
+            : UIColor.white
+    }
+    
+    /// Dynamic white - adapts to dark mode (white in light, near-black in dark)
+    static let white = UIColor { traitCollection in
+        traitCollection.userInterfaceStyle == .dark
+            ? UIColor(red: 0.11, green: 0.11, blue: 0.12, alpha: 1.0)
+            : UIColor.white
+    }
+    
+    // MARK: - System Colors
+    
+    static let red = UIColor.systemRed
+    static let green = UIColor.systemGreen
+    static let gray = UIColor.systemGray
+    static let gray2 = UIColor.systemGray2
+    static let gray6 = UIColor.systemGray6
+    static let clear = UIColor.clear
+    static let secondaryBackground = UIColor.secondarySystemBackground
+    
+    // MARK: - Static Colors (do NOT adapt to dark mode)
+    
+    static let staticWhite = UIColor.white
+}
+
+// MARK: - ExampleAppTheme
+
 internal enum ExampleAppTheme: String, CaseIterable {
     case defaultTheme = "Default"
-    case ocean = "Ocean"
-    case forest = "Forest"
-    case sunset = "Sunset"
     case midnight = "Midnight"
-    case minimal = "Minimal"
-    case rounded = "Rounded"
-    case corporate = "Corporate"
-    case playful = "Playful"
+    case sunset = "Sunset"
+    case staticBrand = "Static Brand"
     
     internal static let defaultOption = ExampleAppTheme.defaultTheme
     
@@ -27,382 +92,131 @@ internal enum ExampleAppTheme: String, CaseIterable {
         switch self {
         case .defaultTheme:
             return defaultAppTheme
-        case .ocean:
-            return oceanTheme
-        case .forest:
-            return forestTheme
-        case .sunset:
-            return sunsetTheme
         case .midnight:
             return midnightTheme
-        case .minimal:
-            return minimalTheme
-        case .rounded:
-            return roundedTheme
-        case .corporate:
-            return corporateTheme
-        case .playful:
-            return playfulTheme
+        case .sunset:
+            return sunsetTheme
+        case .staticBrand:
+            return staticBrandTheme
         }
     }
     
     // MARK: - Theme Definitions
     
-    /// Default theme - SDK defaults with Adyen green accent
-    /// Demonstrates: Basic primary button customization
+    /// Default theme - SDK defaults
     private var defaultAppTheme: AdyenTheme {
-        let adyenGreen = UIColor(red: 0.04, green: 0.75, blue: 0.33, alpha: 1.0) // #0ABF53
-        
-        return AdyenTheme.default
-            .primaryButton(backgroundColor: adyenGreen)
+        AdyenTheme.default
     }
     
-    /// Ocean theme - Deep blue color scheme
-    /// Demonstrates: Full color palette customization with AdyenColors
-    private var oceanTheme: AdyenTheme {
-        let deepBlue = UIColor(red: 0.02, green: 0.216, blue: 0.494, alpha: 1.0) // #053779
-        let lightBlue = UIColor(red: 0.0, green: 0.631, blue: 0.894, alpha: 1.0) // #00A1E4
-        let oceanBackground = UIColor(red: 0.95, green: 0.97, blue: 1.0, alpha: 1.0) // Light blue tint
-        let containerColor = UIColor(red: 0.90, green: 0.95, blue: 1.0, alpha: 1.0)
-        
-        return AdyenTheme(
+    /// Midnight theme - Dark purple accent (Dynamic)
+    private var midnightTheme: AdyenTheme {
+        AdyenTheme(
             colors: AdyenColors(
-                background: oceanBackground,
-                container: containerColor,
-                containerOutline: lightBlue.withAlphaComponent(0.3),
-                primary: deepBlue,
-                textOnPrimary: .white,
-                highlight: lightBlue,
-                destructive: UIColor(red: 0.8, green: 0.2, blue: 0.2, alpha: 1.0),
-                text: deepBlue,
-                textSecondary: deepBlue.withAlphaComponent(0.6)
+                background: ExampleColors.darkBackground,
+                container: ExampleColors.darkContainer,
+                containerOutline: ExampleColors.white.withAlphaComponent(0.15),
+                primary: ExampleColors.purple,
+                textOnPrimary: ExampleColors.white,
+                highlight: ExampleColors.purple,
+                destructive: ExampleColors.red,
+                success: ExampleColors.green,
+                textOnDestructive: ExampleColors.white,
+                disabled: ExampleColors.gray,
+                textOnDisabled: ExampleColors.gray2,
+                separator: ExampleColors.white.withAlphaComponent(0.1),
+                text: ExampleColors.white,
+                textSecondary: ExampleColors.gray
             )
         )
         .primaryButton(
-            backgroundColor: deepBlue,
-            textColor: .white,
-            disabledBackgroundColor: deepBlue.withAlphaComponent(0.4),
-            disabledTextColor: .white.withAlphaComponent(0.6),
+            backgroundColor: ExampleColors.purple,
+            textColor: ExampleColors.white,
+            disabledBackgroundColor: ExampleColors.purple.withAlphaComponent(0.3),
+            disabledTextColor: ExampleColors.white.withAlphaComponent(0.4),
             cornerRadius: 8.0
         )
         .destructiveButton(
-            backgroundColor: .clear,
-            textColor: UIColor(red: 0.8, green: 0.2, blue: 0.2, alpha: 1.0),
+            backgroundColor: ExampleColors.clear,
+            textColor: ExampleColors.red,
             cornerRadius: 8.0
-        )
-        .bodyLabel(
-            color: deepBlue,
-            textAlignment: .left
         )
         .cornerRadius(8.0)
     }
     
-    /// Forest theme - Natural green tones
-    /// Demonstrates: Custom fonts with body label styling
-    private var forestTheme: AdyenTheme {
-        let forestGreen = UIColor(red: 0.13, green: 0.55, blue: 0.13, alpha: 1.0) // #228B22
-        let darkGreen = UIColor(red: 0.0, green: 0.39, blue: 0.0, alpha: 1.0) // #006400
-        let leafGreen = UIColor(red: 0.20, green: 0.80, blue: 0.20, alpha: 1.0) // #33CC33
-        
-        let bodyFont = UIFont.systemFont(ofSize: 16.0, weight: .regular)
-        let emphasizedFont = UIFont.systemFont(ofSize: 16.0, weight: .semibold)
-        
-        return AdyenTheme(
+    /// Sunset theme - Warm orange tones (Dynamic)
+    private var sunsetTheme: AdyenTheme {
+        AdyenTheme(
             colors: AdyenColors(
-                background: UIColor(red: 0.97, green: 0.99, blue: 0.97, alpha: 1.0),
-                container: UIColor(red: 0.94, green: 0.98, blue: 0.94, alpha: 1.0),
-                containerOutline: forestGreen.withAlphaComponent(0.3),
-                primary: forestGreen,
-                textOnPrimary: .white,
-                highlight: leafGreen,
-                destructive: UIColor(red: 0.7, green: 0.1, blue: 0.1, alpha: 1.0),
-                success: leafGreen,
-                text: darkGreen,
-                textSecondary: forestGreen.withAlphaComponent(0.7)
+                background: ExampleColors.gray6,
+                container: ExampleColors.secondaryBackground,
+                containerOutline: ExampleColors.orange.withAlphaComponent(0.3),
+                primary: ExampleColors.orange,
+                textOnPrimary: ExampleColors.white,
+                highlight: ExampleColors.gold,
+                destructive: ExampleColors.coral,
+                textOnDestructive: ExampleColors.white,
+                disabled: ExampleColors.gray2,
+                textOnDisabled: ExampleColors.gray,
+                separator: ExampleColors.orange.withAlphaComponent(0.2),
+                text: ExampleColors.darkBackground,
+                textSecondary: ExampleColors.gray
             )
         )
         .primaryButton(
-            backgroundColor: forestGreen,
-            textColor: .white,
-            disabledBackgroundColor: forestGreen.withAlphaComponent(0.3),
-            disabledTextColor: .white.withAlphaComponent(0.5),
+            backgroundColor: ExampleColors.orange,
+            textColor: ExampleColors.white,
+            disabledBackgroundColor: ExampleColors.orange.withAlphaComponent(0.3),
+            disabledTextColor: ExampleColors.white.withAlphaComponent(0.5),
             cornerRadius: 12.0
         )
-        .bodyLabel(
-            font: bodyFont,
-            color: darkGreen,
-            disabledColor: darkGreen.withAlphaComponent(0.4),
-            textAlignment: .left
+        .destructiveButton(
+            backgroundColor: ExampleColors.clear,
+            textColor: ExampleColors.coral,
+            cornerRadius: 12.0
         )
         .cornerRadius(12.0)
     }
-    
-    /// Sunset theme - Warm orange and red tones
-    /// Demonstrates: Gradient-like warm color scheme with custom disabled states
-    private var sunsetTheme: AdyenTheme {
-        let sunsetOrange = UIColor(red: 1.0, green: 0.45, blue: 0.0, alpha: 1.0) // #FF7300
-        let warmRed = UIColor(red: 0.9, green: 0.25, blue: 0.2, alpha: 1.0) // #E64033
-        let goldenYellow = UIColor(red: 1.0, green: 0.84, blue: 0.0, alpha: 1.0) // #FFD700
-        let darkBrown = UIColor(red: 0.36, green: 0.20, blue: 0.09, alpha: 1.0) // #5C3317
+
+    /// Static Brand theme - Non-dynamic colors (does NOT adapt to dark mode)
+    private var staticBrandTheme: AdyenTheme {
+        let brandPrimary = UIColor(red: 0.0, green: 0.48, blue: 1.0, alpha: 1.0) // #007AFF
+        let brandAccent = UIColor(red: 1.0, green: 0.58, blue: 0.0, alpha: 1.0) // #FF9500
+        let brandBackground = UIColor(red: 0.98, green: 0.98, blue: 0.99, alpha: 1.0) // #FAFAFC
+        let brandContainer = UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0) // #FFFFFF
+        let brandText = UIColor(red: 0.1, green: 0.1, blue: 0.12, alpha: 1.0) // #1A1A1F
+        let brandTextSecondary = UIColor(red: 0.4, green: 0.4, blue: 0.45, alpha: 1.0) // #666673
+        let brandDestructive = UIColor(red: 1.0, green: 0.23, blue: 0.19, alpha: 1.0) // #FF3B30
         
         return AdyenTheme(
             colors: AdyenColors(
-                background: UIColor(red: 1.0, green: 0.98, blue: 0.95, alpha: 1.0),
-                container: UIColor(red: 1.0, green: 0.96, blue: 0.90, alpha: 1.0),
-                containerOutline: sunsetOrange.withAlphaComponent(0.3),
-                primary: sunsetOrange,
-                textOnPrimary: .white,
-                highlight: goldenYellow,
-                destructive: warmRed,
-                textOnDestructive: .white,
-                disabled: UIColor(red: 0.9, green: 0.85, blue: 0.8, alpha: 1.0),
-                textOnDisabled: UIColor(red: 0.6, green: 0.5, blue: 0.4, alpha: 1.0),
-                separator: sunsetOrange.withAlphaComponent(0.2),
-                text: darkBrown,
-                textSecondary: darkBrown.withAlphaComponent(0.6)
+                background: brandBackground,
+                container: brandContainer,
+                containerOutline: brandPrimary.withAlphaComponent(0.2),
+                primary: brandPrimary,
+                textOnPrimary: ExampleColors.staticWhite,
+                highlight: brandAccent,
+                destructive: brandDestructive,
+                success: UIColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1.0),
+                textOnDestructive: ExampleColors.staticWhite,
+                disabled: UIColor(red: 0.9, green: 0.9, blue: 0.92, alpha: 1.0),
+                textOnDisabled: UIColor(red: 0.6, green: 0.6, blue: 0.65, alpha: 1.0),
+                separator: UIColor(red: 0.85, green: 0.85, blue: 0.87, alpha: 1.0),
+                text: brandText,
+                textSecondary: brandTextSecondary
             )
         )
         .primaryButton(
-            backgroundColor: sunsetOrange,
-            textColor: .white,
-            disabledBackgroundColor: sunsetOrange.withAlphaComponent(0.3),
-            disabledTextColor: .white.withAlphaComponent(0.5),
-            cornerRadius: 6.0
+            backgroundColor: brandPrimary,
+            textColor: ExampleColors.staticWhite,
+            disabledBackgroundColor: brandPrimary.withAlphaComponent(0.4),
+            disabledTextColor: ExampleColors.staticWhite.withAlphaComponent(0.6),
+            cornerRadius: 10.0
         )
         .destructiveButton(
-            backgroundColor: warmRed,
-            textColor: .white,
-            disabledBackgroundColor: warmRed.withAlphaComponent(0.3),
-            disabledTextColor: .white.withAlphaComponent(0.5),
-            cornerRadius: 6.0
+            backgroundColor: ExampleColors.clear,
+            textColor: brandDestructive,
+            cornerRadius: 10.0
         )
-        .bodyLabel(color: darkBrown)
-        .cornerRadius(6.0)
-    }
-    
-    /// Midnight theme - Dark mode with accent colors
-    /// Demonstrates: Full dark mode color scheme with all color properties
-    private var midnightTheme: AdyenTheme {
-        let accentPurple = UIColor(red: 0.6, green: 0.4, blue: 0.9, alpha: 1.0) // #9966E6
-        let darkBackground = UIColor(red: 0.08, green: 0.08, blue: 0.12, alpha: 1.0) // #14141F
-        let containerDark = UIColor(red: 0.12, green: 0.12, blue: 0.18, alpha: 1.0) // #1F1F2E
-        let lightText = UIColor(red: 0.93, green: 0.93, blue: 0.95, alpha: 1.0) // #EDEDED
-        let mutedText = UIColor(red: 0.6, green: 0.6, blue: 0.65, alpha: 1.0) // #9999A6
-        
-        return AdyenTheme(
-            colors: AdyenColors(
-                background: darkBackground,
-                container: containerDark,
-                containerOutline: UIColor(white: 1.0, alpha: 0.15),
-                primary: accentPurple,
-                textOnPrimary: .white,
-                highlight: accentPurple,
-                destructive: UIColor(red: 0.95, green: 0.3, blue: 0.3, alpha: 1.0),
-                success: UIColor(red: 0.3, green: 0.85, blue: 0.5, alpha: 1.0),
-                textOnDestructive: .white,
-                disabled: UIColor(white: 0.25, alpha: 1.0),
-                textOnDisabled: UIColor(white: 0.5, alpha: 1.0),
-                separator: UIColor(white: 1.0, alpha: 0.1),
-                text: lightText,
-                textSecondary: mutedText,
-                supportShadow: UIColor.black.withAlphaComponent(0.5)
-            )
-        )
-        .primaryButton(
-            backgroundColor: accentPurple,
-            textColor: .white,
-            disabledBackgroundColor: accentPurple.withAlphaComponent(0.3),
-            disabledTextColor: .white.withAlphaComponent(0.4),
-            cornerRadius: 8.0
-        )
-        .destructiveButton(
-            backgroundColor: .clear,
-            textColor: UIColor(red: 0.95, green: 0.3, blue: 0.3, alpha: 1.0),
-            cornerRadius: 8.0
-        )
-        .bodyLabel(
-            color: lightText,
-            disabledColor: mutedText
-        )
-        .cornerRadius(8.0)
-    }
-    
-    /// Minimal theme - Clean black and white design
-    /// Demonstrates: Sharp corners (0 radius) and monochrome styling
-    private var minimalTheme: AdyenTheme {
-        let pureBlack = UIColor.black
-        let pureWhite = UIColor.white
-        let mediumGray = UIColor(white: 0.5, alpha: 1.0)
-        let lightGray = UIColor(white: 0.95, alpha: 1.0)
-        
-        return AdyenTheme(
-            colors: AdyenColors(
-                background: pureWhite,
-                container: lightGray,
-                containerOutline: UIColor(white: 0.8, alpha: 1.0),
-                primary: pureBlack,
-                textOnPrimary: pureWhite,
-                highlight: pureBlack,
-                destructive: pureBlack,
-                textOnDestructive: pureWhite,
-                disabled: UIColor(white: 0.9, alpha: 1.0),
-                textOnDisabled: mediumGray,
-                separator: UIColor(white: 0.85, alpha: 1.0),
-                text: pureBlack,
-                textSecondary: mediumGray
-            )
-        )
-        .primaryButton(
-            backgroundColor: pureBlack,
-            textColor: pureWhite,
-            disabledBackgroundColor: UIColor(white: 0.7, alpha: 1.0),
-            disabledTextColor: pureWhite,
-            cornerRadius: 0.0
-        )
-        .destructiveButton(
-            backgroundColor: .clear,
-            textColor: pureBlack,
-            cornerRadius: 0.0
-        )
-        .bodyLabel(
-            font: UIFont.systemFont(ofSize: 15.0, weight: .light),
-            color: pureBlack
-        )
-        .cornerRadius(0.0)
-    }
-    
-    /// Rounded theme - Soft, pill-shaped buttons
-    /// Demonstrates: Large corner radius for pill-shaped elements
-    private var roundedTheme: AdyenTheme {
-        let softBlue = UIColor(red: 0.0, green: 0.48, blue: 1.0, alpha: 1.0) // #007AFF (iOS blue)
-        let softPink = UIColor(red: 1.0, green: 0.4, blue: 0.6, alpha: 1.0) // #FF6699
-        
-        return AdyenTheme(
-            colors: AdyenColors(
-                background: UIColor(red: 0.98, green: 0.98, blue: 1.0, alpha: 1.0),
-                container: .white,
-                containerOutline: softBlue.withAlphaComponent(0.2),
-                primary: softBlue,
-                textOnPrimary: .white,
-                highlight: softBlue,
-                destructive: softPink,
-                textOnDestructive: .white,
-                text: UIColor(red: 0.1, green: 0.1, blue: 0.2, alpha: 1.0),
-                textSecondary: UIColor(red: 0.4, green: 0.4, blue: 0.5, alpha: 1.0)
-            )
-        )
-        .primaryButton(
-            backgroundColor: softBlue,
-            textColor: .white,
-            disabledBackgroundColor: softBlue.withAlphaComponent(0.3),
-            disabledTextColor: .white.withAlphaComponent(0.6),
-            cornerRadius: 24.0
-        )
-        .destructiveButton(
-            backgroundColor: softPink,
-            textColor: .white,
-            cornerRadius: 24.0
-        )
-        .bodyLabel(
-            font: UIFont.systemFont(ofSize: 16.0, weight: .medium),
-            textAlignment: .center
-        )
-        .cornerRadius(16.0)
-    }
-    
-    /// Corporate theme - Professional blue-gray scheme
-    /// Demonstrates: Subtle, professional color palette with custom text styling
-    private var corporateTheme: AdyenTheme {
-        let corporateBlue = UIColor(red: 0.15, green: 0.25, blue: 0.45, alpha: 1.0) // #263D73
-        let steelGray = UIColor(red: 0.45, green: 0.50, blue: 0.55, alpha: 1.0) // #73808C
-        let lightSteelBg = UIColor(red: 0.96, green: 0.97, blue: 0.98, alpha: 1.0)
-        
-        let professionalFont = UIFont.systemFont(ofSize: 15.0, weight: .regular)
-        
-        return AdyenTheme(
-            colors: AdyenColors(
-                background: lightSteelBg,
-                container: .white,
-                containerOutline: UIColor(red: 0.85, green: 0.87, blue: 0.90, alpha: 1.0),
-                primary: corporateBlue,
-                textOnPrimary: .white,
-                highlight: UIColor(red: 0.2, green: 0.4, blue: 0.7, alpha: 1.0),
-                destructive: UIColor(red: 0.75, green: 0.15, blue: 0.15, alpha: 1.0),
-                success: UIColor(red: 0.15, green: 0.55, blue: 0.25, alpha: 1.0),
-                textOnDestructive: .white,
-                disabled: UIColor(red: 0.88, green: 0.90, blue: 0.92, alpha: 1.0),
-                textOnDisabled: steelGray,
-                separator: UIColor(red: 0.88, green: 0.90, blue: 0.92, alpha: 1.0),
-                text: corporateBlue,
-                textSecondary: steelGray
-            )
-        )
-        .primaryButton(
-            backgroundColor: corporateBlue,
-            textColor: .white,
-            disabledBackgroundColor: corporateBlue.withAlphaComponent(0.4),
-            disabledTextColor: .white.withAlphaComponent(0.7),
-            cornerRadius: 4.0
-        )
-        .destructiveButton(
-            backgroundColor: .clear,
-            textColor: UIColor(red: 0.75, green: 0.15, blue: 0.15, alpha: 1.0),
-            cornerRadius: 4.0
-        )
-        .bodyLabel(
-            font: professionalFont,
-            color: corporateBlue,
-            disabledColor: steelGray,
-            textAlignment: .left
-        )
-        .cornerRadius(4.0)
-    }
-    
-    /// Playful theme - Vibrant, fun colors
-    /// Demonstrates: Bold, vibrant colors with medium corner radius
-    private var playfulTheme: AdyenTheme {
-        let vibrantPink = UIColor(red: 1.0, green: 0.2, blue: 0.5, alpha: 1.0) // #FF3380
-        let electricBlue = UIColor(red: 0.0, green: 0.8, blue: 1.0, alpha: 1.0) // #00CCFF
-        let sunnyYellow = UIColor(red: 1.0, green: 0.9, blue: 0.0, alpha: 1.0) // #FFE600
-        let darkPurple = UIColor(red: 0.3, green: 0.1, blue: 0.4, alpha: 1.0) // #4D1A66
-        
-        let funFont = UIFont.systemFont(ofSize: 17.0, weight: .bold)
-        
-        return AdyenTheme(
-            colors: AdyenColors(
-                background: UIColor(red: 1.0, green: 0.98, blue: 0.98, alpha: 1.0),
-                container: .white,
-                containerOutline: vibrantPink.withAlphaComponent(0.2),
-                primary: vibrantPink,
-                textOnPrimary: .white,
-                highlight: electricBlue,
-                destructive: UIColor(red: 0.9, green: 0.1, blue: 0.1, alpha: 1.0),
-                success: UIColor(red: 0.2, green: 0.9, blue: 0.4, alpha: 1.0),
-                textOnDestructive: .white,
-                disabled: UIColor(red: 0.95, green: 0.9, blue: 0.92, alpha: 1.0),
-                textOnDisabled: UIColor(red: 0.7, green: 0.6, blue: 0.65, alpha: 1.0),
-                separator: vibrantPink.withAlphaComponent(0.15),
-                text: darkPurple,
-                textSecondary: darkPurple.withAlphaComponent(0.6)
-            )
-        )
-        .primaryButton(
-            backgroundColor: vibrantPink,
-            textColor: .white,
-            disabledBackgroundColor: vibrantPink.withAlphaComponent(0.3),
-            disabledTextColor: .white.withAlphaComponent(0.5),
-            cornerRadius: 14.0
-        )
-        .destructiveButton(
-            backgroundColor: UIColor(red: 0.9, green: 0.1, blue: 0.1, alpha: 1.0),
-            textColor: .white,
-            cornerRadius: 14.0
-        )
-        .bodyLabel(
-            font: funFont,
-            color: darkPurple,
-            textAlignment: .center
-        )
-        .cornerRadius(14.0)
+        .cornerRadius(10.0)
     }
 }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -22,6 +22,8 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
 
     /// comes from demo app protocol, unused on new structure
     internal var context: AdyenContext?
+    
+    internal var selectedTheme: ExampleAppTheme = .forest
 
     internal init() {}
 
@@ -70,21 +72,7 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
                     print("Bin lookup response \(brands)")
                 }
         }
-        .theme(
-            AdyenTheme(
-                colors:
-                .default
-//                AdyenColors(primary: .systemPurple)
-            )
-            .bodyLabel(font: AdyenFonts.default.bodyEmphasized)
-            .destructiveButton(
-                backgroundColor: .systemRed,
-                textColor: .white,
-                disabledBackgroundColor: .systemGray,
-                disabledTextColor: .lightGray
-            )
-            .cornerRadius(8.0)
-        )
+        .theme(selectedTheme.theme)
         .onSubmit { [weak self] data, handler in
             self?.callPayments(with: data, completion: handler)
         }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -23,7 +23,9 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
     /// comes from demo app protocol, unused on new structure
     internal var context: AdyenContext?
     
-    internal var selectedTheme: ExampleAppTheme = .forest
+    internal var selectedTheme: ExampleAppTheme {
+        ConfigurationConstants.current.themeSettings.theme
+    }
 
     internal init() {}
 

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -141,6 +141,14 @@ internal struct AnalyticsSettings: Codable {
     internal var isEnabled: Bool = true
 }
 
+internal struct ThemeSettings: Codable {
+    internal var selectedTheme: String = ExampleAppTheme.defaultOption.rawValue
+    
+    internal var theme: ExampleAppTheme {
+        ExampleAppTheme(rawValue: selectedTheme) ?? .defaultTheme
+    }
+}
+
 internal struct DemoAppSettings: Codable {
     private static let defaultsKey = "ConfigurationKey"
     
@@ -154,6 +162,7 @@ internal struct DemoAppSettings: Codable {
     internal let threeDSConfigurationSettings: ThreeDSConfigurationSettings
     internal let applePaySettings: ApplePaySettings
     internal let analyticsSettings: AnalyticsSettings
+    internal let themeSettings: ThemeSettings
 
     internal var amount: Amount {
         Amount(value: value, currencyCode: currencyCode, localeIdentifier: nil)
@@ -182,7 +191,8 @@ internal struct DemoAppSettings: Codable {
         dropInSettings: defaultDropInSettings,
         threeDSConfigurationSettings: threeDSConfigurationSettings,
         applePaySettings: defaultApplePaySettings,
-        analyticsSettings: defaultAnalyticsSettings
+        analyticsSettings: defaultAnalyticsSettings,
+        themeSettings: defaultThemeSettings
     )
 
     internal static let defaultCardSettings = CardSettings(
@@ -214,6 +224,8 @@ internal struct DemoAppSettings: Codable {
     )
 
     internal static let defaultAnalyticsSettings = AnalyticsSettings(isEnabled: true)
+    
+    internal static let defaultThemeSettings = ThemeSettings()
     
     fileprivate static func loadConfiguration() -> DemoAppSettings {
         var config = UserDefaults.standard.data(forKey: defaultsKey)
@@ -269,8 +281,7 @@ internal struct DemoAppSettings: Codable {
         var style = DropInComponent.Style()
         style.navigation.tintColor = .red
 
-        // TODO: Add new style here
-        let theme = AdyenTheme.default
+        let theme = themeSettings.theme.theme
 
         let dropInConfig = DropInComponent.Configuration(
             style: style,

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
@@ -45,13 +45,13 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
     }
     
     func testSettingThreeDSRequestorAppURL() {
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: ThreeDSServiceableMock())
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, theme: .default, service: ThreeDSServiceableMock())
         sut.threeDSRequestorAppURL = URL(string: "https://google.com")
         XCTAssertEqual(sut.coreActionHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
     }
 
     func testWrappedComponent() {
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: ThreeDSServiceableMock())
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, theme: .default, service: ThreeDSServiceableMock())
         XCTAssertEqual(sut.wrappedComponent.context.apiContext.clientKey, Dummy.apiContext.clientKey)
         
         XCTAssertEqual(sut.wrappedComponent.context.apiContext.environment.baseURL, Dummy.apiContext.environment.baseURL)
@@ -81,7 +81,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2ClassicActionHandler(
             context: Dummy.context(analyticsProvider: analyticsProviderMock),
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
         sut.handle(fingerprintAction) { fingerprintResult in
@@ -133,7 +133,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
         )
 
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: service)
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, theme: .default, service: service)
         sut.handle(fingerprintAction) { result in
             switch result {
             case .success:
@@ -164,7 +164,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2ClassicActionHandler(
             context: Dummy.context(analyticsProvider: analyticsProviderMock),
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
         sut.threeDSRequestorAppURL = URL(string: "https://google.com")
@@ -211,7 +211,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
         service.onPerformFingerprint = { $1(.success(self.authenticationRequestParameters)) }
         service.onPerformChallenge = { $1(.failure(.challengeError(errorPayload: ""))) }
         service.onResetTransaction = {}
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: service)
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, theme: .default, service: service)
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
 
         sut.handle(challengeAction) { result in
@@ -244,7 +244,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
 
     func testChallengeFlowMissingTransaction() {
         let service = ThreeDSServiceableMock()
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: service)
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, theme: .default, service: service)
         service.onPerformChallenge = { $1(.failure(.transactionNotInitialized)) }
         service.onResetTransaction = {}
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
@@ -273,7 +273,7 @@ class ThreeDS2ClassicActionHandlerTests: XCTestCase {
         service.onPerformChallenge = { parameters, completion in
             XCTFail()
         }
-        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, appearanceConfiguration: ADYAppearanceConfiguration(), service: service)
+        let sut = ThreeDS2ClassicActionHandler(context: Dummy.context, theme: .default, service: service)
         let resultExpectation = expectation(description: "Expect ThreeDS2ActionHandler completion closure to be called.")
 
         let challengeAction = ThreeDS2ChallengeAction(challengeToken: "Invalid-token", authorisationToken: "AuthToken", paymentData: "paymentData")

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ClassicActionHandlerTests.swift
@@ -5,7 +5,6 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-import Adyen3DS2
 @_spi(AdyenInternal) @testable import AdyenActions
 @testable @_spi(AdyenInternal) import AdyenCard
 import XCTest

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
@@ -45,13 +45,13 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
     }
     
     func testSettingThreeDSRequestorAppURL() {
-        let sut = ThreeDS2CompactActionHandler(context: Dummy.context, service: ThreeDSServiceableMock(), appearanceConfiguration: ADYAppearanceConfiguration(), delegatedAuthenticationConfiguration: nil)
+        let sut = ThreeDS2CompactActionHandler(context: Dummy.context, theme: .default, service: ThreeDSServiceableMock(), delegatedAuthenticationConfiguration: nil)
         sut.threeDSRequestorAppURL = URL(string: "https://google.com")
         XCTAssertEqual(sut.coreActionHandler.threeDSRequestorAppURL, URL(string: "https://google.com"))
     }
 
     func testWrappedComponent() {
-        let sut = ThreeDS2CompactActionHandler(context: Dummy.context, service: ThreeDSServiceableMock(), appearanceConfiguration: ADYAppearanceConfiguration(), delegatedAuthenticationConfiguration: nil)
+        let sut = ThreeDS2CompactActionHandler(context: Dummy.context, theme: .default, service: ThreeDSServiceableMock(), delegatedAuthenticationConfiguration: nil)
         XCTAssertEqual(sut.wrappedComponent.context.apiContext.clientKey, Dummy.apiContext.clientKey)
         XCTAssertEqual(sut.wrappedComponent.context.apiContext.environment.baseURL, Dummy.apiContext.environment.baseURL)
 
@@ -82,7 +82,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(analyticsProvider: analyticsProviderMock),
             fingerprintSubmitter: submitter,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
         sut.handle(fingerprintAction) { result in
@@ -123,7 +123,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let analyticsProviderMock = AnalyticsProviderMock()
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(analyticsProvider: analyticsProviderMock),
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
         sut.threeDSRequestorAppURL = URL(string: "https://google.com")
@@ -175,7 +175,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(analyticsProvider: analyticsProviderMock),
             fingerprintSubmitter: submitter,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
 
@@ -230,7 +230,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(analyticsProvider: analyticsProviderMock),
             fingerprintSubmitter: submitter,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
 
@@ -267,7 +267,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(analyticsProvider: analyticsProviderMock),
             fingerprintSubmitter: submitter,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
         service.onPerformChallenge = { $1(.failure(.transactionNotInitialized)) }
@@ -327,7 +327,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context(analyticsProvider: analyticsProviderMock),
             fingerprintSubmitter: submitter,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
         sut.handle(fingerprintAction) { result in
@@ -372,7 +372,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
                 analyticsProvider: analyticsProviderMock
             ),
             fingerprintSubmitter: submitter,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
         sut.handle(fingerprintAction) { result in
@@ -420,7 +420,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context,
             fingerprintSubmitter: submitter,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
         sut.handle(fingerprintAction) { result in
@@ -458,7 +458,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
         let sut = ThreeDS2CompactActionHandler(
             context: Dummy.context,
             fingerprintSubmitter: submitter,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
         sut.handle(fingerprintAction) { result in
@@ -497,7 +497,7 @@ class ThreeDS2CompactActionHandlerTests: XCTestCase {
                 analyticsProvider: analyticsProviderMock
             ),
             fingerprintSubmitter: submitter,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             service: service
         )
         sut.handle(fingerprintAction) { result in

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2CompactActionHandlerTests.swift
@@ -5,7 +5,6 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-import Adyen3DS2
 @_spi(AdyenInternal) @testable import AdyenActions
 @testable @_spi(AdyenInternal) import AdyenCard
 import XCTest

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
@@ -8,7 +8,6 @@
 @testable @_spi(AdyenInternal) import AdyenCard
 import XCTest
 @_spi(AdyenInternal) import Adyen
-import Adyen3DS2
 @_spi(AdyenInternal) import AdyenUI
 
 @available(iOS 16.0, *)

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ComponentTests.swift
@@ -491,6 +491,7 @@ class ThreeDS2ComponentTests: XCTestCase {
                     localizedParameters: nil,
                     context: Dummy.context
                 ),
+                theme: .default,
                 delegatedAuthenticationConfiguration: .init(relyingPartyIdentifier: ""),
                 delegatedAuthenticationService: authenticationServiceMock,
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
@@ -498,7 +499,7 @@ class ThreeDS2ComponentTests: XCTestCase {
                 
             let classicActionHandler = ThreeDS2ClassicActionHandler(
                 context: Dummy.context,
-                appearanceConfiguration: ADYAppearanceConfiguration(),
+                theme: .default,
                 service: mockService,
                 coreActionHandler: threeDS2ActionHandler
             )
@@ -602,6 +603,7 @@ class ThreeDS2ComponentTests: XCTestCase {
                     localizedParameters: nil,
                     context: Dummy.context
                 ),
+                theme: .default,
                 delegatedAuthenticationConfiguration: .init(relyingPartyIdentifier: ""),
                 delegatedAuthenticationService: authenticationServiceMock,
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
@@ -609,7 +611,7 @@ class ThreeDS2ComponentTests: XCTestCase {
                 
             let classicActionHandler = ThreeDS2ClassicActionHandler(
                 context: Dummy.context,
-                appearanceConfiguration: ADYAppearanceConfiguration(),
+                theme: .default,
                 service: mockService,
                 coreActionHandler: threeDS2ActionHandler
             )
@@ -731,6 +733,7 @@ class ThreeDS2ComponentTests: XCTestCase {
                     localizedParameters: nil,
                     context: Dummy.context
                 ),
+                theme: .default,
                 delegatedAuthenticationConfiguration: .init(relyingPartyIdentifier: ""),
                 delegatedAuthenticationService: authenticationServiceMock,
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
@@ -738,7 +741,7 @@ class ThreeDS2ComponentTests: XCTestCase {
             threeDS2ActionHandler.delegatedAuthenticationState.attemptRegistration = true
             let classicActionHandler = ThreeDS2ClassicActionHandler(
                 context: Dummy.context,
-                appearanceConfiguration: ADYAppearanceConfiguration(),
+                theme: .default,
                 service: mockService,
                 coreActionHandler: threeDS2ActionHandler
             )
@@ -836,6 +839,7 @@ class ThreeDS2ComponentTests: XCTestCase {
                     localizedParameters: nil,
                     context: Dummy.context
                 ),
+                theme: .default,
                 delegatedAuthenticationConfiguration: .init(relyingPartyIdentifier: ""),
                 delegatedAuthenticationService: authenticationServiceMock,
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
@@ -843,7 +847,7 @@ class ThreeDS2ComponentTests: XCTestCase {
             threeDS2ActionHandler.delegatedAuthenticationState.attemptRegistration = true
             let classicActionHandler = ThreeDS2ClassicActionHandler(
                 context: Dummy.context,
-                appearanceConfiguration: ADYAppearanceConfiguration(),
+                theme: .default,
                 service: mockService,
                 coreActionHandler: threeDS2ActionHandler
             )

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2DAScreenPresenterMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2DAScreenPresenterMock.swift
@@ -8,7 +8,6 @@ import Foundation
 
 #if canImport(AdyenAuthentication)
     @_spi(AdyenInternal) @testable import Adyen
-    import Adyen3DS2
     @_spi(AdyenInternal) @testable import AdyenActions
     import AdyenAuthentication
     import Foundation

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -102,6 +102,7 @@ import XCTest
                 context: Dummy.context,
                 service: service,
                 presenter: ThreeDS2DAScreenPresenterMock(showRegistrationReturnState: .fallback, showApprovalScreenReturnState: .fallback),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
             )
@@ -136,6 +137,7 @@ import XCTest
                 context: Dummy.context,
                 service: service,
                 presenter: ThreeDS2DAScreenPresenterMock(showRegistrationReturnState: .fallback, showApprovalScreenReturnState: .fallback),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
             )
@@ -176,6 +178,7 @@ import XCTest
                 context: Dummy.context,
                 service: service,
                 presenter: ThreeDS2DAScreenPresenterMock(showRegistrationReturnState: .register, showApprovalScreenReturnState: .fallback),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock,
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
@@ -225,6 +228,7 @@ import XCTest
                 context: Dummy.context,
                 service: service,
                 presenter: ThreeDS2DAScreenPresenterMock(showRegistrationReturnState: .register, showApprovalScreenReturnState: .fallback),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock,
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
@@ -255,6 +259,7 @@ import XCTest
                 context: Dummy.context,
                 service: service,
                 presenter: ThreeDS2DAScreenPresenterMock(showRegistrationReturnState: .fallback, showApprovalScreenReturnState: .fallback),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
             )
@@ -286,6 +291,7 @@ import XCTest
                 context: Dummy.context,
                 service: ThreeDSServiceProvider(),
                 presenter: ThreeDS2DAScreenPresenterMock(showRegistrationReturnState: .fallback, showApprovalScreenReturnState: .fallback),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
             )
@@ -322,6 +328,7 @@ import XCTest
                 context: Dummy.context,
                 service: service,
                 presenter: ThreeDS2DAScreenPresenterMock(showRegistrationReturnState: .fallback, showApprovalScreenReturnState: .fallback),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
             )
@@ -381,6 +388,7 @@ import XCTest
                 context: Dummy.context,
                 service: service,
                 presenter: presenterMock,
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
             )
@@ -431,6 +439,7 @@ import XCTest
                     showRegistrationReturnState: .fallback,
                     showApprovalScreenReturnState: .approve
                 ),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
             )
@@ -478,6 +487,7 @@ import XCTest
                     showRegistrationReturnState: .fallback,
                     showApprovalScreenReturnState: .fallback
                 ),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
             )
@@ -535,6 +545,7 @@ import XCTest
                     showRegistrationReturnState: .fallback,
                     showApprovalScreenReturnState: .removeCredentials
                 ),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock
             )
@@ -586,6 +597,7 @@ import XCTest
                     showRegistrationReturnState: .fallback,
                     showApprovalScreenReturnState: .fallback
                 ),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock,
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)
@@ -638,6 +650,7 @@ import XCTest
                 context: Dummy.context,
                 service: service,
                 presenter: presenterMock,
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations,
                 delegatedAuthenticationService: authenticationServiceMock,
                 deviceSupportCheckerService: DeviceSupportCheckerMock(isDeviceSupported: true)

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -8,7 +8,6 @@ import XCTest
 
 #if canImport(AdyenAuthentication)
     @_spi(AdyenInternal) @testable import Adyen
-    import Adyen3DS2
     @_spi(AdyenInternal) @testable import AdyenActions
     import AdyenAuthentication
     import Foundation

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -60,7 +60,7 @@ import XCTest
             let sut = ThreeDS2PlusDACoreActionHandler(
                 context: Dummy.context,
                 service: ThreeDSServiceableMock(),
-                appearanceConfiguration: ADYAppearanceConfiguration(),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations
             )
             sut.threeDSRequestorAppURL = URL(string: "https://google.com")
@@ -71,7 +71,7 @@ import XCTest
             let sut = ThreeDS2PlusDACoreActionHandler(
                 context: Dummy.context,
                 service: ThreeDSServiceableMock(),
-                appearanceConfiguration: ADYAppearanceConfiguration(),
+                theme: .default,
                 delegatedAuthenticationConfiguration: Self.delegatedAuthenticationConfigurations
             )
             XCTAssertEqual(sut.context.apiContext.clientKey, Dummy.apiContext.clientKey)

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ServiceLegacyTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDS2ServiceLegacyTests.swift
@@ -27,7 +27,7 @@ final class ThreeDS2ServiceLegacyTests: XCTestCase {
             directoryServerPublicKey: "",
             directoryServerRootCertificates: "",
             deviceExcludedParameters: nil,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             threeDSMessageVersion: ""
         )
         let expectationFingerprintCreated = expectation(description: "expectationFingerprintCreated")
@@ -57,7 +57,7 @@ final class ThreeDS2ServiceLegacyTests: XCTestCase {
             directoryServerPublicKey: "",
             directoryServerRootCertificates: "",
             deviceExcludedParameters: nil,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             threeDSMessageVersion: "threeDSMessageVersion"
         )
         let expectationFingerprintCreated = expectation(description: "expectationFingerprintCreated")
@@ -102,7 +102,7 @@ final class ThreeDS2ServiceLegacyTests: XCTestCase {
             directoryServerPublicKey: "",
             directoryServerRootCertificates: "",
             deviceExcludedParameters: nil,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             threeDSMessageVersion: ""
         )
         let challengeToken = ThreeDS2Component.ChallengeToken(acsReferenceNumber: "", acsSignedContent: "", acsTransactionIdentifier: "", serverTransactionIdentifier: "", threeDSRequestorAppURL: nil, delegatedAuthenticationSDKInput: nil, paymentInfo: nil)
@@ -152,7 +152,7 @@ final class ThreeDS2ServiceLegacyTests: XCTestCase {
             directoryServerPublicKey: "",
             directoryServerRootCertificates: "",
             deviceExcludedParameters: nil,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             threeDSMessageVersion: ""
         )
         let challengeToken = ThreeDS2Component.ChallengeToken(acsReferenceNumber: "", acsSignedContent: "", acsTransactionIdentifier: "", serverTransactionIdentifier: "", threeDSRequestorAppURL: nil, delegatedAuthenticationSDKInput: nil, paymentInfo: nil)
@@ -206,7 +206,7 @@ final class ThreeDS2ServiceLegacyTests: XCTestCase {
             directoryServerPublicKey: "",
             directoryServerRootCertificates: "",
             deviceExcludedParameters: nil,
-            appearanceConfiguration: ADYAppearanceConfiguration(),
+            theme: .default,
             threeDSMessageVersion: ""
         )
         let challengeToken = ThreeDS2Component.ChallengeToken(acsReferenceNumber: "", acsSignedContent: "", acsTransactionIdentifier: "", serverTransactionIdentifier: "", threeDSRequestorAppURL: nil, delegatedAuthenticationSDKInput: nil, paymentInfo: nil)

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceProviderTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceProviderTests.swift
@@ -136,7 +136,7 @@ private extension FingerprintServiceParameters {
         directoryServerPublicKey: "",
         directoryServerRootCertificates: "",
         deviceExcludedParameters: nil,
-        appearanceConfiguration: ADYAppearanceConfiguration(),
+        theme: .default,
         threeDSMessageVersion: ""
     )
 }

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceProviderTests.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceProviderTests.swift
@@ -4,7 +4,6 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen3DS2
 @_spi(AdyenInternal) @testable import AdyenActions
 @testable @_spi(AdyenInternal) import AdyenCard
 import XCTest

--- a/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceableMock.swift
+++ b/Tests/IntegrationTests/Card Tests/3DS2 Component/ThreeDSServiceableMock.swift
@@ -4,7 +4,6 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen3DS2
 @_spi(AdyenInternal) @testable import AdyenActions
 import Foundation
 


### PR DESCRIPTION
# Summary [Required]
- An initial version to migrate AdyenTheme to ADYAppearanceConfiguration. -> The `ADYAppearanceConfigurationBuilder` : Note this is not perfect and finalized, there is still some dicussions i need to have with Android and Arjen about this mapping, and it is based on best effort right now. Will iterate on this, but those changes can be more targeted and specific. 

- Passing AdyenTheme to ThreeDS2Component, even in the default configuration - i think theme is minimally required. @erenbesel  please confirm this part specifically. 

- Took the liberty to add a test app configuration to switch some themes. I can remove this if not required, but thought this would be something good to have for the test app in general. Especially during development.


# Demo [Required for UI changes]

https://github.com/user-attachments/assets/cd1d6b69-d646-4bca-936b-21cdf06bde9e


https://github.com/user-attachments/assets/8381c588-65b7-4702-a2b4-25fa8a81b85b


https://github.com/user-attachments/assets/eccbedeb-ee0f-443d-b0eb-2545aeca2c82


https://github.com/user-attachments/assets/3bd882bc-74da-425c-b0b2-03bf43f09eb9


## Ticket [Optional]
COSDK-1099

## Checklist [Required]
- [x] Tested changes locally
