### PR TITLE
Localization: Add SDK localization completeness unit tests

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -648,6 +648,8 @@
 		B643C7682EEC53E200EF8407 /* FormItemView+ValidationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B643C7652EEC53E200EF8407 /* FormItemView+ValidationState.swift */; };
 		B643C76A2EF444DF00EF8407 /* FormCardNumberValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B643C7692EF444DF00EF8407 /* FormCardNumberValidationTests.swift */; };
 		B643C76C2EF4454600EF8407 /* FormTextItemViewValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B643C76B2EF4454600EF8407 /* FormTextItemViewValidationTests.swift */; };
+		B64744262F74467800DD4A81 /* LocalizationTableCompletenessValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B64744202F74467800DD4A81 /* LocalizationTableCompletenessValidatorTests.swift */; };
+		B64744272F74467800DD4A81 /* LocalizationTableCompletenessValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B647441F2F74467800DD4A81 /* LocalizationTableCompletenessValidator.swift */; };
 		B65F0EB42ED493250015AC41 /* FormButtonItemViewThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65F0EB32ED493250015AC41 /* FormButtonItemViewThemeTests.swift */; };
 		B65F0EBA2ED89EC00015AC41 /* TestTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65F0EB92ED89EC00015AC41 /* TestTheme.swift */; };
 		B65F0EBB2ED89EC00015AC41 /* TestTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B65F0EB92ED89EC00015AC41 /* TestTheme.swift */; };
@@ -2301,6 +2303,8 @@
 		B643C7652EEC53E200EF8407 /* FormItemView+ValidationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormItemView+ValidationState.swift"; sourceTree = "<group>"; };
 		B643C7692EF444DF00EF8407 /* FormCardNumberValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardNumberValidationTests.swift; sourceTree = "<group>"; };
 		B643C76B2EF4454600EF8407 /* FormTextItemViewValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormTextItemViewValidationTests.swift; sourceTree = "<group>"; };
+		B647441F2F74467800DD4A81 /* LocalizationTableCompletenessValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationTableCompletenessValidator.swift; sourceTree = "<group>"; };
+		B64744202F74467800DD4A81 /* LocalizationTableCompletenessValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationTableCompletenessValidatorTests.swift; sourceTree = "<group>"; };
 		B65F0EB32ED493250015AC41 /* FormButtonItemViewThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormButtonItemViewThemeTests.swift; sourceTree = "<group>"; };
 		B65F0EB92ED89EC00015AC41 /* TestTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTheme.swift; sourceTree = "<group>"; };
 		B65F0EBD2ED89EC60015AC41 /* FormViewExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormViewExtractor.swift; sourceTree = "<group>"; };
@@ -4206,6 +4210,7 @@
 				E7CC63D5288016080034108B /* Mocks */,
 				E9E3DB042226B3A100697074 /* Utilities */,
 				0019C4132E5F2B2F00B0C3A3 /* AdyenUI */,
+				B64744212F74467800DD4A81 /* Localization */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -4224,6 +4229,15 @@
 				B643C7622EEAD2CF00EF8407 /* FormSectionHeaderItem.swift */,
 			);
 			path = SectionHeader;
+			sourceTree = "<group>";
+		};
+		B64744212F74467800DD4A81 /* Localization */ = {
+			isa = PBXGroup;
+			children = (
+				B647441F2F74467800DD4A81 /* LocalizationTableCompletenessValidator.swift */,
+				B64744202F74467800DD4A81 /* LocalizationTableCompletenessValidatorTests.swift */,
+			);
+			path = Localization;
 			sourceTree = "<group>";
 		};
 		B67D1F572E4615390000C37F /* Components */ = {
@@ -8430,6 +8444,8 @@
 				B6D808072BCD147600F3F5EB /* TimeIntervalExtensionsTests.swift in Sources */,
 				B6D808082BCD147600F3F5EB /* URLExtensionsTest.swift in Sources */,
 				B6D8080E2BCD147D00F3F5EB /* APIContextTests.swift in Sources */,
+				B64744262F74467800DD4A81 /* LocalizationTableCompletenessValidatorTests.swift in Sources */,
+				B64744272F74467800DD4A81 /* LocalizationTableCompletenessValidator.swift in Sources */,
 				B6D808212BCD151F00F3F5EB /* URLProtocolMock.swift in Sources */,
 				B6D8081B2BCD151F00F3F5EB /* StoredPaymentMethodMock.swift in Sources */,
 				A0E1B6422EAB9D0E0070B915 /* BLIKComponentFactoryTests.swift in Sources */,

--- a/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewModel.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewModel.swift
@@ -103,20 +103,21 @@ internal final class StoredCardInputViewModel: StoredCardInputViewModelProtocol 
         localizedString(.cardSecurityCodeTitle, localizationParameters)
     }
 
