### PR TITLE
V6 - Run BrowserInfo on the main thread

### DIFF
--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -62,12 +62,11 @@ extension PaymentComponent {
     ///   - data: The Payment data to be submitted
     ///   - component: The component from which the payment originates.
     public func submit(data: PaymentComponentData, component: PaymentComponent? = nil) {
-        sendSubmitEvent()
-        
-        let component = component ?? self
-        
-        prepareSubmitData(from: data) { [weak self] updatedData in
+        Task { [weak self] in
             guard let self else { return }
+            sendSubmitEvent()
+            let component = component ?? self
+            let updatedData = await prepareSubmitData(from: data)
             self.delegate?.didSubmit(updatedData, from: component)
         }
     }
@@ -77,18 +76,17 @@ extension PaymentComponent {
     }
     
     /// Adds SDK related info to payment data object and returns the final data in the completion.
-    public func prepareSubmitData(from data: PaymentComponentData, completion: @escaping (PaymentComponentData) -> Void) {
-        
+    public func prepareSubmitData(from data: PaymentComponentData) async -> PaymentComponentData {
+
         let sdkData = SDKData(
             checkoutAttemptId: checkoutAttemptId,
             authenticationProvider: data.paymentMethod as? SDKDataAuthenticationProvider
         )
         
-        let updatedData = data
+        return await data
             .replacing(checkoutAttemptId: checkoutAttemptId)
             .replacing(sdkData: sdkData)
-        
-        updatedData.dataByAddingBrowserInfo(completion: completion)
+            .replacing(browserInfo: BrowserInfo.initialize())
     }
     
     private func sendSubmitEvent() {

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -86,7 +86,7 @@ extension PaymentComponent {
         return await data
             .replacing(checkoutAttemptId: checkoutAttemptId)
             .replacing(sdkData: sdkData)
-            .replacing(browserInfo: BrowserInfo.initialize())
+            .replacing(browserInfo: BrowserInfo())
     }
     
     private func sendSubmitEvent() {

--- a/Adyen/Model/BrowserInfo.swift
+++ b/Adyen/Model/BrowserInfo.swift
@@ -13,23 +13,21 @@ public struct BrowserInfo: Encodable {
     /// The device default user-agent.
     public var userAgent: String?
     
-    /// Initializes a `BrowserInfo` instance asynchronously.
-    ///
-    /// - Parameters:
-    ///   - completion: A call back when the `BrowserInfo` instance is ready or when initialization fails.
-    public static func initialize(completion: @escaping ((_ info: BrowserInfo?) -> Void)) {
+    @MainActor public static func initialize() async -> BrowserInfo? {
         guard cachedUserAgent == nil else {
-            completion(BrowserInfo(userAgent: cachedUserAgent))
-            return
+            return BrowserInfo(userAgent: cachedUserAgent)
         }
-        webView = WKWebView()
-        webView?.evaluateJavaScript("navigator.userAgent") { result, _ in
-            webView = nil
-            guard let result = result as? String else {
-                return completion(nil)
+        return await withCheckedContinuation { continuation in
+            webView = WKWebView()
+            webView?.evaluateJavaScript("navigator.userAgent") { result, _ in
+                webView = nil
+                guard let result = result as? String else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                BrowserInfo.cachedUserAgent = result
+                continuation.resume(returning: BrowserInfo(userAgent: result))
             }
-            BrowserInfo.cachedUserAgent = result
-            completion(BrowserInfo(userAgent: cachedUserAgent))
         }
     }
     

--- a/Adyen/Model/BrowserInfo.swift
+++ b/Adyen/Model/BrowserInfo.swift
@@ -21,6 +21,9 @@ public struct BrowserInfo: Encodable {
         case userAgent
     }
 
+    /// Initializes a `BrowserInfo` instance asynchronously by retrieving the device's user agent.
+    ///
+    /// - Returns: A `BrowserInfo` instance if the user agent was successfully retrieved, or `nil` if the evaluation failed.
     @MainActor public init?() async {
         if let cached = Self.cachedUserAgent {
             self.userAgent = cached

--- a/Adyen/Model/BrowserInfo.swift
+++ b/Adyen/Model/BrowserInfo.swift
@@ -28,25 +28,12 @@ public struct BrowserInfo: Encodable {
         }
 
         self.webView = WKWebView()
-
-        let userAgent: String? = await withCheckedContinuation { [webView] continuation in
-            guard let webView else { return }
-            webView.evaluateJavaScript("navigator.userAgent") { result, _ in
-                guard let result = result as? String else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                continuation.resume(returning: result)
-            }
-        }
-
-        self.webView = nil
-
-        if let userAgent {
-            self.userAgent = userAgent
-            BrowserInfo.cachedUserAgent = userAgent
-        } else {
+        guard let userAgent = try? await webView?.evaluateJavaScript("navigator.userAgent") as? String else {
             return nil
         }
+        self.webView = nil
+        
+        self.userAgent = userAgent
+        BrowserInfo.cachedUserAgent = userAgent
     }
 }

--- a/Adyen/Model/BrowserInfo.swift
+++ b/Adyen/Model/BrowserInfo.swift
@@ -13,7 +13,7 @@ public struct BrowserInfo: Encodable {
     internal static var cachedUserAgent: String?
 
     /// The device default user-agent.
-    public var userAgent: String
+    public let userAgent: String
 
     @MainActor internal var webView: WKWebView?
 

--- a/Adyen/Model/BrowserInfo.swift
+++ b/Adyen/Model/BrowserInfo.swift
@@ -9,29 +9,44 @@ import WebKit
 
 /// Provides the device default browser info.
 public struct BrowserInfo: Encodable {
-    
+
+    internal static var cachedUserAgent: String?
+
     /// The device default user-agent.
-    public var userAgent: String?
-    
-    @MainActor public static func initialize() async -> BrowserInfo? {
-        guard cachedUserAgent == nil else {
-            return BrowserInfo(userAgent: cachedUserAgent)
+    public var userAgent: String
+
+    @MainActor internal var webView: WKWebView?
+
+    private enum CodingKeys: CodingKey {
+        case userAgent
+    }
+
+    @MainActor public init?() async {
+        if let cached = Self.cachedUserAgent {
+            self.userAgent = cached
+            return
         }
-        return await withCheckedContinuation { continuation in
-            webView = WKWebView()
-            webView?.evaluateJavaScript("navigator.userAgent") { result, _ in
-                webView = nil
+
+        self.webView = WKWebView()
+
+        let userAgent: String? = await withCheckedContinuation { [webView] continuation in
+            guard let webView else { return }
+            webView.evaluateJavaScript("navigator.userAgent") { result, _ in
                 guard let result = result as? String else {
                     continuation.resume(returning: nil)
                     return
                 }
-                BrowserInfo.cachedUserAgent = result
-                continuation.resume(returning: BrowserInfo(userAgent: result))
+                continuation.resume(returning: result)
             }
         }
+
+        self.webView = nil
+
+        if let userAgent {
+            self.userAgent = userAgent
+            BrowserInfo.cachedUserAgent = userAgent
+        } else {
+            return nil
+        }
     }
-    
-    private static var webView: WKWebView?
-    
-    internal static var cachedUserAgent: String?
 }

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -149,26 +149,15 @@ public struct PaymentComponentData {
             installments: installments
         )
     }
-    
-    /// Creates a new `PaymentComponentData` by populating the `browserInfo`,
-    /// in case the browser info like the user-agent is needed, but its not needed for mobile payments.
-    ///
-    /// - Parameters:
-    ///   - completion: The completion closure that is called with the new `PaymentComponentData` instance.
-    package func dataByAddingBrowserInfo(completion: @escaping ((_ newData: PaymentComponentData) -> Void)) {
-        Task { @MainActor in
-            let browserInfo = await BrowserInfo.initialize()
-            completion(
-                PaymentComponentData(
-                    paymentMethodDetails: paymentMethod,
-                    amount: amount,
-                    order: order,
-                    storePaymentMethod: storePaymentMethod,
-                    browserInfo: browserInfo,
-                    installments: installments
-                )
-            )
-        }
+
+    package func replacing(browserInfo: BrowserInfo?) -> PaymentComponentData {
+        PaymentComponentData(
+            paymentMethodDetails: paymentMethod,
+            amount: amount,
+            order: order,
+            storePaymentMethod: storePaymentMethod,
+            browserInfo: browserInfo,
+            installments: installments
+        )
     }
-    
 }

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -156,15 +156,18 @@ public struct PaymentComponentData {
     /// - Parameters:
     ///   - completion: The completion closure that is called with the new `PaymentComponentData` instance.
     package func dataByAddingBrowserInfo(completion: @escaping ((_ newData: PaymentComponentData) -> Void)) {
-        BrowserInfo.initialize {
-            completion(PaymentComponentData(
-                paymentMethodDetails: paymentMethod,
-                amount: amount,
-                order: order,
-                storePaymentMethod: storePaymentMethod,
-                browserInfo: $0,
-                installments: installments
-            ))
+        Task { @MainActor in
+            let browserInfo = await BrowserInfo.initialize()
+            completion(
+                PaymentComponentData(
+                    paymentMethodDetails: paymentMethod,
+                    amount: amount,
+                    order: order,
+                    storePaymentMethod: storePaymentMethod,
+                    browserInfo: browserInfo,
+                    installments: installments
+                )
+            )
         }
     }
     

--- a/AdyenDropIn/Modules/DropInFlowManager.swift
+++ b/AdyenDropIn/Modules/DropInFlowManager.swift
@@ -75,11 +75,11 @@ internal class DropInFlowManager: DropInFlowManaging {
         from component: PaymentComponent,
         actionPresenter: ActionPresenter
     ) {
-        guard let dropInComponent else { return }
-        self.actionPresenter = actionPresenter
-
-        component.prepareSubmitData(from: data) { [weak self] updatedData in
-            self?.dropInComponentDelegate?.didSubmit(updatedData, from: component, in: dropInComponent)
+        Task { [weak self] in
+            guard let self, let dropInComponent else { return }
+            self.actionPresenter = actionPresenter
+            let updatedData = await component.prepareSubmitData(from: data)
+            dropInComponentDelegate?.didSubmit(updatedData, from: component, in: dropInComponent)
         }
     }
 

--- a/Tests/IntegrationTests/Components Tests/IssuerList/IssuerListComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/IssuerList/IssuerListComponentTests.swift
@@ -59,9 +59,10 @@ class IssuerListComponentTests: XCTestCase {
             let details = paymentData.paymentMethod as! IssuerListDetails
             XCTAssertEqual(details.issuer, expectedIssuer.identifier)
             
-            XCTAssertEqual(analyticsProviderMock.infos.count, 1)
+            XCTAssertEqual(analyticsProviderMock.infos.count, 2)
             let infoType = analyticsProviderMock.infos.first?.type
             XCTAssertEqual(infoType, .rendered)
+            XCTAssertEqual(analyticsProviderMock.infos[1].type, .selected)
 
             expectation.fulfill()
         }

--- a/Tests/UnitTests/Core/BrowserInfoTests.swift
+++ b/Tests/UnitTests/Core/BrowserInfoTests.swift
@@ -18,18 +18,7 @@ struct BrowserInfoTests {
     
     @Test func paymentComponentDataBrowserInfo() async {
         let data = PaymentComponentData(paymentMethodDetails: InstantPaymentDetails(type: .payPal), amount: nil, order: nil)
-
-        var updatedPaymentComponentData: PaymentComponentData? = nil
-        await confirmation("onImageLoaded called") { confirm in
-            await withCheckedContinuation { continuation in
-                data.dataByAddingBrowserInfo {
-                    updatedPaymentComponentData = $0
-                    confirm()
-                    continuation.resume()
-                }
-            }
-        }
-
-        #expect(updatedPaymentComponentData?.browserInfo?.userAgent != nil)
+        let updatedPaymentComponentData = await data.replacing(browserInfo: BrowserInfo.initialize())
+        #expect(updatedPaymentComponentData.browserInfo?.userAgent != nil)
     }
 }

--- a/Tests/UnitTests/Core/BrowserInfoTests.swift
+++ b/Tests/UnitTests/Core/BrowserInfoTests.swift
@@ -4,27 +4,32 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-import XCTest
+import Adyen
+import Testing
 
-class BrowserInfoTests: XCTestCase {
-    
-    func testBrowserInfoInitialize() {
-        let browserInfoExpectation = expectation(description: "Expect the BrowserInfo.initialize() to return a valid instance")
-        BrowserInfo.initialize { info in
-            XCTAssertNotNil(info?.userAgent)
-            browserInfoExpectation.fulfill()
-        }
-        waitForExpectations(timeout: 120, handler: nil)
+/// Making this test serialized as BrowserInfo deals with some static vars and hence cannot be run in parallel.
+@Suite(.serialized)
+struct BrowserInfoTests {
+
+    @Test func browserInfoInitialize() async {
+        let browserInfo = await BrowserInfo.initialize()
+        #expect(browserInfo?.userAgent != nil)
     }
     
-    func testPaymentComponentDataBrowserInfo() {
-        let browserInfoExpectation = expectation(description: "Expect the BrowserInfo.initialize() to return a valid instance")
+    @Test func paymentComponentDataBrowserInfo() async {
         let data = PaymentComponentData(paymentMethodDetails: InstantPaymentDetails(type: .payPal), amount: nil, order: nil)
-        data.dataByAddingBrowserInfo {
-            XCTAssertNotNil($0.browserInfo?.userAgent)
-            browserInfoExpectation.fulfill()
+
+        var updatedPaymentComponentData: PaymentComponentData? = nil
+        await confirmation("onImageLoaded called") { confirm in
+            await withCheckedContinuation { continuation in
+                data.dataByAddingBrowserInfo {
+                    updatedPaymentComponentData = $0
+                    confirm()
+                    continuation.resume()
+                }
+            }
         }
-        waitForExpectations(timeout: 120, handler: nil)
+
+        #expect(updatedPaymentComponentData?.browserInfo?.userAgent != nil)
     }
 }

--- a/Tests/UnitTests/Core/BrowserInfoTests.swift
+++ b/Tests/UnitTests/Core/BrowserInfoTests.swift
@@ -4,21 +4,27 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
+@testable import Adyen
 import Testing
 
-/// Making this test serialized as BrowserInfo deals with some static vars and hence cannot be run in parallel.
-@Suite(.serialized)
 struct BrowserInfoTests {
 
-    @Test func browserInfoInitialize() async {
-        let browserInfo = await BrowserInfo.initialize()
+    @Test @MainActor func browserInfoInitialize() async {
+        let browserInfo = await BrowserInfo()
         #expect(browserInfo?.userAgent != nil)
+        #expect(browserInfo?.webView == nil)
     }
     
     @Test func paymentComponentDataBrowserInfo() async {
         let data = PaymentComponentData(paymentMethodDetails: InstantPaymentDetails(type: .payPal), amount: nil, order: nil)
-        let updatedPaymentComponentData = await data.replacing(browserInfo: BrowserInfo.initialize())
+        let updatedPaymentComponentData = await data.replacing(browserInfo: BrowserInfo())
         #expect(updatedPaymentComponentData.browserInfo?.userAgent != nil)
+    }
+
+    @Test func initialization_whenCached() async {
+        let mockedCachedUserAgent = "testValue"
+        BrowserInfo.cachedUserAgent = mockedCachedUserAgent
+        let browserInfo = await BrowserInfo()
+        #expect(browserInfo?.userAgent == mockedCachedUserAgent)
     }
 }


### PR DESCRIPTION
# Summary [Required]
1. BrowserInfo run things on WKWebView which needs to be run on the main thread.
2. Refactored the browserInfo consuming api to be async instead of completion to a point that was logically possible.

Context: When trying to connect the StoredView, found this intermittent crash on browserInfo. 

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests