### PR TITLE
Refactor `StoredCardComponentTests` & added more tests to `StoredCardInputViewModelTests` (3/6)

### DIFF
--- a/Adyen/Helpers/StringHelpers.swift
+++ b/Adyen/Helpers/StringHelpers.swift
@@ -12,6 +12,9 @@ extension String: AdyenCompatible {
 
     public enum Adyen {
 
+        /// A masked string prefix used to indicate secured/hidden card digits (e.g., "••••1234").
+        /// Uses `\u{00a0}` (non-breaking space) after the bullets to prevent line breaks
+        /// between the masked prefix and the following digits.
         public static let securedString: String = "••••\u{00a0}"
     }
 }

--- a/Demo/Common/Assets/AdyenUIHost.strings
+++ b/Demo/Common/Assets/AdyenUIHost.strings
@@ -29,6 +29,8 @@
 "adyen.card.stored.title" = "Test-Verify your card";
 "adyen.card.stored.message" = "Test-Please enter the CVC code for %@";
 "adyen.card.stored.expires" = "Test-Expires %@";
+"adyen.card.securityCode.title" = "Test-Enter security code";
+"adyen.card.securityCode.description" = "Test-Enter the security code for %@";
 "adyen.dropIn.stored.title" = "Test-Confirm %@ payment";
 "adyen.phoneNumber.title" = "Test-Phone Number";
 "adyen.phoneNumber.placeholder" = "Test-123 456 789";

--- a/Demo/Common/Assets/AdyenUIHostCustomSeparator.strings
+++ b/Demo/Common/Assets/AdyenUIHostCustomSeparator.strings
@@ -29,6 +29,8 @@
 "adyen_card_stored_title" = "Test-Verify your card";
 "adyen_card_stored_message" = "Test-Please enter the CVC code for %@";
 "adyen_card_stored_expires" = "Test-Expires %@";
+"adyen_card_securityCode_title" = "Test-Enter security code";
+"adyen_card_securityCode_description" = "Test-Enter the security code for %@";
 "adyen_dropIn_stored_title" = "Test-Confirm %@ payment";
 "adyen_phoneNumber_title" = "Phone Number";
 "adyen_phoneNumber_placeholder" = "Test 123 456 789";

