### PR TITLE
Localization: internalize legacy APIs

### DIFF
--- a/Adyen/Core/APIClient/Responses/OrderStatusResponse.swift
+++ b/Adyen/Core/APIClient/Responses/OrderStatusResponse.swift
@@ -64,8 +64,7 @@ public struct OrderPaymentMethod: PaymentMethod {
         self.amount = amount
     }
 
-    @_spi(AdyenInternal)
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         let disclosureText = AmountFormatter.formatted(
             amount: -amount.value,
             currencyCode: amount.currencyCode,
@@ -99,3 +98,5 @@ public struct OrderPaymentMethod: PaymentMethod {
         case type
     }
 }
+
+extension OrderPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/APIClient/Responses/OrderStatusResponse.swift
+++ b/Adyen/Core/APIClient/Responses/OrderStatusResponse.swift
@@ -98,5 +98,3 @@ public struct OrderPaymentMethod: PaymentMethod {
         case type
     }
 }
-
-extension OrderPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Core Protocols/PaymentMethod.swift
+++ b/Adyen/Core/Core Protocols/PaymentMethod.swift
@@ -41,20 +41,10 @@ public extension PaymentMethod {
 /// A protocol to define any partial payment method such as gift cards, `MealVoucher` etc.
 public protocol PartialPaymentMethod: PaymentMethod {}
 
-package protocol LocalizedPaymentMethod: PaymentMethod {
-    func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation
-}
-
 package extension PaymentMethod {
     
     func displayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
-        let defaultDisplayInformation: DisplayInformation
-        if let localizedPaymentMethod = self as? any LocalizedPaymentMethod {
-            defaultDisplayInformation = localizedPaymentMethod.defaultDisplayInformation(using: parameters)
-        } else {
-            defaultDisplayInformation = DisplayInformation(title: name, subtitle: nil, logoName: type.rawValue)
-        }
-
+        let defaultDisplayInformation = defaultDisplayInformation(using: parameters)
         if let merchantProvidedDisplayInformation {
             let subtitle = merchantProvidedDisplayInformation.subtitle ?? defaultDisplayInformation.subtitle
             return DisplayInformation(
@@ -67,6 +57,47 @@ package extension PaymentMethod {
         }
         return defaultDisplayInformation
     }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+        switch self {
+        case let cardPaymentMethod as CardPaymentMethod:
+            return cardPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let storedCardPaymentMethod as StoredCardPaymentMethod:
+            return storedCardPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let storedBCMCPaymentMethod as StoredBCMCPaymentMethod:
+            return storedBCMCPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let storedPayPalPaymentMethod as StoredPayPalPaymentMethod:
+            return storedPayPalPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let achDirectDebitPaymentMethod as ACHDirectDebitPaymentMethod:
+            return achDirectDebitPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let storedACHDirectDebitPaymentMethod as StoredACHDirectDebitPaymentMethod:
+            return storedACHDirectDebitPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let storedTwintPaymentMethod as StoredTwintPaymentMethod:
+            return storedTwintPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let blikPaymentMethod as BLIKPaymentMethod:
+            return blikPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let storedBLIKPaymentMethod as StoredBLIKPaymentMethod:
+            return storedBLIKPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let storedCashAppPayPaymentMethod as StoredCashAppPayPaymentMethod:
+            return storedCashAppPayPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let mealVoucherPaymentMethod as MealVoucherPaymentMethod:
+            return mealVoucherPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let payByBankUSPaymentMethod as PayByBankUSPaymentMethod:
+            return payByBankUSPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let storedPayByBankUSPaymentMethod as StoredPayByBankUSPaymentMethod:
+            return storedPayByBankUSPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let giftCardPaymentMethod as GiftCardPaymentMethod:
+            return giftCardPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let storedPayToPaymentMethod as StoredPayToPaymentMethod:
+            return storedPayToPaymentMethod.defaultDisplayInformation(using: parameters)
+        case let orderPaymentMethod as OrderPaymentMethod:
+            return orderPaymentMethod.defaultDisplayInformation(using: parameters)
+        default:
+            return DisplayInformation(title: name, subtitle: nil, logoName: type.rawValue)
+        }
+    }
+    
 }
 
 /// A payment method that has been stored for later use.

--- a/Adyen/Core/Core Protocols/PaymentMethod.swift
+++ b/Adyen/Core/Core Protocols/PaymentMethod.swift
@@ -19,13 +19,6 @@ public protocol PaymentMethod: Codable {
     /// and if not `nil`, will override the default display information.
     var merchantProvidedDisplayInformation: MerchantCustomDisplayInformation? { get set }
     
-    /// Display information for the payment method, adapted for displaying in a list.
-    ///
-    /// - Parameters:
-    ///   - using: The localization parameters.
-    @_spi(AdyenInternal)
-    func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation
-    
     @_spi(AdyenInternal)
     func buildComponent(using builder: PaymentComponentBuilder) -> PaymentComponent?
 }
@@ -48,11 +41,20 @@ public extension PaymentMethod {
 /// A protocol to define any partial payment method such as gift cards, `MealVoucher` etc.
 public protocol PartialPaymentMethod: PaymentMethod {}
 
-@_spi(AdyenInternal)
-public extension PaymentMethod {
+package protocol LocalizedPaymentMethod: PaymentMethod {
+    func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation
+}
+
+package extension PaymentMethod {
     
     func displayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
-        let defaultDisplayInformation = defaultDisplayInformation(using: parameters)
+        let defaultDisplayInformation: DisplayInformation
+        if let localizedPaymentMethod = self as? any LocalizedPaymentMethod {
+            defaultDisplayInformation = localizedPaymentMethod.defaultDisplayInformation(using: parameters)
+        } else {
+            defaultDisplayInformation = DisplayInformation(title: name, subtitle: nil, logoName: type.rawValue)
+        }
+
         if let merchantProvidedDisplayInformation {
             let subtitle = merchantProvidedDisplayInformation.subtitle ?? defaultDisplayInformation.subtitle
             return DisplayInformation(
@@ -65,12 +67,6 @@ public extension PaymentMethod {
         }
         return defaultDisplayInformation
     }
-
-    @_spi(AdyenInternal)
-    func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
-        DisplayInformation(title: name, subtitle: nil, logoName: type.rawValue)
-    }
-    
 }
 
 /// A payment method that has been stored for later use.

--- a/Adyen/Core/Core Protocols/PresentableComponent.swift
+++ b/Adyen/Core/Core Protocols/PresentableComponent.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Describes any entity that is UI localizable.
-public protocol Localizable {
+package protocol Localizable {
     
     /// Indicates the localization parameters, leave it nil to use the default parameters.
     var localizationParameters: LocalizationParameters? { get set }

--- a/Adyen/Core/Payment Methods/ACHDirectDebitPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/ACHDirectDebitPaymentMethod.swift
@@ -20,8 +20,7 @@ public struct ACHDirectDebitPaymentMethod: PaymentMethod {
         builder.build(paymentMethod: self)
     }
     
-    @_spi(AdyenInternal)
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         DisplayInformation(title: name.uppercased(), subtitle: nil, logoName: type.rawValue)
     }
 
@@ -52,8 +51,7 @@ public struct StoredACHDirectDebitPaymentMethod: StoredPaymentMethod {
         builder.build(paymentMethod: self)
     }
     
-    @_spi(AdyenInternal)
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         let bankAccountLastFour = String(bankAccountNumber.suffix(4))
         let lastFourSeparated = bankAccountLastFour.map { String($0) }.joined(separator: ", ")
         let accessibilityLabel = [
@@ -81,3 +79,7 @@ public struct StoredACHDirectDebitPaymentMethod: StoredPaymentMethod {
         case bankAccountNumber
     }
 }
+
+extension ACHDirectDebitPaymentMethod: LocalizedPaymentMethod {}
+
+extension StoredACHDirectDebitPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/ACHDirectDebitPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/ACHDirectDebitPaymentMethod.swift
@@ -79,7 +79,3 @@ public struct StoredACHDirectDebitPaymentMethod: StoredPaymentMethod {
         case bankAccountNumber
     }
 }
-
-extension ACHDirectDebitPaymentMethod: LocalizedPaymentMethod {}
-
-extension StoredACHDirectDebitPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/BLIKPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/BLIKPaymentMethod.swift
@@ -20,7 +20,7 @@ public struct BLIKPaymentMethod: PaymentMethod {
         builder.build(paymentMethod: self)
     }
     
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         DisplayInformation(title: name.uppercased(), subtitle: nil, logoName: type.rawValue)
     }
 
@@ -29,3 +29,5 @@ public struct BLIKPaymentMethod: PaymentMethod {
         case name
     }
 }
+
+extension BLIKPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/BLIKPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/BLIKPaymentMethod.swift
@@ -29,5 +29,3 @@ public struct BLIKPaymentMethod: PaymentMethod {
         case name
     }
 }
