### PR TITLE
Update AnyPaymentMethodDecoder to enable IRIS as InstantPaymentMethod

### DIFF
--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethod.swift
@@ -19,7 +19,6 @@ internal enum AnyPaymentMethod: Codable {
     case storedPayTo(StoredPayToPaymentMethod)
 
     case instant(PaymentMethod)
-    case iris(InstantPaymentMethod)
     case card(AnyCardPaymentMethod)
     case issuerList(IssuerListPaymentMethod)
     case sepaDirectDebit(SEPADirectDebitPaymentMethod)
@@ -58,7 +57,6 @@ internal enum AnyPaymentMethod: Codable {
         case let .storedPayPal(paymentMethod): return paymentMethod
         case let .storedBCMC(paymentMethod): return paymentMethod
         case let .instant(paymentMethod): return paymentMethod
-        case let .iris(paymentMethod): return paymentMethod
         case let .storedInstant(paymentMethod): return paymentMethod
         case let .storedAchDirectDebit(paymentMethod): return paymentMethod
         case let .storedCashAppPay(paymentMethod): return paymentMethod

--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethod.swift
@@ -19,6 +19,7 @@ internal enum AnyPaymentMethod: Codable {
     case storedPayTo(StoredPayToPaymentMethod)
 
     case instant(PaymentMethod)
+    case iris(InstantPaymentMethod)
     case card(AnyCardPaymentMethod)
     case issuerList(IssuerListPaymentMethod)
     case sepaDirectDebit(SEPADirectDebitPaymentMethod)
@@ -57,6 +58,7 @@ internal enum AnyPaymentMethod: Codable {
         case let .storedPayPal(paymentMethod): return paymentMethod
         case let .storedBCMC(paymentMethod): return paymentMethod
         case let .instant(paymentMethod): return paymentMethod
+        case let .iris(paymentMethod): return paymentMethod
         case let .storedInstant(paymentMethod): return paymentMethod
         case let .storedAchDirectDebit(paymentMethod): return paymentMethod
         case let .storedCashAppPay(paymentMethod): return paymentMethod
@@ -117,14 +119,14 @@ internal enum AnyPaymentMethod: Codable {
 
 extension AnyPaymentMethod {
     
-    init(_ paymentMethod: PaymentMethod) {
+    internal init(_ paymentMethod: PaymentMethod) {
         self = AnyPaymentMethodDecoder.anyPaymentMethod(from: paymentMethod)
     }
 }
 
 extension PaymentMethod {
     
-    var toAnyPaymentMethod: AnyPaymentMethod {
+    internal var toAnyPaymentMethod: AnyPaymentMethod {
         .init(self)
     }
 }

--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
@@ -92,7 +92,8 @@ internal enum AnyPaymentMethodDecoder {
         .twint: TwintPaymentMethodDecoder(),
         .payByBankAISDD: PayByBankUSPaymentMethodDecoder(),
         .payTo: PayToPaymentMethodDecoder(),
-        .iris: IrisPaymentMethodDecoder()
+        .iris: IrisPaymentMethodDecoder(),
+        .ideal: InstantPaymentMethodDecoder()
     ]
     
     private static var defaultDecoder: PaymentMethodDecoder = InstantPaymentMethodDecoder()
@@ -105,18 +106,6 @@ internal enum AnyPaymentMethodDecoder {
             let brand = try? container.decode(String.self, forKey: .brand)
             let isIssuersList = try container.containsValue(.issuers)
             
-            if type == .ideal || type == .iris {
-                return try InstantPaymentMethodDecoder().decode(from: decoder, isStored: isStored)
-            }
-            
-            if isIssuersList {
-                if type == .onlineBankingCZ || type == .onlineBankingSK {
-                    return try OnlineBankingPaymentMethodDecoder().decode(from: decoder, isStored: isStored)
-                }
-                
-                return try IssuerListPaymentMethodDecoder().decode(from: decoder, isStored: isStored)
-            }
-
             // This is a hack to handle stored Bancontact as a separate
             // payment method, even though Bancontact is just another
             // scheme of a card payment method,
@@ -129,8 +118,17 @@ internal enum AnyPaymentMethodDecoder {
                 return try decoders[.bcmc, default: defaultDecoder].decode(from: decoder, isStored: true)
             }
             
-            let paymentDecoder = type.map { decoders[$0, default: defaultDecoder] } ?? defaultDecoder
-            return try paymentDecoder.decode(from: decoder, isStored: isStored)
+            // Use type-specific decoder if available
+            if let type, let paymentDecoder = decoders[type] {
+                return try paymentDecoder.decode(from: decoder, isStored: isStored)
+            }
+            
+            // Fallback: decode unknown payment methods with issuers as IssuerListPaymentMethod
+            if isIssuersList {
+                return try IssuerListPaymentMethodDecoder().decode(from: decoder, isStored: isStored)
+            }
+            
+            return try defaultDecoder.decode(from: decoder, isStored: isStored)
         } catch {
             return .none
         }

--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
@@ -92,7 +92,7 @@ internal enum AnyPaymentMethodDecoder {
         .twint: TwintPaymentMethodDecoder(),
         .payByBankAISDD: PayByBankUSPaymentMethodDecoder(),
         .payTo: PayToPaymentMethodDecoder(),
-        .iris: IrisPaymentMethodDecoder(),
+        .iris: InstantPaymentMethodDecoder(),
         .ideal: InstantPaymentMethodDecoder()
     ]
     
@@ -558,16 +558,6 @@ private struct PayToPaymentMethodDecoder: PaymentMethodDecoder {
         default:
             return nil
         }
-    }
-}
-
-private struct IrisPaymentMethodDecoder: PaymentMethodDecoder {
-    func decode(from decoder: Decoder, isStored: Bool) throws -> AnyPaymentMethod {
-        try .iris(InstantPaymentMethod(from: decoder))
-    }
-
-    func anyPaymentMethod(from paymentMethod: any PaymentMethod) -> AnyPaymentMethod? {
-        (paymentMethod as? InstantPaymentMethod).map { .iris($0) }
     }
 }
 

--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
@@ -91,7 +91,8 @@ internal enum AnyPaymentMethodDecoder {
         .cashAppPay: CashAppPayPaymentMethodDecoder(),
         .twint: TwintPaymentMethodDecoder(),
         .payByBankAISDD: PayByBankUSPaymentMethodDecoder(),
-        .payTo: PayToPaymentMethodDecoder()
+        .payTo: PayToPaymentMethodDecoder(),
+        .iris: IrisPaymentMethodDecoder()
     ]
     
     private static var defaultDecoder: PaymentMethodDecoder = InstantPaymentMethodDecoder()
@@ -104,7 +105,7 @@ internal enum AnyPaymentMethodDecoder {
             let brand = try? container.decode(String.self, forKey: .brand)
             let isIssuersList = try container.containsValue(.issuers)
             
-            if type == .ideal {
+            if type == .ideal || type == .iris {
                 return try InstantPaymentMethodDecoder().decode(from: decoder, isStored: isStored)
             }
             
@@ -559,6 +560,16 @@ private struct PayToPaymentMethodDecoder: PaymentMethodDecoder {
         default:
             return nil
         }
+    }
+}
+
+private struct IrisPaymentMethodDecoder: PaymentMethodDecoder {
+    func decode(from decoder: Decoder, isStored: Bool) throws -> AnyPaymentMethod {
+        try .iris(InstantPaymentMethod(from: decoder))
+    }
+
+    func anyPaymentMethod(from paymentMethod: any PaymentMethod) -> AnyPaymentMethod? {
+        (paymentMethod as? InstantPaymentMethod).map { .iris($0) }
     }
 }
 

--- a/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
+++ b/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
@@ -64,6 +64,7 @@ public enum PaymentMethodType: RawRepresentable, Hashable, Codable {
     case twint
     case payByBankAISDD
     case payTo
+    case iris
     case other(String)
     
     // Unsupported
@@ -214,6 +215,7 @@ public enum PaymentMethodType: RawRepresentable, Hashable, Codable {
         case .twint: return "twint"
         case .payByBankAISDD: return "paybybank_AIS_DD"
         case .payTo: return "payto"
+        case .iris: return "iris"
         case let .other(value): return value
         }
     }
@@ -289,6 +291,7 @@ extension PaymentMethodType {
         case .twint: return "twint"
         case .payByBankAISDD: return "Pay By Bank Direct Debit"
         case .payTo: return "payto"
+        case .iris: return "IRIS"
         case let .other(name): return name.replacingOccurrences(of: "_", with: " ")
         }
     }

--- a/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
+++ b/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
@@ -147,6 +147,7 @@ public enum PaymentMethodType: RawRepresentable, Hashable, Codable {
         case "twint": self = .twint
         case "paybybank_AIS_DD": self = .payByBankAISDD
         case "payto": self = .payTo
+        case "iris": self = .iris
         default: self = .other(rawValue)
         }
     }

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -84,7 +84,8 @@ class PaymentMethodTests: XCTestCase {
                 upi,
                 cashAppPay,
                 idealDictionary,
-                payto
+                payto,
+                irisDictionary
             ]
         ]
     }
@@ -183,7 +184,7 @@ class PaymentMethodTests: XCTestCase {
         
         // Regular payment methods
         
-        XCTAssertEqual(paymentMethods.regular.count, 36)
+        XCTAssertEqual(paymentMethods.regular.count, 37)
 
         let creditCardPaymentMethod = try XCTUnwrap(paymentMethods.regular[0] as? CardPaymentMethod)
         XCTAssertEqual(creditCardPaymentMethod.fundingSource, .credit)
@@ -342,6 +343,11 @@ class PaymentMethodTests: XCTestCase {
         XCTAssertTrue(paymentMethods.regular[35] is PayToPaymentMethod)
         XCTAssertEqual(paymentMethods.regular[35].name, "payto")
         XCTAssertEqual(paymentMethods.regular[35].type.rawValue, "payto")
+        
+        // IRIS has issuers but should decode as InstantPaymentMethod, not IssuerListPaymentMethod
+        XCTAssertTrue(paymentMethods.regular[36] is InstantPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[36].type.rawValue, "iris")
+        XCTAssertEqual(paymentMethods.regular[36].name, "IRIS")
     }
     
     // MARK: - Display Information Override

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -336,8 +336,9 @@ class PaymentMethodTests: XCTestCase {
         XCTAssertEqual(cashAppPay.clientId, "testClient")
         XCTAssertEqual(cashAppPay.scopeId, "testScope")
         
+        // iDEAL has issuers but should decode as InstantPaymentMethod, not IssuerListPaymentMethod
         XCTAssertTrue(paymentMethods.regular[34] is InstantPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[34].type.rawValue, "ideal")
+        XCTAssertEqual(paymentMethods.regular[34].type, .ideal)
         XCTAssertEqual(paymentMethods.regular[34].name, "iDeal")
 
         XCTAssertTrue(paymentMethods.regular[35] is PayToPaymentMethod)

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -337,18 +337,18 @@ class PaymentMethodTests: XCTestCase {
         XCTAssertEqual(cashAppPay.scopeId, "testScope")
         
         // iDEAL has issuers but should decode as InstantPaymentMethod, not IssuerListPaymentMethod
-        XCTAssertTrue(paymentMethods.regular[34] is InstantPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[34].type, .ideal)
-        XCTAssertEqual(paymentMethods.regular[34].name, "iDeal")
+        let iDealPaymentMethod = try XCTUnwrap(paymentMethods.regular[34] as? InstantPaymentMethod)
+        XCTAssertEqual(iDealPaymentMethod.type, .ideal)
+        XCTAssertEqual(iDealPaymentMethod.name, "iDeal")
 
-        XCTAssertTrue(paymentMethods.regular[35] is PayToPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[35].name, "payto")
-        XCTAssertEqual(paymentMethods.regular[35].type.rawValue, "payto")
-        
+        let payToPaymentMethod = try XCTUnwrap(paymentMethods.regular[35] as? PayToPaymentMethod)
+        XCTAssertEqual(payToPaymentMethod.type.rawValue, "payto")
+        XCTAssertEqual(payToPaymentMethod.name, "payto")
+
         // IRIS has issuers but should decode as InstantPaymentMethod, not IssuerListPaymentMethod
-        XCTAssertTrue(paymentMethods.regular[36] is InstantPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[36].type, .iris)
-        XCTAssertEqual(paymentMethods.regular[36].name, "IRIS")
+        let irisPaymentMethod = try XCTUnwrap(paymentMethods.regular[36] as? InstantPaymentMethod)
+        XCTAssertEqual(irisPaymentMethod.type, .iris)
+        XCTAssertEqual(irisPaymentMethod.name, "IRIS")
     }
     
     // MARK: - Display Information Override

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -346,7 +346,7 @@ class PaymentMethodTests: XCTestCase {
         
         // IRIS has issuers but should decode as InstantPaymentMethod, not IssuerListPaymentMethod
         XCTAssertTrue(paymentMethods.regular[36] is InstantPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[36].type.rawValue, "iris")
+        XCTAssertEqual(paymentMethods.regular[36].type, .iris)
         XCTAssertEqual(paymentMethods.regular[36].name, "IRIS")
     }
     

--- a/Tests/UnitTests/Mocks/DummyData/DummyPaymentMethods.swift
+++ b/Tests/UnitTests/Mocks/DummyData/DummyPaymentMethods.swift
@@ -78,7 +78,11 @@ let applePayDictionary = [
 
 let idealDictionary = [
     "type": "ideal",
-    "name": "iDeal"
+    "name": "iDeal",
+    "issuers": [
+        ["id": "1121", "name": "Test Issuer"],
+        ["id": "1154", "name": "Test Issuer 2"]
+    ]
 ] as [String: Any]
 
 let irisDictionary = [

--- a/Tests/UnitTests/Mocks/DummyData/DummyPaymentMethods.swift
+++ b/Tests/UnitTests/Mocks/DummyData/DummyPaymentMethods.swift
@@ -81,6 +81,16 @@ let idealDictionary = [
     "name": "iDeal"
 ] as [String: Any]
 
+let irisDictionary = [
+    "type": "iris",
+    "name": "IRIS",
+    "issuers": [
+        ["id": "PIRBGRAA", "name": "Piraeus Bank"],
+        ["id": "ERBKGRAA", "name": "Eurobank"],
+        ["id": "ETHNGRAA", "name": "National Bank of Greece"]
+    ]
+] as [String: Any]
+
 let bcmcCardDictionary = [
     "name": "Bancontact card",
     "supportsRecurring": true,


### PR DESCRIPTION
### Summary
- Added IRIS as a supported payment method, decoded as `InstantPaymentMethod` (same as iDEAL)
- Refactored `AnyPaymentMethodDecoder.decode()` to prioritize type-specific decoders from the dictionary
- Moved `isIssuersList` handling to a fallback for unknown payment methods with issuers

### Why
- Cleaner, data-driven approach via the decoder dictionary
- Removes special-case branching for individual payment methods
- `isIssuersList` now only catches truly unknown payment methods with issuers

### Testing
- Added IRIS test data with issuers to verify it decodes as `InstantPaymentMethod`, not `IssuerListPaymentMethod`

### Demo

This is a demo of IRIS as a Hosted Checkout component.


https://github.com/user-attachments/assets/d9eb6d4f-f45b-4c84-bf11-280fe635fc56


## Ticket
<ticket>
COSDK-1149
</ticket>

## Checklist
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