--- a/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
@@ -12,218 +12,154 @@ import XCTest
 @MainActor
 class StoredCardComponentTests: XCTestCase {
 
-    private var context = Dummy.context
+    // MARK: - UI Display
 
-    let method = StoredCardPaymentMethod(
-        type: .card,
-        name: "name",
-        identifier: "id",
-        fundingSource: .credit,
-        supportedShopperInteractions: [.shopperPresent],
-        brand: .visa,
-        lastFour: "1234",
-        expiryMonth: "12",
-        expiryYear: "22",
-        holderName: "holderName"
-    )
+    /// Verifies that the component displays a security code field, cancel button, and pay button.
+    func testUIWithClientKey() {
+        // Given
+        let proxy = makeSUT()
 
-    // let payment = Payment(amount: Amount(value: 174, currencyCode: "EUR"), countryCode: "NL")
+        // When
+        proxy.present(on: self)
 
-    func testUIWithClientKey() throws {
-        let sut = StoredCardComponent(storedCardPaymentMethod: method, context: context, theme: CheckoutTheme())
-
-        presentOnRoot(sut.viewController)
-        
-        let alertController = try XCTUnwrap(sut.viewController as? UIAlertController)
-        let textField: UITextField! = try XCTUnwrap(alertController.textFields?.first)
-        XCTAssertNotNil(textField)
-
-        XCTAssertTrue(alertController.actions.contains { $0.title == localizedString(.cancelButton, nil) })
-        XCTAssertTrue(alertController.actions.contains { $0.title == localizedSubmitButtonTitle(with: context.amount, style: .immediate, nil) })
-
-        alertController.dismiss(animated: false, completion: nil)
+        // Then
+        XCTAssertNotNil(proxy.securityCodeText)
+        XCTAssertTrue(proxy.hasCancelButton)
+        XCTAssertTrue(proxy.hasPayButton)
     }
 
+    // MARK: - Payment Submit
+
+    /// Verifies that submitting a valid security code encrypts and submits card details to the delegate.
     func testPaymentSubmitWithValidPublicKey() throws {
-        let sut = StoredCardComponent(storedCardPaymentMethod: method, context: context, theme: CheckoutTheme())
-
-        let delegateExpectation = expectation(description: "expect delegate to be called.")
+        // Given
+        let proxy = makeSUT()
         let delegate = PaymentComponentDelegateMock()
-        delegate.onDidSubmit = { data, component in
-            XCTAssertTrue(component === sut)
-            XCTAssertNotNil(data.paymentMethod as? CardDetails)
+        proxy.component.delegate = delegate
 
-            let cardDetails = data.paymentMethod as! CardDetails
-            XCTAssertNotNil(cardDetails.encryptedSecurityCode)
-            XCTAssertNil(cardDetails.encryptedCardNumber)
-            XCTAssertNil(cardDetails.encryptedExpiryYear)
-            XCTAssertNil(cardDetails.encryptedExpiryMonth)
+        let submitExpectation = expectation(description: "Expect didSubmit to be called")
+        delegate.onDidSubmit = { _, _ in submitExpectation.fulfill() }
+        delegate.onDidFail = { _, _ in XCTFail("didFail should not be called") }
 
-            delegateExpectation.fulfill()
-        }
-        delegate.onDidFail = { _, _ in
-            XCTFail("delegate.didFail() should never be called.")
-        }
-        sut.delegate = delegate
+        // When
+        proxy.present(on: self)
+        proxy.enterSecurityCode("737")
+        proxy.tapPayButton()
 
-        presentOnRoot(sut.viewController)
-        
-        let alertController = try XCTUnwrap(sut.viewController as? UIAlertController)
-        let textField: UITextField! = try XCTUnwrap(alertController.textFields?.first)
-        XCTAssertNotNil(textField)
+        // Then
+        waitForExpectations(timeout: 1)
 
-        textField?.text = "737"
-        textField?.sendActions(for: .editingChanged)
+        let args = try XCTUnwrap(delegate.didSubmitReceivedArguments)
+        XCTAssertTrue(args.component === proxy.component)
 
-        let payAction = try XCTUnwrap(alertController.actions.first { $0.title == localizedSubmitButtonTitle(with: context.amount, style: .immediate, nil) })
+        let cardDetails = try XCTUnwrap(args.data.paymentMethod as? CardDetails)
+        XCTAssertNotNil(cardDetails.encryptedSecurityCode)
+        XCTAssertNil(cardDetails.encryptedCardNumber)
+        XCTAssertNil(cardDetails.encryptedExpiryYear)
+        XCTAssertNil(cardDetails.encryptedExpiryMonth)
 
-        payAction.tap()
-        
-        XCTAssertTrue(try XCTUnwrap(textField?.text?.isEmpty))
-        XCTAssertFalse(payAction.isEnabled)
-
-        alertController.dismiss(animated: false, completion: nil)
-        
-        waitForExpectations(timeout: 10, handler: nil)
+        XCTAssertTrue(proxy.securityCodeText?.isEmpty == true)
+        XCTAssertFalse(proxy.isPayButtonEnabled)
     }
 
+    /// Verifies that encryption failure with an invalid public key calls didFail on the delegate.
     func testPaymentSubmitWithInvalidPublicKey() throws {
-        let contextWithInvalidKey = AdyenContext(
-            apiContext: Dummy.apiContext,
-            amount: Dummy.amount,
-            publicKey: "invalid_key",
-            analyticsProvider: AnalyticsProviderMock()
-        )
-        let sut = StoredCardComponent(storedCardPaymentMethod: method, context: contextWithInvalidKey, theme: CheckoutTheme())
-
+        // Given
+        let proxy = makeSUT(publicKey: "invalid_key")
         let delegate = PaymentComponentDelegateMock()
-        delegate.onDidSubmit = { _, _ in
-            XCTFail("delegate.didSubmit() should never be called.")
-        }
-        let delegateExpectation = expectation(description: "expect delegate to be called.")
-        delegate.onDidFail = { error, component in
-            XCTAssertTrue(component === sut)
-            delegateExpectation.fulfill()
-        }
-        sut.delegate = delegate
+        proxy.component.delegate = delegate
 
-        presentOnRoot(sut.viewController)
-        
-        let alertController = try XCTUnwrap(sut.viewController as? UIAlertController)
-        let textField: UITextField! = try XCTUnwrap(alertController.textFields?.first)
-        XCTAssertNotNil(textField)
+        let failExpectation = expectation(description: "Expect didFail to be called")
+        delegate.onDidSubmit = { _, _ in XCTFail("didSubmit should not be called") }
+        delegate.onDidFail = { _, _ in failExpectation.fulfill() }
 
-        textField.text = "737"
-        textField.sendActions(for: .editingChanged)
+        // When
+        proxy.present(on: self)
+        proxy.enterSecurityCode("737")
+        proxy.tapPayButton()
 
-        let payAction = try XCTUnwrap(alertController.actions.first { $0.title == localizedSubmitButtonTitle(with: context.amount, style: .immediate, nil) })
+        // Then
+        waitForExpectations(timeout: 1)
 
-        payAction.tap()
-
-        alertController.dismiss(animated: false, completion: nil)
-        waitForExpectations(timeout: 10, handler: nil)
+        let args = try XCTUnwrap(delegate.didFailReceivedArguments)
+        XCTAssertTrue(args.component === proxy.component)
     }
 
-    func testCVCLimitForAMEX() throws {
-        let method = StoredCardPaymentMethod(
-            type: .card,
-            name: "name",
-            identifier: "id",
-            fundingSource: .credit,
-            supportedShopperInteractions: [.shopperPresent],
-            brand: .americanExpress,
-            lastFour: "1234",
-            expiryMonth: "12",
-            expiryYear: "22",
-            holderName: "holderName"
-        )
-        let sut = StoredCardComponent(storedCardPaymentMethod: method, context: context, theme: CheckoutTheme())
+    // MARK: - CVC Validation
 
-        presentOnRoot(sut.viewController)
-        
-        let alertController = try XCTUnwrap(sut.viewController as? UIAlertController)
-        let textField: UITextField! = try XCTUnwrap(alertController.textFields?.first)
-        let payAction = try XCTUnwrap(alertController.actions.first { $0.title == localizedSubmitButtonTitle(with: context.amount, style: .immediate, nil) })
+    /// Verifies that AMEX cards require exactly 4 digits for the security code.
+    func testCVCLimitForAMEX() {
+        // Given
+        let proxy = makeSUT(brand: .americanExpress)
+        proxy.present(on: self)
 
-        textField.insertText("a")
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.text, "")
+        // When / Then - non-numeric characters are filtered
+        proxy.enterSecurityCode("a")
+        XCTAssertEqual(proxy.securityCodeText, "")
 
-        textField.insertText("1")
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.text, "1")
+        // When / Then - build up to 4 digits
+        proxy.enterSecurityCode("1")
+        XCTAssertEqual(proxy.securityCodeText, "1")
 
-        textField.insertText("1")
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.text, "11")
+        proxy.enterSecurityCode("11")
+        XCTAssertEqual(proxy.securityCodeText, "11")
 
-        textField.insertText("1")
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.text, "111")
-        
-        XCTAssertEqual(payAction.isEnabled, false)
+        proxy.enterSecurityCode("111")
+        XCTAssertEqual(proxy.securityCodeText, "111")
+        XCTAssertFalse(proxy.isPayButtonEnabled)
 
