### PR TITLE
[v5] Add new SDK data fields

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -597,6 +597,7 @@
 		C982FFDC2694792F00AED849 /* AffirmPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = C982FFDB2694792F00AED849 /* AffirmPaymentMethod.swift */; };
 		C98FF6672C5A793A00B0050D /* StoredTwintPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98FF6662C5A793A00B0050D /* StoredTwintPaymentMethod.swift */; };
 		C991A62D2F855B6500601613 /* CheckoutPlatformParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = C991A62C2F855B6500601613 /* CheckoutPlatformParams.swift */; };
+		C991A62F2F87990800601613 /* CheckoutPlatformParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C991A62E2F87990800601613 /* CheckoutPlatformParamsTests.swift */; };
 		C99AA1422D6DF6480043AA96 /* CardScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99AA1412D6DF6480043AA96 /* CardScanner.swift */; };
 		C99FF2BB2D50E872007179C5 /* CardScannerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99FF2B22D50E872007179C5 /* CardScannerError.swift */; };
 		C99FF2BC2D50E872007179C5 /* CreditCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99FF2B32D50E872007179C5 /* CreditCard.swift */; };
@@ -2070,6 +2071,7 @@
 		C982FFDB2694792F00AED849 /* AffirmPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AffirmPaymentMethod.swift; sourceTree = "<group>"; };
 		C98FF6662C5A793A00B0050D /* StoredTwintPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredTwintPaymentMethod.swift; sourceTree = "<group>"; };
 		C991A62C2F855B6500601613 /* CheckoutPlatformParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutPlatformParams.swift; sourceTree = "<group>"; };
+		C991A62E2F87990800601613 /* CheckoutPlatformParamsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutPlatformParamsTests.swift; sourceTree = "<group>"; };
 		C99AA1412D6DF6480043AA96 /* CardScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScanner.swift; sourceTree = "<group>"; };
 		C99FF2B22D50E872007179C5 /* CardScannerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerError.swift; sourceTree = "<group>"; };
 		C99FF2B32D50E872007179C5 /* CreditCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCard.swift; sourceTree = "<group>"; };
@@ -5117,6 +5119,7 @@
 				F9F1A98526CCFD090005CB1D /* Encryption */,
 				E97B9719229D54D600505476 /* ActionTests.swift */,
 				5AF730E92667C3F10091C573 /* APIContextTests.swift */,
+				C991A62E2F87990800601613 /* CheckoutPlatformParamsTests.swift */,
 				F90FB7BD2446EBB9005BFE0E /* BrowserInfoTests.swift */,
 				E262128C22A8FE6700F2B133 /* PaymentMethodTests.swift */,
 				F9639B4624E283060073F38A /* BackoffSchedulerTests.swift */,
@@ -7413,6 +7416,7 @@
 				C92245BE2EE9CB0900815A51 /* PKPaymentNetworkExtensionsTests.swift in Sources */,
 				C92245B62EE988F200815A51 /* ApplePayNetworksProvidingMock.swift in Sources */,
 				B6D808062BCD147600F3F5EB /* UIButtonHelpersTests.swift in Sources */,
+				C991A62F2F87990800601613 /* CheckoutPlatformParamsTests.swift in Sources */,
 				B62D48C42BBE8F25001EF01A /* XCTestCase+Wait.swift in Sources */,
 				B6D808352BCD1F8900F3F5EB /* ObservableTests.swift in Sources */,
 				B6D8081E2BCD151F00F3F5EB /* PresentingViewControllerMock.swift in Sources */,

--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -596,6 +596,7 @@
 		C982FFD826946F0800AED849 /* AffirmComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C982FFD726946F0800AED849 /* AffirmComponent.swift */; };
 		C982FFDC2694792F00AED849 /* AffirmPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = C982FFDB2694792F00AED849 /* AffirmPaymentMethod.swift */; };
 		C98FF6672C5A793A00B0050D /* StoredTwintPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98FF6662C5A793A00B0050D /* StoredTwintPaymentMethod.swift */; };
+		C991A62D2F855B6500601613 /* CheckoutPlatformParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = C991A62C2F855B6500601613 /* CheckoutPlatformParams.swift */; };
 		C99AA1422D6DF6480043AA96 /* CardScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99AA1412D6DF6480043AA96 /* CardScanner.swift */; };
 		C99FF2BB2D50E872007179C5 /* CardScannerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99FF2B22D50E872007179C5 /* CardScannerError.swift */; };
 		C99FF2BC2D50E872007179C5 /* CreditCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99FF2B32D50E872007179C5 /* CreditCard.swift */; };
@@ -2068,6 +2069,7 @@
 		C982FFD726946F0800AED849 /* AffirmComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AffirmComponent.swift; sourceTree = "<group>"; };
 		C982FFDB2694792F00AED849 /* AffirmPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AffirmPaymentMethod.swift; sourceTree = "<group>"; };
 		C98FF6662C5A793A00B0050D /* StoredTwintPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredTwintPaymentMethod.swift; sourceTree = "<group>"; };
+		C991A62C2F855B6500601613 /* CheckoutPlatformParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutPlatformParams.swift; sourceTree = "<group>"; };
 		C99AA1412D6DF6480043AA96 /* CardScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScanner.swift; sourceTree = "<group>"; };
 		C99FF2B22D50E872007179C5 /* CardScannerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerError.swift; sourceTree = "<group>"; };
 		C99FF2B32D50E872007179C5 /* CreditCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCard.swift; sourceTree = "<group>"; };
@@ -4605,6 +4607,7 @@
 				A06B7AA62A274A83008FC09D /* ResultHelpers.swift */,
 				81EE958B2BB1D73C006B21CB /* ImageLoader */,
 				81FC2C882BB17E53007F1316 /* AdyenCancellable.swift */,
+				C991A62C2F855B6500601613 /* CheckoutPlatformParams.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -7607,6 +7610,7 @@
 				8128977C2CCA660A00275487 /* StoredPayByBankUSPaymentMethod.swift in Sources */,
 				F9639B3324DD96990073F38A /* PaymentStatusRequest.swift in Sources */,
 				A0DB48662AFD020400348C83 /* AnalyticsRequest.swift in Sources */,
+				C991A62D2F855B6500601613 /* CheckoutPlatformParams.swift in Sources */,
 				5AD40E75262F04440090E01C /* UIProgressViewHelpers.swift in Sources */,
 				F91664F023E41D7300C10738 /* AnyEncodable.swift in Sources */,
 				E7D531192446F525000046B4 /* FormSeparatorItemView.swift in Sources */,

