### PR TITLE
StoredCardInputViewController: Offset scroll view when keyboard is displayed (5.1/6)

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -244,6 +244,8 @@
 		211BBD662F6C4F6700EF2172 /* CardImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211BBD652F6C4F6700EF2172 /* CardImageView.swift */; };
 		211BBD712F6C4FDD00EF2172 /* StoredCardInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211BBD702F6C4FDD00EF2172 /* StoredCardInputViewModelTests.swift */; };
 		211BBD732F6C905100EF2172 /* StoredCardInputViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211BBD722F6C904800EF2172 /* StoredCardInputViewControllerTests.swift */; };
+		212B656C2FB32253002AAFA7 /* KeyboardScrollViewHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B656B2FB32253002AAFA7 /* KeyboardScrollViewHandlerTests.swift */; };
+		212B656E2FB3226A002AAFA7 /* KeyboardScrollViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 212B656D2FB3226A002AAFA7 /* KeyboardScrollViewHandler.swift */; };
 		2144A4162F3A8D1400CCD7F8 /* AdyenUIImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144A4152F3A8D1400CCD7F8 /* AdyenUIImages.swift */; };
 		2144A4182F3A8D4D00CCD7F8 /* BundleSPMExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144A4172F3A8D4D00CCD7F8 /* BundleSPMExtension.swift */; };
 		2144A41B2F3A8F2500CCD7F8 /* AdyenUIAssetsAccessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2144A4192F3A8F2500CCD7F8 /* AdyenUIAssetsAccessTests.swift */; };
