### PR TITLE
StoredCardInputViewController: Fix CVV validation by resigning first responder (5.2/6)

### DIFF
--- a/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewController.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewController.swift
@@ -89,10 +89,10 @@ internal class StoredCardInputViewController: UIViewController {
     }()
 
     private lazy var securityCodeItemView: FormCardSecurityCodeItemView = {
-        // TODO: Robert: StoredView: 🐞 There is a bug(COSDK-572) with FormCardSecurityCodeItemView that when i type more than 3 characters only 3 display but validation happens with 4+ characters and then it fails validation. Needs to be debugged separately.
         let view = FormCardSecurityCodeItemView(item: viewModel.securityCodeItem, theme: theme)
         view.translatesAutoresizingMaskIntoConstraints = false
         view.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "securityCodeItemView")
+        view.delegate = self
         return view
     }()
 
@@ -177,6 +177,7 @@ internal class StoredCardInputViewController: UIViewController {
         configureContent()
         setupBindings()
         disableSwipeDownToDismissScreen()
+        securityCodeItemView.textField.becomeFirstResponder()
     }
 
     private func disableSwipeDownToDismissScreen() {
@@ -205,6 +206,9 @@ internal class StoredCardInputViewController: UIViewController {
     }
 
     private func updateLoadingState(_ isLoading: Bool) {
+        if isLoading {
+            securityCodeItemView.resignFirstResponder()
+        }
         primaryButton.isEnabled = !isLoading
         primaryButton.showsActivityIndicator = isLoading
         securityCodeItemView.isUserInteractionEnabled = !isLoading
@@ -231,5 +235,19 @@ internal class StoredCardInputViewController: UIViewController {
         Task { @MainActor [weak self] in
             await self?.viewModel.submit()
         }
+    }
+}
+
+extension StoredCardInputViewController: FormTextItemViewDelegate {
+    internal func didReachMaximumLength(in itemView: FormTextItemView<some FormTextItem>) {
+        handleReturnKey(from: itemView)
+    }
+
+    internal func didSelectReturnKey(in itemView: FormTextItemView<some FormTextItem>) {
+        handleReturnKey(from: itemView)
+    }
+
+    internal func handleReturnKey(from itemView: FormTextItemView<some FormTextItem>) {
+        itemView.resignFirstResponder()
     }
 }

--- a/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewController.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewController.swift
@@ -177,7 +177,7 @@ internal class StoredCardInputViewController: UIViewController {
         configureContent()
         setupBindings()
         disableSwipeDownToDismissScreen()
-        securityCodeItemView.textField.becomeFirstResponder()
+        securityCodeItemView.becomeFirstResponder()
     }
 
     private func disableSwipeDownToDismissScreen() {
@@ -240,14 +240,10 @@ internal class StoredCardInputViewController: UIViewController {
 
 extension StoredCardInputViewController: FormTextItemViewDelegate {
     internal func didReachMaximumLength(in itemView: FormTextItemView<some FormTextItem>) {
-        handleReturnKey(from: itemView)
+        securityCodeItemView.resignFirstResponder()
     }
 
     internal func didSelectReturnKey(in itemView: FormTextItemView<some FormTextItem>) {
-        handleReturnKey(from: itemView)
-    }
-
-    internal func handleReturnKey(from itemView: FormTextItemView<some FormTextItem>) {
-        itemView.resignFirstResponder()
+        securityCodeItemView.resignFirstResponder()
     }
 }

--- a/Tests/IntegrationTests/Card Tests/StoredCardInputViewControllerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardInputViewControllerTests.swift
@@ -129,6 +129,19 @@ struct StoredCardInputViewControllerTests {
         #expect(viewModel.viewDidDisappearCallsCount == 1)
     }
 
+    // MARK: - D: Security code input behavior
+
+    @Test
+    func typingThreeCharactersInSecurityCode_resignsFirstResponder() async throws {
+        let (proxy, _) = makeSUT()
+        await proxy.load()
+
+        let securityCodeView = try proxy.securityCodeItemView()
+        #expect(securityCodeView.isFirstResponder)
+        try proxy.enterCode("123")
+        #expect(!securityCodeView.isFirstResponder)
+    }
+
     // MARK: - Helpers
 
     private func makeSUT(
@@ -214,6 +227,12 @@ struct StoredCardInputViewControllerProxy {
             viewController.view.findView(by: "securityCodeItemView") as? FormCardSecurityCodeItemView,
             "Cannot find securityCodeItemView"
         )
+    }
+
+    func enterCode(_ code: String) throws {
+        let textField = try securityCodeItemView().textField
+        code.forEach { textField.insertText(String($0)) }
+        textField.sendActions(for: .editingChanged)
     }
 
     func tapPrimaryButton() throws {


### PR DESCRIPTION
# Summary [Required]
Fix bug 🐞 Validation issue with the FormCardSecurityItem - it accepts 4 digits even though UI accepts only 3.

Behaviour same as CardComponent - When the user enters the cvv code and reaches the max limit then it automatically resigns responder so the possibility of validation error is avoided. 

Whats next?

Fix bug 🐞 Constraints issue with the FormCardSecurityCodeItemView.

Previous MR - https://github.com/Adyen/adyen-ios/pull/2506


## Ticket [Optional]
<ticket>
COSDK-1140
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