-
-extension BLIKPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/CardPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/CardPaymentMethod.swift
@@ -129,7 +129,3 @@ public struct StoredCardPaymentMethod: StoredPaymentMethod, AnyCardPaymentMethod
     }
     
 }
-
-extension CardPaymentMethod: LocalizedPaymentMethod {}
-
-extension StoredCardPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/CardPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/CardPaymentMethod.swift
@@ -35,7 +35,7 @@ public struct CardPaymentMethod: AnyCardPaymentMethod {
         builder.build(paymentMethod: self)
     }
     
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         DisplayInformation(title: name, subtitle: nil, logoName: "card")
     }
     
@@ -72,7 +72,7 @@ public struct StoredCardPaymentMethod: StoredPaymentMethod, AnyCardPaymentMethod
 
     public var fundingSource: CardFundingSource?
 
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         let expireDate = expiryMonth + "/" + String(expiryYear.suffix(2))
         let localizedExpiryDate = localizedString(.cardStoredExpires, parameters, expireDate)
         
@@ -129,3 +129,7 @@ public struct StoredCardPaymentMethod: StoredPaymentMethod, AnyCardPaymentMethod
     }
     
 }
+
+extension CardPaymentMethod: LocalizedPaymentMethod {}
+
+extension StoredCardPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/GiftCardPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/GiftCardPaymentMethod.swift
@@ -34,6 +34,5 @@ public struct GiftCardPaymentMethod: PartialPaymentMethod {
         case name
         case brand
     }
-}
 
-extension GiftCardPaymentMethod: LocalizedPaymentMethod {}
+}

--- a/Adyen/Core/Payment Methods/GiftCardPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/GiftCardPaymentMethod.swift
@@ -23,7 +23,7 @@ public struct GiftCardPaymentMethod: PartialPaymentMethod {
         builder.build(paymentMethod: self)
     }
 
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         DisplayInformation(title: name, subtitle: nil, logoName: brand)
     }
 
@@ -34,5 +34,6 @@ public struct GiftCardPaymentMethod: PartialPaymentMethod {
         case name
         case brand
     }
-
 }
+
+extension GiftCardPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/MealVoucherPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/MealVoucherPaymentMethod.swift
@@ -30,6 +30,5 @@ public struct MealVoucherPaymentMethod: PartialPaymentMethod {
         case type
         case name
     }
-}
 
-extension MealVoucherPaymentMethod: LocalizedPaymentMethod {}
+}

--- a/Adyen/Core/Payment Methods/MealVoucherPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/MealVoucherPaymentMethod.swift
@@ -20,7 +20,7 @@ public struct MealVoucherPaymentMethod: PartialPaymentMethod {
         builder.build(paymentMethod: self)
     }
 
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         DisplayInformation(title: name, subtitle: nil, logoName: type.rawValue)
     }
 
@@ -30,5 +30,6 @@ public struct MealVoucherPaymentMethod: PartialPaymentMethod {
         case type
         case name
     }
-
 }
+
+extension MealVoucherPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/PayByBankUSPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/PayByBankUSPaymentMethod.swift
@@ -19,7 +19,7 @@ public struct PayByBankUSPaymentMethod: PaymentMethod {
         ["US-1", "US-2", "US-3", "US-4"]
     }
     
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         .init(
             title: name,
             subtitle: nil,
@@ -42,3 +42,5 @@ public struct PayByBankUSPaymentMethod: PaymentMethod {
         case name
     }
 }
+
+extension PayByBankUSPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/PayByBankUSPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/PayByBankUSPaymentMethod.swift
@@ -42,5 +42,3 @@ public struct PayByBankUSPaymentMethod: PaymentMethod {
         case name
     }
 }
-
-extension PayByBankUSPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/PayToPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/PayToPaymentMethod.swift
@@ -49,7 +49,7 @@ public struct StoredPayToPaymentMethod: StoredPaymentMethod {
         builder.build(paymentMethod: self)
     }
     
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         let accessibilityLabel = [
             name,
             label
@@ -71,3 +71,5 @@ public struct StoredPayToPaymentMethod: StoredPaymentMethod {
         case supportedShopperInteractions
     }
 }
+
+extension StoredPayToPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/PayToPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/PayToPaymentMethod.swift
@@ -71,5 +71,3 @@ public struct StoredPayToPaymentMethod: StoredPaymentMethod {
         case supportedShopperInteractions
     }
 }
-
-extension StoredPayToPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/StoredBCMCPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredBCMCPaymentMethod.swift
@@ -26,7 +26,7 @@ public struct StoredBCMCPaymentMethod: StoredPaymentMethod {
         storedCardPaymentMethod.identifier
     }
 
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         storedCardPaymentMethod.displayInformation(using: parameters)
     }
     