@@ -1959,6 +1961,8 @@
 		211BBD652F6C4F6700EF2172 /* CardImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardImageView.swift; sourceTree = "<group>"; };
 		211BBD702F6C4FDD00EF2172 /* StoredCardInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCardInputViewModelTests.swift; sourceTree = "<group>"; };
 		211BBD722F6C904800EF2172 /* StoredCardInputViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredCardInputViewControllerTests.swift; sourceTree = "<group>"; };
+		212B656B2FB32253002AAFA7 /* KeyboardScrollViewHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollViewHandlerTests.swift; sourceTree = "<group>"; };
+		212B656D2FB3226A002AAFA7 /* KeyboardScrollViewHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardScrollViewHandler.swift; sourceTree = "<group>"; };
 		2144A4152F3A8D1400CCD7F8 /* AdyenUIImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenUIImages.swift; sourceTree = "<group>"; };
 		2144A4172F3A8D4D00CCD7F8 /* BundleSPMExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleSPMExtension.swift; sourceTree = "<group>"; };
 		2144A4192F3A8F2500CCD7F8 /* AdyenUIAssetsAccessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdyenUIAssetsAccessTests.swift; sourceTree = "<group>"; };
@@ -4216,6 +4220,7 @@
 		B62F517C2E97A47000610EFD /* Form */ = {
 			isa = PBXGroup;
 			children = (
+				212B656B2FB32253002AAFA7 /* KeyboardScrollViewHandlerTests.swift */,
 				B62F517F2E97AA6600610EFD /* TextFieldTests.swift */,
 			);
 			path = Form;
@@ -5318,6 +5323,7 @@
 		E2C0E094220B04E9008616F6 /* Form */ = {
 			isa = PBXGroup;
 			children = (
+				212B656D2FB3226A002AAFA7 /* KeyboardScrollViewHandler.swift */,
 				E216D3B42217096E0013CBCF /* Items */,
 				E2C0E095220B04F0008616F6 /* FormViewController.swift */,
 				C90D26A627565750001A488F /* FormViewController+ViewProtocol.swift */,
@@ -8212,6 +8218,7 @@
 				0019C45C2E6ADFB700B0C3A3 /* ListSectionHeaderStyle.swift in Sources */,
 				0019C45D2E6ADFB700B0C3A3 /* ListItemStyle.swift in Sources */,
 				0019C45E2E6ADFB700B0C3A3 /* ListCell.swift in Sources */,
+				212B656E2FB3226A002AAFA7 /* KeyboardScrollViewHandler.swift in Sources */,
 				0019C45F2E6ADFB700B0C3A3 /* ListViewController.swift in Sources */,
 				0019C4602E6ADFB700B0C3A3 /* ListItem.swift in Sources */,
 				B627200B2EBBDAA8009E9149 /* CheckoutTheme+Equatable.swift in Sources */,
@@ -8386,6 +8393,7 @@
 				2144A41B2F3A8F2500CCD7F8 /* AdyenUIAssetsAccessTests.swift in Sources */,
 				A0E1B6492EABA05F0070B915 /* PaymentComponentFactoryProtocolTests.swift in Sources */,
 				B6D808162BCD151F00F3F5EB /* CardPaymentMethodMock.swift in Sources */,
+				212B656C2FB32253002AAFA7 /* KeyboardScrollViewHandlerTests.swift in Sources */,
 				B6D8082E2BCD179400F3F5EB /* XCTestCase+FirstResponder.swift in Sources */,
 				B6D808202BCD151F00F3F5EB /* PaymentComponentMock.swift in Sources */,
 				B6D8080B2BCD147D00F3F5EB /* SimpleSchedulerTests.swift in Sources */,

--- a/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewController.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewController.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
+@_spi(AdyenInternal) import Adyen
 import Combine
 import Foundation
 import UIKit
@@ -117,6 +117,7 @@ internal class StoredCardInputViewController: UIViewController {
 
     private let viewModel: StoredCardInputViewModelProtocol
     private var cancellables = Set<AnyCancellable>()
+    private var keyboardScrollViewHandler: KeyboardScrollViewHandler?
 
     private var theme: CheckoutTheme {
         viewModel.theme
@@ -151,7 +152,6 @@ internal class StoredCardInputViewController: UIViewController {
 
     private func setupView() {
         view.backgroundColor = theme.colors.background
-        // TODO: Robert: StoredView: 🐞 The scroll view isn't working in this screen. Needs separate investigation.
         view.addSubview(scrollView)
         scrollView.addSubview(contentStackView)
 
@@ -176,6 +176,7 @@ internal class StoredCardInputViewController: UIViewController {
         configureConstraints()
         configureContent()
         setupBindings()
+        setupKeyboardObserver()
         disableSwipeDownToDismissScreen()
     }
 
@@ -196,6 +197,7 @@ internal class StoredCardInputViewController: UIViewController {
             contentStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -Constants.buttonsBottomPadding),
             contentStackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, constant: -2 * Constants.contentPadding)
         ])
+
     }
 
     private func configureContent() {
@@ -232,4 +234,15 @@ internal class StoredCardInputViewController: UIViewController {
             await self?.viewModel.submit()
         }
     }
+
+    // MARK: - Keyboard handling
+
+    private func setupKeyboardObserver() {
+        keyboardScrollViewHandler = KeyboardScrollViewHandler(
+            scrollView: scrollView,
+            view: view
+        )
+        keyboardScrollViewHandler?.startObserving()
+    }
+
 }

--- a/AdyenUI/UI/Form/FormViewController.swift
+++ b/AdyenUI/UI/Form/FormViewController.swift
@@ -251,8 +251,7 @@ open class FormViewController: UIViewController, AdyenObserver {
 
         keyboardScrollViewHandler = KeyboardScrollViewHandler(
             scrollView: scrollView,
-            view: view,
-            animationKey: Animations.keyboardBottomInset
+            view: view
         )
         keyboardScrollViewHandler?.startObserving()
     }

--- a/AdyenUI/UI/Form/FormViewController.swift
+++ b/AdyenUI/UI/Form/FormViewController.swift
@@ -48,7 +48,7 @@ open class FormViewController: UIViewController, AdyenObserver {
 
     // MARK: - Private properties
 
-    private var keyboardObserver = KeyboardObserver()
+    private var keyboardScrollViewHandler: KeyboardScrollViewHandler?
     private var scrollEnabled: Bool
 
     // MARK: - Initializers
@@ -249,44 +249,12 @@ open class FormViewController: UIViewController, AdyenObserver {
     private func setupKeyboardObserver() {
         guard scrollEnabled else { return }
 
-        observe(keyboardObserver.$keyboardTransition) { [weak self] in
-            self?.handleKeyboardTransitionDidChange($0)
-        }
-    }
-
-    private func handleKeyboardTransitionDidChange(_ transition: KeyboardTransition) {
-        let updateInsets: () -> Void = { [weak self] in
-            guard let self else { return }
-
-            let bottomInset = self.keyboardOverlap(with: transition.keyboardRect)
-
-            var contentInset = self.scrollView.contentInset
-            contentInset.bottom = bottomInset
-            self.scrollView.contentInset = contentInset
-
-            var scrollIndicatorInsets = self.scrollView.scrollIndicatorInsets
-            scrollIndicatorInsets.bottom = bottomInset
-            self.scrollView.scrollIndicatorInsets = scrollIndicatorInsets
-        }
-
-        guard view.window != nil else {
-            updateInsets()
-            return
-        }
-
-        view.adyen.animate(context: AnimationContext(
-            animationKey: Animations.keyboardBottomInset,
-            duration: transition.animationDuration,
-            options: transition.animationOptions.union(.beginFromCurrentState),
-            animations: updateInsets
-        ))
-    }
-
-    private func keyboardOverlap(with keyboardRect: CGRect) -> CGFloat {
-        guard view.window != nil else { return keyboardRect.height }
-
-        let scrollViewFrame = scrollView.convert(scrollView.bounds, to: nil)
-        return scrollViewFrame.intersection(keyboardRect).height
+        keyboardScrollViewHandler = KeyboardScrollViewHandler(
+            scrollView: scrollView,
+            view: view,
+            animationKey: Animations.keyboardBottomInset
+        )
+        keyboardScrollViewHandler?.startObserving()
     }
 
     private func addSubviews() {

--- a/AdyenUI/UI/Form/KeyboardScrollViewHandler.swift
+++ b/AdyenUI/UI/Form/KeyboardScrollViewHandler.swift
@@ -1,0 +1,79 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+import UIKit
+
+/// Handles keyboard appearance/disappearance by adjusting scroll view content insets.
+/// This provides a reusable way to keep scroll view content visible when the keyboard appears.
+/// To check this behavior select a small device like a iPhone(SE) and load card component, or stored card component and see the cvv input screen with the keyboard visible,
+/// you should be able to scroll to see the primary button.
+package class KeyboardScrollViewHandler: AdyenObserver {
+
+    // MARK: - Properties
+
+    private weak var scrollView: UIScrollView?
+    private weak var view: UIView?
+    private let keyboardObserver = KeyboardObserver()
+    private let animationKey: String
+
+    // MARK: - Initializers
+
+    package init(
+        scrollView: UIScrollView,
+        view: UIView,
+        animationKey: String = "keyboardBottomInset"
+    ) {
+        self.scrollView = scrollView
+        self.view = view
+        self.animationKey = animationKey
+    }
+
+    package func startObserving() {
+        observe(keyboardObserver.$keyboardTransition) { [weak self] in
+            self?.handleKeyboardTransitionDidChange($0)
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func handleKeyboardTransitionDidChange(_ transition: KeyboardTransition) {
+        let updateInsets: () -> Void = { [weak self] in
+            guard let self, let scrollView = self.scrollView else { return }
+
+            let bottomInset = self.keyboardOverlap(with: transition.keyboardRect)
+
+            var contentInset = scrollView.contentInset
+            contentInset.bottom = bottomInset
+            scrollView.contentInset = contentInset
+
+            var verticalInsets = scrollView.verticalScrollIndicatorInsets
+            verticalInsets.bottom = bottomInset
+            scrollView.verticalScrollIndicatorInsets = verticalInsets
+        }
+
+        guard let view, view.window != nil else {
+            updateInsets()
+            return
+        }
+
+        view.adyen.animate(context: AnimationContext(
+            animationKey: animationKey,
+            duration: transition.animationDuration,
+            options: transition.animationOptions.union(.beginFromCurrentState),
+            animations: updateInsets
+        ))
+    }
+
+    private func keyboardOverlap(with keyboardRect: CGRect) -> CGFloat {
+        guard let scrollView, let view, view.window != nil else {
+            return keyboardRect.height
+        }
+
+        let scrollViewFrame = scrollView.convert(scrollView.bounds, to: nil)
+        return scrollViewFrame.intersection(keyboardRect).height
+    }
+}

--- a/AdyenUI/UI/Form/KeyboardScrollViewHandler.swift
+++ b/AdyenUI/UI/Form/KeyboardScrollViewHandler.swift
@@ -13,23 +13,24 @@ import UIKit
 /// you should be able to scroll to see the primary button.
 package class KeyboardScrollViewHandler: AdyenObserver {
 
+    private enum Constants {
+        static let animationKey = "keyboardBottomInset"
+    }
+
     // MARK: - Properties
 
     private weak var scrollView: UIScrollView?
     private weak var view: UIView?
     private let keyboardObserver = KeyboardObserver()
-    private let animationKey: String
 
     // MARK: - Initializers
 
     package init(
         scrollView: UIScrollView,
-        view: UIView,
-        animationKey: String = "keyboardBottomInset"
+        view: UIView
     ) {
         self.scrollView = scrollView
         self.view = view
-        self.animationKey = animationKey
     }
 
     package func startObserving() {
@@ -61,7 +62,7 @@ package class KeyboardScrollViewHandler: AdyenObserver {
         }
 
         view.adyen.animate(context: AnimationContext(
-            animationKey: animationKey,
+            animationKey: Constants.animationKey,
             duration: transition.animationDuration,
             options: transition.animationOptions.union(.beginFromCurrentState),
             animations: updateInsets
@@ -69,11 +70,12 @@ package class KeyboardScrollViewHandler: AdyenObserver {
     }
 
     private func keyboardOverlap(with keyboardRect: CGRect) -> CGFloat {
-        guard let scrollView, let view, view.window != nil else {
+        guard let scrollView, let view, let window = view.window else {
             return keyboardRect.height
         }
 
-        let scrollViewFrame = scrollView.convert(scrollView.bounds, to: nil)
-        return scrollViewFrame.intersection(keyboardRect).height
+        let keyboardRectInWindow = window.convert(keyboardRect, from: nil)
+        let scrollViewRectInWindow = scrollView.convert(scrollView.bounds, to: window)
+        return scrollViewRectInWindow.intersection(keyboardRectInWindow).height
     }
 }

--- a/Tests/UnitTests/AdyenUI/Form/KeyboardScrollViewHandlerTests.swift
+++ b/Tests/UnitTests/AdyenUI/Form/KeyboardScrollViewHandlerTests.swift
@@ -1,0 +1,141 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@testable import Adyen
+@testable import AdyenUI
+import Testing
+
+@MainActor
+struct KeyboardScrollViewHandlerTests {
+
+    @Test
+    func viewIsReset_whenKeyboardIsShownAndHidden() async {
+        let sut = makeSUT()
+
+        await sut.load()
+
+        await sut.showKeyboard()
+        sut.checkIfViewIsAdjustedForKeyboardShown()
+
+        await sut.hideKeyboard()
+        sut.checkIfViewIsAdjustedForKeyboardHidden()
+    }
+
+    func makeSUT() -> SampleViewControllerProxy {
+        SampleViewControllerProxy()
+    }
+
+    @MainActor
+    struct SampleViewControllerProxy {
+
+        private enum Constants {
+            static let keyboardHeight: CGFloat = 300
+        }
+
+        let viewController: SampleViewController = .init()
+        private let window = UIWindow(frame: UIScreen.main.bounds)
+        private let rootController = UIViewController()
+
+        func load() async {
+            window.rootViewController = rootController
+            window.makeKeyAndVisible()
+            await withCheckedContinuation { continuation in
+                rootController.present(viewController, animated: false) {
+                    viewController.loadViewIfNeeded()
+                    viewController.view.layoutIfNeeded()
+                    continuation.resume()
+                }
+            }
+        }
+
+        func showKeyboard() async {
+            let screenBounds = UIScreen.main.bounds
+            let keyboardRect = CGRect(
+                x: 0,
+                y: screenBounds.height - Constants.keyboardHeight,
+                width: screenBounds.width,
+                height: Constants.keyboardHeight
+            )
+            NotificationCenter.default.post(
+                name: UIResponder.keyboardWillChangeFrameNotification,
+                object: nil,
+                userInfo: [
+                    UIResponder.keyboardFrameEndUserInfoKey: keyboardRect,
+                    UIResponder.keyboardAnimationDurationUserInfoKey: 0.25,
+                    UIResponder.keyboardAnimationCurveUserInfoKey: UIView.AnimationCurve.easeInOut.rawValue
+                ]
+            )
+            try? await Task.sleep(for: .milliseconds(300))
+        }
+
+        func hideKeyboard() async {
+
+            NotificationCenter.default.post(
+                name: UIResponder.keyboardWillChangeFrameNotification,
+                object: nil,
+                userInfo: [
+                    UIResponder.keyboardFrameEndUserInfoKey: CGRect.zero,
+                    UIResponder.keyboardAnimationDurationUserInfoKey: 0.25,
+                    UIResponder.keyboardAnimationCurveUserInfoKey: UIView.AnimationCurve.easeInOut.rawValue
+                ]
+            )
+            try? await Task.sleep(for: .milliseconds(300))
+        }
+
+        func checkIfViewIsAdjustedForKeyboardShown() {
+            #expect(viewController.scrollView.contentInset.bottom == Constants.keyboardHeight)
+            #expect(viewController.scrollView.verticalScrollIndicatorInsets.bottom == Constants.keyboardHeight)
+        }
+
+        func checkIfViewIsAdjustedForKeyboardHidden() {
+            #expect(viewController.scrollView.contentInset.bottom == 0)
+            #expect(viewController.scrollView.verticalScrollIndicatorInsets.bottom == 0)
+        }
+    }
+
+    class SampleViewController: UIViewController {
+        lazy var scrollView: UIScrollView = {
+            let scrollView = UIScrollView()
+            scrollView.translatesAutoresizingMaskIntoConstraints = false
+            scrollView.showsVerticalScrollIndicator = true
+            scrollView.showsHorizontalScrollIndicator = false
+            return scrollView
+        }()
+
+        private var keyboardHandler: KeyboardScrollViewHandler?
+
+        lazy var contentView: UIStackView = {
+            let view = UIStackView()
+            view.translatesAutoresizingMaskIntoConstraints = false
+            view.addArrangedSubview(UIButton())
+            view.addArrangedSubview(UIButton())
+            return view
+        }()
+
+        init() {
+            super.init(nibName: nil, bundle: nil)
+        }
+        
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
+        override func viewDidLoad() {
+            super.viewDidLoad()
+            view.addSubview(scrollView)
+            scrollView.addSubview(contentView)
+            NSLayoutConstraint.activate([
+                scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+                scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            ])
+            keyboardHandler = KeyboardScrollViewHandler(scrollView: scrollView, view: view)
+            keyboardHandler?.startObserving()
+        }
+    }
+}


### PR DESCRIPTION
# Summary [Required]
Fixed bug 🐞 ScrollView not working with the keyboard.

Extract the logic for scroll view offsetting from `FormViewController` into `KeyboardScrollViewHandler` and consuming it at both StoredCardInputViewController and FormViewController.

Whats next?

- Fix bug 🐞 Constraints issue with the FormCardSecurityCodeItemView.
- Fix bug 🐞 Validation issue with the FormCardSecurityItem - it accepts 4 digits even though UI accepts only 3.

Previous MR - https://github.com/Adyen/adyen-ios/pull/2506

# Demo [Required for UI changes]
<img width="296" height="640" alt="Simulator Screen Recording - iPhone 17e - 2026-05-12 at 11 10 27" src="https://github.com/user-attachments/assets/fb49b5bf-db03-485d-bdcc-c16d445cdacd" />


## Ticket [Optional]
<ticket>
COSDK-1140
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