--- a/Adyen/Analytics/AnalyticsProvider/EventAnalyticsProvider.swift
+++ b/Adyen/Analytics/AnalyticsProvider/EventAnalyticsProvider.swift
@@ -27,19 +27,16 @@ internal final class EventAnalyticsProvider: AnyEventAnalyticsProvider {
     internal let apiClient: APIClientProtocol
     internal let eventDataSource: AnyAnalyticsEventDataSource
     
-    private let context: AnalyticsContext
     private var batchTimer: Timer?
     private let batchInterval: TimeInterval
     
     internal init(
         apiClient: APIClientProtocol,
-        context: AnalyticsContext,
         eventDataSource: AnyAnalyticsEventDataSource,
         batchInterval: TimeInterval = Constants.batchInterval
     ) {
         self.apiClient = apiClient
         self.eventDataSource = eventDataSource
-        self.context = context
         self.batchInterval = batchInterval
     }
     
@@ -88,7 +85,7 @@ internal final class EventAnalyticsProvider: AnyEventAnalyticsProvider {
         
         // as per this call's limitation, we only send up to the
         // limit of each event and discard the older ones
-        let platform = context.platform.rawValue
+        let platform = checkoutPlatformParams.platform.rawValue
         var request = AnalyticsRequest(
             checkoutAttemptId: checkoutAttemptId,
             platform: platform

--- a/Adyen/Analytics/Models/AdyenAnalytics.swift
+++ b/Adyen/Analytics/Models/AdyenAnalytics.swift
@@ -51,9 +51,6 @@ public struct AnalyticsConfiguration {
 
     /// A Boolean value that determines whether analytics is enabled.
     public var isEnabled = true
-    
-    @_spi(AdyenInternal)
-    public var context: AnalyticsContext = .init()
 
     // MARK: - Initializers
     

--- a/Adyen/Analytics/Models/AnalyticsData.swift
+++ b/Adyen/Analytics/Models/AnalyticsData.swift
@@ -7,34 +7,6 @@
 import Foundation
 import UIKit
 
-/// The context in which the SDK operates
-///
-/// Used to e.g. override the version + platform from within the Flutter SDK
-@_spi(AdyenInternal)
-public struct AnalyticsContext {
-    
-    internal let version: String
-    internal let platform: Platform
-    
-    public init(
-        version: String = adyenSdkVersion,
-        platform: Platform = .iOS
-    ) {
-        self.version = version
-        self.platform = platform
-    }
-}
-
-@_spi(AdyenInternal)
-public extension AnalyticsContext {
-
-    enum Platform: String {
-        case iOS = "iOS"
-        case reactNative = "react-native"
-        case flutter
-    }
-}
-
 internal struct AnalyticsData: Encodable {
 
     // MARK: - Properties
@@ -100,8 +72,8 @@ internal struct AnalyticsData: Encodable {
         self.amount = additionalFields?.amount
         self.sessionId = additionalFields?.sessionId
         
-        self.version = configuration.context.version
-        self.platform = configuration.context.platform.rawValue
+        self.version = checkoutPlatformParams.version
+        self.platform = checkoutPlatformParams.platform.rawValue
         
         self.level = configuration.analyticsLevel
 

--- a/Adyen/Analytics/Models/AnalyticsData.swift
+++ b/Adyen/Analytics/Models/AnalyticsData.swift
@@ -14,7 +14,7 @@ internal struct AnalyticsData: Encodable {
     /// The version of the SDK
     internal let version: String
 
-    internal let channel: String = "iOS"
+    internal let channel: String = "ios"
     
     /// The platform the SDK is running on (e.g. ios, flutter, react-native)
     internal let platform: String
@@ -74,7 +74,7 @@ internal struct AnalyticsData: Encodable {
         
         self.version = checkoutPlatformParams.version
         self.platform = checkoutPlatformParams.platform.rawValue
-        
+
         self.level = configuration.analyticsLevel
 
         switch flavor {

--- a/Adyen/Analytics/Models/AnalyticsData.swift
+++ b/Adyen/Analytics/Models/AnalyticsData.swift
@@ -14,8 +14,8 @@ internal struct AnalyticsData: Encodable {
     /// The version of the SDK
     internal let version: String
 
-    internal let channel: String = "ios"
-    
+    internal let channel: String = CheckoutPlatformParams.shared.channel
+
     /// The platform the SDK is running on (e.g. ios, flutter, react-native)
     internal let platform: String
 

--- a/Adyen/Analytics/Requests/AnalyticsRequest.swift
+++ b/Adyen/Analytics/Requests/AnalyticsRequest.swift
@@ -21,8 +21,8 @@ internal struct AnalyticsRequest: APIRequest {
 
     internal let method: HTTPMethod = .post
     
-    internal var channel: String = "ios"
-    
+    internal var channel: String = CheckoutPlatformParams.shared.channel
+
     internal var platform: String
     
     internal var infos: [AnalyticsEventInfo] = []

--- a/Adyen/Analytics/Requests/AnalyticsRequest.swift
+++ b/Adyen/Analytics/Requests/AnalyticsRequest.swift
@@ -21,7 +21,7 @@ internal struct AnalyticsRequest: APIRequest {
 
     internal let method: HTTPMethod = .post
     
-    internal var channel: String = "iOS"
+    internal var channel: String = "ios"
     
     internal var platform: String
     

--- a/Adyen/Core/AdyenContext/AdyenContext.swift
+++ b/Adyen/Core/AdyenContext/AdyenContext.swift
@@ -79,7 +79,6 @@ public final class AdyenContext: PaymentAware {
             let syncEventDataSource = ThreadSafeAnalyticsEventDataSource(dataSource: eventDataSource)
             eventAnalyticsProvider = EventAnalyticsProvider(
                 apiClient: APIClient(apiContext: analyticsApiContext),
-                context: analyticsConfiguration.context,
                 eventDataSource: syncEventDataSource
             )
         }

--- a/Adyen/Core/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
+++ b/Adyen/Core/Components/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
@@ -288,6 +288,7 @@ extension AbstractPersonalInformationComponent: ViewControllerPresenter {
 
 @_spi(AdyenInternal)
 extension AbstractPersonalInformationComponent: ViewControllerDelegate {
+
     // MARK: - ViewControllerDelegate
 
     public func viewWillAppear(viewController: UIViewController) {

--- a/Adyen/Core/Components/AlreadyPaidPaymentComponent.swift
+++ b/Adyen/Core/Components/AlreadyPaidPaymentComponent.swift
@@ -24,5 +24,4 @@ public final class AlreadyPaidPaymentComponent: PaymentComponent {
         self.paymentMethod = paymentMethod
         self.context = context
     }
-    
 }

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -19,7 +19,9 @@ public protocol PaymentComponent: Component, PartialPaymentOrderAware, PaymentMe
     
     /// The delegate of the payment component.
     var delegate: PaymentComponentDelegate? { get set }
-    
+
+    @_spi(AdyenInternal)
+    var paymentMethodBehavior: SDKData.PaymentMethodBehavior { get }
 }
 
 @_spi(AdyenInternal)
@@ -46,11 +48,6 @@ extension PaymentComponent {
     
     /// Adds SDK related info to payment data object and returns the final data in the completion.
     public func prepareSubmitData(from data: PaymentComponentData, completion: @escaping (PaymentComponentData) -> Void) {
-        let isInstantPaymentComponent = self is InstantPaymentComponent
-        let paymentMethodBehavior: SDKData.PaymentMethodBehavior = isInstantPaymentComponent
-            ? .genericComponent
-            : .nativeComponent
-
         let sdkData = SDKData(
             checkoutAttemptId: checkoutAttemptId,
             paymentMethodBehavior: paymentMethodBehavior,

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -46,9 +46,14 @@ extension PaymentComponent {
     
     /// Adds SDK related info to payment data object and returns the final data in the completion.
     public func prepareSubmitData(from data: PaymentComponentData, completion: @escaping (PaymentComponentData) -> Void) {
-        
+        let isInstantPaymentComponent = self is InstantPaymentComponent
+        let paymentMethodBehavior: SDKData.PaymentMethodBehavior = isInstantPaymentComponent
+            ? .genericComponent
+            : .nativeComponent
+
         let sdkData = SDKData(
             checkoutAttemptId: checkoutAttemptId,
+            paymentMethodBehavior: paymentMethodBehavior,
             authenticationProvider: data.paymentMethod as? SDKDataAuthenticationProvider
         )
         

--- a/Adyen/Helpers/CheckoutPlatformParams.swift
+++ b/Adyen/Helpers/CheckoutPlatformParams.swift
@@ -32,6 +32,12 @@ public final class CheckoutPlatformParams {
 
     private init() {}
 
+    /// Internal initializer for testing purposes.
+    internal init(version: String, platform: Platform) {
+        self.version = version
+        self.platform = platform
+    }
+
     // MARK: - Mutation (restricted)
 
     private let lock = NSLock()

--- a/Adyen/Helpers/CheckoutPlatformParams.swift
+++ b/Adyen/Helpers/CheckoutPlatformParams.swift
@@ -36,7 +36,10 @@ public class CheckoutPlatformParams {
     private let lock = NSLock()
 
     @_spi(AdyenInternal)
-    public func override(version: String, platform: Platform) {
+    public func overrideForCrossPlatform(
+        platform: Platform,
+        version: String
+    ) {
         lock.lock()
         defer { lock.unlock() }
 

--- a/Adyen/Helpers/CheckoutPlatformParams.swift
+++ b/Adyen/Helpers/CheckoutPlatformParams.swift
@@ -17,20 +17,33 @@ public class CheckoutPlatformParams {
         case flutter
     }
 
+    // MARK: - Global shared instance
+
+    public static let shared = CheckoutPlatformParams()
+
     // MARK: - Properties
 
     public private(set) var version: String = adyenSdkVersion
     public private(set) var platform: Platform = .ios
     public let channel: String = "ios"
 
-    // MARK: - Methods
+    // MARK: - Initializers
 
+    private init() {}
+
+    // MARK: - Mutation (restricted)
+
+    private let lock = NSLock()
+
+    @_spi(AdyenInternal)
     public func override(version: String, platform: Platform) {
+        lock.lock()
+        defer { lock.unlock() }
+
         self.version = version
         self.platform = platform
     }
 }
 
 @_spi(AdyenInternal)
-public let checkoutPlatformParams = CheckoutPlatformParams()
-
+public let checkoutPlatformParams = CheckoutPlatformParams.shared

--- a/Adyen/Helpers/CheckoutPlatformParams.swift
+++ b/Adyen/Helpers/CheckoutPlatformParams.swift
@@ -1,0 +1,36 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+@_spi(AdyenInternal)
+public class CheckoutPlatformParams {
+
+    // MARK: - Types
+
+    public enum Platform: String {
+        case ios
+        case reactNative = "react-native"
+        case flutter
+    }
+
+    // MARK: - Properties
+
+    public private(set) var version: String = adyenSdkVersion
+    public private(set) var platform: Platform = .ios
+    public let channel: String = "ios"
+
+    // MARK: - Methods
+
+    public func override(version: String, platform: Platform) {
+        self.version = version
+        self.platform = platform
+    }
+}
+
+@_spi(AdyenInternal)
+public let checkoutPlatformParams = CheckoutPlatformParams()
+

--- a/Adyen/Helpers/CheckoutPlatformParams.swift
+++ b/Adyen/Helpers/CheckoutPlatformParams.swift
@@ -7,7 +7,8 @@
 import Foundation
 
 @_spi(AdyenInternal)
-public class CheckoutPlatformParams {
+/// Reference to the Android counterpart: https://github.com/Adyen/adyen-android/blob/main/core/src/main/java/com/adyen/checkout/core/common/internal/helper/CheckoutPlatformParams.kt
+public final class CheckoutPlatformParams {
 
     // MARK: - Types
 

--- a/Adyen/Model/SDKData.swift
+++ b/Adyen/Model/SDKData.swift
@@ -20,13 +20,23 @@ public struct SDKData: Codable {
             self.threeDS2SdkVersion = threeDS2SdkVersion
         }
     }
-    
+
+    internal enum PaymentMethodBehavior: String, Codable {
+        case nativeComponent
+        case genericComponent
+    }
+
     internal let analytics: Analytics
     internal private(set) var authentication: Authentication?
     internal let schemaVersion: Int = SchemaVersions.v1
     private let supportNativeRedirect: Bool = true
     private let timestamp = Int(Date().timeIntervalSince1970 * 1000)
-    
+
+    private let paymentMethodBehavior: PaymentMethodBehavior
+    private let channel: String = checkoutPlatformParams.channel
+    private let platform: String = checkoutPlatformParams.platform.rawValue
+    private let sdkVersion: String = checkoutPlatformParams.version
+
     @_spi(AdyenInternal)
     public var encodedValue: String? {
         try? AdyenCoder.encodeBase64(self)
@@ -34,9 +44,11 @@ public struct SDKData: Codable {
     
     internal init(
         checkoutAttemptId: String,
+        paymentMethodBehavior: PaymentMethodBehavior,
         authenticationProvider: SDKDataAuthenticationProvider? = nil
     ) {
         self.analytics = .init(checkoutAttemptId: checkoutAttemptId)
+        self.paymentMethodBehavior = paymentMethodBehavior
         self.authentication = authenticationProvider?.authentication
     }
     
@@ -46,6 +58,10 @@ public struct SDKData: Codable {
         case supportNativeRedirect
         case schemaVersion
         case timestamp = "createdAt"
+        case paymentMethodBehavior
+        case channel
+        case platform
+        case sdkVersion
     }
     
     private enum SchemaVersions {

--- a/Adyen/Model/SDKData.swift
+++ b/Adyen/Model/SDKData.swift
@@ -21,7 +21,7 @@ public struct SDKData: Codable {
         }
     }
 
-    internal enum PaymentMethodBehavior: String, Codable {
+    public enum PaymentMethodBehavior: String, Codable {
         /// Indicates that the SDK has a specific component for this payment method.
         case nativeComponent
 
@@ -76,4 +76,20 @@ public struct SDKData: Codable {
 @_spi(AdyenInternal)
 public protocol SDKDataAuthenticationProvider {
     var authentication: SDKData.Authentication { get }
+}
+
+@_spi(AdyenInternal)
+public extension PaymentComponent {
+
+    var paymentMethodBehavior: SDKData.PaymentMethodBehavior {
+        .nativeComponent
+    }
+}
+
+@_spi(AdyenInternal)
+public extension InstantPaymentComponent {
+
+    var paymentMethodBehavior: SDKData.PaymentMethodBehavior {
+        .genericComponent
+    }
 }

--- a/Adyen/Model/SDKData.swift
+++ b/Adyen/Model/SDKData.swift
@@ -22,7 +22,11 @@ public struct SDKData: Codable {
     }
 
     internal enum PaymentMethodBehavior: String, Codable {
+        /// Indicates that the SDK has a specific component for this payment method.
         case nativeComponent
+
+        /// Indicates that the SDK does not have native component support for this payment method
+        /// and will handle it through the Instant Payment Component.
         case genericComponent
     }
 

--- a/AdyenCardScannerTests/Mocks/CardImageParsingMock.swift
+++ b/AdyenCardScannerTests/Mocks/CardImageParsingMock.swift
@@ -8,6 +8,7 @@
 import CoreImage
 
 class CardImageParsingMock: CardImageParsing {
+
     // MARK: - parse
 
     var parseCallsCount = 0

--- a/AdyenCardScannerTests/Mocks/CardScannerViewMock.swift
+++ b/AdyenCardScannerTests/Mocks/CardScannerViewMock.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 class CardScannerPresentingMock: CardScannerPresenting {
+
     // MARK: - dismiss
 
     var dismissCallsCount = 0

--- a/AdyenCardScannerTests/Mocks/ExpirationDateFormattingMock.swift
+++ b/AdyenCardScannerTests/Mocks/ExpirationDateFormattingMock.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 class ExpirationDateFormattingMock: ExpirationDateFormatting {
+
     // MARK: - date(from:)
 
     var dateCallsCount = 0

--- a/Demo/Common/Assets/session_response.json
+++ b/Demo/Common/Assets/session_response.json
@@ -5,7 +5,7 @@
         "currency" : "EUR",
         "value" : 17408
     },
-    "channel" : "iOS",
+    "channel" : "ios",
     "countryCode" : "NL",
     "additionalData" : {
         "allow3DS2" : "true"

--- a/Demo/Common/Networking/PaymentsRequest.swift
+++ b/Demo/Common/Networking/PaymentsRequest.swift
@@ -53,7 +53,7 @@ internal struct PaymentsRequest: APIRequest {
         try container.encodeIfPresent(data.socialSecurityNumber, forKey: .socialSecurityNumber)
         try container.encode(Locale.current.identifier, forKey: .shopperLocale)
         try container.encodeIfPresent(data.browserInfo, forKey: .browserInfo)
-        try container.encode("iOS", forKey: .channel)
+        try container.encode("ios", forKey: .channel)
         try container.encode(ConfigurationConstants.reference, forKey: .reference)
         try container.encode(currentConfiguration.countryCode, forKey: .countryCode)
         try container.encode(ConfigurationConstants.returnUrl.absoluteString, forKey: .returnUrl)

--- a/Demo/Common/Networking/SessionRequest.swift
+++ b/Demo/Common/Networking/SessionRequest.swift
@@ -36,7 +36,7 @@ internal struct SessionRequest: APIRequest {
         try container.encode(currentConfiguration.amount, forKey: .amount)
         try container.encode(ConfigurationConstants.returnUrl.absoluteString, forKey: .returnUrl)
         try container.encode(ConfigurationConstants.reference, forKey: .reference)
-        try container.encode("iOS", forKey: .channel)
+        try container.encode("ios", forKey: .channel)
         try container.encode(ConfigurationConstants.lineItems, forKey: .lineItems)
         try container.encode(ConfigurationConstants.mandate, forKey: .mandate)
         

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubject.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubject.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
+@_spi(AdyenInternal) import Adyen
 import Foundation
 
 class PaymentComponentSubject: PaymentComponent {
@@ -13,6 +13,7 @@ class PaymentComponentSubject: PaymentComponent {
 
     var context: AdyenContext
     var delegate: PaymentComponentDelegate?
+    var paymentMethodBehavior: SDKData.PaymentMethodBehavior = .nativeComponent
     var payment: Payment?
     var order: PartialPaymentOrder?
     var paymentMethod: PaymentMethod

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -47,26 +47,26 @@ class PaymentComponentSubjectTests: XCTestCase {
         let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
-        
+
         // When
         XCTAssertNil(paymentComponentData.paymentMethod.sdkData)
-        
+
         // Then
         paymentComponentDelegate.onDidSubmit = { data, _ in
             XCTAssertNotNil(data.paymentMethod.sdkData)
-            
+
             guard let sdkDataDecoded = self.sdkData(from: data.paymentMethod.sdkData) else {
                 XCTFail("SDKData should be present and decodable")
                 return
             }
-            
+
             XCTAssertEqual(sdkDataDecoded.analytics.checkoutAttemptId, "fetch-checkoutAttemptId-failed")
             XCTAssertEqual(data.checkoutAttemptId, "fetch-checkoutAttemptId-failed")
             didSubmitExpectation.fulfill()
         }
-        
+
         sut.submit(data: paymentComponentData, component: sut)
-        
+
         wait(for: [didSubmitExpectation], timeout: 3)
     }
 
@@ -76,7 +76,7 @@ class PaymentComponentSubjectTests: XCTestCase {
         let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
-        
+
         // When
         XCTAssertNil(paymentComponentData.browserInfo)
 
@@ -85,20 +85,20 @@ class PaymentComponentSubjectTests: XCTestCase {
             XCTAssertNotNil(data.browserInfo)
             didSubmitExpectation.fulfill()
         }
-        
+
         sut.submit(data: paymentComponentData, component: sut)
-        
+
         wait(for: [didSubmitExpectation], timeout: 3)
     }
-    
+
     func test_submit_event() {
         let expectedCheckoutAttemptId = "d06da733-ec41-4739-a532-5e8deab1262e16547639430681e1b021221a98c4bf13f7366b30fec4b376cc8450067ff98998682dd24fc9bda"
         analyticsProviderMock._checkoutAttemptId = expectedCheckoutAttemptId
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
         let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
-        
+
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
-        
+
         paymentComponentDelegate.onDidSubmit = { data, _ in
             let submitEvent = self.analyticsProviderMock.logs[0]
             XCTAssertEqual(submitEvent.type, .submit)
@@ -106,12 +106,12 @@ class PaymentComponentSubjectTests: XCTestCase {
         }
 
         sut.submit(data: paymentComponentData, component: sut)
-        
+
         wait(for: [didSubmitExpectation], timeout: 3)
     }
-    
+
     // MARK: - SDKData Tests
-    
+
     func test_submit_creates_sdkData_with_analytics() {
         // Given
         let expectedCheckoutAttemptId = "d06da733-ec41-4739-a532-5e8deab1262e16547639430681e1b021221a98c4bf13f7366b30fec4b376cc8450067ff98998682dd24fc9bda"
@@ -120,19 +120,19 @@ class PaymentComponentSubjectTests: XCTestCase {
         let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
-        
+
         // When
         XCTAssertNil(paymentComponentData.paymentMethod.sdkData)
 
         // Then
         paymentComponentDelegate.onDidSubmit = { data, _ in
             XCTAssertNotNil(data.paymentMethod.sdkData)
-            
+
             guard let sdkDataDecoded = self.sdkData(from: data.paymentMethod.sdkData) else {
                 XCTFail("SDKData should be present and decodable")
                 return
             }
-            
+
             // Verify SDKData contains checkoutAttemptId
             XCTAssertEqual(sdkDataDecoded.analytics.checkoutAttemptId, expectedCheckoutAttemptId)
             XCTAssertEqual(sdkDataDecoded.schemaVersion, 1)
@@ -140,84 +140,84 @@ class PaymentComponentSubjectTests: XCTestCase {
             XCTAssertEqual(data.checkoutAttemptId, expectedCheckoutAttemptId)
             didSubmitExpectation.fulfill()
         }
-        
+
         sut.submit(data: paymentComponentData, component: sut)
-        
+
         wait(for: [didSubmitExpectation], timeout: 3)
     }
-    
+
     func test_submit_with_authenticationProvider_includes_authentication_in_sdkData() {
         // Given
         let expectedCheckoutAttemptId = "test-checkout-attempt-id"
         analyticsProviderMock.checkoutAttemptId = expectedCheckoutAttemptId
-        
+
         // Create a mock payment method that provides authentication
         let mockAuthProvider = MockSDKDataAuthenticationProvider()
         let paymentMethodDetails = MockAuthenticationPaymentDetails(authProvider: mockAuthProvider)
         let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
-        
+
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
-        
+
         // Then
         paymentComponentDelegate.onDidSubmit = { data, _ in
             XCTAssertNotNil(data.paymentMethod.sdkData, "SDKData should be created")
-            
+
             guard let sdkDataDecoded = self.sdkData(from: data.paymentMethod.sdkData) else {
                 XCTFail("SDKData should be present and decodable")
                 return
             }
-            
+
             // Verify the SDKData contains authentication
             XCTAssertNotNil(sdkDataDecoded.authentication)
             XCTAssertEqual(sdkDataDecoded.authentication?.threeDS2SdkVersion, "0.0.0")
             didSubmitExpectation.fulfill()
         }
-        
+
         sut.submit(data: paymentComponentData, component: sut)
-        
+
         wait(for: [didSubmitExpectation], timeout: 3)
     }
-    
+
     func test_submit_without_authenticationProvider_includes_only_analytics_in_sdkData() {
         // Given
         let expectedCheckoutAttemptId = "test-checkout-attempt-id"
         analyticsProviderMock.checkoutAttemptId = expectedCheckoutAttemptId
-        
+
         // Use a payment method that doesn't provide authentication
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
         let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
-        
+
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
-        
+
         // Then
         paymentComponentDelegate.onDidSubmit = { data, _ in
-            
+
             guard let sdkDataDecoded = self.sdkData(from: data.paymentMethod.sdkData) else {
                 XCTFail("SDKData should be present and decodable")
                 return
             }
-            
+
             XCTAssertEqual(sdkDataDecoded.analytics.checkoutAttemptId, expectedCheckoutAttemptId)
             XCTAssertNil(sdkDataDecoded.authentication)
             didSubmitExpectation.fulfill()
         }
-        
+
         sut.submit(data: paymentComponentData, component: sut)
-        
+
         wait(for: [didSubmitExpectation], timeout: 3)
     }
-    
+
     func test_submit_includes_sdkData_other_fields() {
         // Given
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
         let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
-        
+
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
-        
+
         // Then
         paymentComponentDelegate.onDidSubmit = { data, _ in
             XCTAssertNotNil(data.paymentMethod.sdkData)
-            
+
             // Verify timestamp is present
             guard let sdkDataString = data.paymentMethod.sdkData,
                   let decodedData = Data(base64Encoded: sdkDataString),
@@ -229,12 +229,77 @@ class PaymentComponentSubjectTests: XCTestCase {
             XCTAssertTrue(jsonString.contains("\"supportNativeRedirect\""), "SDKData should contain supportNativeRedirect ")
             didSubmitExpectation.fulfill()
         }
-        
+
         sut.submit(data: paymentComponentData, component: sut)
-        
+
         wait(for: [didSubmitExpectation], timeout: 3)
     }
-    
+
+    func test_submit_sets_nativeComponent_behavior_for_regular_component() {
+        // Given
+        let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
+        let paymentComponentData = PaymentComponentData(
+            paymentMethodDetails: paymentMethodDetails,
+            amount: nil,
+            order: nil
+        )
+
+        let didSubmitExpectation = expectation(description: "didSubmit should get called")
+
+        // Then
+        paymentComponentDelegate.onDidSubmit = {
+            data,
+            _ in
+            guard let sdkDataString = data.paymentMethod.sdkData,
+                  let decodedData = Data(base64Encoded: sdkDataString),
+                  let jsonString = String(data: decodedData, encoding: .utf8) else {
+                XCTFail("SDKData should be present and decodable to a string")
+                return
+            }
+
+            XCTAssertTrue(
+                jsonString.contains("\"paymentMethodBehavior\":\"nativeComponent\""),
+                "Regular PaymentComponent should use nativeComponent behavior"
+            )
+            didSubmitExpectation.fulfill()
+        }
+
+        sut.submit(data: paymentComponentData, component: sut)
+
+        wait(for: [didSubmitExpectation], timeout: 3)
+    }
+
+    func test_submit_includes_platform_fields_in_sdkData() {
+        // Given
+        let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
+        let paymentComponentData = PaymentComponentData(
+            paymentMethodDetails: paymentMethodDetails,
+            amount: nil,
+            order: nil
+        )
+
+        let didSubmitExpectation = expectation(description: "didSubmit should get called")
+
+        // Then
+        paymentComponentDelegate.onDidSubmit = { data, _ in
+            guard let sdkDataString = data.paymentMethod.sdkData,
+                  let decodedData = Data(base64Encoded: sdkDataString),
+                  let jsonString = String(data: decodedData, encoding: .utf8) else {
+                XCTFail("SDKData should be present and decodable to a string")
+                return
+            }
+
+            XCTAssertTrue(jsonString.contains("\"channel\":\"ios\""), "SDKData should contain channel field")
+            XCTAssertTrue(jsonString.contains("\"platform\""), "SDKData should contain platform field")
+            XCTAssertTrue(jsonString.contains("\"sdkVersion\""), "SDKData should contain sdkVersion field")
+            didSubmitExpectation.fulfill()
+        }
+
+        sut.submit(data: paymentComponentData, component: sut)
+
+        wait(for: [didSubmitExpectation], timeout: 3)
+    }
+
     private func sdkData(from sdkDataString: String?) -> SDKData? {
         guard let sdkDataString,
               let sdkDataDecoded: SDKData = try? AdyenCoder.decodeBase64(sdkDataString) else {
@@ -258,11 +323,11 @@ private struct MockAuthenticationPaymentDetails: PaymentMethodDetails, SDKDataAu
     var checkoutAttemptId: String?
     let authProvider: MockSDKDataAuthenticationProvider
     var sdkData: String?
-    
+
     var authentication: SDKData.Authentication {
         authProvider.authentication
     }
-    
+
     private enum CodingKeys: String, CodingKey {
         case type
     }

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -289,9 +289,13 @@ class PaymentComponentSubjectTests: XCTestCase {
                 return
             }
 
-            XCTAssertTrue(jsonString.contains("\"channel\":\"ios\""), "SDKData should contain channel field")
-            XCTAssertTrue(jsonString.contains("\"platform\""), "SDKData should contain platform field")
-            XCTAssertTrue(jsonString.contains("\"sdkVersion\""), "SDKData should contain sdkVersion field")
+            let expectedChannel = "\"channel\":\"\(checkoutPlatformParams.channel)\""
+            let expectedPlatform = "\"platform\":\"\(checkoutPlatformParams.platform.rawValue)\""
+            let expectedSdkVersion = "\"sdkVersion\":\"\(checkoutPlatformParams.version)\""
+
+            XCTAssertTrue(jsonString.contains(expectedChannel), "SDKData should contain channel: \(checkoutPlatformParams.channel)")
+            XCTAssertTrue(jsonString.contains(expectedPlatform), "SDKData should contain platform: \(checkoutPlatformParams.platform.rawValue)")
+            XCTAssertTrue(jsonString.contains(expectedSdkVersion), "SDKData should contain sdkVersion: \(checkoutPlatformParams.version)")
             didSubmitExpectation.fulfill()
         }
 
@@ -318,15 +322,22 @@ class PaymentComponentSubjectTests: XCTestCase {
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
 
         // Then
-        paymentComponentDelegate.onDidSubmit = { data, _ in
+        paymentComponentDelegate.onDidSubmit = {
+            data,
+            _ in
             guard let sdkDataString = data.paymentMethod.sdkData,
                   let decodedData = Data(base64Encoded: sdkDataString),
                   let jsonString = String(data: decodedData, encoding: .utf8) else {
                 XCTFail("SDKData should be present and decodable to a string")
                 return
             }
-
-            XCTAssertTrue(jsonString.contains("\"paymentMethodBehavior\":\"genericComponent\""), "InstantPaymentComponent should use genericComponent behavior")
+            
+            XCTAssertTrue(
+                jsonString.contains(
+                    "\"paymentMethodBehavior\":\"genericComponent\""
+                ),
+                "InstantPaymentComponent should use genericComponent behavior"
+            )
             didSubmitExpectation.fulfill()
         }
 

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -300,6 +300,41 @@ class PaymentComponentSubjectTests: XCTestCase {
         wait(for: [didSubmitExpectation], timeout: 3)
     }
 
+    func test_submit_sets_genericComponent_behavior_for_generic_component() {
+        // Given
+        analyticsProviderMock.checkoutAttemptId = "test-checkout-attempt-id"
+
+        let instantPaymentMethod = InstantPaymentMethod(type: .other("test"), name: "Test")
+        let instantPaymentDetails = InstantPaymentDetails(type: .other("test"))
+        let paymentData = PaymentComponentData(paymentMethodDetails: instantPaymentDetails, amount: nil, order: nil)
+
+        let instantComponent = InstantPaymentComponent(
+            paymentMethod: instantPaymentMethod,
+            context: context,
+            paymentData: paymentData
+        )
+        instantComponent.delegate = paymentComponentDelegate
+
+        let didSubmitExpectation = expectation(description: "didSubmit should get called")
+
+        // Then
+        paymentComponentDelegate.onDidSubmit = { data, _ in
+            guard let sdkDataString = data.paymentMethod.sdkData,
+                  let decodedData = Data(base64Encoded: sdkDataString),
+                  let jsonString = String(data: decodedData, encoding: .utf8) else {
+                XCTFail("SDKData should be present and decodable to a string")
+                return
+            }
+
+            XCTAssertTrue(jsonString.contains("\"paymentMethodBehavior\":\"genericComponent\""), "InstantPaymentComponent should use genericComponent behavior")
+            didSubmitExpectation.fulfill()
+        }
+
+        instantComponent.initiatePayment()
+
+        wait(for: [didSubmitExpectation], timeout: 3)
+    }
+
     private func sdkData(from sdkDataString: String?) -> SDKData? {
         guard let sdkDataString,
               let sdkDataDecoded: SDKData = try? AdyenCoder.decodeBase64(sdkDataString) else {

--- a/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
@@ -192,8 +192,8 @@ class AnalyticsProviderTests: XCTestCase {
         apiClient.onExecute = { request in
             if let initialAnalyticsdRequest = request as? InitialAnalyticsRequest {
                 XCTAssertEqual(initialAnalyticsdRequest.amount, amount)
-                XCTAssertEqual(initialAnalyticsdRequest.version)
-                XCTAssertEqual(initialAnalyticsdRequest.platform, "react-native")
+                XCTAssertEqual(initialAnalyticsdRequest.version, adyenSdkVersion)
+                XCTAssertEqual(initialAnalyticsdRequest.platform, "ios")
                 analyticsExpectation.fulfill()
             }
         }
@@ -230,7 +230,7 @@ class AnalyticsProviderTests: XCTestCase {
         let expectedDecodedRequest = [
             "locale": "en_US",
             "paymentMethods": analyticsData.paymentMethods,
-            "platform": "flutter",
+            "platform": "ios",
             "component": "ach",
             "flavor": "components",
             "channel": "ios",
@@ -245,7 +245,7 @@ class AnalyticsProviderTests: XCTestCase {
                 "value": 1
             ] as [String: Any],
             "sessionId": "test_session_id",
-            "version": "version"
+            "version": adyenSdkVersion
         ] as [String: Any]
         
         XCTAssertEqual(

--- a/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
@@ -124,7 +124,6 @@ class AnalyticsProviderTests: XCTestCase {
         
         let eventAnalyticsProvider = EventAnalyticsProvider(
             apiClient: eventApiClient,
-            context: AnalyticsContext(),
             eventDataSource: AnalyticsEventDataSource()
         )
         let sut = AnalyticsProvider(
@@ -193,14 +192,13 @@ class AnalyticsProviderTests: XCTestCase {
         apiClient.onExecute = { request in
             if let initialAnalyticsdRequest = request as? InitialAnalyticsRequest {
                 XCTAssertEqual(initialAnalyticsdRequest.amount, amount)
-                XCTAssertEqual(initialAnalyticsdRequest.version, "version")
+                XCTAssertEqual(initialAnalyticsdRequest.version)
                 XCTAssertEqual(initialAnalyticsdRequest.platform, "react-native")
                 analyticsExpectation.fulfill()
             }
         }
         
-        var configuration = AnalyticsConfiguration()
-        configuration.context = AnalyticsContext(version: "version", platform: .reactNative)
+        let configuration = AnalyticsConfiguration()
         let analyticsProvider = AnalyticsProvider(
             apiClient: apiClient,
             configuration: configuration,
@@ -216,9 +214,8 @@ class AnalyticsProviderTests: XCTestCase {
     
     func testInitialRequestEncoding() throws {
         
-        var configuration = AnalyticsConfiguration()
-        configuration.context = AnalyticsContext(version: "version", platform: .flutter)
-        
+        let configuration = AnalyticsConfiguration()
+
         let analyticsData = AnalyticsData(
             flavor: .components(type: .achDirectDebit),
             additionalFields: AdditionalAnalyticsFields(amount: .init(value: 1, currencyCode: "EUR"), sessionId: "test_session_id"),

--- a/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
@@ -101,7 +101,7 @@ class AnalyticsProviderTests: XCTestCase {
             if let initialAnalyticsdRequest = request as? InitialAnalyticsRequest {
                 XCTAssertNil(initialAnalyticsdRequest.amount)
                 XCTAssertEqual(initialAnalyticsdRequest.version, adyenSdkVersion)
-                XCTAssertEqual(initialAnalyticsdRequest.platform, "iOS")
+                XCTAssertEqual(initialAnalyticsdRequest.platform, "ios")
                 XCTAssertEqual(initialAnalyticsdRequest.level, "all")
                 analyticsExpectation.fulfill()
             }
@@ -236,7 +236,7 @@ class AnalyticsProviderTests: XCTestCase {
             "platform": "flutter",
             "component": "ach",
             "flavor": "components",
-            "channel": "iOS",
+            "channel": "ios",
             "systemVersion": analyticsData.systemVersion,
             "screenWidth": analyticsData.screenWidth,
             "referrer": analyticsData.referrer,

--- a/Tests/UnitTests/Analytics/EventAnalyticsProviderTests.swift
+++ b/Tests/UnitTests/Analytics/EventAnalyticsProviderTests.swift
@@ -158,7 +158,6 @@ final class EventAnalyticsProviderTests: XCTestCase {
         
         EventAnalyticsProvider(
             apiClient: apiClient,
-            context: AnalyticsContext(),
             eventDataSource: eventDataSource
         )
     }

--- a/Tests/UnitTests/Core/CheckoutPlatformParamsTests.swift
+++ b/Tests/UnitTests/Core/CheckoutPlatformParamsTests.swift
@@ -18,9 +18,7 @@ class CheckoutPlatformParamsTests: XCTestCase {
     }
 
     func test_override_updates_version_and_platform() {
-        let sut = CheckoutPlatformParams.shared
-        let originalVersion = sut.version
-        let originalPlatform = sut.platform
+        let sut = CheckoutPlatformParams(version: adyenSdkVersion, platform: .ios)
 
         // When
         sut.overrideForCrossPlatform(platform: .flutter, version: "1.0.0")
@@ -28,15 +26,10 @@ class CheckoutPlatformParamsTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.version, "1.0.0")
         XCTAssertEqual(sut.platform, .flutter)
-
-        // Cleanup - restore original values
-        sut.overrideForCrossPlatform(platform: originalPlatform, version: originalVersion)
     }
 
     func test_override_with_react_native_platform() {
-        let sut = CheckoutPlatformParams.shared
-        let originalVersion = sut.version
-        let originalPlatform = sut.platform
+        let sut = CheckoutPlatformParams(version: adyenSdkVersion, platform: .ios)
 
         // When
         sut.overrideForCrossPlatform(platform: .reactNative, version: "2.0.0")
@@ -45,24 +38,16 @@ class CheckoutPlatformParamsTests: XCTestCase {
         XCTAssertEqual(sut.version, "2.0.0")
         XCTAssertEqual(sut.platform, .reactNative)
         XCTAssertEqual(sut.platform.rawValue, "react-native")
-
-        // Cleanup - restore original values
-        sut.overrideForCrossPlatform(platform: originalPlatform, version: originalVersion)
     }
 
     func test_channel_is_always_ios() {
-        let sut = CheckoutPlatformParams.shared
-        let originalVersion = sut.version
-        let originalPlatform = sut.platform
+        let sut = CheckoutPlatformParams(version: adyenSdkVersion, platform: .ios)
 
         // When - override to different platform
         sut.overrideForCrossPlatform(platform: .flutter, version: "1.0.0")
 
         // Then - channel should still be ios
         XCTAssertEqual(sut.channel, "ios")
-
-        // Cleanup
-        sut.overrideForCrossPlatform(platform: originalPlatform, version: originalVersion)
     }
 
     func test_shared_returns_same_instance() {

--- a/Tests/UnitTests/Core/CheckoutPlatformParamsTests.swift
+++ b/Tests/UnitTests/Core/CheckoutPlatformParamsTests.swift
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import XCTest
+@_spi(AdyenInternal) @testable import Adyen
+
+class CheckoutPlatformParamsTests: XCTestCase {
+
+    func test_default_values() {
+        let sut = CheckoutPlatformParams.shared
+
+        XCTAssertEqual(sut.version, adyenSdkVersion)
+        XCTAssertEqual(sut.platform, .ios)
+        XCTAssertEqual(sut.channel, "ios")
+    }
+
+    func test_override_updates_version_and_platform() {
+        let sut = CheckoutPlatformParams.shared
+        let originalVersion = sut.version
+        let originalPlatform = sut.platform
+
+        // When
+        sut.override(version: "1.0.0", platform: .flutter)
+
+        // Then
+        XCTAssertEqual(sut.version, "1.0.0")
+        XCTAssertEqual(sut.platform, .flutter)
+
+        // Cleanup - restore original values
+        sut.override(version: originalVersion, platform: originalPlatform)
+    }
+
+    func test_override_with_react_native_platform() {
+        let sut = CheckoutPlatformParams.shared
+        let originalVersion = sut.version
+        let originalPlatform = sut.platform
+
+        // When
+        sut.override(version: "2.0.0", platform: .reactNative)
+
+        // Then
+        XCTAssertEqual(sut.version, "2.0.0")
+        XCTAssertEqual(sut.platform, .reactNative)
+        XCTAssertEqual(sut.platform.rawValue, "react-native")
+
+        // Cleanup - restore original values
+        sut.override(version: originalVersion, platform: originalPlatform)
+    }
+
+    func test_channel_is_always_ios() {
+        let sut = CheckoutPlatformParams.shared
+        let originalVersion = sut.version
+        let originalPlatform = sut.platform
+
+        // When - override to different platform
+        sut.override(version: "1.0.0", platform: .flutter)
+
+        // Then - channel should still be ios
+        XCTAssertEqual(sut.channel, "ios")
+
+        // Cleanup
+        sut.override(version: originalVersion, platform: originalPlatform)
+    }
+
+    func test_shared_returns_same_instance() {
+        let instance1 = CheckoutPlatformParams.shared
+        let instance2 = CheckoutPlatformParams.shared
+
+        XCTAssertTrue(instance1 === instance2)
+    }
+
+    func test_checkoutPlatformParams_global_returns_shared_instance() {
+        XCTAssertTrue(checkoutPlatformParams === CheckoutPlatformParams.shared)
+    }
+}

--- a/Tests/UnitTests/Core/CheckoutPlatformParamsTests.swift
+++ b/Tests/UnitTests/Core/CheckoutPlatformParamsTests.swift
@@ -23,14 +23,14 @@ class CheckoutPlatformParamsTests: XCTestCase {
         let originalPlatform = sut.platform
 
         // When
-        sut.override(version: "1.0.0", platform: .flutter)
+        sut.overrideForCrossPlatform(platform: .flutter, version: "1.0.0")
 
         // Then
         XCTAssertEqual(sut.version, "1.0.0")
         XCTAssertEqual(sut.platform, .flutter)
 
         // Cleanup - restore original values
-        sut.override(version: originalVersion, platform: originalPlatform)
+        sut.overrideForCrossPlatform(platform: originalPlatform, version: originalVersion)
     }
 
     func test_override_with_react_native_platform() {
@@ -39,7 +39,7 @@ class CheckoutPlatformParamsTests: XCTestCase {
         let originalPlatform = sut.platform
 
         // When
-        sut.override(version: "2.0.0", platform: .reactNative)
+        sut.overrideForCrossPlatform(platform: .reactNative, version: "2.0.0")
 
         // Then
         XCTAssertEqual(sut.version, "2.0.0")
@@ -47,7 +47,7 @@ class CheckoutPlatformParamsTests: XCTestCase {
         XCTAssertEqual(sut.platform.rawValue, "react-native")
 
         // Cleanup - restore original values
-        sut.override(version: originalVersion, platform: originalPlatform)
+        sut.overrideForCrossPlatform(platform: originalPlatform, version: originalVersion)
     }
 
     func test_channel_is_always_ios() {
@@ -56,13 +56,13 @@ class CheckoutPlatformParamsTests: XCTestCase {
         let originalPlatform = sut.platform
 
         // When - override to different platform
-        sut.override(version: "1.0.0", platform: .flutter)
+        sut.overrideForCrossPlatform(platform: .flutter, version: "1.0.0")
 
         // Then - channel should still be ios
         XCTAssertEqual(sut.channel, "ios")
 
         // Cleanup
-        sut.override(version: originalVersion, platform: originalPlatform)
+        sut.overrideForCrossPlatform(platform: originalPlatform, version: originalVersion)
     }
 
     func test_shared_returns_same_instance() {


### PR DESCRIPTION
## Summary

This PR introduces some key changes related with `SDKData`:
- Adds 4 new fields to `SDKData` in order to support hosted checkout components. These are:
  - `channel`
  - `platform`
  - `sdkVersion`
  - `paymentMethodBehavior`
- Every usage of `channel` and `platform` needs to be **lowercase**. Thus, every instance of `iOS` has been replaced with `ios`.
- Introduces `CheckoutPlatformParams`. [Similar to Android](https://github.com/Adyen/adyen-android/blob/main/core/src/main/java/com/adyen/checkout/core/common/internal/helper/CheckoutPlatformParams.kt), there's a centralized place where _cross-platform_ can override platform parameters such as `version` and `channel`.

## Release Notes

<changed>
- The payload returned in the `onSubmit` callback has increased in size, because of changes to the included `sdkData` field.
</changed>

## Ticket
<ticket>
COSDK-1149
</ticket>

## Checklist
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