@@ -73,3 +73,5 @@ public struct StoredBCMCPaymentMethod: StoredPaymentMethod {
     }
     
 }
+
+extension StoredBCMCPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/StoredBCMCPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredBCMCPaymentMethod.swift
@@ -73,5 +73,3 @@ public struct StoredBCMCPaymentMethod: StoredPaymentMethod {
     }
     
 }
-
-extension StoredBCMCPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/StoredBLIKPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredBLIKPaymentMethod.swift
@@ -36,6 +36,5 @@ public struct StoredBLIKPaymentMethod: StoredPaymentMethod {
         case identifier = "id"
         case supportedShopperInteractions
     }
-}
 
-extension StoredBLIKPaymentMethod: LocalizedPaymentMethod {}
+}

--- a/Adyen/Core/Payment Methods/StoredBLIKPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredBLIKPaymentMethod.swift
@@ -24,8 +24,7 @@ public struct StoredBLIKPaymentMethod: StoredPaymentMethod {
         builder.build(paymentMethod: self)
     }
     
-    @_spi(AdyenInternal)
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         DisplayInformation(title: name.uppercased(), subtitle: nil, logoName: type.rawValue)
     }
 
@@ -37,5 +36,6 @@ public struct StoredBLIKPaymentMethod: StoredPaymentMethod {
         case identifier = "id"
         case supportedShopperInteractions
     }
-
 }
+
+extension StoredBLIKPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/StoredCashAppPayPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredCashAppPayPaymentMethod.swift
@@ -25,8 +25,7 @@ public struct StoredCashAppPayPaymentMethod: StoredPaymentMethod {
         builder.build(paymentMethod: self)
     }
     
-    @_spi(AdyenInternal)
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         let accessibilityLabel = [
             name,
             "\(localizedString(.cashAppPayCashtag, parameters)): \(cashtag)"
@@ -49,3 +48,5 @@ public struct StoredCashAppPayPaymentMethod: StoredPaymentMethod {
 
     }
 }
+
+extension StoredCashAppPayPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/StoredCashAppPayPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredCashAppPayPaymentMethod.swift
@@ -48,5 +48,3 @@ public struct StoredCashAppPayPaymentMethod: StoredPaymentMethod {
 
     }
 }
-
-extension StoredCashAppPayPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/StoredPayByBankUSPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredPayByBankUSPaymentMethod.swift
@@ -50,6 +50,5 @@ public struct StoredPayByBankUSPaymentMethod: StoredPaymentMethod {
         case identifier = "id"
         case supportedShopperInteractions
     }
-}
 
-extension StoredPayByBankUSPaymentMethod: LocalizedPaymentMethod {}
+}

--- a/Adyen/Core/Payment Methods/StoredPayByBankUSPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredPayByBankUSPaymentMethod.swift
@@ -26,8 +26,7 @@ public struct StoredPayByBankUSPaymentMethod: StoredPaymentMethod {
         builder.build(paymentMethod: self)
     }
     
-    @_spi(AdyenInternal)
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         let title: String
         let subtitle: String?
         
@@ -51,5 +50,6 @@ public struct StoredPayByBankUSPaymentMethod: StoredPaymentMethod {
         case identifier = "id"
         case supportedShopperInteractions
     }
-
 }
+
+extension StoredPayByBankUSPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/StoredPayPalPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredPayPalPaymentMethod.swift
@@ -19,7 +19,7 @@ public struct StoredPayPalPaymentMethod: StoredPaymentMethod {
 
     public let supportedShopperInteractions: [ShopperInteraction]
 
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         DisplayInformation(title: name, subtitle: emailAddress, logoName: type.rawValue)
     }
     
@@ -40,5 +40,6 @@ public struct StoredPayPalPaymentMethod: StoredPaymentMethod {
         case emailAddress = "shopperEmail"
         case supportedShopperInteractions
     }
-    
 }
+
+extension StoredPayPalPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/StoredPayPalPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredPayPalPaymentMethod.swift
@@ -40,6 +40,5 @@ public struct StoredPayPalPaymentMethod: StoredPaymentMethod {
         case emailAddress = "shopperEmail"
         case supportedShopperInteractions
     }
+    
 }
-
-extension StoredPayPalPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/StoredTwintPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredTwintPaymentMethod.swift
@@ -24,8 +24,7 @@ public struct StoredTwintPaymentMethod: StoredPaymentMethod {
         builder.build(paymentMethod: self)
     }
 
-    @_spi(AdyenInternal)
-    public func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+    package func defaultDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         DisplayInformation(
             title: name,
             subtitle: nil,
@@ -41,3 +40,5 @@ public struct StoredTwintPaymentMethod: StoredPaymentMethod {
 
     }
 }
+
+extension StoredTwintPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Core/Payment Methods/StoredTwintPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredTwintPaymentMethod.swift
@@ -40,5 +40,3 @@ public struct StoredTwintPaymentMethod: StoredPaymentMethod {
 
     }
 }
-
-extension StoredTwintPaymentMethod: LocalizedPaymentMethod {}

