### PR TITLE
Localization: Split card flow tests

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -621,6 +621,7 @@
 		B605AC122D8D988D0084D583 /* AdyenCardScanner.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C9FC2C3D2D50D0B700C9D0F3 /* AdyenCardScanner.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B60946132DA562FD00CEE6CF /* CardScannerProviderDispatchOnceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60946122DA562FD00CEE6CF /* CardScannerProviderDispatchOnceTests.swift */; };
 		B60946152DA5656100CEE6CF /* CardScannerTestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60946142DA5656100CEE6CF /* CardScannerTestsHelpers.swift */; };
+		B60946172DA5656100CEE6CF /* CardComponentLocalizationFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60946162DA5656100CEE6CF /* CardComponentLocalizationFlowTests.swift */; };
 		B60FB35C2F33769500F77471 /* CardComponentValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60FB35B2F33769500F77471 /* CardComponentValidationTests.swift */; };
 		B61CE9152DDDD7C3009B7503 /* FormButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B61CE9142DDDD7C3009B7503 /* FormButtonTests.swift */; };
 		B6244E082E327A5300F42780 /* Configuration+secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6244E072E327A5300F42780 /* Configuration+secrets.swift */; };
@@ -2282,6 +2283,7 @@
 		B605AC092D897A930084D583 /* CardScannerControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerControllerTests.swift; sourceTree = "<group>"; };
 		B60946122DA562FD00CEE6CF /* CardScannerProviderDispatchOnceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerProviderDispatchOnceTests.swift; sourceTree = "<group>"; };
 		B60946142DA5656100CEE6CF /* CardScannerTestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardScannerTestsHelpers.swift; sourceTree = "<group>"; };
+		B60946162DA5656100CEE6CF /* CardComponentLocalizationFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardComponentLocalizationFlowTests.swift; sourceTree = "<group>"; };
 		B60FB35B2F33769500F77471 /* CardComponentValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardComponentValidationTests.swift; sourceTree = "<group>"; };
 		B61CE9142DDDD7C3009B7503 /* FormButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormButtonTests.swift; sourceTree = "<group>"; };
 		B6244DFF2E3224BE00F42780 /* Secrets.template.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.template.xcconfig; sourceTree = "<group>"; };
@@ -6027,6 +6029,7 @@
 				21E641B62F3F65910087253F /* PublicKeyFetcherTests.swift */,
 				A0B4B9B02BC027DE00C99926 /* CardComponentEventTests.swift */,
 				B60FB35B2F33769500F77471 /* CardComponentValidationTests.swift */,
+				B60946162DA5656100CEE6CF /* CardComponentLocalizationFlowTests.swift */,
 				F924C071246BEEF0006DDAB8 /* CardDetailsTests.swift */,
 				F9EDB78E23964FC000CFB3C9 /* StoredCardAlertManagerTests.swift */,
 				F919DF9F24EABCC10027976E /* StoredCardComponentTests.swift */,
@@ -8819,6 +8822,7 @@
 				F96AE51B26038602009F82BD /* XCTestCase+FormTextItemView.swift in Sources */,
 				8107F4852BB1CE96007745FC /* String+UIImage.swift in Sources */,
 				F9EDB78D2395643A00CFB3C9 /* CardComponentTests.swift in Sources */,
+				B60946172DA5656100CEE6CF /* CardComponentLocalizationFlowTests.swift in Sources */,
 				5A988C342657D5290007F4C0 /* BoletoVoucherShareableVoucherViewProviderTests.swift in Sources */,
 				81896E852A4DB5F300C532CA /* SearchViewControllerTests.swift in Sources */,
 				F9842CD025710BF00063CE5A /* ThreeDS2ClassicActionHandlerTests.swift in Sources */,

