### PR TITLE
[v5] Add support for Bizum back to iOS SDK

### DIFF
--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
@@ -42,7 +42,7 @@ internal enum AnyPaymentMethodDecoder {
         .afterpay: UnsupportedPaymentMethodDecoder(),
         .androidPay: UnsupportedPaymentMethodDecoder(),
         .amazonPay: UnsupportedPaymentMethodDecoder(),
-        .bizum: UnsupportedPaymentMethodDecoder(),
+        
         .upiQr: UnsupportedPaymentMethodDecoder(),
         .upiIntent: UnsupportedPaymentMethodDecoder(),
         .upiCollect: UnsupportedPaymentMethodDecoder(),
@@ -63,6 +63,7 @@ internal enum AnyPaymentMethodDecoder {
         .achDirectDebit: ACHDirectDebitPaymentMethodDecoder(),
         .applePay: ApplePayPaymentMethodDecoder(),
         .payPal: PayPalPaymentMethodDecoder(),
+        .bizum: InstantPaymentMethodDecoder(),
         .bcmc: BCMCCardPaymentMethodDecoder(),
         .weChatPaySDK: WeChatPayPaymentMethodDecoder(),
         .qiwiWallet: QiwiWalletPaymentMethodDecoder(),

--- a/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
+++ b/Adyen/Core/Payment Methods/Abstract/AnyPaymentMethodDecoder.swift
@@ -42,7 +42,6 @@ internal enum AnyPaymentMethodDecoder {
         .afterpay: UnsupportedPaymentMethodDecoder(),
         .androidPay: UnsupportedPaymentMethodDecoder(),
         .amazonPay: UnsupportedPaymentMethodDecoder(),
-        
         .upiQr: UnsupportedPaymentMethodDecoder(),
         .upiIntent: UnsupportedPaymentMethodDecoder(),
         .upiCollect: UnsupportedPaymentMethodDecoder(),

--- a/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
+++ b/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
@@ -61,6 +61,7 @@ public enum PaymentMethodType: RawRepresentable, Hashable, Codable {
     case mealVoucherSodexo
     case upi
     case cashAppPay
+    case bizum
     case twint
     case payByBankAISDD
     case payTo
@@ -79,7 +80,6 @@ public enum PaymentMethodType: RawRepresentable, Hashable, Codable {
     case upiCollect
     case upiIntent
     case upiQr
-    case bizum
     
     // swiftlint:disable cyclomatic_complexity function_body_length
     

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -74,7 +74,6 @@ class PaymentMethodTests: XCTestCase {
                 giftCard1,
                 givexGiftCard,
                 mealVoucherSodexo,
-                bizum,
                 boletoBancario,
                 boletoBancarioSantander,
                 primeiroPayBoleto,
@@ -85,7 +84,8 @@ class PaymentMethodTests: XCTestCase {
                 cashAppPay,
                 idealDictionary,
                 payto,
-                irisDictionary
+                irisDictionary,
+                bizum
             ]
         ]
     }
@@ -302,57 +302,57 @@ class PaymentMethodTests: XCTestCase {
         XCTAssertEqual(paymentMethods.regular[25].name, "Sodexo")
         XCTAssertEqual(paymentMethods.regular[25].type.rawValue, "mealVoucher_FR_sodexo")
         
-        XCTAssertTrue(paymentMethods.regular[26] is InstantPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[26].name, "Bizum")
-        XCTAssertEqual(paymentMethods.regular[26].type.rawValue, "bizum")
-        
+        XCTAssertTrue(paymentMethods.regular[26] is BoletoPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[26].name, "Boleto Bancario")
+        XCTAssertEqual(paymentMethods.regular[26].type.rawValue, "boletobancario")
+
         XCTAssertTrue(paymentMethods.regular[27] is BoletoPaymentMethod)
         XCTAssertEqual(paymentMethods.regular[27].name, "Boleto Bancario")
-        XCTAssertEqual(paymentMethods.regular[27].type.rawValue, "boletobancario")
+        XCTAssertEqual(paymentMethods.regular[27].type.rawValue, "boletobancario_santander")
 
         XCTAssertTrue(paymentMethods.regular[28] is BoletoPaymentMethod)
         XCTAssertEqual(paymentMethods.regular[28].name, "Boleto Bancario")
-        XCTAssertEqual(paymentMethods.regular[28].type.rawValue, "boletobancario_santander")
+        XCTAssertEqual(paymentMethods.regular[28].type.rawValue, "primeiropay_boleto")
 
         XCTAssertTrue(paymentMethods.regular[29] is BoletoPaymentMethod)
         XCTAssertEqual(paymentMethods.regular[29].name, "Boleto Bancario")
-        XCTAssertEqual(paymentMethods.regular[29].type.rawValue, "primeiropay_boleto")
+        XCTAssertEqual(paymentMethods.regular[29].type.rawValue, "boletobancario_itau")
 
-        XCTAssertTrue(paymentMethods.regular[30] is BoletoPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[30].name, "Boleto Bancario")
-        XCTAssertEqual(paymentMethods.regular[30].type.rawValue, "boletobancario_itau")
+        XCTAssertTrue(paymentMethods.regular[30] is AffirmPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[30].name, "Affirm")
+        XCTAssertEqual(paymentMethods.regular[30].type.rawValue, "affirm")
 
-        XCTAssertTrue(paymentMethods.regular[31] is AffirmPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[31].name, "Affirm")
-        XCTAssertEqual(paymentMethods.regular[31].type.rawValue, "affirm")
+        XCTAssertTrue(paymentMethods.regular[31] is AtomePaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[31].name, "Atome")
+        XCTAssertEqual(paymentMethods.regular[31].type.rawValue, "atome")
 
-        XCTAssertTrue(paymentMethods.regular[32] is AtomePaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[32].name, "Atome")
-        XCTAssertEqual(paymentMethods.regular[32].type.rawValue, "atome")
+        XCTAssertTrue(paymentMethods.regular[32] is UPIPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[32].name, "UPI")
+        XCTAssertEqual(paymentMethods.regular[32].type.rawValue, "upi")
 
-        XCTAssertTrue(paymentMethods.regular[33] is UPIPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[33].name, "UPI")
-        XCTAssertEqual(paymentMethods.regular[33].type.rawValue, "upi")
-
-        let cashAppPay = try XCTUnwrap(paymentMethods.regular[34] as? CashAppPayPaymentMethod)
+        let cashAppPay = try XCTUnwrap(paymentMethods.regular[33] as? CashAppPayPaymentMethod)
         XCTAssertEqual(cashAppPay.name, "Cash App Pay")
         XCTAssertEqual(cashAppPay.type.rawValue, "cashapp")
         XCTAssertEqual(cashAppPay.clientId, "testClient")
         XCTAssertEqual(cashAppPay.scopeId, "testScope")
         
         // iDEAL has issuers but should decode as InstantPaymentMethod, not IssuerListPaymentMethod
-        let iDealPaymentMethod = try XCTUnwrap(paymentMethods.regular[35] as? InstantPaymentMethod)
+        let iDealPaymentMethod = try XCTUnwrap(paymentMethods.regular[34] as? InstantPaymentMethod)
         XCTAssertEqual(iDealPaymentMethod.type, .ideal)
         XCTAssertEqual(iDealPaymentMethod.name, "iDeal")
 
-        let payToPaymentMethod = try XCTUnwrap(paymentMethods.regular[36] as? PayToPaymentMethod)
+        let payToPaymentMethod = try XCTUnwrap(paymentMethods.regular[35] as? PayToPaymentMethod)
         XCTAssertEqual(payToPaymentMethod.type.rawValue, "payto")
         XCTAssertEqual(payToPaymentMethod.name, "payto")
 
         // IRIS has issuers but should decode as InstantPaymentMethod, not IssuerListPaymentMethod
-        let irisPaymentMethod = try XCTUnwrap(paymentMethods.regular[37] as? InstantPaymentMethod)
+        let irisPaymentMethod = try XCTUnwrap(paymentMethods.regular[36] as? InstantPaymentMethod)
         XCTAssertEqual(irisPaymentMethod.type, .iris)
         XCTAssertEqual(irisPaymentMethod.name, "IRIS")
+        
+        XCTAssertTrue(paymentMethods.regular[37] is InstantPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[37].name, "Bizum")
+        XCTAssertEqual(paymentMethods.regular[37].type.rawValue, "bizum")
     }
     
     // MARK: - Display Information Override

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -184,7 +184,7 @@ class PaymentMethodTests: XCTestCase {
         
         // Regular payment methods
         
-        XCTAssertEqual(paymentMethods.regular.count, 37)
+        XCTAssertEqual(paymentMethods.regular.count, 38)
 
         let creditCardPaymentMethod = try XCTUnwrap(paymentMethods.regular[0] as? CardPaymentMethod)
         XCTAssertEqual(creditCardPaymentMethod.fundingSource, .credit)
@@ -302,51 +302,55 @@ class PaymentMethodTests: XCTestCase {
         XCTAssertEqual(paymentMethods.regular[25].name, "Sodexo")
         XCTAssertEqual(paymentMethods.regular[25].type.rawValue, "mealVoucher_FR_sodexo")
         
-        XCTAssertTrue(paymentMethods.regular[26] is BoletoPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[26].name, "Boleto Bancario")
-        XCTAssertEqual(paymentMethods.regular[26].type.rawValue, "boletobancario")
-
+        XCTAssertTrue(paymentMethods.regular[26] is InstantPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[26].name, "Bizum")
+        XCTAssertEqual(paymentMethods.regular[26].type.rawValue, "bizum")
+        
         XCTAssertTrue(paymentMethods.regular[27] is BoletoPaymentMethod)
         XCTAssertEqual(paymentMethods.regular[27].name, "Boleto Bancario")
-        XCTAssertEqual(paymentMethods.regular[27].type.rawValue, "boletobancario_santander")
+        XCTAssertEqual(paymentMethods.regular[27].type.rawValue, "boletobancario")
 
         XCTAssertTrue(paymentMethods.regular[28] is BoletoPaymentMethod)
         XCTAssertEqual(paymentMethods.regular[28].name, "Boleto Bancario")
-        XCTAssertEqual(paymentMethods.regular[28].type.rawValue, "primeiropay_boleto")
+        XCTAssertEqual(paymentMethods.regular[28].type.rawValue, "boletobancario_santander")
 
         XCTAssertTrue(paymentMethods.regular[29] is BoletoPaymentMethod)
         XCTAssertEqual(paymentMethods.regular[29].name, "Boleto Bancario")
-        XCTAssertEqual(paymentMethods.regular[29].type.rawValue, "boletobancario_itau")
+        XCTAssertEqual(paymentMethods.regular[29].type.rawValue, "primeiropay_boleto")
 
-        XCTAssertTrue(paymentMethods.regular[30] is AffirmPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[30].name, "Affirm")
-        XCTAssertEqual(paymentMethods.regular[30].type.rawValue, "affirm")
+        XCTAssertTrue(paymentMethods.regular[30] is BoletoPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[30].name, "Boleto Bancario")
+        XCTAssertEqual(paymentMethods.regular[30].type.rawValue, "boletobancario_itau")
 
-        XCTAssertTrue(paymentMethods.regular[31] is AtomePaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[31].name, "Atome")
-        XCTAssertEqual(paymentMethods.regular[31].type.rawValue, "atome")
+        XCTAssertTrue(paymentMethods.regular[31] is AffirmPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[31].name, "Affirm")
+        XCTAssertEqual(paymentMethods.regular[31].type.rawValue, "affirm")
 
-        XCTAssertTrue(paymentMethods.regular[32] is UPIPaymentMethod)
-        XCTAssertEqual(paymentMethods.regular[32].name, "UPI")
-        XCTAssertEqual(paymentMethods.regular[32].type.rawValue, "upi")
+        XCTAssertTrue(paymentMethods.regular[32] is AtomePaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[32].name, "Atome")
+        XCTAssertEqual(paymentMethods.regular[32].type.rawValue, "atome")
 
-        let cashAppPay = try XCTUnwrap(paymentMethods.regular[33] as? CashAppPayPaymentMethod)
+        XCTAssertTrue(paymentMethods.regular[33] is UPIPaymentMethod)
+        XCTAssertEqual(paymentMethods.regular[33].name, "UPI")
+        XCTAssertEqual(paymentMethods.regular[33].type.rawValue, "upi")
+
+        let cashAppPay = try XCTUnwrap(paymentMethods.regular[34] as? CashAppPayPaymentMethod)
         XCTAssertEqual(cashAppPay.name, "Cash App Pay")
         XCTAssertEqual(cashAppPay.type.rawValue, "cashapp")
         XCTAssertEqual(cashAppPay.clientId, "testClient")
         XCTAssertEqual(cashAppPay.scopeId, "testScope")
         
         // iDEAL has issuers but should decode as InstantPaymentMethod, not IssuerListPaymentMethod
-        let iDealPaymentMethod = try XCTUnwrap(paymentMethods.regular[34] as? InstantPaymentMethod)
+        let iDealPaymentMethod = try XCTUnwrap(paymentMethods.regular[35] as? InstantPaymentMethod)
         XCTAssertEqual(iDealPaymentMethod.type, .ideal)
         XCTAssertEqual(iDealPaymentMethod.name, "iDeal")
 
-        let payToPaymentMethod = try XCTUnwrap(paymentMethods.regular[35] as? PayToPaymentMethod)
+        let payToPaymentMethod = try XCTUnwrap(paymentMethods.regular[36] as? PayToPaymentMethod)
         XCTAssertEqual(payToPaymentMethod.type.rawValue, "payto")
         XCTAssertEqual(payToPaymentMethod.name, "payto")
 
         // IRIS has issuers but should decode as InstantPaymentMethod, not IssuerListPaymentMethod
-        let irisPaymentMethod = try XCTUnwrap(paymentMethods.regular[36] as? InstantPaymentMethod)
+        let irisPaymentMethod = try XCTUnwrap(paymentMethods.regular[37] as? InstantPaymentMethod)
         XCTAssertEqual(irisPaymentMethod.type, .iris)
         XCTAssertEqual(irisPaymentMethod.name, "IRIS")
     }


### PR DESCRIPTION
# Summary [Required]
Add Bizum as a supported payment method on v5. It's a full redirect payment method that used to work until it was actively added to the blocked payment method list due to its redirect being POST instead of GET.

This is a backport of #2534 from `develop`.

## Release Notes [Optional]
<fixed>
- Fixed: re-enabled Bizum as supported instant payment method
</fixed>

## Ticket [Optional]
<ticket>
PF-3969
</ticket>

## Checklist [Required]
- [] Tested changes locally
- [x] Added/updated unit tests
- [ ] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)