### PR TITLE
Localization: Phase 3.1 - Card localization provider coverage

### DIFF
--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -2550,6 +2550,24 @@ extension CardComponentTests {
         XCTAssertEqual(sut.cardViewController.items.numberContainerItem.numberItem.title, "Custom number")
     }
 
+    func test_cardComponent_withProviderOverride_shouldRenderCustomSecurityCodeTitle() {
+        var configuration = CardComponentConfiguration()
+        configuration.localizationProvider = CardLocalizationProviderMock(values: [.cardSecurityCode: "Custom security code"])
+
+        let sut = CardComponent(paymentMethod: method, context: context, configuration: configuration)
+
+        XCTAssertEqual(sut.cardViewController.items.securityCodeItem.title, "Custom security code")
+    }
+
+    func test_cardComponent_withProviderOverride_shouldRenderCustomStorePaymentMethodTitle() {
+        var configuration = CardComponentConfiguration()
+        configuration.localizationProvider = CardLocalizationProviderMock(values: [.cardStorePaymentMethod: "Remember this card"])
+
+        let sut = CardComponent(paymentMethod: method, context: context, configuration: configuration)
+
+        XCTAssertEqual(sut.cardViewController.items.storeDetailsItem.title, "Remember this card")
+    }
+
     func test_cardComponent_withProviderReturningNil_shouldFallbackToSDKLocalization() {
         var configuration = CardComponentConfiguration()
         configuration.localizationProvider = CardLocalizationProviderMock(values: [:])

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -275,7 +275,51 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         XCTAssertEqual(localizationProvider.localizedString(CheckoutLocalizationKey.cardNumber, locale: locale), "Localized card number")
         XCTAssertEqual(provider.recordedCalls.count, 1)
         XCTAssertEqual(provider.recordedCalls.first?.locale.identifier, locale.identifier)
-        XCTAssertEqual(provider.recordedCalls.first?.key, CheckoutLocalizationKey.cardNumber)
+        XCTAssertTrue(provider.recordedCalls.contains { $0.key == CheckoutLocalizationKey.cardNumber })
+    }
+
+    func test_cardComponent_withLocalizationProviderOnCheckoutConfiguration_shouldRenderGlobalProviderValue() throws {
+        // Given
+        let paymentMethod = try XCTUnwrap(createCardPaymentMethod())
+        let provider = CheckoutLocalizationProviderMock(result: "Global number")
+        checkoutConfiguration = makeCheckoutConfiguration().localizationProvider(provider)
+
+        // When
+        let component = CheckoutComponentBuilder.build(
+            for: paymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+
+        // Then
+        let cardComponent = try XCTUnwrap(component as? CardComponent)
+        XCTAssertEqual(cardComponent.cardViewController.items.numberContainerItem.numberItem.title, "Global number")
+        XCTAssertTrue(provider.recordedCalls.contains { $0.key == CheckoutLocalizationKey.cardNumber })
+    }
+
+    func test_cardComponent_withComponentLevelLocalizationProvider_shouldOverrideCheckoutConfigurationProvider() throws {
+        // Given
+        let paymentMethod = try XCTUnwrap(createCardPaymentMethod())
+        let globalProvider = CheckoutLocalizationProviderMock(result: "Global number")
+        let componentProvider = CheckoutLocalizationProviderMock(result: "Component number")
+        var cardConfiguration = CardComponentConfiguration()
+        cardConfiguration.localizationProvider = componentProvider
+        checkoutConfiguration = makeCheckoutConfiguration(
+            configurations: [.payment(.scheme): cardConfiguration]
+        ).localizationProvider(globalProvider)
+
+        // When
+        let component = CheckoutComponentBuilder.build(
+            for: paymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+
+        // Then
+        let cardComponent = try XCTUnwrap(component as? CardComponent)
+        XCTAssertEqual(cardComponent.cardViewController.items.numberContainerItem.numberItem.title, "Component number")
+        XCTAssertTrue(componentProvider.recordedCalls.contains { $0.key == CheckoutLocalizationKey.cardNumber })
+        XCTAssertTrue(globalProvider.recordedCalls.isEmpty)
     }
     
     // MARK: - ACH Direct Debit Component Tests


### PR DESCRIPTION
# Summary 
This stacked follow-up PR adds the remaining Phase 3 localization coverage for the card flow. It verifies visible card strings already exposed through the localization provider API and covers checkout-level versus component-level provider precedence. This slice is test-only and keeps the production diff unchanged and reviewable.

✅ Phase 0 - [Localization: Add phase 0 baseline integration tests](https://github.com/Adyen/adyen-ios/pull/2463)
✅ Phase 1 - [Localization: internalize legacy APIs](https://github.com/Adyen/adyen-ios/pull/2470)
✅ Phase 2 - [Localization: Phase 2 - public API](https://github.com/Adyen/adyen-ios/pull/2477)
✅ Phase 3 - [Localization: Phase 3 - Card provider wiring](https://github.com/Adyen/adyen-ios/pull/2515)
➡️ Phase 3.1 - Add card provider coverage
Phase 4 - Unsupported locale warnings
Phase 5 - Final confidence pass for card alpha scope

## Ticket 
<ticket>
COSDK-1097
</ticket>

## Checklist 
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