-        textField.insertText("1")
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.text, "1111")
-        XCTAssertEqual(payAction.isEnabled, true)
+        proxy.enterSecurityCode("1111")
+        XCTAssertEqual(proxy.securityCodeText, "1111")
+        XCTAssertTrue(proxy.isPayButtonEnabled)
 
-        textField.insertText("1")
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.text, "1111")
-
-        alertController.dismiss(animated: false, completion: nil)
+        // When / Then - cannot exceed 4 digits
+        proxy.enterSecurityCode("11111")
+        XCTAssertEqual(proxy.securityCodeText, "1111")
     }
 
-    func testCVCLimitForNonAMEX() throws {
-        let sut = StoredCardComponent(storedCardPaymentMethod: method, context: context, theme: CheckoutTheme())
+    /// Verifies that non-AMEX cards require exactly 3 digits for the security code.
+    func testCVCLimitForNonAMEX() {
+        // Given
+        let proxy = makeSUT(brand: .visa)
+        proxy.present(on: self)
 
-        presentOnRoot(sut.viewController)
-        
-        let alertController = try XCTUnwrap(sut.viewController as? UIAlertController)
-        let textField: UITextField! = try XCTUnwrap(alertController.textFields?.first)
-        let payAction = try XCTUnwrap(alertController.actions.first { $0.title == localizedSubmitButtonTitle(with: context.amount, style: .immediate, nil) })
+        // When / Then - build up to 3 digits
+        proxy.enterSecurityCode("11")
+        XCTAssertEqual(proxy.securityCodeText, "11")
 
-        textField.insertText("11")
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.text, "11")
+        proxy.enterSecurityCode("111")
+        XCTAssertEqual(proxy.securityCodeText, "111")
+        XCTAssertTrue(proxy.isPayButtonEnabled)
 
-        textField.insertText("1")
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.text, "111")
-        
-        XCTAssertEqual(payAction.isEnabled, true)
-
-        textField.insertText("1")
-        textField?.sendActions(for: .editingChanged)
-        XCTAssertEqual(textField.text, "111")
-        XCTAssertEqual(payAction.isEnabled, true)
-
-        alertController.dismiss(animated: false, completion: nil)
+        // When / Then - cannot exceed 3 digits
+        proxy.enterSecurityCode("1111")
+        XCTAssertEqual(proxy.securityCodeText, "111")
+        XCTAssertTrue(proxy.isPayButtonEnabled)
     }
 
