### PR TITLE
Apple pay payment method change callback

### DIFF
--- a/Adyen/ResponseModels/CheckoutPaymentsResponse.swift
+++ b/Adyen/ResponseModels/CheckoutPaymentsResponse.swift
@@ -70,12 +70,17 @@ public struct CheckoutResult {
 }
 
 /// Wrapper type to contain checkout related errors.
-// TODO: if not needed, can remove?
-public struct CheckoutError: Error {
+// TODO: Convert to fully implemented CheckoutError
+// and return non-sensitive messages.
+public struct CheckoutError: LocalizedError {
     
     private let error: Error
     
     public init(error: Error) {
         self.error = error
+    }
+    
+    public var errorDescription: String? {
+        error.localizedDescription
     }
 }

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -127,14 +127,14 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
         return PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: networks)
     }
     
+    // TODO: turn this into async, as now the sheet dismisses immediately
+    // before user can see the success checkmark on Apple Pay
     /// Resumes the suspended Apple Pay authorization so the sheet shows a success/failure animation
     /// and dismisses. Called by the Checkout layer once the backend payment result is known.
     ///
     /// - Parameters:
     ///   - success: `true` if the payment succeeded, `false` otherwise.
     ///   - completion: Invoked once the continuation has been resumed.
-    // TODO: turn this into async, as now the sheet dismisses immediately
-    // before user can see the success checkmark on Apple Pay
     public func didFinalize(with success: Bool, completion: (() -> Void)?) {
         resumeContinuation(success: success)
         completion?()

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -34,6 +34,15 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         await handleAuthorize(payment: payment)
     }
 
+    // MARK: - Payment Method (async)
+
+    public func paymentAuthorizationViewController(
+        _ controller: PKPaymentAuthorizationViewController,
+        didSelect paymentMethod: PKPaymentMethod
+    ) async -> PKPaymentRequestPaymentMethodUpdate {
+        await handlePaymentMethodChange(paymentMethod)
+    }
+
     // MARK: - Shipping Contact (async)
 
     public func paymentAuthorizationViewController(
@@ -117,7 +126,7 @@ extension ApplePayComponent {
         }
 
         let result = await onShippingContactChange(contact, paymentRequest.paymentSummaryItems)
-        result.paymentSummaryItems = validatedPaymentSummaryItems(from: result)
+        result.paymentSummaryItems = validSummaryItems(from: result)
         return result
     }
 
@@ -127,7 +136,7 @@ extension ApplePayComponent {
         }
 
         let result = await onShippingMethodChange(shippingMethod, paymentRequest.paymentSummaryItems)
-        result.paymentSummaryItems = validatedPaymentSummaryItems(from: result)
+        result.paymentSummaryItems = validSummaryItems(from: result)
         return result
     }
 
@@ -137,11 +146,21 @@ extension ApplePayComponent {
         }
 
         let result = await onCouponCodeChange(couponCode, paymentRequest.paymentSummaryItems)
-        result.paymentSummaryItems = validatedPaymentSummaryItems(from: result)
+        result.paymentSummaryItems = validSummaryItems(from: result)
         return result
     }
 
-    /// Validates the summary items from a merchant-returned update result.
+    private func handlePaymentMethodChange(_ paymentMethod: PKPaymentMethod) async -> PKPaymentRequestPaymentMethodUpdate {
+        guard let onPaymentMethodChange = configuration.onPaymentMethodChange else {
+            return PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: paymentRequest.paymentSummaryItems)
+        }
+
+        let result = await onPaymentMethodChange(paymentMethod, paymentRequest.paymentSummaryItems)
+        result.paymentSummaryItems = validSummaryItems(from: result)
+        return result
+    }
+
+    /// Returns valid summary items from a merchant-returned update result.
     ///
     /// If the result indicates failure or has empty items, the current `paymentRequest.paymentSummaryItems`
     /// are returned unchanged.