-    /// We construct something like - Enter the security code for BOLD[Visa •••• 4556] to complete the payment of BOLD[$140.98]
+    // We construct something like - Enter the security code for BOLD[Visa •••• 4556] to complete the payment of BOLD[$140.98]
     // TODO: Robert: StoredView: This & the pay button title needs to change according to the amount.
     internal var subtitleText: NSAttributedString {
         let displayInformation = storedCardPaymentMethod.displayInformation(using: localizationParameters)
         let paymentMethodTitle = storedCardPaymentMethod.name + " " + displayInformation.title
-        let localizedString = localizedString(.cardSecurityCodeDescription, localizationParameters, paymentMethodTitle, formattedAmount)
+        // TODO: Replace hardcoded English subtitle with finalized localization before release.
+        let subtitle = "Enter the security code for \(paymentMethodTitle) to complete the payment of \(formattedAmount)"
 
-        let attributed = NSMutableAttributedString(string: localizedString)
+        let attributed = NSMutableAttributedString(string: subtitle)
 
-        let range = (localizedString as NSString).range(of: paymentMethodTitle)
+        let range = (subtitle as NSString).range(of: paymentMethodTitle)
         attributed.addAttribute(.font, value: theme.elements.labels.bodyEmphasized.font, range: range)
         attributed.addAttribute(.foregroundColor, value: theme.elements.labels.bodyEmphasized.color, range: range)
 
-        let amountRange = (localizedString as NSString).range(of: formattedAmount)
+        let amountRange = (subtitle as NSString).range(of: formattedAmount)
         attributed.addAttribute(.font, value: theme.elements.labels.bodyEmphasized.font, range: amountRange)
         attributed.addAttribute(.foregroundColor, value: theme.elements.labels.bodyEmphasized.color, range: amountRange)
 

--- a/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodViewModel.swift
+++ b/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodViewModel.swift
@@ -110,7 +110,8 @@ internal final class PreselectedPaymentMethodViewModel: PreselectedPaymentMethod
     }
 
     internal var subtitleText: String {
-        localizedString(.preselectedPaymentMethodSubtitle, localizationParameters, component.paymentMethod.name, formattedAmount)
+        // TODO: Replace hardcoded English subtitle with finalized localization before release.
+        "Use \(component.paymentMethod.name) to pay \(formattedAmount)"
     }
 
     internal var submitButtonTitle: String {
@@ -122,7 +123,8 @@ internal final class PreselectedPaymentMethodViewModel: PreselectedPaymentMethod
     }
 
     internal var showAllPaymentMethodsButtonTitle: String {
-        localizedString(.preselectedPaymentMethodOtherOptions, localizationParameters)
+        // TODO: Replace hardcoded English button title with finalized localization before release.
+        "Other payment options"
     }
 
     internal func showAllPaymentMethods() {

--- a/Tests/UnitTests/Localization/LocalizationTableCompletenessValidator.swift
+++ b/Tests/UnitTests/Localization/LocalizationTableCompletenessValidator.swift
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+struct LocalizationTableCompletenessValidator {
+
+    struct MissingKeys: Equatable {
+        let locale: String
+        let keys: [String]
+    }
+
+    enum ValidationError: Error {
+        case supportedLocalesNotFound(bundlePath: String)
+        case tableNotFound(locale: String, tableName: String)
+        case unableToLoadTable(locale: String, tableName: String)
+    }
+
+    func supportedLocales(in bundle: Bundle) throws -> [String] {
+        let lprojDirectories = try FileManager.default.contentsOfDirectory(atPath: bundle.bundlePath)
+            .filter { $0.hasSuffix(".lproj") && $0 != "Base.lproj" }
+            .map { String($0.dropLast(".lproj".count)) }
+            .sorted()
+
+        guard lprojDirectories.isEmpty == false else {
+            throw ValidationError.supportedLocalesNotFound(bundlePath: bundle.bundlePath)
+        }
+
+        return lprojDirectories
+    }
+
+    func missingKeys(
+        in bundle: Bundle,
+        tableName: String?,
+        sourceLocale: String,
+        locales: [String]? = nil
+    ) throws -> [MissingKeys] {
+        let localesToValidate = try locales ?? supportedLocales(in: bundle)
+        let source = try localizedStrings(in: bundle, tableName: tableName, locale: sourceLocale)
+        let sourceKeys = Set(source.keys)
+
+        return try localesToValidate
+            .map { locale in
+                let localized = try localizedStrings(in: bundle, tableName: tableName, locale: locale)
+                let missing = sourceKeys.subtracting(localized.keys).sorted()
+                return MissingKeys(locale: locale, keys: missing)
+            }
+            .filter { $0.keys.isEmpty == false }
+    }
+
+    private func localizedStrings(
+        in bundle: Bundle,
+        tableName: String?,
+        locale: String
+    ) throws -> [String: String] {
+        let resourceTableName = tableName ?? "Localizable"
+        guard let path = bundle.path(
+            forResource: resourceTableName,
+            ofType: "strings",
+            inDirectory: nil,
+            forLocalization: locale
+        ) else {
+            throw ValidationError.tableNotFound(locale: locale, tableName: resourceTableName)
+        }
+
+        guard let dictionary = NSDictionary(contentsOfFile: path) as? [String: String] else {
+            throw ValidationError.unableToLoadTable(locale: locale, tableName: resourceTableName)
+        }
+
+        return dictionary
+    }
+}

--- a/Tests/UnitTests/Localization/LocalizationTableCompletenessValidatorTests.swift
+++ b/Tests/UnitTests/Localization/LocalizationTableCompletenessValidatorTests.swift
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+import XCTest
+
+final class LocalizationTableCompletenessValidatorTests: XCTestCase {
+
+    func test_sdkLocalizableTable_shouldContainAllKeysForAllSupportedLocales() throws {
+        let validator = LocalizationTableCompletenessValidator()
+
+        let missingKeys = try validator.missingKeys(
+            in: Bundle.coreInternalResources,
+            tableName: nil,
+            sourceLocale: "en-US"
+        )
+
+        let errorDetails = missingKeys
+            .map { "\($0.locale): \($0.keys.joined(separator: ", "))" }
+            .joined(separator: "\n")
+
+        XCTAssertTrue(
+            missingKeys.isEmpty,
+            """
+            Missing localization keys detected in SDK Localizable table.
+            \(errorDetails)
+            """
+        )
+    }
+
+    func test_validator_withExplicitTableName_shouldMatchDefaultTableResults() throws {
+        let validator = LocalizationTableCompletenessValidator()
+        let supportedLocales = try validator.supportedLocales(in: Bundle.coreInternalResources)
+
+        let missingForDefault = try validator.missingKeys(
+            in: Bundle.coreInternalResources,
+            tableName: nil,
+            sourceLocale: "en-US",
+            locales: supportedLocales
+        )
+
+        let missingForExplicitTable = try validator.missingKeys(
+            in: Bundle.coreInternalResources,
+            tableName: "Localizable",
+            sourceLocale: "en-US",
+            locales: supportedLocales
+        )
+
+        XCTAssertEqual(missingForDefault, missingForExplicitTable)
+    }
+}


### PR DESCRIPTION
# Summary 
This PR adds generic localization completeness validation for SDK localization resources. It introduces a reusable validator helper API that accepts any bundle and table name, then verifies that all keys from the source locale are present across all SDK-supported locales. The initial coverage targets the SDK internal `Localizable` table and fails on any missing key.

## Technical note
- Added `LocalizationTableCompletenessValidator` in unit tests:
  - supports `bundle`, `tableName`, `sourceLocale`, and optional locale subset
  - discovers supported locales from `.lproj` directories in the provided bundle
  - reports missing keys per locale
- Added `LocalizationTableCompletenessValidatorTests`:
  - validates SDK internal localization completeness (`Bundle.coreInternalResources`, `Localizable`, source locale `en-US`)
  - validates explicit table-name API path (`tableName: "Localizable"`) against default behavior

This new test is expected to fail because of new strings added recently that are not translated yet:

## Ticket 
<ticket>
COSDK-1097
</ticket>

## Checklist 
- [ ] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