--- a/Adyen/Model/PostalAddress.swift
+++ b/Adyen/Model/PostalAddress.swift
@@ -149,8 +149,7 @@ public struct AddressLookupResult {
 extension PostalAddress {
     
     /// Multi line mailing address
-    @_spi(AdyenInternal)
-    public func formatted(using localizationParameters: LocalizationParameters?) -> String {
+    package func formatted(using localizationParameters: LocalizationParameters?) -> String {
         let address = CNMutablePostalAddress()
         city.map { address.city = $0 }
         country.map {
@@ -177,8 +176,7 @@ extension PostalAddress {
             .replacingOccurrences(of: "\n", with: ", ")
     }
     
-    @_spi(AdyenInternal)
-    public func formattedLocation(using localizationParameters: LocalizationParameters?) -> String {
+    package func formattedLocation(using localizationParameters: LocalizationParameters?) -> String {
         let address = CNMutablePostalAddress()
         city.map { address.city = $0 }
         country.map {
@@ -194,7 +192,7 @@ extension PostalAddress {
     
     package func formattedSingleLine(using localizationParameters: LocalizationParameters?) -> String {
         // Use CNPostalAddressFormatter for locale-aware formatting, then convert to single line
-        return formatted(using: localizationParameters)
+        formatted(using: localizationParameters)
             .replacingOccurrences(of: "\n", with: ", ")
     }
 

--- a/Adyen/Utilities/External/LogoURLProvider.swift
+++ b/Adyen/Utilities/External/LogoURLProvider.swift
@@ -36,7 +36,7 @@ public final class LogoURLProvider {
     /// - Parameter paymentMethod: The issuer payment method.
     /// - Parameter environment: The environment to be used.
     /// - Returns: The URL for the issuer logo.
-    public static func logoURL(
+    package static func logoURL(
         for issuer: Issuer,
         localizedParameters: LocalizationParameters?,
         paymentMethod: IssuerListPaymentMethod,

--- a/Adyen/Utilities/LocalizationParameters.swift
+++ b/Adyen/Utilities/LocalizationParameters.swift
@@ -13,13 +13,13 @@ internal enum LocalizationMode: Equatable {
 
 /// The localization parameters to control some aspects of how localized strings are fetched,
 /// like the localization table to use and the separator of the key strings.
-public struct LocalizationParameters: Equatable {
+package struct LocalizationParameters: Equatable {
 
     internal let mode: LocalizationMode
 
     /// The locale identifier for external resources and numeric formats.
     /// By default current locale is used.
-    public var locale: String? {
+    package var locale: String? {
         switch mode {
         case let .natural(_, _, _, locale: locale):
             return locale
@@ -30,7 +30,7 @@ public struct LocalizationParameters: Equatable {
 
     /// The string table to search. If tableName is nil or is an empty string,
     /// the Localizable.strings is used instead.
-    public var tableName: String? {
+    package var tableName: String? {
         switch mode {
         case let .natural(_, tableName: tableName, _, _):
             return tableName
@@ -41,7 +41,7 @@ public struct LocalizationParameters: Equatable {
 
     /// Indicates the key separator string, set it if you want the localization keys to have a different separator other than ".",
     /// otherwise a "." is used.
-    public var keySeparator: String? {
+    package var keySeparator: String? {
         switch mode {
         case let .natural(_, _, keySeparator: keySeparator, _):
             return keySeparator
@@ -53,7 +53,7 @@ public struct LocalizationParameters: Equatable {
     /// Indicates the `Bundle` in which to look for translations,
     /// if `nil`, then the SDK try to fetch the translations from the `Bundle.main`,
     /// if not found, then the internal SDK bundle is used.
-    public var bundle: Bundle? {
+    package var bundle: Bundle? {
         switch mode {
         case let .natural(bundle: bundle, _, _, _):
             return bundle
@@ -72,7 +72,7 @@ public struct LocalizationParameters: Equatable {
     ///   - tableName: The string table to search.
     ///   - keySeparator: The key separator string.
     ///   - locale: The locale for external resources and formatting of monetary values..
-    public init(bundle: Bundle? = nil, tableName: String? = nil, keySeparator: String? = nil, locale: String? = nil) {
+    package init(bundle: Bundle? = nil, tableName: String? = nil, keySeparator: String? = nil, locale: String? = nil) {
         mode = .natural(bundle: bundle, tableName: tableName, keySeparator: keySeparator, locale: locale)
     }
 
@@ -84,7 +84,7 @@ public struct LocalizationParameters: Equatable {
     ///   `Bundle.main` takes precedence over the custom bundle provided.
     ///   - tableName: The string table to search.
     ///   - keySeparator: The key separator string.
-    public init(enforcedLocale: String, bundle: Bundle? = nil, tableName: String? = nil, keySeparator: String? = nil) {
+    package init(enforcedLocale: String, bundle: Bundle? = nil, tableName: String? = nil, keySeparator: String? = nil) {
         mode = .enforced(bundle: bundle, tableName: tableName, keySeparator: keySeparator, locale: enforcedLocale)
     }
 }

--- a/AdyenActions/CheckoutActionComponent.swift
+++ b/AdyenActions/CheckoutActionComponent.swift
@@ -33,7 +33,7 @@ public final class CheckoutActionComponent: ActionComponent, ActionHandlingCompo
     public struct Configuration: Localizable {
         
         /// Localization parameters.
-        public var localizationParameters: LocalizationParameters?
+        package var localizationParameters: LocalizationParameters?
         
         /// The UI style configurations.
         public var style: ActionComponentStyle = .init()
@@ -52,6 +52,19 @@ public final class CheckoutActionComponent: ActionComponent, ActionHandlingCompo
         ///   - threeDS: Three DS configurations.
         ///   - twint: Twint configurations.
         public init(
+            style: ActionComponentStyle = .init(),
+            threeDS: ThreeDS2ActionConfiguration = .init(),
+            twint: TwintActionConfiguration? = nil
+        ) {
+            self.init(
+                localizationParameters: nil,
+                style: style,
+                threeDS: threeDS,
+                twint: twint
+            )
+        }
+
+        package init(
             localizationParameters: LocalizationParameters? = nil,
             style: ActionComponentStyle = .init(),
             threeDS: ThreeDS2ActionConfiguration = .init(),

--- a/AdyenActions/Components/Await/AwaitComponent.swift
+++ b/AdyenActions/Components/Await/AwaitComponent.swift
@@ -29,14 +29,18 @@ public final class AwaitComponent: ActionComponent, Cancellable {
         public var style: AwaitComponentStyle
         
         /// The localization parameters, leave it nil to use the default parameters.
-        public var localizationParameters: LocalizationParameters?
+        package var localizationParameters: LocalizationParameters?
         
         /// Initializes an instance of `Configuration`
         ///
         /// - Parameters:
         ///   - style: The Component UI style.
         ///   - localizationParameters: The localization parameters, leave it nil to use the default parameters.
-        public init(
+        public init(style: AwaitComponentStyle = .init()) {
+            self.init(style: style, localizationParameters: nil)
+        }
+
+        package init(
             style: AwaitComponentStyle = .init(),
             localizationParameters: LocalizationParameters? = nil
         ) {

--- a/AdyenActions/Components/Document/DocumentComponent.swift
+++ b/AdyenActions/Components/Document/DocumentComponent.swift
@@ -31,14 +31,18 @@ public final class DocumentComponent: ActionComponent, ShareableComponent {
         public var style: DocumentComponentStyle
         
         /// The localization parameters, leave it nil to use the default parameters.
-        public var localizationParameters: LocalizationParameters?
+        package var localizationParameters: LocalizationParameters?
         
         /// Initializes an instance of `Configuration`
         ///
         /// - Parameters:
         ///   - style: The Component UI style.
         ///   - localizationParameters: The localization parameters, leave it nil to use the default parameters.
-        public init(style: DocumentComponentStyle = DocumentComponentStyle(), localizationParameters: LocalizationParameters? = nil) {
+        public init(style: DocumentComponentStyle = DocumentComponentStyle()) {
+            self.init(style: style, localizationParameters: nil)
+        }
+
+        package init(style: DocumentComponentStyle = DocumentComponentStyle(), localizationParameters: LocalizationParameters? = nil) {
             self.style = style
             self.localizationParameters = localizationParameters
         }

--- a/AdyenActions/Components/QRCode/QRCodeActionComponent.swift
+++ b/AdyenActions/Components/QRCode/QRCodeActionComponent.swift
@@ -42,14 +42,18 @@ public final class QRCodeActionComponent: ActionComponent, Cancellable, Shareabl
         public var style: QRCodeComponentStyle = .init()
         
         /// The localization parameters, leave it nil to use the default parameters.
-        public var localizationParameters: LocalizationParameters?
+        package var localizationParameters: LocalizationParameters?
         
         /// Initializes an instance of `Configuration`
         ///
         /// - Parameters:
         ///   - style: The Component UI style.
         ///   - localizationParameters: The localization parameters, leave it nil to use the default parameters.
-        public init(style: QRCodeComponentStyle = QRCodeComponentStyle(), localizationParameters: LocalizationParameters? = nil) {
+        public init(style: QRCodeComponentStyle = QRCodeComponentStyle()) {
+            self.init(style: style, localizationParameters: nil)
+        }
+
+        package init(style: QRCodeComponentStyle = QRCodeComponentStyle(), localizationParameters: LocalizationParameters? = nil) {
             self.style = style
             self.localizationParameters = localizationParameters
         }

--- a/AdyenActions/Components/Voucher/VoucherComponent.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponent.swift
@@ -37,14 +37,18 @@ public final class VoucherComponent: AnyVoucherActionHandler, ShareableComponent
         public var style: VoucherComponentStyle = .init()
         
         /// The localization parameters, leave it nil to use the default parameters.
-        public var localizationParameters: LocalizationParameters?
+        package var localizationParameters: LocalizationParameters?
         
         /// Initializes an instance of `Configuration`
         ///
         /// - Parameters:
         ///   - style: The Component UI style.
         ///   - localizationParameters: The localization parameters, leave it nil to use the default parameters.
-        public init(style: VoucherComponentStyle = VoucherComponentStyle(), localizationParameters: LocalizationParameters? = nil) {
+        public init(style: VoucherComponentStyle = VoucherComponentStyle()) {
+            self.init(style: style, localizationParameters: nil)
+        }
+
+        package init(style: VoucherComponentStyle = VoucherComponentStyle(), localizationParameters: LocalizationParameters? = nil) {
             self.style = style
             self.localizationParameters = localizationParameters
         }

--- a/AdyenActions/Utilities/BundleSPMExtension.swift
+++ b/AdyenActions/Utilities/BundleSPMExtension.swift
@@ -18,7 +18,7 @@ internal extension Bundle {
     static let actions: Bundle = .init(for: RedirectComponent.self)
 
     /// The bundle in which the framework's resources are located.
-    static let actionsInternalResources: Bundle = .module
+    static let actionsInternalResources: Bundle = actions
 
     // swiftlint:enable explicit_acl
 }

--- a/AdyenActions/Utilities/BundleSPMExtension.swift
+++ b/AdyenActions/Utilities/BundleSPMExtension.swift
@@ -12,13 +12,9 @@ import Foundation
 /// that doesn't compile in a normal xcode project.
 /// The Bundle extension in `BundleExtension.swift` is used instead.
 internal extension Bundle {
-    // swiftlint:disable explicit_acl
-
     /// The main bundle of the framework.
     static let actions: Bundle = .init(for: RedirectComponent.self)
 
     /// The bundle in which the framework's resources are located.
-    static let actionsInternalResources: Bundle = actions
-
-    // swiftlint:enable explicit_acl
+    static let actionsInternalResources: Bundle = .module
 }

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -63,7 +63,7 @@ public final class GiftCardComponent: PresentableComponent,
     public weak var readyToSubmitComponentDelegate: ReadyToSubmitPaymentComponentDelegate?
 
     /// The localization parameters.
-    public var localizationParameters: LocalizationParameters?
+    package var localizationParameters: LocalizationParameters?
 
     /// Indicates whether to show the security code field at all.
     internal let showsSecurityCodeField: Bool

--- a/AdyenCard/Utilities/BundleSPMExtension.swift
+++ b/AdyenCard/Utilities/BundleSPMExtension.swift
@@ -12,10 +12,6 @@ import Foundation
 /// that doesn't compile in a normal xcode project.
 /// The Bundle extension in `BundleExtension.swift` is used instead.
 internal extension Bundle {
-    // swiftlint:disable explicit_acl
-
     /// The bundle in which the framework's resources are located.
-    static let cardInternalResources: Bundle = .init(for: FormCardNumberItem.self)
-
-    // swiftlint:enable explicit_acl
+    static let cardInternalResources: Bundle = .module
 }

--- a/AdyenCard/Utilities/BundleSPMExtension.swift
+++ b/AdyenCard/Utilities/BundleSPMExtension.swift
@@ -15,7 +15,7 @@ internal extension Bundle {
     // swiftlint:disable explicit_acl
 
     /// The bundle in which the framework's resources are located.
-    static let cardInternalResources: Bundle = .module
+    static let cardInternalResources: Bundle = .init(for: FormCardNumberItem.self)
 
     // swiftlint:enable explicit_acl
 }

--- a/AdyenCashAppPay/CashAppPayConfiguration.swift
+++ b/AdyenCashAppPay/CashAppPayConfiguration.swift
@@ -33,7 +33,7 @@ public struct CashAppPayConfiguration: AnyCashAppPayConfiguration {
     internal let showsSubmitButton: Bool
 
     /// The localization parameters, leave it nil to use the default parameters.
-    public var localizationParameters: LocalizationParameters?
+    package var localizationParameters: LocalizationParameters?
 
     /// Initializes an instance of `CashAppPayComponent.Configuration`
     ///
@@ -48,6 +48,25 @@ public struct CashAppPayConfiguration: AnyCashAppPayConfiguration {
     ///   Defaults to `true`.
     ///   - localizationParameters: The localization parameters, leave it nil to use the default parameters.
     public init(
+        redirectURL: URL,
+        referenceId: String? = nil,
+        showsStorePaymentMethodField: Bool = true,
+        storePaymentMethod: Bool = false,
+        style: FormComponentStyle = FormComponentStyle(),
+        showsSubmitButton: Bool = true
+    ) {
+        self.init(
+            redirectURL: redirectURL,
+            referenceId: referenceId,
+            showsStorePaymentMethodField: showsStorePaymentMethodField,
+            storePaymentMethod: storePaymentMethod,
+            style: style,
+            showsSubmitButton: showsSubmitButton,
+            localizationParameters: nil
+        )
+    }
+
+    package init(
         redirectURL: URL,
         referenceId: String? = nil,
         showsStorePaymentMethodField: Bool = true,

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponentConfiguration.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponentConfiguration.swift
@@ -59,7 +59,7 @@ extension ACHDirectDebitComponentConfiguration {
     /// Sets the localization parameters.
     /// - Parameter localizationParameters: The localization parameters to use.
     /// - Returns: A modified configuration with the updated localization parameters.
-    public func localizationParameters(_ localizationParameters: LocalizationParameters?) -> Self {
+    package func localizationParameters(_ localizationParameters: LocalizationParameters?) -> Self {
         var config = self
         config.localizationParameters = localizationParameters
         return config

--- a/AdyenComponents/BLIK/BLIKComponentConfiguration.swift
+++ b/AdyenComponents/BLIK/BLIKComponentConfiguration.swift
@@ -24,7 +24,11 @@ public struct BLIKComponentConfiguration: CheckoutComponentConfiguration {
 
     package var localizationParameters: LocalizationParameters?
     
-    public init(
+    public init(style: FormComponentStyle) {
+        self.init(style: style, localizationParameters: nil)
+    }
+
+    package init(
         style: FormComponentStyle,
         localizationParameters: LocalizationParameters? = nil
     ) {
@@ -33,6 +37,13 @@ public struct BLIKComponentConfiguration: CheckoutComponentConfiguration {
     }
 
     public init(
+        theme: AdyenTheme = .default,
+        style: FormComponentStyle = .init()
+    ) {
+        self.init(localizationParameters: nil, theme: theme, style: style)
+    }
+
+    package init(
         localizationParameters: LocalizationParameters? = nil,
         theme: AdyenTheme = .default,
         style: FormComponentStyle = .init()

--- a/AdyenComponents/Boleto/BoletoComponentExtensions.swift
+++ b/AdyenComponents/Boleto/BoletoComponentExtensions.swift
@@ -21,7 +21,7 @@ extension BoletoComponent {
         /// A Boolean value that determines whether the payment button is displayed. Defaults to `true`.
         internal let showsSubmitButton: Bool
 
-        public var localizationParameters: LocalizationParameters?
+        package var localizationParameters: LocalizationParameters?
         
         /// Pre-filled optional personal information about the shopper
         public let shopperInformation: PrefilledShopperInformation?
@@ -38,6 +38,21 @@ extension BoletoComponent {
         ///   - shopperInformation: Pre-filled optional personal information about the shopper
         ///   - showEmailAddress: Indicates whether to show `sendCopyByEmail` checkbox and email text field
         public init(
+            style: FormComponentStyle = FormComponentStyle(),
+            showsSubmitButton: Bool = true,
+            shopperInformation: PrefilledShopperInformation?,
+            showEmailAddress: Bool
+        ) {
+            self.init(
+                style: style,
+                showsSubmitButton: showsSubmitButton,
+                localizationParameters: nil,
+                shopperInformation: shopperInformation,
+                showEmailAddress: showEmailAddress
+            )
+        }
+
+        package init(
             style: FormComponentStyle = FormComponentStyle(),
             showsSubmitButton: Bool = true,
             localizationParameters: LocalizationParameters? = nil,

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -177,13 +177,17 @@ extension IssuerListComponent {
         /// The UI style of the component.
         public var style: ListComponentStyle
 
-        public var localizationParameters: LocalizationParameters?
+        package var localizationParameters: LocalizationParameters?
         
         /// Initializes the configuration for Issuer list type components.
         /// - Parameters:
         ///   - style: The UI style of the component.
         ///   - localizationParameters: Localization parameters.
-        public init(
+        public init(style: ListComponentStyle = .init()) {
+            self.init(style: style, localizationParameters: nil)
+        }
+
+        package init(
             style: ListComponentStyle = .init(),
             localizationParameters: LocalizationParameters? = nil
         ) {

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent+Configuration.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent+Configuration.swift
@@ -16,7 +16,7 @@ extension PayByBankUSComponent {
         /// The UI style of the component.
         public var style: PayByBankUSComponent.Style
         
-        public var localizationParameters: LocalizationParameters?
+        package var localizationParameters: LocalizationParameters?
         
         /// Initializes a new instance of `PayByBankUSComponent.Configuration`
         ///
@@ -24,6 +24,12 @@ extension PayByBankUSComponent {
         ///   - style: The form style.
         ///   - localizationParameters: The localization parameters.
         public init(
+            style: PayByBankUSComponent.Style = .init()
+        ) {
+            self.init(style: style, localizationParameters: nil)
+        }
+
+        package init(
             style: PayByBankUSComponent.Style = .init(),
             localizationParameters: LocalizationParameters? = nil
         ) {

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent+Configuration.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent+Configuration.swift
@@ -23,9 +23,7 @@ extension PayByBankUSComponent {
         /// - Parameters:
         ///   - style: The form style.
         ///   - localizationParameters: The localization parameters.
-        public init(
-            style: PayByBankUSComponent.Style = .init()
-        ) {
+        public init(style: PayByBankUSComponent.Style = .init()) {
             self.init(style: style, localizationParameters: nil)
         }
 

--- a/AdyenDropIn/Models/DropInConfiguration.swift
+++ b/AdyenDropIn/Models/DropInConfiguration.swift
@@ -42,7 +42,7 @@ public extension DropInComponent {
         public var shopperInformation: PrefilledShopperInformation?
         
         /// Indicates the localization parameters, leave it nil to use the default parameters.
-        public var localizationParameters: LocalizationParameters?
+        package var localizationParameters: LocalizationParameters?
         
         /// Determines whether to enable skipping payment list step
         /// when there is only one non-instant payment method.

--- a/AdyenUI/Components/Base/BasicComponentConfiguration.swift
+++ b/AdyenUI/Components/Base/BasicComponentConfiguration.swift
@@ -30,7 +30,7 @@ public struct BasicComponentConfiguration {
     public private(set) var showsSubmitButton: Bool
 
     /// Indicates the localization parameters, leave it nil to use the default parameters.
-    public var localizationParameters: LocalizationParameters?
+    package var localizationParameters: LocalizationParameters?
 
     /// Initializes a new instance of `BasicComponentConfiguration`
     ///
@@ -40,6 +40,17 @@ public struct BasicComponentConfiguration {
     ///   Defaults to `true`.
     ///   - localizationParameters: The localization parameters.
     public init(
+        style: FormComponentStyle = FormComponentStyle(),
+        showsSubmitButton: Bool = true
+    ) {
+        self.init(
+            style: style,
+            showsSubmitButton: showsSubmitButton,
+            localizationParameters: nil
+        )
+    }
+
+    package init(
         style: FormComponentStyle = FormComponentStyle(),
         showsSubmitButton: Bool = true,
         localizationParameters: LocalizationParameters? = nil
@@ -66,7 +77,7 @@ public struct PersonalInformationConfiguration: AnyPersonalInformationConfigurat
 
     public var shopperInformation: PrefilledShopperInformation?
     
-    public var localizationParameters: LocalizationParameters?
+    package var localizationParameters: LocalizationParameters?
 
     /// Initializes a new instance of `PersonalInformationConfiguration`
     ///
@@ -77,6 +88,19 @@ public struct PersonalInformationConfiguration: AnyPersonalInformationConfigurat
     ///   - shopperInformation: The shopper information to be prefilled.
     ///   - localizationParameters: The localization parameters.
     public init(
+        style: FormComponentStyle = FormComponentStyle(),
+        showsSubmitButton: Bool = true,
+        shopperInformation: PrefilledShopperInformation? = nil
+    ) {
+        self.init(
+            style: style,
+            showsSubmitButton: showsSubmitButton,
+            shopperInformation: shopperInformation,
+            localizationParameters: nil
+        )
+    }
+
+    package init(
         style: FormComponentStyle = FormComponentStyle(),
         showsSubmitButton: Bool = true,
         shopperInformation: PrefilledShopperInformation? = nil,

--- a/AdyenUI/UI/Form/FormViewController.swift
+++ b/AdyenUI/UI/Form/FormViewController.swift
@@ -59,7 +59,18 @@ open class FormViewController: UIViewController, AdyenObserver {
     ///   - scrollEnabled: Boolean value that determines whether the form view contains a scroll view in its view hierarchy.
     ///   - style: The `FormViewController` UI style.
     ///   - localizationParameters: The localization parameters.
-    public init(
+    public convenience init(
+        scrollEnabled: Bool,
+        style: ViewStyle
+    ) {
+        self.init(
+            scrollEnabled: scrollEnabled,
+            style: style,
+            localizationParameters: nil
+        )
+    }
+
+    package init(
         scrollEnabled: Bool,
         style: ViewStyle,
         localizationParameters: LocalizationParameters?
@@ -189,7 +200,7 @@ open class FormViewController: UIViewController, AdyenObserver {
 
     // MARK: - Localizable
 
-    public let localizationParameters: LocalizationParameters?
+    package let localizationParameters: LocalizationParameters?
 
     // MARK: - Validity
 

--- a/AdyenUI/UI/Form/Items/Address/FormAddressItem+Configuration.swift
+++ b/AdyenUI/UI/Form/Items/Address/FormAddressItem+Configuration.swift
@@ -30,6 +30,19 @@ public extension FormAddressItem {
         ///   - showsHeader: Whether to show a title header.
         public init(
             style: AddressStyle = AddressStyle(),
+            supportedCountryCodes: [String]? = nil,
+            showsHeader: Bool = true
+        ) {
+            self.init(
+                style: style,
+                localizationParameters: nil,
+                supportedCountryCodes: supportedCountryCodes,
+                showsHeader: showsHeader
+            )
+        }
+
+        package init(
+            style: AddressStyle = AddressStyle(),
             localizationParameters: LocalizationParameters? = nil,
             supportedCountryCodes: [String]? = nil,
             showsHeader: Bool = true

--- a/AdyenUI/UI/Form/Items/Address/FormPostalCodeItem.swift
+++ b/AdyenUI/UI/Form/Items/Address/FormPostalCodeItem.swift
@@ -18,13 +18,24 @@ public final class FormPostalCodeItem: FormTextItem {
     internal var localizationParameters: LocalizationParameters?
 
     /// Initializes the form postal code item.
-    public init(
+    override public init(
+        style: FormTextItemStyle = FormTextItemStyle()
+    ) {
+        self.localizationParameters = nil
+        super.init(style: style)
+        setup()
+    }
+
+    package init(
         style: FormTextItemStyle = FormTextItemStyle(),
         localizationParameters: LocalizationParameters? = nil
     ) {
         self.localizationParameters = localizationParameters
         super.init(style: style)
-        
+        setup()
+    }
+
+    private func setup() {
         title = localizedString(.postalCodeFieldTitle, localizationParameters)
         placeholder = localizedString(.postalCodeFieldPlaceholder, localizationParameters)
         validator = PostalCodeValidator(minimumLength: Constants.minLength, maximumLength: Constants.maxLength)

--- a/AdyenUI/UI/Form/Items/Address/FormPostalCodeItem.swift
+++ b/AdyenUI/UI/Form/Items/Address/FormPostalCodeItem.swift
@@ -18,9 +18,7 @@ public final class FormPostalCodeItem: FormTextItem {
     internal var localizationParameters: LocalizationParameters?
 
     /// Initializes the form postal code item.
-    override public init(
-        style: FormTextItemStyle = FormTextItemStyle()
-    ) {
+    override public init(style: FormTextItemStyle = FormTextItemStyle()) {
         self.localizationParameters = nil
         super.init(style: style)
         setup()

--- a/AdyenUI/UI/Form/Items/Phone Number/FormPhoneNumberItem.swift
+++ b/AdyenUI/UI/Form/Items/Phone Number/FormPhoneNumberItem.swift
@@ -28,7 +28,22 @@ public final class FormPhoneNumberItem: FormTextItem {
     /// - Parameter selectableValues: The list of values to select from.
     /// - Parameter style: The `FormTextItemStyle` UI style.
     /// - Parameter localizationParameters: Parameters for custom localization, leave it nil to use the default parameters.
-    public init(
+    public convenience init(
+        phoneNumber: PhoneNumber?,
+        selectableValues: [PhoneExtension],
+        style: FormTextItemStyle,
+        presenter: WeakReferenceViewControllerPresenter
+    ) {
+        self.init(
+            phoneNumber: phoneNumber,
+            selectableValues: selectableValues,
+            style: style,
+            localizationParameters: nil,
+            presenter: presenter
+        )
+    }
+
+    package init(
         phoneNumber: PhoneNumber?,
         selectableValues: [PhoneExtension],
         style: FormTextItemStyle,

--- a/AdyenUI/UI/Form/Items/Phone Number/Phone Extension Picker/FormPhoneExtensionPickerItem.swift
+++ b/AdyenUI/UI/Form/Items/Phone Number/Phone Extension Picker/FormPhoneExtensionPickerItem.swift
@@ -38,7 +38,26 @@ public final class FormPhoneExtensionPickerItem: FormPickerItem<PhoneExtension> 
         selectableValues.count > 1
     }
     
-    public required init(
+    public required convenience init(
+        preselectedExtension: PhoneExtension?,
+        selectableExtensions: [PhoneExtension],
+        validationFailureMessage: String?,
+        style: FormTextItemStyle,
+        presenter: WeakReferenceViewControllerPresenter,
+        identifier: String? = nil
+    ) {
+        self.init(
+            preselectedExtension: preselectedExtension,
+            selectableExtensions: selectableExtensions,
+            validationFailureMessage: validationFailureMessage,
+            style: style,
+            presenter: presenter,
+            localizationParameters: nil,
+            identifier: identifier
+        )
+    }
+
+    package required init(
         preselectedExtension: PhoneExtension?,
         selectableExtensions: [PhoneExtension],
         validationFailureMessage: String?,

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerItem.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerItem.swift
@@ -46,7 +46,7 @@ public struct FormPickerElement: FormPickable {
 @_spi(AdyenInternal)
 open class FormPickerItem<Value: FormPickable>: FormSelectableValueItem<Value?> {
     
-    public let localizationParameters: LocalizationParameters?
+    package let localizationParameters: LocalizationParameters?
     public private(set) var isOptional: Bool = false
     internal private(set) weak var presenter: ViewControllerPresenter?
     
@@ -69,7 +69,28 @@ open class FormPickerItem<Value: FormPickable>: FormSelectableValueItem<Value?> 
     ///   - style: The `FormTextItemStyle` UI style.
     ///   - localizationParameters: The localization parameters.
     ///   - identifier: The item identifier
-    public init(
+    public convenience init(
+        preselectedValue: Value?,
+        selectableValues: [Value],
+        title: String,
+        placeholder: String,
+        style: FormTextItemStyle,
+        presenter: ViewControllerPresenter?,
+        identifier: String? = nil
+    ) {
+        self.init(
+            preselectedValue: preselectedValue,
+            selectableValues: selectableValues,
+            title: title,
+            placeholder: placeholder,
+            style: style,
+            presenter: presenter,
+            localizationParameters: nil,
+            identifier: identifier
+        )
+    }
+
+    package init(
         preselectedValue: Value?,
         selectableValues: [Value],
         title: String,

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController.swift
@@ -10,7 +10,22 @@ import UIKit
 @_spi(AdyenInternal)
 public final class FormPickerSearchViewController<Option: FormPickable>: UINavigationController {
     
-    public init(
+    public convenience init(
+        style: Style = .init(),
+        title: String?,
+        options: [Option],
+        selectionHandler: @escaping (Option) -> Void
+    ) {
+        self.init(
+            localizationParameters: nil,
+            style: style,
+            title: title,
+            options: options,
+            selectionHandler: selectionHandler
+        )
+    }
+
+    package init(
         localizationParameters: LocalizationParameters? = nil,
         style: Style = .init(),
         title: String?,

--- a/AdyenUI/UI/View Controllers/SearchViewController/SearchViewController+ViewModel.swift
+++ b/AdyenUI/UI/View Controllers/SearchViewController/SearchViewController+ViewModel.swift
@@ -33,6 +33,21 @@ extension SearchViewController {
         ///   - shouldFocusSearchBarOnAppearance: Whether to focus the search bar on viewWillAppear.
         ///   - resultProvider: A closure to provide result list items for a search term.
         public init(
+            style: ViewStyle,
+            searchBarPlaceholder: String? = nil,
+            shouldFocusSearchBarOnAppearance: Bool = false,
+            resultProvider: @escaping ResultProvider
+        ) {
+            self.init(
+                localizationParameters: nil,
+                style: style,
+                searchBarPlaceholder: searchBarPlaceholder,
+                shouldFocusSearchBarOnAppearance: shouldFocusSearchBarOnAppearance,
+                resultProvider: resultProvider
+            )
+        }
+
+        package init(
             localizationParameters: LocalizationParameters? = nil,
             style: ViewStyle,
             searchBarPlaceholder: String? = nil,

--- a/AdyenUI/UI/Views/CopyLabelView.swift
+++ b/AdyenUI/UI/Views/CopyLabelView.swift
@@ -10,7 +10,7 @@ import UIKit
 @_spi(AdyenInternal)
 public final class CopyLabelView: UIView, Localizable {
 
-    public var localizationParameters: LocalizationParameters?
+    package var localizationParameters: LocalizationParameters?
 
     private let style: TextStyle
 

--- a/AdyenUI/Utilities/BundleSPMExtension.swift
+++ b/AdyenUI/Utilities/BundleSPMExtension.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2026 Adyen N.V.
+// Copyright (c) 2020 Adyen N.V.
 //
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
@@ -10,8 +10,7 @@ internal extension Bundle {
     static let adyenUI: Bundle = .init(for: FormButton.self)
 
     #if SWIFT_PACKAGE
-        /// The bundle in which the framework's resources are located. This will be available when using swift packages, open the Package.swift file and see.
-        static let adyenUIInternalResources: Bundle = .module
+        static let adyenUIInternalResources: Bundle = adyenUI
     #else
         internal static let adyenUIInternalResources: Bundle = {
             let url = adyenUI.url(forResource: "AdyenUI", withExtension: "bundle")

--- a/AdyenUI/Utilities/BundleSPMExtension.swift
+++ b/AdyenUI/Utilities/BundleSPMExtension.swift
@@ -10,9 +10,11 @@ internal extension Bundle {
     static let adyenUI: Bundle = .init(for: FormButton.self)
 
     #if SWIFT_PACKAGE
-        static let adyenUIInternalResources: Bundle = adyenUI
+        /// The bundle in which the framework's resources are located.
+        /// This will be available when using swift packages, open the `Package.swift` file and see.
+        static let adyenUIInternalResources: Bundle = .module
     #else
-        internal static let adyenUIInternalResources: Bundle = {
+        static let adyenUIInternalResources: Bundle = {
             let url = adyenUI.url(forResource: "AdyenUI", withExtension: "bundle")
             let bundle = url.flatMap { Bundle(url: $0) }
             return bundle ?? adyenUI

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
@@ -52,7 +52,12 @@ internal final class DropInAdvancedFlowExample: InitialDataAdvancedFlowProtocol 
     // MARK: - Presentation
 
     private func presentComponent(with paymentMethods: PaymentMethods) {
-        let dropIn = dropInComponent(from: paymentMethods)
+        var _paymentMethods = paymentMethods
+        _paymentMethods.overrideDisplayInformation(
+            ofRegularPaymentMethod: .scheme,
+            with: .init(title: "Card", subtitle: "Pay with your credit card")
+        )
+        let dropIn = dropInComponent(from: _paymentMethods)
         presenter?.present(viewController: dropIn.viewController, completion: nil)
         dropInComponent = dropIn
     }


### PR DESCRIPTION
# Summary
This PR completes Phase 1 of the iOS custom localization plan by removing the legacy localization API from the merchant-facing v6 surface while keeping the existing localization path available internally. The main goal is to avoid exposing two competing localization contracts in v6 before the new provider-based API is introduced. This narrows the public API now and keeps the follow-up Phase 2 migration clearer and safer.

# Progress tracker
✅ Phase 0 — [Baseline safety net for current localization behavior](https://github.com/Adyen/adyen-ios/pull/2463)
✅ Phase 1 — Internalize legacy localization API
Phase 2 — Introduce the new public contract
Phase 3 — Wire provider resolution into card flow
Phase 4 — Unsupported locale warnings
Phase 5 — Final confidence pass for card alpha scope

## Technical Information 
Grouped changes:
- Internalized `LocalizationParameters`, `Localizable`, and related localization helpers by changing them from public/SPI exposure to `package`
- Updated component, action, and Drop-in configuration types so `localizationParameters` stays internal to the package
- Added public initializer overloads where needed so public configuration APIs remain usable without exposing `LocalizationParameters`

## Ticket
<ticket>
COSDK-1097
</ticket>

## Checklist [Required]
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
