### PR TITLE
Localization: Add phase 0 baseline integration tests

### DIFF
--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -125,6 +125,36 @@ class CardComponentTests: XCTestCase {
         XCTAssertEqual(items.button.title, localizedSubmitButtonTitle(with: context.amount, style: .immediate, sut.configuration.localizationParameters))
     }
 
+    func test_cardComponent_withLegacyLocalizationParameters_shouldRenderLocalizedTitles() {
+        var configuration = CardComponentConfiguration()
+        configuration.showsHolderNameField = true
+        configuration.localizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
+
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: configuration
+        )
+        let items = sut.cardViewController.items
+
+        XCTAssertEqual(items.expiryDateItem.placeholder, localizedString(.cardExpiryItemPlaceholder, configuration.localizationParameters))
+        XCTAssertEqual(items.securityCodeItem.title, localizedString(.cardCvcItemTitle, configuration.localizationParameters))
+        XCTAssertEqual(items.holderNameItem.title, localizedString(.cardNameItemTitle, configuration.localizationParameters))
+    }
+
+    func test_cardComponent_withLegacyLocalizationParameters_shouldRenderLocalizedSubmitButton() {
+        var configuration = CardComponentConfiguration()
+        configuration.localizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
+
+        let sut = CardComponent(
+            paymentMethod: method,
+            context: context,
+            configuration: configuration
+        )
+
+        XCTAssertEqual(sut.cardViewController.items.button.title, "Test-Pay €1.00")
+    }
+
     func test_component_withCustomTheme_shouldApplyThemeStyles() {
         // Given - custom theme with distinctive colors and button styling
         let colorToTest = UIColor.blue

--- a/Tests/IntegrationTests/Localization/LocalizationTests.swift
+++ b/Tests/IntegrationTests/Localization/LocalizationTests.swift
@@ -84,6 +84,34 @@ class LocalizationTests: XCTestCase {
         XCTAssertEqual(localizedString(.submitButton, parameters), "Pay")
     }
 
+    func test_localizedString_withNilParameters_shouldReturnSDKDefault() {
+        XCTAssertEqual(localizedString(.cardStoredTitle, nil), "Verify your card")
+    }
+
+    func test_localizedString_withFormattedKeyAndArguments_shouldFormatString() {
+        XCTAssertEqual(localizedString(.dropInStoredTitle, nil, "test"), "Confirm test payment")
+    }
+
+    func test_localizedString_withFormattedKeyAndMissingTranslation_shouldFallbackToEnglish() {
+        let parameters = LocalizationParameters(
+            bundle: Bundle(for: LocalizationTests.self),
+            tableName: "EnforceLocaleTests",
+            keySeparator: "-"
+        )
+
+        XCTAssertEqual(localizedString(.submitButtonFormatted, parameters, "€1.00"), "Pay €1.00")
+    }
+
+    func test_localizedString_withUnsupportedEnforcedLocaleAndPartialCustomCoverage_shouldMixCustomAndEnglishFallback() {
+        let parameters = LocalizationParameters(
+            enforcedLocale: "hi",
+            bundle: Bundle(for: LocalizationTests.self)
+        )
+
+        XCTAssertEqual(localizedString(.cardStoredTitle, parameters), "TestBundle - Verify your card - HI")
+        XCTAssertEqual(localizedString(.submitButton, parameters), "Pay")
+    }
+
     // MARK: - Button title
 
     func testLocalizationWitZeroPayment() {


### PR DESCRIPTION
# Summary
This PR implements Phase 0 of the iOS v6 custom localization plan by adding baseline integration tests before production refactoring. It adds resolver-focused localization coverage and card flow coverage for legacy localization parameters so follow-up phases can safely change API visibility and wiring. 

No production code is changed.

## Progress tracker
✅  Phase 0 — Baseline safety net for current localization behavior
Phase 1 — Internalize legacy localization API
Phase 2 — Introduce the new public contract
Phase 3 — Wire provider resolution into card flow
Phase 4 — Unsupported locale warnings
Phase 5 — Final confidence pass for card alpha scope

## Technical Information
- Added 4 tests in `Tests/IntegrationTests/Localization/LocalizationTests.swift` for baseline resolver behavior:
  - nil-parameter default resolution
  - formatted key argument substitution
  - missing translation fallback to English
  - unsupported enforced locale with partial custom coverage
- Added 2 tests in `Tests/IntegrationTests/Card Tests/CardComponentTests.swift` for card UI behavior with legacy localization parameters:
  - localized field titles/placeholders
  - localized submit button title

## Ticket
<ticket>
COSDK-1097
</ticket>

## Checklist [Required]
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