--- a/Tests/IntegrationTests/Card Tests/CardComponentLocalizationFlowTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentLocalizationFlowTests.swift
@@ -1,0 +1,152 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+@_spi(AdyenInternal) @testable import AdyenUI
+@_spi(AdyenInternal) @testable import AdyenCard
+@_spi(AdyenInternal) @testable import AdyenCheckout
+import XCTest
+
+@MainActor
+final class CardComponentLocalizationFlowTests: XCTestCase {
+
+    private var context: AdyenContext {
+        Dummy.context
+    }
+
+    private var paymentMethod: CardPaymentMethod {
+        .init(
+            type: .scheme,
+            name: "Cards",
+            fundingSource: .credit,
+            brands: [.visa, .americanExpress, .masterCard]
+        )
+    }
+
+    func test_cardComponent_builtFromCheckoutConfiguration_withGlobalProviderAndSupportedLocale_shouldRenderVisibleLocalizedStrings() throws {
+        let provider = CardComponentLocalizationFlowProviderMock(values: [.cardNumber: "Global number"])
+        let localizationParameters = LocalizationParameters(enforcedLocale: "it-IT")
+
+        let sut = try makeSUT(
+            globalProvider: provider,
+            localizationParameters: localizationParameters
+        )
+
+        expectVisibleTitles(
+            of: sut,
+            numberTitle: "Global number",
+            securityCodeTitle: localizedString(.cardCvcItemTitle, localizationParameters)
+        )
+    }
+
+    func test_cardComponent_builtFromCheckoutConfiguration_withGlobalProviderAndUnsupportedLocalePartialOverride_shouldMixCustomAndFallbackStrings() throws {
+        let provider = CardComponentLocalizationFlowProviderMock(values: [.cardNumber: "Card #"])
+        let localizationParameters = LocalizationParameters(enforcedLocale: "zu")
+
+        let sut = try makeSUT(
+            globalProvider: provider,
+            localizationParameters: localizationParameters
+        )
+
+        expectVisibleTitles(
+            of: sut,
+            numberTitle: "Card #",
+            securityCodeTitle: localizedString(.cardCvcItemTitle, localizationParameters)
+        )
+    }
+
+    func test_cardComponent_builtFromCheckoutConfiguration_withComponentLevelProvider_shouldPreferComponentProviderForVisibleCardStrings() throws {
+        let globalProvider = CardComponentLocalizationFlowProviderMock(values: [.cardNumber: "Global number"])
+        let componentProvider = CardComponentLocalizationFlowProviderMock(values: [.cardNumber: "Component number"])
+
+        let sut = try makeSUT(
+            globalProvider: globalProvider,
+            componentProvider: componentProvider
+        )
+
+        expectVisibleTitles(
+            of: sut,
+            numberTitle: "Component number",
+            securityCodeTitle: localizedString(.cardCvcItemTitle, nil)
+        )
+    }
+
+    func test_cardComponent_builtFromCheckoutConfiguration_withoutProvider_shouldUseSDKDefaultLocalization() throws {
+        let sut = try makeSUT()
+
+        expectVisibleTitles(
+            of: sut,
+            numberTitle: localizedString(.cardNumberItemTitle, nil),
+            securityCodeTitle: localizedString(.cardCvcItemTitle, nil)
+        )
+    }
+
+    private func makeSUT(
+        globalProvider: (any CheckoutLocalizationProvider)? = nil,
+        componentProvider: (any CheckoutLocalizationProvider)? = nil,
+        localizationParameters: LocalizationParameters? = nil
+    ) throws -> CardComponent {
+        var cardConfiguration = CardComponentConfiguration()
+        cardConfiguration.localizationProvider = componentProvider
+        cardConfiguration.localizationParameters = localizationParameters
+
+        var checkoutConfiguration = makeCheckoutConfiguration(
+            configurations: [.payment(.scheme): cardConfiguration]
+        )
+
+        if let globalProvider {
+            checkoutConfiguration = checkoutConfiguration.localizationProvider(globalProvider)
+        }
+
+        return try makeBuiltCardComponent(checkoutConfiguration: checkoutConfiguration)
+    }
+
+    private func makeBuiltCardComponent(checkoutConfiguration: CheckoutConfiguration) throws -> CardComponent {
+        let component = CheckoutComponentBuilder.build(
+            for: paymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+        return try XCTUnwrap(component as? CardComponent)
+    }
+
+    private func makeCheckoutConfiguration(
+        configurations: [CheckoutComponentType: CheckoutComponentConfiguration] = [:]
+    ) -> CheckoutConfiguration {
+        CheckoutConfiguration(
+            apiContext: Dummy.apiContext,
+            amount: Dummy.amount,
+            analyticsApiContext: nil,
+            analyticsConfiguration: .init(),
+            configurations: configurations
+        )
+    }
+
+    private func expectVisibleTitles(
+        of sut: CardComponent,
+        numberTitle: String,
+        securityCodeTitle: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let items = sut.cardViewController.items
+        XCTAssertEqual(items.numberContainerItem.numberItem.title, numberTitle, file: file, line: line)
+        XCTAssertEqual(items.securityCodeItem.title, securityCodeTitle, file: file, line: line)
+    }
+}
+
+private final class CardComponentLocalizationFlowProviderMock: CheckoutLocalizationProvider {
+
+    private let values: [CheckoutLocalizationKey: String]
+
+    init(values: [CheckoutLocalizationKey: String]) {
+        self.values = values
+    }
+
+    func localizedString(_ key: CheckoutLocalizationKey, locale: Locale) -> String? {
+        values[key]
+    }
+}


### PR DESCRIPTION
# Summary 
✅ Phase 0 - [Localization: Add phase 0 baseline integration tests](https://github.com/Adyen/adyen-ios/pull/2463)
✅ Phase 1 - [Localization: internalize legacy APIs](https://github.com/Adyen/adyen-ios/pull/2470)
✅ Phase 2 - [Localization: Phase 2 - public API](https://github.com/Adyen/adyen-ios/pull/2477)
✅ Phase 3 - [Localization: Phase 3 - Card provider wiring](https://github.com/Adyen/adyen-ios/pull/2515) and [Localization: Phase 3.1 - Card localization provider coverage](https://github.com/Adyen/adyen-ios/pull/2517)
✅ Phase 4 - [Localization: Add unsupported locale warnings](https://github.com/Adyen/adyen-ios/pull/2527)
➡️ Phase 5 - Final confidence pass for card alpha scope

This PR implements the Phase 5 confidence-pass test cleanup for the card alpha scope by splitting the builder-driven localization coverage into a dedicated integration test suite. It keeps `CardComponentTests` focused on direct card component behavior while making checkout-builder localization flows easier to review and maintain.

## Use cases covered
- Global localization provider with a supported locale renders the expected visible custom card strings.
- Global localization provider with an unsupported locale and partial overrides mixes merchant-provided strings with SDK fallback strings.
- Component-level localization provider takes precedence over the global provider for visible card strings.
- No localization provider configured falls back to the default SDK localization for visible card strings.

## Technical Information 
- Added `CardComponentLocalizationFlowTests` under `Tests/IntegrationTests/Card Tests/`.
- Wired the new test file into `IntegrationUIKitTests` in `Adyen.xcodeproj`.
- Preserved the existing builder-driven coverage while moving it into a focused suite.

## Ticket 
<ticket>
COSDK-1097
</ticket>

## Checklist
- [x] Tested changes locally
- [x] Added/updated tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
