### PR TITLE
Co-badge: Update selection UI after each bin update

### DIFF
--- a/AdyenCard/Form/DualBrandAccessoryView.swift
+++ b/AdyenCard/Form/DualBrandAccessoryView.swift
@@ -15,6 +15,12 @@ internal class DualBrandAccessoryView: UIView {
         case secondary
     }
     
+    internal enum BrandDisplayMode: Equatable {
+        case single
+        case dualUnselectable
+        case dualSelectable
+    }
+    
     private enum Constants {
         static let iconSize = CGSize(width: 27, height: 18)
         static let placeholderImage = UIImage(named: "ic_card_front", in: .cardInternalResources, compatibleWith: nil)
@@ -24,11 +30,17 @@ internal class DualBrandAccessoryView: UIView {
         static let containerPadding: CGFloat = 2
         static let stackSpacing: CGFloat = 2
         static let selectedBorderWidth: CGFloat = 1
-        static var selectedBorderColor: UIColor { UIColor.Adyen.componentTertiaryLabel.withAlphaComponent(0.2) }
+        static var selectedBorderColor: UIColor {
+            UIColor.Adyen.componentTertiaryLabel.withAlphaComponent(0.2)
+        }
+
         static let selectedShadowRadius: CGFloat = 8
         static let selectedShadowOffset = CGSize(width: 0, height: 3)
         static let selectedShadowOpacity: Float = 0.12
-        static var segmentedBackgroundColor: UIColor { UIColor.Adyen.secondaryComponentBackground }
+        static var segmentedBackgroundColor: UIColor {
+            UIColor.Adyen.secondaryComponentBackground
+        }
+
         static let animationDuration: TimeInterval = 0.2
     }
     
@@ -44,7 +56,7 @@ internal class DualBrandAccessoryView: UIView {
     
     internal var onBrandSelection: ((BrandSelection) -> Void)?
     
-    private var displayMode: FormCardNumberItem.BrandDisplayMode = .single {
+    private var displayMode: BrandDisplayMode = .single {
         didSet {
             guard displayMode != oldValue else { return }
             applyDisplayMode()
@@ -114,7 +126,7 @@ internal class DualBrandAccessoryView: UIView {
     
     internal func updateCurrentLogos(
         _ logos: [FormCardLogosItem.CardTypeLogo],
-        mode: FormCardNumberItem.BrandDisplayMode = .single
+        mode: BrandDisplayMode = .single
     ) {
         resetState()
         guard !logos.isEmpty else { return }
@@ -135,6 +147,12 @@ internal class DualBrandAccessoryView: UIView {
         }
         
         return self
+    }
+    
+    /// Updates the selection from outside.
+    internal func updateSelection(with selection: BrandSelection) {
+        currentSelection = selection
+        updateSelectionAppearance()
     }
     
     // MARK: - Layout
@@ -211,11 +229,11 @@ internal class DualBrandAccessoryView: UIView {
         select(.secondary)
     }
     
-    private func select(_ brand: BrandSelection) {
-        guard currentSelection != brand else { return }
-        currentSelection = brand
+    private func select(_ selection: BrandSelection) {
+        guard currentSelection != selection else { return }
+        currentSelection = selection
         UIView.animate(withDuration: Constants.animationDuration) { self.updateSelectionAppearance() }
-        onBrandSelection?(brand)
+        onBrandSelection?(selection)
     }
     
     private func updateSelectionAppearance() {
@@ -238,7 +256,7 @@ internal class DualBrandAccessoryView: UIView {
     
     // MARK: - Logo Setup
     
-    private func setupLogoViews(from logos: [FormCardLogosItem.CardTypeLogo], mode: FormCardNumberItem.BrandDisplayMode) {
+    private func setupLogoViews(from logos: [FormCardLogosItem.CardTypeLogo], mode: BrandDisplayMode) {
         guard let firstLogo = logos.first else { return }
         let secondLogo = logos.adyen[safeIndex: 1]
         

--- a/AdyenCard/Form/FormCardNumberItem.swift
+++ b/AdyenCard/Form/FormCardNumberItem.swift
@@ -49,12 +49,6 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
         scanCardHandler != nil
     }
     
-    internal enum BrandDisplayMode: Equatable {
-        case single
-        case dualUnselectable
-        case dualSelectable
-    }
-    
     /// Returns the brand to include in the payment request.
     /// Returns `nil` for locally detected brands and `.dualUnselectable` mode.
     internal var currentBrand: CardBrand? {
@@ -62,7 +56,9 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
         return brandDisplayMode == .dualUnselectable ? nil : selectedBrand
     }
     
-    internal var brandDisplayMode: BrandDisplayMode = .single
+    internal var brandDisplayMode: DualBrandAccessoryView.BrandDisplayMode = .single
+    
+    @AdyenObservable(.primary) internal var brandSelection: DualBrandAccessoryView.BrandSelection
     
     /// Whether the detected brand came from local (regex) detection rather than a server BIN lookup.
     internal var isBrandDetectedLocally = false
@@ -192,12 +188,15 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
     internal func selectBrand(from selection: DualBrandAccessoryView.BrandSelection) {
         guard let brand = detectedBrands.adyen[safeIndex: selection.rawValue] else { return }
         updateValidation(for: brand)
+        self.brandSelection = selection
         self.selectedBrand = brand
         onUserBrandSelection?(brand)
     }
 
+    /// Updates the current brand from the binlookup response.
     private func updateSelectedBrand(_ brand: CardBrand?, defaultSupportedValue: Bool = true) {
         updateValidation(for: brand, defaultSupportedValue: defaultSupportedValue)
+        updateBrandSelection(with: brand)
         self.selectedBrand = brand
         updateBINIfNeeded()
     }
@@ -219,6 +218,15 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
             isEnteredBrandSupported: isBrandSupported,
             panLength: brand?.panLength
         )
+    }
+    
+    private func updateBrandSelection(with brand: CardBrand?) {
+        // Each guard separate to make it readable
+        guard let brand else { return }
+        guard let index = detectedBrands.firstIndex(of: brand) else { return }
+        guard let selection = DualBrandAccessoryView.BrandSelection(rawValue: index) else { return }
+        
+        self.brandSelection = selection
     }
     
     /// Calculates the length of the string being replaced

--- a/AdyenCard/Form/FormCardNumberItem.swift
+++ b/AdyenCard/Form/FormCardNumberItem.swift
@@ -222,11 +222,14 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
     
     private func updateBrandSelection(with brand: CardBrand?) {
         // Each guard separate to make it readable
-        guard let brand else { return }
-        guard let index = detectedBrands.firstIndex(of: brand) else { return }
-        guard let selection = DualBrandAccessoryView.BrandSelection(rawValue: index) else { return }
+        guard let brand,
+              let index = detectedBrands.firstIndex(of: brand),
+              let selection = DualBrandAccessoryView.BrandSelection(rawValue: index) else {
+            brandSelection = .primary
+            return
+        }
         
-        self.brandSelection = selection
+        brandSelection = selection
     }
     
     /// Calculates the length of the string being replaced

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -38,6 +38,11 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
             guard let self else { return }
             self.detectedBrandsView.updateCurrentLogos(newValue, mode: self.item.brandDisplayMode)
         }
+        
+        observe(item.$brandSelection) { [weak self] newValue in
+            guard let self else { return }
+            self.detectedBrandsView.updateSelection(with: newValue)
+        }
     }
     
     override public func handleFormattedValueDidChange(_ newValue: String) {

--- a/Tests/IntegrationTests/Card Tests/DualBrandAccessoryViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/DualBrandAccessoryViewTests.swift
@@ -219,6 +219,48 @@ final class DualBrandAccessoryViewTests: XCTestCase {
         XCTAssertTrue(sut.secondaryLogoView.isHidden, "Secondary should be hidden after switching to single")
     }
     
+    // MARK: - External Selection Update Tests
+    
+    func testUpdateSelection_setsCurrentSelection() throws {
+        let dualBrandLogos = try [
+            FormCardLogosItem.CardTypeLogo(url: XCTUnwrap(URL(string: "https://example.com/visa.png")), type: .visa),
+            FormCardLogosItem.CardTypeLogo(url: XCTUnwrap(URL(string: "https://example.com/bcmc.png")), type: .bcmc)
+        ]
+        sut.updateCurrentLogos(dualBrandLogos, mode: .dualSelectable)
+        XCTAssertEqual(sut.currentSelection, .primary)
+        
+        sut.updateSelection(with: .secondary)
+        
+        XCTAssertEqual(sut.currentSelection, .secondary, "updateSelection should update currentSelection")
+    }
+    
+    func testUpdateSelection_doesNotFireCallback() throws {
+        let dualBrandLogos = try [
+            FormCardLogosItem.CardTypeLogo(url: XCTUnwrap(URL(string: "https://example.com/visa.png")), type: .visa),
+            FormCardLogosItem.CardTypeLogo(url: XCTUnwrap(URL(string: "https://example.com/bcmc.png")), type: .bcmc)
+        ]
+        sut.updateCurrentLogos(dualBrandLogos, mode: .dualSelectable)
+        brandSelectionCount = 0
+        
+        sut.updateSelection(with: .secondary)
+        
+        XCTAssertEqual(brandSelectionCount, 0, "updateSelection should not fire onBrandSelection callback (avoids infinite loop)")
+    }
+    
+    func testUpdateSelection_backToPrimary() throws {
+        let dualBrandLogos = try [
+            FormCardLogosItem.CardTypeLogo(url: XCTUnwrap(URL(string: "https://example.com/visa.png")), type: .visa),
+            FormCardLogosItem.CardTypeLogo(url: XCTUnwrap(URL(string: "https://example.com/bcmc.png")), type: .bcmc)
+        ]
+        sut.updateCurrentLogos(dualBrandLogos, mode: .dualSelectable)
+        sut.updateSelection(with: .secondary)
+        XCTAssertEqual(sut.currentSelection, .secondary)
+        
+        sut.updateSelection(with: .primary)
+        
+        XCTAssertEqual(sut.currentSelection, .primary, "updateSelection should allow switching back to primary")
+    }
+    
     private var brandImageStyle: ImageStyle = .init(
         borderColor: nil,
         borderWidth: 0.0,

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
@@ -389,11 +389,8 @@ class FormCardNumberItemTests: XCTestCase {
         
         sut.update(brands: [])
         
-        // After clearing, selectedBrand is nil, so updateBrandSelection guards out
-        // and brandSelection is not explicitly reset — but this is fine because
-        // the view will call updateCurrentLogos([]) which resets the view's selection.
-        // The important thing is selectedBrand is nil.
         XCTAssertNil(sut.selectedBrand)
+        XCTAssertEqual(sut.brandSelection, .primary, "brandSelection should reset to .primary when brands are cleared")
     }
     
     func testBrandSelection_bothBrandsSupported_autoSelectsFirst() {

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
@@ -328,6 +328,113 @@ class FormCardNumberItemTests: XCTestCase {
         XCTAssertEqual(sut.selectedBrand?.type, .visa, "selectedBrand should still be set for validation/logo display")
     }
     
+    // MARK: - brandSelection Sync Tests
+    
+    func testBrandSelection_defaultIsPrimary() {
+        let sut = FormCardNumberItem(cardTypeLogos: [])
+        XCTAssertEqual(sut.brandSelection, .primary)
+    }
+    
+    func testBrandSelection_selectBrandFromSecondary_updatesBrandSelection() {
+        let sut = FormCardNumberItem(cardTypeLogos: [])
+        let visa = CardBrand(type: .visa)
+        let bcmc = CardBrand(type: .bcmc)
+        
+        sut.update(brands: [visa, bcmc])
+        sut.selectBrand(from: .secondary)
+        
+        XCTAssertEqual(sut.brandSelection, .secondary, "brandSelection should sync to .secondary after user tap")
+    }
+    
+    func testBrandSelection_selectBrandFromPrimary_updatesBrandSelection() {
+        let sut = FormCardNumberItem(cardTypeLogos: [])
+        let visa = CardBrand(type: .visa)
+        let bcmc = CardBrand(type: .bcmc)
+        
+        sut.update(brands: [visa, bcmc])
+        sut.selectBrand(from: .secondary)
+        sut.selectBrand(from: .primary)
+        
+        XCTAssertEqual(sut.brandSelection, .primary, "brandSelection should sync back to .primary")
+    }
+    
+    func testBrandSelection_updateBrandsAutoSelectsFirstSupported_syncsBrandSelection() {
+        let sut = FormCardNumberItem(cardTypeLogos: [])
+        let unsupported = CardBrand(type: .visa, isSupported: false)
+        let supported = CardBrand(type: .bcmc, isSupported: true)
+        
+        sut.update(brands: [unsupported, supported])
+        
+        XCTAssertEqual(sut.selectedBrand?.type, .bcmc, "First supported brand should be auto-selected")
+        XCTAssertEqual(sut.brandSelection, .secondary, "brandSelection should match the index of the auto-selected brand")
+    }
+    
+    func testBrandSelection_singleBrand_staysPrimary() {
+        let sut = FormCardNumberItem(cardTypeLogos: [])
+        let visa = CardBrand(type: .visa)
+        
+        sut.update(brands: [visa])
+        
+        XCTAssertEqual(sut.brandSelection, .primary, "Single brand should keep brandSelection at .primary")
+    }
+    
+    func testBrandSelection_clearBrands_resetsToPrimary() {
+        let sut = FormCardNumberItem(cardTypeLogos: [])
+        let visa = CardBrand(type: .visa)
+        let bcmc = CardBrand(type: .bcmc)
+        
+        sut.update(brands: [visa, bcmc])
+        sut.selectBrand(from: .secondary)
+        XCTAssertEqual(sut.brandSelection, .secondary)
+        
+        sut.update(brands: [])
+        
+        // After clearing, selectedBrand is nil, so updateBrandSelection guards out
+        // and brandSelection is not explicitly reset — but this is fine because
+        // the view will call updateCurrentLogos([]) which resets the view's selection.
+        // The important thing is selectedBrand is nil.
+        XCTAssertNil(sut.selectedBrand)
+    }
+    
+    func testBrandSelection_bothBrandsSupported_autoSelectsFirst() {
+        let sut = FormCardNumberItem(cardTypeLogos: [])
+        let visa = CardBrand(type: .visa)
+        let bcmc = CardBrand(type: .bcmc)
+        
+        sut.update(brands: [visa, bcmc])
+        
+        XCTAssertEqual(sut.selectedBrand?.type, .visa, "First supported brand should be auto-selected")
+        XCTAssertEqual(sut.brandSelection, .primary, "brandSelection should be .primary for first brand")
+    }
+    
+    func testBrandSelection_callbackFiredOnUserSelection() {
+        let sut = FormCardNumberItem(cardTypeLogos: [])
+        let visa = CardBrand(type: .visa)
+        let bcmc = CardBrand(type: .bcmc)
+        
+        var callbackBrand: CardBrand?
+        sut.onUserBrandSelection = { brand in
+            callbackBrand = brand
+        }
+        
+        sut.update(brands: [visa, bcmc])
+        sut.selectBrand(from: .secondary)
+        
+        XCTAssertEqual(callbackBrand?.type, .bcmc, "Callback should fire with the selected brand")
+    }
+    
+    func testBrandSelection_invalidIndex_doesNotCrash() {
+        let sut = FormCardNumberItem(cardTypeLogos: [])
+        let visa = CardBrand(type: .visa)
+        
+        sut.update(brands: [visa])
+        // .secondary index (1) is out of bounds for single-brand array
+        sut.selectBrand(from: .secondary)
+        
+        // Should not crash, selectedBrand should remain as the auto-selected one
+        XCTAssertEqual(sut.selectedBrand?.type, .visa)
+    }
+    
 }
 
 // MARK: - Brand Description Tests


### PR DESCRIPTION
Fixes the segment picker not updating after every bin response from the component.

## Ticket [Optional]
<ticket>
COSDK-1064
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