@@ -150,7 +169,7 @@ extension ApplePayComponent {
     /// previous valid summary items to keep the Apple Pay sheet in a consistent state.
     ///
     /// Otherwise the new items are accepted and stored on `paymentRequest`.
-    private func validatedPaymentSummaryItems(from result: some PKPaymentRequestUpdate) -> [PKPaymentSummaryItem] {
+    private func validSummaryItems(from result: some PKPaymentRequestUpdate) -> [PKPaymentSummaryItem] {
         guard result.status == .success, !result.paymentSummaryItems.isEmpty else {
             return paymentRequest.paymentSummaryItems
         }

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -52,6 +52,13 @@ public struct ApplePayConfiguration: CheckoutComponentConfiguration {
         ) async -> PKPaymentRequestCouponCodeUpdate
     )?
 
+    internal var onPaymentMethodChange: (
+        @MainActor (
+            PKPaymentMethod,
+            [PKPaymentSummaryItem]
+        ) async -> PKPaymentRequestPaymentMethodUpdate
+    )?
+
     /// The payment request object needed for Apple Pay. Must contain all the required fields
     /// such as `merchantIdentifier`, `summaryItems`, `currencyCode`, and `countryCode`.
     internal var paymentRequest: PKPaymentRequest
@@ -160,7 +167,10 @@ extension ApplePayConfiguration {
     ///   - Returns: A `PKPaymentRequestShippingContactUpdate` with updated summary items, shipping methods, and/or errors.
     /// - Returns: A modified copy of the configuration.
     public func onShippingContactChange(
-        _ onShippingContactChange: @escaping @MainActor (PKContact, [PKPaymentSummaryItem]) async -> PKPaymentRequestShippingContactUpdate
+        _ onShippingContactChange: @escaping @MainActor (
+            PKContact,
+            [PKPaymentSummaryItem]
+        ) async -> PKPaymentRequestShippingContactUpdate
     ) -> Self {
         var copy = self
         copy.onShippingContactChange = onShippingContactChange
@@ -177,7 +187,10 @@ extension ApplePayConfiguration {
     ///   - Returns: A `PKPaymentRequestShippingMethodUpdate` with updated summary items reflecting the new shipping cost.
     /// - Returns: A modified copy of the configuration.
     public func onShippingMethodChange(
-        _ onShippingMethodChange: @escaping @MainActor (PKShippingMethod, [PKPaymentSummaryItem]) async -> PKPaymentRequestShippingMethodUpdate
+        _ onShippingMethodChange: @escaping @MainActor (
+            PKShippingMethod,
+            [PKPaymentSummaryItem]
+        ) async -> PKPaymentRequestShippingMethodUpdate
     ) -> Self {
         var copy = self
         copy.onShippingMethodChange = onShippingMethodChange
@@ -191,13 +204,37 @@ extension ApplePayConfiguration {
     ///   - Parameters:
     ///     - couponCode: The entered or updated coupon code string.
     ///     - summaryItems: The current array of `PKPaymentSummaryItem` objects representing line items and total.
-    ///   - Returns: A `PKPaymentRequestCouponCodeUpdate` with updated summary items reflecting the applied discount or errors if the code is invalid.
+    ///   - Returns: A `PKPaymentRequestCouponCodeUpdate` with updated summary items reflecting the applied discount
+    ///    or errors if the code is invalid.
     /// - Returns: A modified copy of the configuration.
     public func onCouponCodeChange(
-        _ onCouponCodeChange: @escaping @MainActor (String, [PKPaymentSummaryItem]) async -> PKPaymentRequestCouponCodeUpdate
+        _ onCouponCodeChange: @escaping @MainActor (
+            String,
+            [PKPaymentSummaryItem]
+        ) async -> PKPaymentRequestCouponCodeUpdate
     ) -> Self {
         var copy = self
         copy.onCouponCodeChange = onCouponCodeChange
+        return copy
+    }
+
+    /// Sets the handler called when the shopper selects a payment method.
+    ///
+    /// Return an updated `PKPaymentRequestPaymentMethodUpdate` with revised summary items.
+    /// - Parameter onPaymentMethodChange: The closure to call when the payment method changes.
+    ///   - Parameters:
+    ///     - paymentMethod: The selected `PKPaymentMethod` containing the payment card details.
+    ///     - summaryItems: The current array of `PKPaymentSummaryItem` objects representing line items and total.
+    ///   - Returns: A `PKPaymentRequestPaymentMethodUpdate` with updated summary items reflecting any changes based on the payment method.
+    /// - Returns: A modified copy of the configuration.
+    public func onPaymentMethodChange(
+        _ onPaymentMethodChange: @escaping @MainActor (
+            PKPaymentMethod,
+            [PKPaymentSummaryItem]
+        ) async -> PKPaymentRequestPaymentMethodUpdate
+    ) -> Self {
+        var copy = self
+        copy.onPaymentMethodChange = onPaymentMethodChange
         return copy
     }
     

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
@@ -100,6 +100,20 @@ internal final class ApplePayComponentAdvancedFlowExample: InitialDataAdvancedFl
                     }
                     return PKPaymentRequestCouponCodeUpdate(paymentSummaryItems: items)
                 }
+                .onPaymentMethodChange { paymentMethod, summaryItems in
+                    // Example: Add a processing fee based on card type
+                    var items = summaryItems
+                    if let last = items.last {
+                        items = items.dropLast()
+                        let cardType = paymentMethod.displayName ?? "Card"
+                        items.append(.init(
+                            label: "Processing Fee (\(cardType))",
+                            amount: NSDecimalNumber(value: 1.0)
+                        ))
+                        items.append(.init(label: last.label, amount: NSDecimalNumber(value: last.amount.floatValue + 1.0)))
+                    }
+                    return PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: items)
+                }
         }
         .onSubmit { [weak self] data in
             guard let self else { throw CancellationError() }

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -163,7 +163,7 @@ class ApplePayComponentTest: XCTestCase {
         let configuration = try ApplePayConfiguration(
             paymentRequest: Dummy.createTestApplePayPaymentRequest()
         )
-            .allowOnboarding(false)
+        .allowOnboarding(false)
 
         // When / Then
         XCTAssertThrowsError(
@@ -299,6 +299,41 @@ class ApplePayComponentTest: XCTestCase {
         let result = await sut.paymentAuthorizationViewController(controller, didChangeCouponCode: "Coupon")
 
         XCTAssertEqual(receivedCoupon, "Coupon")
+        XCTAssertEqual(self.sut.paymentRequest.paymentSummaryItems.count, 2)
+        XCTAssertEqual(self.sut.paymentRequest.paymentSummaryItems.last?.label, "New Item 2")
+        XCTAssertEqual(result.paymentSummaryItems.count, 2)
+    }
+
+    func testApplePayPaymentMethod() async throws {
+        var receivedPaymentMethod: PKPaymentMethod?
+        var configuration = try ApplePayConfiguration(
+            paymentRequest: Dummy.createTestApplePayPaymentRequest()
+        )
+        configuration.onPaymentMethodChange = { paymentMethod, _ in
+            receivedPaymentMethod = paymentMethod
+            return PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: [
+                PKPaymentSummaryItem(label: "New Item 1", amount: 1111),
+                PKPaymentSummaryItem(label: "New Item 2", amount: 2222)
+            ])
+        }
+
+        sut = try ApplePayComponent(
+            paymentMethod: paymentMethod,
+            context: Dummy.context,
+            configuration: configuration
+        )
+
+        try await Task.sleep(for: .seconds(1))
+
+        XCTAssertEqual(self.sut.paymentRequest.paymentSummaryItems.count, 5)
+        XCTAssertEqual(self.sut.paymentRequest.paymentSummaryItems.last?.label, "summary_4")
+
+        let controller = try XCTUnwrap(sut.paymentAuthorizationViewController)
+        let mockPaymentMethod = PKPaymentMethodMock()
+
+        let result = await sut.paymentAuthorizationViewController(controller, didSelect: mockPaymentMethod)
+
+        XCTAssertNotNil(receivedPaymentMethod)
         XCTAssertEqual(self.sut.paymentRequest.paymentSummaryItems.count, 2)
         XCTAssertEqual(self.sut.paymentRequest.paymentSummaryItems.last?.label, "New Item 2")
         XCTAssertEqual(result.paymentSummaryItems.count, 2)


### PR DESCRIPTION
# Summary [Required]
Add the missing callback to align with Web, triggered on every payment method selection from ApplePay's delegate.

## Ticket [Optional]
<ticket>
COSDK-931
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