+    // MARK: - Analytics
+
+    /// Verifies that accessing the view controller sends an initial analytics event.
     func testViewDidLoadShouldSendInitialEvent() {
         // Given
         let analyticsProviderMock = AnalyticsProviderMock()
-        let context = Dummy.context(analyticsProvider: analyticsProviderMock)
-        let paymentMethod = storedCardPaymentMethod(brand: .masterCard)
-        let sut = StoredCardComponent(
-            storedCardPaymentMethod: paymentMethod,
-            context: context,
-            theme: CheckoutTheme()
-        )
+        let proxy = makeSUT(analyticsProvider: analyticsProviderMock)
 
         // When
-        sut.viewController.viewDidLoad()
+        _ = proxy.component.viewController
 
         // Then
         XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)
     }
 
-    // MARK: - Private
+    // MARK: - Helpers
 
-    private func storedCardPaymentMethod(brand: CardType) -> StoredCardPaymentMethod {
-        .init(
+    private func makeSUT(
+        brand: CardType = .visa,
+        publicKey: String = Dummy.publicKey,
+        analyticsProvider: AnyAnalyticsProvider? = nil
+    ) -> StoredCardComponentProxy {
+        let paymentMethod = StoredCardPaymentMethod(
             type: .card,
             name: "name",
             identifier: "id",
@@ -235,8 +171,93 @@ class StoredCardComponentTests: XCTestCase {
             expiryYear: "22",
             holderName: "holderName"
         )
+
+        let context = AdyenContext(
+            apiContext: Dummy.apiContext,
+            amount: Dummy.amount,
+            publicKey: publicKey,
+            analyticsProvider: analyticsProvider ?? AnalyticsProviderMock()
+        )
+
+        let component = StoredCardComponent(
+            storedCardPaymentMethod: paymentMethod,
+            context: context,
+            theme: CheckoutTheme()
+        )
+
+        return StoredCardComponentProxy(component: component, context: context)
     }
 }
+
+// MARK: - StoredCardComponentProxy
+
+/// A test proxy that abstracts the UI implementation details of StoredCardComponent.
+/// This allows tests to be agnostic to whether the component uses UIAlertController
+/// or StoredCardInputViewController underneath.
+@MainActor
+final class StoredCardComponentProxy {
+
+    let component: StoredCardComponent
+    let context: AdyenContext
+
+    init(component: StoredCardComponent, context: AdyenContext) {
+        self.component = component
+        self.context = context
+    }
+
+    // MARK: - Presentation
+
+    func present(on testCase: XCTestCase) {
+        testCase.presentOnRoot(component.viewController)
+    }
+
+    // MARK: - Security Code
+
+    var securityCodeText: String? {
+        alertTextField?.text
+    }
+
+    func enterSecurityCode(_ code: String) {
+        guard let textField = alertTextField else { return }
+        textField.text = code
+        textField.sendActions(for: .editingChanged)
+    }
+
+    // MARK: - Buttons
+
+    var hasCancelButton: Bool {
+        alertController?.actions.contains { $0.title == localizedString(.cancelButton, nil) } ?? false
+    }
+
+    var hasPayButton: Bool {
+        payAction != nil
+    }
+
+    var isPayButtonEnabled: Bool {
+        payAction?.isEnabled ?? false
+    }
+
+    func tapPayButton() {
+        payAction?.tap()
+    }
+
+    // MARK: - Private (UIAlertController implementation)
+
+    private var alertController: UIAlertController? {
+        component.viewController as? UIAlertController
+    }
+
+    private var alertTextField: UITextField? {
+        alertController?.textFields?.first
+    }
+
+    private var payAction: UIAlertAction? {
+        let buttonTitle = localizedSubmitButtonTitle(with: context.amount, style: .immediate, nil)
+        return alertController?.actions.first { $0.title == buttonTitle }
+    }
+}
+
+// MARK: - UIAlertAction+Tap
 
 extension UIAlertAction {
     typealias AlertHandler = @convention(block) (UIAlertAction) -> Void

--- a/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
@@ -194,9 +194,6 @@ class StoredCardComponentTests: XCTestCase {
 
 // MARK: - StoredCardComponentProxy
 
-/// A test proxy that abstracts the UI implementation details of StoredCardComponent.
-/// This allows tests to be agnostic to whether the component uses UIAlertController
-/// or StoredCardInputViewController underneath.
 @MainActor
 final class StoredCardComponentProxy {
 

--- a/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
@@ -45,7 +45,7 @@ class StoredCardComponentTests: XCTestCase {
 
         // When
         proxy.present()
-        proxy.enterSecurityCode("737")
+        proxy.enterText("737")
         proxy.tapPayButton()
 
         // Then
@@ -78,7 +78,7 @@ class StoredCardComponentTests: XCTestCase {
 
         // When
         proxy.present()
-        proxy.enterSecurityCode("737")
+        proxy.enterText("737")
         proxy.tapPayButton()
 
         // Then
@@ -98,26 +98,26 @@ class StoredCardComponentTests: XCTestCase {
         proxy.present()
 
         // When / Then - non-numeric characters are filtered
-        proxy.enterSecurityCode("a")
+        proxy.enterText("a")
         XCTAssertEqual(proxy.securityCodeText, "")
 
         // When / Then - build up to 4 digits
-        proxy.enterSecurityCode("1")
+        proxy.enterText("1")
         XCTAssertEqual(proxy.securityCodeText, "1")
 
-        proxy.enterSecurityCode("11")
+        proxy.enterText("1")
         XCTAssertEqual(proxy.securityCodeText, "11")
 
-        proxy.enterSecurityCode("111")
+        proxy.enterText("1")
         XCTAssertEqual(proxy.securityCodeText, "111")
         XCTAssertFalse(proxy.isPayButtonEnabled)
 
-        proxy.enterSecurityCode("1111")
+        proxy.enterText("1")
         XCTAssertEqual(proxy.securityCodeText, "1111")
         XCTAssertTrue(proxy.isPayButtonEnabled)
 
         // When / Then - cannot exceed 4 digits
-        proxy.enterSecurityCode("11111")
+        proxy.enterText("1")
         XCTAssertEqual(proxy.securityCodeText, "1111")
     }
 
@@ -129,15 +129,15 @@ class StoredCardComponentTests: XCTestCase {
         proxy.present()
 
         // When / Then - build up to 3 digits
-        proxy.enterSecurityCode("11")
+        proxy.enterText("11")
         XCTAssertEqual(proxy.securityCodeText, "11")
 
-        proxy.enterSecurityCode("111")
+        proxy.enterText("1")
         XCTAssertEqual(proxy.securityCodeText, "111")
         XCTAssertTrue(proxy.isPayButtonEnabled)
 
         // When / Then - cannot exceed 3 digits
-        proxy.enterSecurityCode("1111")
+        proxy.enterText("1")
         XCTAssertEqual(proxy.securityCodeText, "111")
         XCTAssertTrue(proxy.isPayButtonEnabled)
     }
@@ -217,16 +217,16 @@ final class StoredCardComponentProxy {
         alertTextField?.text
     }
 
-    func enterSecurityCode(_ code: String) {
+    func enterText(_ code: String) {
         guard let textField = alertTextField else { return }
-        textField.text = code
+        code.forEach { textField.insertText(String($0)) }
         textField.sendActions(for: .editingChanged)
     }
 
     // MARK: - Buttons
 
     var hasCancelButton: Bool {
-        alertController?.actions.contains { $0.title == localizedString(.cancelButton, nil) } ?? false
+        alertController?.actions.contains { $0.title == localizedString(.cancelButton, component.localizationParameters) } ?? false
     }
 
     var hasPayButton: Bool {
@@ -252,7 +252,7 @@ final class StoredCardComponentProxy {
     }
 
     private var payAction: UIAlertAction? {
-        let buttonTitle = localizedSubmitButtonTitle(with: component.context.amount, style: .immediate, nil)
+        let buttonTitle = localizedSubmitButtonTitle(with: component.context.amount, style: .immediate, component.localizationParameters)
         return alertController?.actions.first { $0.title == buttonTitle }
     }
 }

--- a/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
@@ -17,10 +17,11 @@ class StoredCardComponentTests: XCTestCase {
     /// Verifies that the component displays a security code field, cancel button, and pay button.
     func testUIWithClientKey() {
         // Given
-        let proxy = makeSUT()
+        let sut = makeSUT()
+        let proxy = StoredCardComponentProxy(component: sut, testCase: self)
 
         // When
-        proxy.present(on: self)
+        proxy.present()
 
         // Then
         XCTAssertNotNil(proxy.securityCodeText)
@@ -33,16 +34,17 @@ class StoredCardComponentTests: XCTestCase {
     /// Verifies that submitting a valid security code encrypts and submits card details to the delegate.
     func testPaymentSubmitWithValidPublicKey() throws {
         // Given
-        let proxy = makeSUT()
+        let sut = makeSUT()
+        let proxy = StoredCardComponentProxy(component: sut, testCase: self)
         let delegate = PaymentComponentDelegateMock()
-        proxy.component.delegate = delegate
+        sut.delegate = delegate
 
         let submitExpectation = expectation(description: "Expect didSubmit to be called")
         delegate.onDidSubmit = { _, _ in submitExpectation.fulfill() }
         delegate.onDidFail = { _, _ in XCTFail("didFail should not be called") }
 
         // When
-        proxy.present(on: self)
+        proxy.present()
         proxy.enterSecurityCode("737")
         proxy.tapPayButton()
 
@@ -50,7 +52,7 @@ class StoredCardComponentTests: XCTestCase {
         waitForExpectations(timeout: 1)
 
         let args = try XCTUnwrap(delegate.didSubmitReceivedArguments)
-        XCTAssertTrue(args.component === proxy.component)
+        XCTAssertTrue(args.component === sut)
 
         let cardDetails = try XCTUnwrap(args.data.paymentMethod as? CardDetails)
         XCTAssertNotNil(cardDetails.encryptedSecurityCode)
@@ -65,16 +67,17 @@ class StoredCardComponentTests: XCTestCase {
     /// Verifies that encryption failure with an invalid public key calls didFail on the delegate.
     func testPaymentSubmitWithInvalidPublicKey() throws {
         // Given
-        let proxy = makeSUT(publicKey: "invalid_key")
+        let sut = makeSUT(publicKey: "invalid_key")
+        let proxy = StoredCardComponentProxy(component: sut, testCase: self)
         let delegate = PaymentComponentDelegateMock()
-        proxy.component.delegate = delegate
+        sut.delegate = delegate
 
         let failExpectation = expectation(description: "Expect didFail to be called")
         delegate.onDidSubmit = { _, _ in XCTFail("didSubmit should not be called") }
         delegate.onDidFail = { _, _ in failExpectation.fulfill() }
 
         // When
-        proxy.present(on: self)
+        proxy.present()
         proxy.enterSecurityCode("737")
         proxy.tapPayButton()
 
@@ -82,7 +85,7 @@ class StoredCardComponentTests: XCTestCase {
         waitForExpectations(timeout: 1)
 
         let args = try XCTUnwrap(delegate.didFailReceivedArguments)
-        XCTAssertTrue(args.component === proxy.component)
+        XCTAssertTrue(args.component === sut)
     }
 
     // MARK: - CVC Validation
@@ -90,8 +93,9 @@ class StoredCardComponentTests: XCTestCase {
     /// Verifies that AMEX cards require exactly 4 digits for the security code.
     func testCVCLimitForAMEX() {
         // Given
-        let proxy = makeSUT(brand: .americanExpress)
-        proxy.present(on: self)
+        let sut = makeSUT(brand: .americanExpress)
+        let proxy = StoredCardComponentProxy(component: sut, testCase: self)
+        proxy.present()
 
         // When / Then - non-numeric characters are filtered
         proxy.enterSecurityCode("a")
@@ -120,8 +124,9 @@ class StoredCardComponentTests: XCTestCase {
     /// Verifies that non-AMEX cards require exactly 3 digits for the security code.
     func testCVCLimitForNonAMEX() {
         // Given
-        let proxy = makeSUT(brand: .visa)
-        proxy.present(on: self)
+        let sut = makeSUT(brand: .visa)
+        let proxy = StoredCardComponentProxy(component: sut, testCase: self)
+        proxy.present()
 
         // When / Then - build up to 3 digits
         proxy.enterSecurityCode("11")
@@ -143,10 +148,10 @@ class StoredCardComponentTests: XCTestCase {
     func testViewDidLoadShouldSendInitialEvent() {
         // Given
         let analyticsProviderMock = AnalyticsProviderMock()
-        let proxy = makeSUT(analyticsProvider: analyticsProviderMock)
+        let sut = makeSUT(analyticsProvider: analyticsProviderMock)
 
         // When
-        _ = proxy.component.viewController
+        _ = sut.viewController
 
         // Then
         XCTAssertEqual(analyticsProviderMock.initialEventCallsCount, 1)
@@ -158,7 +163,7 @@ class StoredCardComponentTests: XCTestCase {
         brand: CardType = .visa,
         publicKey: String = Dummy.publicKey,
         analyticsProvider: AnyAnalyticsProvider? = nil
-    ) -> StoredCardComponentProxy {
+    ) -> StoredCardComponent {
         let paymentMethod = StoredCardPaymentMethod(
             type: .card,
             name: "name",
@@ -179,13 +184,11 @@ class StoredCardComponentTests: XCTestCase {
             analyticsProvider: analyticsProvider ?? AnalyticsProviderMock()
         )
 
-        let component = StoredCardComponent(
+        return StoredCardComponent(
             storedCardPaymentMethod: paymentMethod,
             context: context,
             theme: CheckoutTheme()
         )
-
-        return StoredCardComponentProxy(component: component, context: context)
     }
 }
 
@@ -198,16 +201,16 @@ class StoredCardComponentTests: XCTestCase {
 final class StoredCardComponentProxy {
 
     let component: StoredCardComponent
-    let context: AdyenContext
+    private let testCase: XCTestCase
 
-    init(component: StoredCardComponent, context: AdyenContext) {
+    init(component: StoredCardComponent, testCase: XCTestCase) {
         self.component = component
-        self.context = context
+        self.testCase = testCase
     }
 
     // MARK: - Presentation
 
-    func present(on testCase: XCTestCase) {
+    func present() {
         testCase.presentOnRoot(component.viewController)
     }
 
@@ -252,7 +255,7 @@ final class StoredCardComponentProxy {
     }
 
     private var payAction: UIAlertAction? {
-        let buttonTitle = localizedSubmitButtonTitle(with: context.amount, style: .immediate, nil)
+        let buttonTitle = localizedSubmitButtonTitle(with: component.context.amount, style: .immediate, nil)
         return alertController?.actions.first { $0.title == buttonTitle }
     }
 }

--- a/Tests/IntegrationTests/Card Tests/StoredCardInputViewModelTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardInputViewModelTests.swift
@@ -248,6 +248,64 @@ struct StoredCardInputViewModelTests {
         #expect(!sut.inProgress)
     }
 
+    // MARK: - Custom Localization
+
+    /// Verifies that the view model correctly uses custom localization strings when a custom table name is provided.
+    ///
+    /// This test ensures merchants can override the default SDK strings by providing their own `.strings` file.
+    /// The test uses `AdyenUIHost.strings` which contains custom translations prefixed with "Test-".
+    @Test
+    func localizationWithCustomTableName() {
+        // Given
+        let localizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
+        let amount = Amount(value: 300, currencyCode: "EUR")
+        let sut = makeSUT(
+            name: "VISA",
+            lastFour: "1111",
+            amount: amount,
+            localizationParameters: localizationParameters
+        )
+
+        let expectedTitleText = "Test-Enter security code"
+        let expectedSubtitleText = "Test-Enter the security code for VISA \(String.Adyen.securedString)1111"
+        let expectedSubmitButtonTitle = "Test-Pay €3.00"
+
+        // Then
+        #expect(sut.titleText == expectedTitleText)
+        #expect(sut.subtitleText.string == expectedSubtitleText)
+        #expect(sut.submitButtonTitle == expectedSubmitButtonTitle)
+    }
+
+    /// Verifies that the view model correctly handles custom key separators in localization keys.
+    ///
+    /// This test ensures the SDK supports alternative key formats where dots (`.`) are replaced with
+    /// underscores (`_`) or other separators. This is useful for merchants whose localization systems
+    /// don't support dots in key names.
+    ///
+    /// The test uses `AdyenUIHostCustomSeparator.strings` where keys use underscores instead of dots
+    /// (e.g., `adyen_card_securityCode_title` instead of `adyen.card.securityCode.title`).
+    @Test
+    func localizationWithCustomKeySeparator() {
+        // Given
+        let localizationParameters = LocalizationParameters(tableName: "AdyenUIHostCustomSeparator", keySeparator: "_")
+        let amount = Amount(value: 300, currencyCode: "EUR")
+        let sut = makeSUT(
+            name: "VISA",
+            lastFour: "1111",
+            amount: amount,
+            localizationParameters: localizationParameters
+        )
+
+        let expectedTitleText = "Test-Enter security code"
+        let expectedSubtitleText = "Test-Enter the security code for VISA \(String.Adyen.securedString)1111"
+        let expectedSubmitButtonTitle = "Test-Pay €3.00"
+
+        // Then
+        #expect(sut.titleText == expectedTitleText)
+        #expect(sut.subtitleText.string == expectedSubtitleText)
+        #expect(sut.submitButtonTitle == expectedSubmitButtonTitle)
+    }
+
     // MARK: - Helpers
 
     private func makeSUT(
@@ -256,7 +314,8 @@ struct StoredCardInputViewModelTests {
         brand: CardType = .visa,
         amount: Amount? = Amount(value: 100, currencyCode: "EUR"),
         publicKey: String = Dummy.publicKey,
-        analyticsProvider: AnyAnalyticsProvider? = AnalyticsProviderMock()
+        analyticsProvider: AnyAnalyticsProvider? = AnalyticsProviderMock(),
+        localizationParameters: LocalizationParameters? = nil
     ) -> StoredCardInputViewModel {
         let storedCardPaymentMethod = StoredCardPaymentMethod(
             type: .card,
@@ -278,7 +337,7 @@ struct StoredCardInputViewModelTests {
             publicKey: publicKey,
             amount: amount,
             analyticsProvider: analyticsProvider,
-            localizationParameters: nil
+            localizationParameters: localizationParameters
         )
     }
 }

--- a/Tests/IntegrationTests/Card Tests/StoredCardInputViewModelTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardInputViewModelTests.swift
@@ -70,7 +70,7 @@ struct StoredCardInputViewModelTests {
         // Given
         let amount = Amount(value: 14098, currencyCode: "USD")
         let expectedTitle = "Enter security code"
-        let expectedSubTitle = "Enter the security code for VISA •••• 4556"
+        let expectedSubTitle = "Enter the security code for VISA \(String.Adyen.securedString)4556"
         let expectedButtonTitle = "Pay $140.98"
         let sut = makeSUT(name: "VISA", lastFour: "4556", amount: amount)
 
@@ -85,7 +85,7 @@ struct StoredCardInputViewModelTests {
         // Given
         let amount = Amount(value: 0, currencyCode: "USD")
         let expectedTitle = "Enter security code"
-        let expectedSubTitle = "Enter the security code for VISA •••• 4556"
+        let expectedSubTitle = "Enter the security code for VISA \(String.Adyen.securedString)4556"
         let expectedButtonTitle = "Confirm preauthorization"
         let sut = makeSUT(name: "VISA", lastFour: "4556", amount: amount)
 
@@ -99,7 +99,7 @@ struct StoredCardInputViewModelTests {
     func textUI_WhenAmountIsNil() {
         // Given
         let expectedTitle = "Enter security code"
-        let expectedSubTitle = "Enter the security code for VISA •••• 4556"
+        let expectedSubTitle = "Enter the security code for VISA \(String.Adyen.securedString)4556"
         let expectedButtonTitle = "Pay"
         let sut = makeSUT(name: "VISA", lastFour: "4556", amount: nil)
 

--- a/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentMethod/PreselectedPaymentMethodIntegrationTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentMethod/PreselectedPaymentMethodIntegrationTests.swift
@@ -26,8 +26,7 @@ struct PreselectedPaymentMethodIntegrationTests {
         preSelectedViewController.load()
         // Expected in the UI
 
-        // TODO: Robert: This is a strange failure, it never seems to match even if the strings are the same.
-        // try #expect(preSelectedViewController.primaryTitleText == testData.expectedTitle, "Card number")
+        try #expect(preSelectedViewController.primaryTitleText == testData.expectedTitle, "Card number")
         try #expect(preSelectedViewController.subTitleText == testData.expectedSubTitleText, "Use payment.method")
         try #expect(preSelectedViewController.submitButtonText == testData.submitButtonText, "Pay button title is incorrect")
         try #expect(preSelectedViewController.showAllPaymentMethodsButtonText == testData.showAllPaymentMethodsButtonText, "Other Payment methods")
@@ -311,8 +310,8 @@ struct PreselectedPaymentMethodIntegrationTests {
 
         var expectedTitle: String {
             switch self {
-            case .visa, .visaWithoutAmount, .visaWithZeroAmount: "•••• 1111"
-            case .bcmc, .initiableBCMC: "•••• 4449"
+            case .visa, .visaWithoutAmount, .visaWithZeroAmount: "\(String.Adyen.securedString)1111"
+            case .bcmc, .initiableBCMC: "\(String.Adyen.securedString)4449"
             }
         }
 


### PR DESCRIPTION
# Summary [Required]

1. Refactored StoredCardComponentTests to use a StoredCardCompoentProxy which encapsulates whatever the underlying view is displayed. (I need to do this first before removing AlertManager and connecting the StoredCardInputViewController)
2. Added 2 tests `localizationWithCustomTableName` & `localizationWithCustomKeySeparator` to the `StoredCardInputViewModel`.
3. Fixed a todo on matching secured strings `TODO: Robert: This is a strange failure, it never seems to match even if the strings are the same `

COSDK-1140

# what next?

1. Remove StoredCardAlertManager and switch to using StoredCardInputViewController
2. Add support for Amex(4 digit) cvv for StoredCardInputController

## Checklist [Required]
- [x] Tested changes locally
- [x] Added/updated unit tests
