### PR TITLE
package access control adoption - make all individual `PUBLIC` Components to package (2.1/4)

### DIFF
--- a/Adyen/Actions/VoucherAction.swift
+++ b/Adyen/Actions/VoucherAction.swift
@@ -104,9 +104,8 @@ public enum VoucherAction: Decodable {
     private enum CodingKeys: String, CodingKey {
         case paymentMethodType
     }
-    
-    @_spi(AdyenInternal)
-    public var anyAction: AnyVoucherAction {
+
+    package var anyAction: AnyVoucherAction {
         switch self {
         case let .boletoBancairoSantander(action):
             return action

--- a/Adyen/Core/Components/Installment/InstallmentOptions.swift
+++ b/Adyen/Core/Components/Installment/InstallmentOptions.swift
@@ -44,7 +44,8 @@ public struct InstallmentOptions: Equatable, Codable {
         assert(maxInstallmentMonth > 1, "Must provide a valid max amount greater than 1.")
         self.init(monthValues: Array(2...maxInstallmentMonth), includesRevolving: includesRevolving)
     }
-
+    
+    @_spi(AdyenInternal)
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.regularInstallmentMonths = try container.decodeIfPresent([UInt].self, forKey: .regularInstallmentMonths) ?? []

--- a/Adyen/Core/Components/Installment/InstallmentOptions.swift
+++ b/Adyen/Core/Components/Installment/InstallmentOptions.swift
@@ -17,13 +17,11 @@ package protocol InstallmentConfigurationAware: AdyenSessionAware {
 public struct InstallmentOptions: Equatable, Codable {
     
     /// Month options for regular installments.
-    @_spi(AdyenInternal)
-    public let regularInstallmentMonths: [UInt]
-    
+    package let regularInstallmentMonths: [UInt]
+
     /// Determines if revolving installment is an option.
-    @_spi(AdyenInternal)
-    public let includesRevolving: Bool
-    
+    package let includesRevolving: Bool
+
     /// Creates a new instance of installment options.
     /// - Parameters:
     ///   - monthValues: Allowed installment month values, such as `[2, 3]` or `[3, 6, 9]` etc.
@@ -46,8 +44,7 @@ public struct InstallmentOptions: Equatable, Codable {
         assert(maxInstallmentMonth > 1, "Must provide a valid max amount greater than 1.")
         self.init(monthValues: Array(2...maxInstallmentMonth), includesRevolving: includesRevolving)
     }
-    
-    @_spi(AdyenInternal)
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.regularInstallmentMonths = try container.decodeIfPresent([UInt].self, forKey: .regularInstallmentMonths) ?? []
@@ -77,18 +74,15 @@ public struct InstallmentOptions: Equatable, Codable {
 public struct InstallmentConfiguration: Decodable {
     
     /// The option that apply to all card types, unless included `cardTypeBased` options.
-    @_spi(AdyenInternal)
-    public let defaultOptions: InstallmentOptions?
+    package let defaultOptions: InstallmentOptions?
 
     /// Options that are specific to given card types
-    @_spi(AdyenInternal)
-    public let cardBasedOptions: [CardType: InstallmentOptions]?
+    package let cardBasedOptions: [CardType: InstallmentOptions]?
 
     /// Determines whether to show the amount next to the installment value.
     /// For example, `3 months X 500 USD` or `3 months`.
     /// Amount is calculated by simple division.
-    @_spi(AdyenInternal)
-    public var showInstallmentAmount: Bool
+    package var showInstallmentAmount: Bool
 
     /// Creates a new installment configuration by providing both the card type based options
     ///  and default options for the rest of the card types.

--- a/Adyen/Core/Components/InstantPaymentComponent.swift
+++ b/Adyen/Core/Components/InstantPaymentComponent.swift
@@ -14,20 +14,19 @@ public protocol InitiablePaymentComponent: PaymentComponent {
 
 /// A component that handles payment methods that don't need any payment detail to be filled.
 @MainActor
-public final class InstantPaymentComponent: InitiablePaymentComponent {
+package final class InstantPaymentComponent: InitiablePaymentComponent {
 
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
+    package let context: AdyenContext
 
     /// The ready to submit payment data.
-    public let paymentData: PaymentComponentData
+    package let paymentData: PaymentComponentData
 
     /// The payment method.
-    public let paymentMethod: PaymentMethod
+    package let paymentMethod: PaymentMethod
 
     /// The delegate of the component.
-    public weak var delegate: PaymentComponentDelegate?
+    package weak var delegate: PaymentComponentDelegate?
 
     /// Initializes a new instance of `InstantPaymentComponent`.
     ///
@@ -35,7 +34,7 @@ public final class InstantPaymentComponent: InitiablePaymentComponent {
     ///   - paymentMethod: The payment method.
     ///   - paymentData: The ready to submit payment data.
     ///   - context: The context object for this component.
-    public init(
+    package init(
         paymentMethod: PaymentMethod,
         context: AdyenContext,
         paymentData: PaymentComponentData
@@ -51,7 +50,7 @@ public final class InstantPaymentComponent: InitiablePaymentComponent {
     ///   - paymentMethod: The payment method.
     ///   - context: The context object for this component.
     ///   - order: The partial order for this payment.
-    public init(
+    package init(
         paymentMethod: PaymentMethod,
         context: AdyenContext,
         order: PartialPaymentOrder?
@@ -68,7 +67,7 @@ public final class InstantPaymentComponent: InitiablePaymentComponent {
     }
 
     /// Generate the payment details and invoke PaymentsComponentDelegate method.
-    public func initiatePayment(delegate: PaymentComponentDelegate) {
+    package func initiatePayment(delegate: PaymentComponentDelegate) {
         // We are not attempting to fetch the checkoutAttemptId as it won't be ready for the payment
         // and we don't want to block it for an analytics call.
         self.delegate = delegate

--- a/Adyen/Core/Components/StoredPaymentMethodComponent.swift
+++ b/Adyen/Core/Components/StoredPaymentMethodComponent.swift
@@ -85,7 +85,6 @@ public final class StoredPaymentMethodComponent: StoredPaymentComponent {
     
 }
 
-@_spi(AdyenInternal)
 extension StoredPaymentMethodComponent: TrackableComponent {}
 
 /// Store payment method details.

--- a/Adyen/Core/Core Protocols/Component.swift
+++ b/Adyen/Core/Core Protocols/Component.swift
@@ -47,10 +47,9 @@ public protocol FinalizableComponent: Component {
     func didFinalize(with success: Bool, completion: (() -> Void)?)
 }
 
-public extension Component {
-    
-    @_spi(AdyenInternal)
-    var _isDropIn: Bool { // swiftlint:disable:this identifier_name
+extension Component {
+
+    package var _isDropIn: Bool { // swiftlint:disable:this identifier_name
         get {
             guard let value = objc_getAssociatedObject(self, &AssociatedKeys.isDropIn) as? Bool else {
                 return false

--- a/Adyen/Core/Core Protocols/PaymentComponentBuilder.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponentBuilder.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Builds a certain `PaymentComponent` based on the concrete `PaymentMethod`.
 @_spi(AdyenInternal)
 public protocol PaymentComponentBuilder: AdyenContextAware {
-    
+
     /// Builds a certain `PaymentComponent` based on a `StoredCardPaymentMethod`.
     func build(paymentMethod: StoredCardPaymentMethod) -> PaymentComponent?
     

--- a/Adyen/Core/Core Protocols/PresentableComponent.swift
+++ b/Adyen/Core/Core Protocols/PresentableComponent.swift
@@ -15,17 +15,21 @@ public protocol Localizable {
 }
 
 /// Represents any object than can handle a cancel event.
-package protocol Cancellable: AnyObject {
+public protocol Cancellable: AnyObject {
     
     /// Called when the user cancels the component.
     func didCancel()
 }
 
-package protocol AnyNavigationBar: UIView {
+@_spi(AdyenInternal)
+public protocol AnyNavigationBar: UIView {
+    
     var onCancelHandler: (() -> Void)? { get set }
+    
 }
 
-package enum NavigationBarType {
+@_spi(AdyenInternal)
+public enum NavigationBarType {
     case regular
     case custom(AnyNavigationBar)
 }
@@ -36,4 +40,18 @@ public protocol PresentableComponent: Component {
     
     /// Returns a view controller that presents the payment details for the shopper to fill.
     var viewController: UIViewController { get }
+    
+    /// Indicates whether Component implements a custom Navigation bar.
+    @_spi(AdyenInternal)
+    var navBarType: NavigationBarType { get }
+}
+
+/// A component that provides a view controller for the shopper to fill payment details.
+public extension PresentableComponent {
+    
+    @_spi(AdyenInternal)
+    var navBarType: NavigationBarType {
+        .regular
+    }
+    
 }

--- a/Adyen/Core/Core Protocols/PresentableComponent.swift
+++ b/Adyen/Core/Core Protocols/PresentableComponent.swift
@@ -15,21 +15,17 @@ public protocol Localizable {
 }
 
 /// Represents any object than can handle a cancel event.
-public protocol Cancellable: AnyObject {
+package protocol Cancellable: AnyObject {
     
     /// Called when the user cancels the component.
     func didCancel()
 }
 
-@_spi(AdyenInternal)
-public protocol AnyNavigationBar: UIView {
-    
+package protocol AnyNavigationBar: UIView {
     var onCancelHandler: (() -> Void)? { get set }
-    
 }
 
-@_spi(AdyenInternal)
-public enum NavigationBarType {
+package enum NavigationBarType {
     case regular
     case custom(AnyNavigationBar)
 }
@@ -40,18 +36,4 @@ public protocol PresentableComponent: Component {
     
     /// Returns a view controller that presents the payment details for the shopper to fill.
     var viewController: UIViewController { get }
-    
-    /// Indicates whether Component implements a custom Navigation bar.
-    @_spi(AdyenInternal)
-    var navBarType: NavigationBarType { get }
-}
-
-/// A component that provides a view controller for the shopper to fill payment details.
-public extension PresentableComponent {
-    
-    @_spi(AdyenInternal)
-    var navBarType: NavigationBarType {
-        .regular
-    }
-    
 }

--- a/Adyen/Core/Core Protocols/ReadyToSubmitPaymentComponentDelegate.swift
+++ b/Adyen/Core/Core Protocols/ReadyToSubmitPaymentComponentDelegate.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// The delegate that handles shopper confirmation UI when the balance of the gift card is sufficient to pay.
 @MainActor
-public protocol ReadyToSubmitPaymentComponentDelegate: AnyObject {
+package protocol ReadyToSubmitPaymentComponentDelegate: AnyObject {
 
     /// Called when the payment component is ready to submit shopper details,
     /// and the delegate needs to show a confirmation screen to the shopper.

--- a/Adyen/Core/Core Protocols/ViewControllerPresenter.swift
+++ b/Adyen/Core/Core Protocols/ViewControllerPresenter.swift
@@ -12,14 +12,13 @@ package protocol ViewControllerPresenter: AnyObject {
     func dismissViewController(animated: Bool)
 }
 
-@_spi(AdyenInternal)
 extension UIViewController: ViewControllerPresenter {
     
-    public func presentViewController(_ viewController: UIViewController, animated: Bool) {
+    package func presentViewController(_ viewController: UIViewController, animated: Bool) {
         self.adyen.topPresenter.present(viewController, animated: animated)
     }
     
-    public func dismissViewController(animated: Bool) {
+    package func dismissViewController(animated: Bool) {
         self.dismiss(animated: animated)
     }
 }

--- a/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
+++ b/Adyen/Core/Payment Methods/Abstract/PaymentMethodType.swift
@@ -224,8 +224,7 @@ extension PaymentMethodType {
     /// The brand name of the card type
     ///
     /// - Warning: Currently only intended to be used as `accessibilityLabel` as it's not localized
-    @_spi(AdyenInternal)
-    public var name: String {
+    package var name: String {
         switch self {
         case .card: return "card payment"
         case .scheme: return "scheme"

--- a/Adyen/Model/SDKData.swift
+++ b/Adyen/Model/SDKData.swift
@@ -87,8 +87,7 @@ public extension PaymentComponent {
     }
 }
 
-@_spi(AdyenInternal)
-public extension InstantPaymentComponent {
+package extension InstantPaymentComponent {
 
     var paymentMethodBehavior: SDKData.PaymentMethodBehavior {
         .genericComponent

--- a/Adyen/Utilities/IBANSpecification.swift
+++ b/Adyen/Utilities/IBANSpecification.swift
@@ -7,28 +7,27 @@
 import Foundation
 
 /// Contains the country-specific specifications for countries that adopt the IBAN standard.
-@_spi(AdyenInternal)
-public struct IBANSpecification {
-    
+package struct IBANSpecification {
+
     /// The highest possible length of an IBAN.
-    public static let highestMaximumLength = 32
-    
+    package static let highestMaximumLength = 32
+
     /// The code of the country to which the specifications apply.
-    public let countryCode: String
-    
+    package let countryCode: String
+
     /// The length of a valid IBAN.
-    public let length: Int
-    
+    package let length: Int
+
     /// The structure of the underlying BBAN.
-    public let structure: String
-    
+    package let structure: String
+
     /// An example of a valid IBAN.
-    public let example: String
-    
+    package let example: String
+
     /// Returns the IBAN specification for the country with the given code, or `nil` if none could be found.
     ///
     /// - Parameter countryCode: The code of the country to retrieve the IBAN specification for.
-    public init?(forCountryCode countryCode: String) {
+    package init?(forCountryCode countryCode: String) {
         guard let specification = IBANSpecification.specifications[countryCode] else {
             return nil
         }

--- a/Adyen/Utilities/Localization.swift
+++ b/Adyen/Utilities/Localization.swift
@@ -110,8 +110,7 @@ private func attemptEnforce(locale: String, _ input: LocalizationInput) -> Strin
     return nil
 }
 
-@_spi(AdyenInternal)
-public enum PaymentStyle {
+package enum PaymentStyle {
     case needsRedirectToThirdParty(String)
 
     case immediate
@@ -123,8 +122,7 @@ public enum PaymentStyle {
 /// - Parameter amount: The amount to include in the submit button title.
 /// - Parameter paymentMethodName: The payment method name.
 /// - Parameter parameters: The localization parameters.
-@_spi(AdyenInternal)
-public func localizedSubmitButtonTitle(
+package func localizedSubmitButtonTitle(
     with amount: Amount?,
     style: PaymentStyle,
     _ parameters: LocalizationParameters?

--- a/Adyen/Utilities/Observable/AdyenObservable.swift
+++ b/Adyen/Utilities/Observable/AdyenObservable.swift
@@ -38,8 +38,8 @@ open class AdyenObservable<ValueType: Equatable>: EventPublisher {
     public typealias Event = ValueType
 
     /// The event handlers attached to the observable.
-    public var eventHandlers = [EventHandlerToken: EventHandler<Event>]()
-    
+    package var eventHandlers = [EventHandlerToken: EventHandler<Event>]()
+
     open var projectedValue: AdyenObservable {
         self
     }

--- a/Adyen/Utilities/Observable/EventPublisher.swift
+++ b/Adyen/Utilities/Observable/EventPublisher.swift
@@ -7,21 +7,19 @@
 import Foundation
 
 /// Conforming types can publish observable events.
-public protocol EventPublisher: AnyObject {
-    
+package protocol EventPublisher: AnyObject {
+
     /// The type of event published.
     associatedtype Event
     
     /// The event handlers that are attached to the publisher.
     var eventHandlers: [EventHandlerToken: EventHandler<Event>] { get set }
     
-    @_spi(AdyenInternal)
     var eventHandlersLock: NSLock { get }
 }
 
-@_spi(AdyenInternal)
-public extension EventPublisher {
-    
+package extension EventPublisher {
+
     /// Adds an event handler.
     ///
     /// - Parameter eventHandler: The event handler to add.
@@ -64,9 +62,9 @@ public extension EventPublisher {
 }
 
 /// Alias for a closure that handles an event.
-public typealias EventHandler<Event> = (Event) -> Void
+package typealias EventHandler<Event> = (Event) -> Void
 
 /// Represents a token that references the event handler.
-public struct EventHandlerToken: Hashable {
+package struct EventHandlerToken: Hashable {
     private let uuid = UUID()
 }

--- a/Adyen/Utilities/Throttler.swift
+++ b/Adyen/Utilities/Throttler.swift
@@ -7,21 +7,20 @@
 import Foundation
 
 /// Throttles come code execution.
-@_spi(AdyenInternal)
-public final class Throttler {
-    
+package final class Throttler {
+
     private var workItem = DispatchWorkItem(block: { /* first work item is idle */ })
     private let queue: DispatchQueue
     private let minimumDelay: TimeInterval
     
-    public init(minimumDelay: TimeInterval, queue: DispatchQueue = DispatchQueue.main) {
+    package init(minimumDelay: TimeInterval, queue: DispatchQueue = DispatchQueue.main) {
         self.minimumDelay = minimumDelay
         self.queue = queue
     }
     
     /// Throttle a block of code after `minimumDelay`.
     /// - Parameter block: Block of code to be throttled.
-    public func throttle(_ block: @escaping () -> Void) {
+    package func throttle(_ block: @escaping () -> Void) {
         // Cancel any existing work item if it has not yet executed
         workItem.cancel()
         

--- a/Adyen/Validators/ClientKeyValidator.swift
+++ b/Adyen/Validators/ClientKeyValidator.swift
@@ -22,10 +22,9 @@ public enum ClientKeyError: Error, LocalizedError {
 }
 
 /// Validates a client key https://docs.adyen.com/user-management/client-side-authentication
-@_spi(AdyenInternal)
-public final class ClientKeyValidator: RegularExpressionValidator {
+package final class ClientKeyValidator: RegularExpressionValidator {
 
-    public init() {
+    package init() {
         let regex = #"^[a-z]{4,8}_[a-zA-Z0-9]{8,128}$"#
         super.init(regularExpression: regex, minimumLength: 13, maximumLength: 140)
     }

--- a/Adyen/Validators/RegularExpressionValidator.swift
+++ b/Adyen/Validators/RegularExpressionValidator.swift
@@ -7,9 +7,8 @@
 import Foundation
 
 /// Validates a string using a regular expression.
-@_spi(AdyenInternal)
-public class RegularExpressionValidator: LengthValidator {
-    
+package class RegularExpressionValidator: LengthValidator {
+
     private let regularExpression: String
     
     /// Initializes a new instance of `RegularExpressionValidator`
@@ -18,18 +17,18 @@ public class RegularExpressionValidator: LengthValidator {
     ///   - regularExpression: The regex to validate against
     ///   - minimumLength: The minimum length allowed.
     ///   - maximumLength: The maximum length allowed.
-    public init(regularExpression: String, minimumLength: Int? = nil, maximumLength: Int? = nil) {
+    package init(regularExpression: String, minimumLength: Int? = nil, maximumLength: Int? = nil) {
         self.regularExpression = regularExpression
         super.init(minimumLength: minimumLength, maximumLength: maximumLength)
     }
     
-    override public func isValid(_ value: String) -> Bool {
+    override package func isValid(_ value: String) -> Bool {
         guard super.isValid(value) else { return false }
         guard let range = value.range(of: regularExpression, options: .regularExpression) else { return false }
         return range == (value.startIndex..<value.endIndex)
     }
     
-    override public func maximumLength(for value: String) -> Int {
+    override package func maximumLength(for value: String) -> Int {
         maximumLength ?? .max
     }
     

--- a/AdyenActions/CheckoutActionComponent.swift
+++ b/AdyenActions/CheckoutActionComponent.swift
@@ -14,36 +14,36 @@ import UIKit
  An action handler component to perform any supported action out of the box.
  */
 @MainActor
-public final class CheckoutActionComponent: ActionComponent, ActionHandlingComponent {
-    
+package final class CheckoutActionComponent: ActionComponent, ActionHandlingComponent {
+
     /// :nodoc:
     /// The context object for this component.
-    public let context: AdyenContext
-    
+    package let context: AdyenContext
+
     /// The object that acts as the delegate of the action component.
-    public weak var delegate: ActionComponentDelegate?
-    
+    package weak var delegate: ActionComponentDelegate?
+
     /// The object that acts as the presentation delegate of the action component.
-    public weak var presentationDelegate: PresentationDelegate?
-    
+    package weak var presentationDelegate: PresentationDelegate?
+
     /// Action handling configurations.
-    public var configuration: Configuration
-    
+    package var configuration: Configuration
+
     /// Action handling configurations.
-    public struct Configuration: Localizable {
-        
+    package struct Configuration: Localizable {
+
         /// Localization parameters.
-        public var localizationParameters: LocalizationParameters?
-        
+        package var localizationParameters: LocalizationParameters?
+
         /// The UI style configurations.
-        public var style: ActionComponentStyle = .init()
-        
+        package var style: ActionComponentStyle = .init()
+
         /// Authentication configuration.
-        public var authentication: AuthenticationConfiguration
+        package var authentication: AuthenticationConfiguration
 
         /// Twint configuration.
-        public var twint: TwintActionConfiguration?
-        
+        package var twint: TwintActionConfiguration?
+
         /// Initializes a new instance.
         ///
         /// - Parameters:
@@ -51,7 +51,7 @@ public final class CheckoutActionComponent: ActionComponent, ActionHandlingCompo
         ///   - style: The UI style configurations.
         ///   - authentication: Authentication configuration.
         ///   - twint: Twint configurations.
-        public init(
+        package init(
             localizationParameters: LocalizationParameters? = nil,
             style: ActionComponentStyle = .init(),
             authentication: AuthenticationConfiguration = .init(),
@@ -73,7 +73,7 @@ public final class CheckoutActionComponent: ActionComponent, ActionHandlingCompo
     /// - Parameters:
     ///   - context: The context object.
     ///   - configuration: The configuration.
-    public init(
+    package init(
         context: AdyenContext,
         configuration: Configuration = Configuration()
     ) {
@@ -86,8 +86,8 @@ public final class CheckoutActionComponent: ActionComponent, ActionHandlingCompo
     /// Handles an action to complete a payment.
     ///
     /// - Parameter action: The action to handle.
-    public func handle(_ action: Action) {
-        
+    package func handle(_ action: Action) {
+
         sendHandleEvent(for: action)
         
         switch action {

--- a/AdyenActions/Components/Authentication/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDAScreenPresenter.swift
+++ b/AdyenActions/Components/Authentication/Action handlers/3DS2+Delegated Authentication/ThreeDS2PlusDAScreenPresenter.swift
@@ -5,7 +5,7 @@
 //
 
 import Adyen
-@_spi(AdyenInternal) import enum Adyen.NavigationBarType
+@_spi(AdyenInternal) import struct Adyen.LocalizationKey
 import Foundation
 import LocalAuthentication
 import UIKit

--- a/AdyenActions/Components/Await/AwaitComponent.swift
+++ b/AdyenActions/Components/Await/AwaitComponent.swift
@@ -10,17 +10,16 @@ import Foundation
 
 /// A component that handles Await action's.
 @MainActor
-public final class AwaitComponent: ActionComponent, Cancellable {
-    
+package final class AwaitComponent: ActionComponent, Cancellable {
+
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
+    package let context: AdyenContext
+
     /// Delegates `PresentableComponent`'s presentation.
-    public weak var presentationDelegate: PresentationDelegate?
-    
-    public weak var delegate: ActionComponentDelegate?
-    
+    package weak var presentationDelegate: PresentationDelegate?
+
+    package weak var delegate: ActionComponentDelegate?
+
     internal var appLauncher: AnyAppLauncher = AppLauncher()
 
     /// The await component configurations.
@@ -47,15 +46,15 @@ public final class AwaitComponent: ActionComponent, Cancellable {
     }
     
     /// The await component configurations.
-    public var configuration: Configuration
-    
+    package var configuration: Configuration
+
     private let awaitComponentBuilder: AnyPollingHandlerProvider
     
     /// Initializes the `AwaitComponent`.
     ///
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The await component configurations.
-    public convenience init(
+    package convenience init(
         context: AdyenContext,
         configuration: Configuration = .init()
     ) {
@@ -86,7 +85,7 @@ public final class AwaitComponent: ActionComponent, Cancellable {
     /// Handles redirect await action.
     ///
     /// - Parameter action: The await action object.
-    public func handle(_ action: RedirectableAwaitAction) {
+    package func handle(_ action: RedirectableAwaitAction) {
         appLauncher.openCustomSchemeUrl(action.url) { [weak self] success in
             guard let self else { return }
             if success {
@@ -104,14 +103,14 @@ public final class AwaitComponent: ActionComponent, Cancellable {
         }
     }
 
-    public func didCancel() {
+    package func didCancel() {
         paymentMethodSpecificPollingComponent?.didCancel()
     }
 
     /// Handles await action.
     ///
     /// - Parameter action: The await action object.
-    public func handle(_ action: AwaitAction) {
+    package func handle(_ action: AwaitAction) {
         Analytics.sendEvent(component: componentName, flavor: _isDropIn ? .dropin : .components, context: context.apiContext)
 
         let viewModel = AwaitComponentViewModel.viewModel(

--- a/AdyenActions/Components/Base/ActionNavigationBar.swift
+++ b/AdyenActions/Components/Base/ActionNavigationBar.swift
@@ -5,7 +5,6 @@
 //
 
 import Adyen
-@_spi(AdyenInternal) import protocol Adyen.AnyNavigationBar
 #if canImport(AdyenUI)
     import AdyenUI
 #endif

--- a/AdyenActions/Components/Base/ActionNavigationBar.swift
+++ b/AdyenActions/Components/Base/ActionNavigationBar.swift
@@ -5,6 +5,7 @@
 //
 
 import Adyen
+@_spi(AdyenInternal) import protocol Adyen.AnyNavigationBar
 #if canImport(AdyenUI)
     import AdyenUI
 #endif

--- a/AdyenActions/Components/Document/DocumentComponent.swift
+++ b/AdyenActions/Components/Document/DocumentComponent.swift
@@ -14,17 +14,16 @@ import UIKit
 
 /// A component that handles document actions.
 @MainActor
-public final class DocumentComponent: ActionComponent, ShareableComponent {
+package final class DocumentComponent: ActionComponent, ShareableComponent {
 
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
-    public weak var delegate: ActionComponentDelegate?
-    
+    package let context: AdyenContext
+
+    package weak var delegate: ActionComponentDelegate?
+
     /// Delegates `PresentableComponent`'s presentation.
-    public weak var presentationDelegate: PresentationDelegate?
-    
+    package weak var presentationDelegate: PresentationDelegate?
+
     /// The document component configurations.
     public struct Configuration {
         
@@ -46,8 +45,8 @@ public final class DocumentComponent: ActionComponent, ShareableComponent {
     }
     
     /// The document component configurations.
-    public var configuration: Configuration = .init()
-    
+    package var configuration: Configuration = .init()
+
     internal let presenterViewController = UIViewController()
     
     private let componentName = "documentAction"
@@ -56,7 +55,7 @@ public final class DocumentComponent: ActionComponent, ShareableComponent {
     ///
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The Component configurations.
-    public init(
+    package init(
         context: AdyenContext,
         configuration: Configuration = .init()
     ) {
@@ -67,7 +66,7 @@ public final class DocumentComponent: ActionComponent, ShareableComponent {
     /// Handles document action.
     ///
     /// - Parameter action: The document action object.
-    public func handle(_ action: DocumentAction) {
+    package func handle(_ action: DocumentAction) {
         Analytics.sendEvent(component: componentName, flavor: _isDropIn ? .dropin : .components, context: context.apiContext)
         
         let imageURL = LogoURLProvider.logoURL(

--- a/AdyenActions/Components/QRCode/QRCodeActionComponent.swift
+++ b/AdyenActions/Components/QRCode/QRCodeActionComponent.swift
@@ -5,7 +5,7 @@
 //
 
 import Adyen
-@_spi(AdyenInternal) import enum Adyen.NavigationBarType
+@_spi(AdyenInternal) import struct Adyen.LocalizationKey
 #if canImport(AdyenUI)
     import AdyenUI
 #endif
@@ -16,23 +16,22 @@ internal enum QRCodeComponentError: LocalizedError {
     /// Indicates the QR code is not longer valid
     case qrCodeExpired
 
-    public var errorDescription: String? {
+    package var errorDescription: String? {
         "QR code is no longer valid"
     }
 }
 
 /// A component  for QRCode action.
 @MainActor
-public final class QRCodeActionComponent: ActionComponent, Cancellable, ShareableComponent {
-    
-    /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
-    /// Delegates `PresentableComponent`'s presentation.
-    public weak var presentationDelegate: PresentationDelegate?
+package final class QRCodeActionComponent: ActionComponent, Cancellable, ShareableComponent {
 
-    public weak var delegate: ActionComponentDelegate?
+    /// The context object for this component.
+    package let context: AdyenContext
+
+    /// Delegates `PresentableComponent`'s presentation.
+    package weak var presentationDelegate: PresentationDelegate?
+
+    package weak var delegate: ActionComponentDelegate?
 
     internal let presenterViewController = UIViewController()
 
@@ -41,7 +40,7 @@ public final class QRCodeActionComponent: ActionComponent, Cancellable, Shareabl
         
         /// The component UI style.
         public var style: QRCodeComponentStyle = .init()
-        
+
         /// The localization parameters, leave it nil to use the default parameters.
         public var localizationParameters: LocalizationParameters?
         
@@ -57,7 +56,7 @@ public final class QRCodeActionComponent: ActionComponent, Cancellable, Shareabl
     }
     
     /// The QR code component configurations.
-    public var configuration: Configuration
+    package var configuration: Configuration
 
     private let pollingComponentBuilder: AnyPollingHandlerProvider?
     
@@ -73,7 +72,7 @@ public final class QRCodeActionComponent: ActionComponent, Cancellable, Shareabl
     ///
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The component configurations
-    public convenience init(
+    package convenience init(
         context: AdyenContext,
         configuration: Configuration = .init()
     ) {
@@ -102,7 +101,7 @@ public final class QRCodeActionComponent: ActionComponent, Cancellable, Shareabl
     /// Handles QR code action.
     ///
     /// - Parameter action: The QR code action.
-    public func handle(_ action: QRCodeAction) {
+    package func handle(_ action: QRCodeAction) {
         AdyenAssertion.assert(message: "presentationDelegate is nil", condition: presentationDelegate == nil)
         
         let viewController = createViewController(with: action)
@@ -253,7 +252,7 @@ public final class QRCodeActionComponent: ActionComponent, Cancellable, Shareabl
         }
     }
 
-    public func didCancel() {
+    package func didCancel() {
         cleanup()
     }
     
@@ -263,17 +262,16 @@ public final class QRCodeActionComponent: ActionComponent, Cancellable, Shareabl
     }
 }
 
-@_spi(AdyenInternal)
 extension QRCodeActionComponent: ActionComponentDelegate {
 
-    public func didProvide(_ data: ActionComponentData, from component: ActionComponent) {
+    package func didProvide(_ data: ActionComponentData, from component: ActionComponent) {
         cleanup()
         delegate?.didProvide(data, from: self)
     }
 
-    public func didComplete(from component: ActionComponent) {}
+    package func didComplete(from component: ActionComponent) {}
 
-    public func didFail(with error: Error, from component: ActionComponent) {
+    package func didFail(with error: Error, from component: ActionComponent) {
         cleanup()
         delegate?.didFail(with: error, from: self)
     }

--- a/AdyenActions/Components/Redirect/RedirectComponent.swift
+++ b/AdyenActions/Components/Redirect/RedirectComponent.swift
@@ -13,18 +13,18 @@ extension RedirectComponent: AnyRedirectComponent {}
 
 /// Handles any redirect Url whether its a web url, an App custom scheme url, or an app universal link.
 @MainActor
-public final class RedirectComponent: ActionComponent {
-    
+package final class RedirectComponent: ActionComponent {
+
     /// Describes the types of errors that can be returned by the component.
-    public enum Error: LocalizedError {
-        
+    package enum Error: LocalizedError {
+
         /// Indicates that no app is installed that can handle the payment.
         case appNotFound
         
         /// Indicates that invalid parameters are passed back from the issuer.
         case invalidRedirectParameters
         
-        public var errorDescription: String? {
+        package var errorDescription: String? {
             switch self {
             case .appNotFound:
                 return "No app installed that can handle the payment."
@@ -52,14 +52,13 @@ public final class RedirectComponent: ActionComponent {
     }
     
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
-    public weak var delegate: ActionComponentDelegate?
+    package let context: AdyenContext
+
+    package weak var delegate: ActionComponentDelegate?
 
     /// Delegates `PresentableComponent`'s presentation.
-    public weak var presentationDelegate: PresentationDelegate?
-    
+    package weak var presentationDelegate: PresentationDelegate?
+
     internal var appLauncher: AnyAppLauncher = AppLauncher()
     
     internal lazy var apiClient: AsyncAPIClientProtocol = {
@@ -69,15 +68,15 @@ public final class RedirectComponent: ActionComponent {
     private var browserComponent: BrowserComponent?
     
     /// The component configurations.
-    public var configuration: Configuration
-    
+    package var configuration: Configuration
+
     private var action: RedirectAction?
     
     /// Initializes the component.
     ///
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The component configurations.
-    public init(
+    package init(
         context: AdyenContext,
         configuration: Configuration = Configuration()
     ) {
@@ -88,7 +87,7 @@ public final class RedirectComponent: ActionComponent {
     /// Handles a redirect action.
     ///
     /// - Parameter action: The redirect action object.
-    public func handle(_ action: RedirectAction) {
+    package func handle(_ action: RedirectAction) {
         Analytics.sendEvent(
             component: configuration.componentName,
             flavor: _isDropIn ? .dropin : .components,
@@ -111,7 +110,7 @@ public final class RedirectComponent: ActionComponent {
     /// - Parameter url: The URL through which the application was opened.
     /// - Returns: A boolean value indicating whether the URL was handled by the redirect component.
     @discardableResult
-    public static func applicationDidOpen(from url: URL) -> Bool {
+    package static func applicationDidOpen(from url: URL) -> Bool {
         do {
             return try RedirectListener.applicationDidOpen(from: url)
         } catch {
@@ -234,22 +233,21 @@ extension RedirectComponent: BrowserComponentDelegate {
     
 }
 
-@_spi(AdyenInternal)
 extension RedirectComponent: ActionComponentDelegate {
     
-    public func didProvide(_ data: ActionComponentData, from component: ActionComponent) {
+    package func didProvide(_ data: ActionComponentData, from component: ActionComponent) {
         delegate?.didProvide(data, from: self)
     }
 
-    public func didComplete(from component: ActionComponent) {
+    package func didComplete(from component: ActionComponent) {
         delegate?.didComplete(from: self)
     }
     
-    public func didFail(with error: Swift.Error, from component: ActionComponent) {
+    package func didFail(with error: Swift.Error, from component: ActionComponent) {
         delegate?.didFail(with: error, from: self)
     }
     
-    public func didOpenExternalApplication(component: ActionComponent) {
+    package func didOpenExternalApplication(component: ActionComponent) {
         delegate?.didOpenExternalApplication(component: self)
     }
     

--- a/AdyenActions/Components/Voucher/VoucherComponent.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponent.swift
@@ -20,20 +20,19 @@ internal protocol AnyVoucherActionHandler: ActionComponent, Cancellable {
 
 /// A component that handles voucher action.
 @MainActor
-public final class VoucherComponent: AnyVoucherActionHandler, ShareableComponent {
+package final class VoucherComponent: AnyVoucherActionHandler, ShareableComponent {
 
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
-    /// Delegates `PresentableComponent`'s presentation.
-    public weak var presentationDelegate: PresentationDelegate?
+    package let context: AdyenContext
 
-    public weak var delegate: ActionComponentDelegate?
-    
+    /// Delegates `PresentableComponent`'s presentation.
+    package weak var presentationDelegate: PresentationDelegate?
+
+    package weak var delegate: ActionComponentDelegate?
+
     /// The voucher component configurations.
     public struct Configuration {
-        
+
         /// The component UI style.
         public var style: VoucherComponentStyle = .init()
         
@@ -52,7 +51,7 @@ public final class VoucherComponent: AnyVoucherActionHandler, ShareableComponent
     }
     
     /// The voucher component configurations.
-    public var configuration: Configuration
+    package var configuration: Configuration
 
     internal var voucherShareableViewProvider: AnyVoucherShareableViewProvider
     
@@ -70,7 +69,7 @@ public final class VoucherComponent: AnyVoucherActionHandler, ShareableComponent
     ///
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The voucher component configurations.
-    public convenience init(
+    package convenience init(
         context: AdyenContext,
         configuration: Configuration = Configuration()
     ) {
@@ -100,12 +99,12 @@ public final class VoucherComponent: AnyVoucherActionHandler, ShareableComponent
         self.passProvider = passProvider ?? AppleWalletPassProvider(context: context)
     }
 
-    public func didCancel() {}
+    package func didCancel() {}
 
     /// Handles await action.
     ///
     /// - Parameter action: The await action object.
-    public func handle(_ action: VoucherAction) {
+    package func handle(_ action: VoucherAction) {
         Analytics.sendEvent(component: componentName, flavor: _isDropIn ? .dropin : .components, context: context.apiContext)
         fetchAndCacheAppleWalletPassIfNeeded(with: action.anyAction)
 

--- a/AdyenActions/Components/Voucher/VoucherComponentExtensions.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponentExtensions.swift
@@ -12,7 +12,6 @@ import Adyen
 import PassKit
 import UIKit
 
-@_spi(AdyenInternal)
 extension VoucherComponent: VoucherViewDelegate, DocumentActionViewDelegate {
     
     private static let maximumDisplayedCodeLength = 10

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DAApprovalViewController.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DAApprovalViewController.swift
@@ -8,7 +8,6 @@ import Adyen
 @_spi(AdyenInternal) import struct Adyen.LocalizationKey
 #if canImport(AdyenUI)
     import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormButton
 #endif
 import UIKit
 

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DAErrorViewController.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DAErrorViewController.swift
@@ -8,7 +8,6 @@ import Adyen
 @_spi(AdyenInternal) import struct Adyen.LocalizationKey
 #if canImport(AdyenUI)
     import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormButton
 #endif
 import UIKit
 

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DARegistrationViewController.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DARegistrationViewController.swift
@@ -8,7 +8,6 @@ import Adyen
 @_spi(AdyenInternal) import struct Adyen.LocalizationKey
 #if canImport(AdyenUI)
     import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormButton
 #endif
 import UIKit
 

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationErrorView.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationErrorView.swift
@@ -7,7 +7,6 @@
 import Adyen
 #if canImport(AdyenUI)
     import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormButton
 #endif
 import UIKit
 

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationView.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/DelegatedAuthenticationView.swift
@@ -7,7 +7,6 @@
 import Adyen
 #if canImport(AdyenUI)
     import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormButton
 #endif
 import Foundation
 import LocalAuthentication

--- a/AdyenActions/UI/View Controllers/QR Code/QRCodeViewController.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/QRCodeViewController.swift
@@ -7,7 +7,6 @@
 import Adyen
 #if canImport(AdyenUI)
     import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormButton
 #endif
 import Foundation
 import UIKit

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherView.swift
@@ -7,7 +7,6 @@
 import Adyen
 #if canImport(AdyenUI)
     import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormButton
 #endif
 import PassKit
 import UIKit

--- a/AdyenActions/Utilities/Non SPM Bundle Extension/ActionsBundleExtension.swift
+++ b/AdyenActions/Utilities/Non SPM Bundle Extension/ActionsBundleExtension.swift
@@ -8,7 +8,6 @@ import Foundation
 
 /// This is excluded from the Swift Package, since swift packages has different code to access internal resources.
 /// The Bundle extension in `BundleSPMExtension.swift` is used instead.
-@_spi(AdyenInternal)
 extension Bundle {
 
     /// The main bundle of the framework.

--- a/AdyenCard/Components/BCMC/BCMCComponent.swift
+++ b/AdyenCard/Components/BCMC/BCMCComponent.swift
@@ -10,14 +10,14 @@ import Foundation
 import UIKit
 
 /// A component that handles BCMC card payments.
-public final class BCMCComponent: CardComponent {
-    
+package final class BCMCComponent: CardComponent {
+
     /// Initializes the BCMC Component.
     /// - Parameters:
     ///   - paymentMethod: BCMC payment method.
     ///   - context: The context object for this component.
     ///   - configuration: The configuration of the component.
-    public init(
+    package init(
         paymentMethod: BCMCPaymentMethod,
         context: AdyenContext,
         configuration: CardConfiguration = .init()

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -21,7 +21,7 @@ import UIKit
  [Implementation guidelines](https://docs.adyen.com/payment-methods/cards/ios-component)
  */
 @MainActor
-public class CardComponent: PresentableComponent,
+package class CardComponent: PresentableComponent,
     PaymentMethodAware,
     LoadingComponent {
 
@@ -33,26 +33,25 @@ public class CardComponent: PresentableComponent,
     }
 
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
+    package let context: AdyenContext
 
     internal let cardPaymentMethod: AnyCardPaymentMethod
 
     internal let binInfoProvider: AnyBinInfoProvider
 
     /// The card payment method.
-    public var paymentMethod: PaymentMethod {
+    package var paymentMethod: PaymentMethod {
         cardPaymentMethod
     }
 
     /// The supported card types.
-    public let supportedCardTypes: [CardType]
+    package let supportedCardTypes: [CardType]
 
     /// Card component configuration.
-    public internal(set) var configuration: CardConfiguration
+    package internal(set) var configuration: CardConfiguration
 
     /// The delegate of the component.
-    public weak var delegate: PaymentComponentDelegate? {
+    package weak var delegate: PaymentComponentDelegate? {
         didSet {
             storedCardComponent?.delegate = delegate
             // override installment config if using session (when session is set as delegate)
@@ -69,7 +68,7 @@ public class CardComponent: PresentableComponent,
     }
 
     /// The partial payment order if any.
-    public var order: PartialPaymentOrder? {
+    package var order: PartialPaymentOrder? {
         didSet {
             storedCardComponent?.order = order
         }
@@ -86,7 +85,7 @@ public class CardComponent: PresentableComponent,
     ///   - paymentMethod: The card payment method.
     ///   - context: The context object for this component.
     ///   - configuration: The configuration of the component.
-    public convenience init(
+    package convenience init(
         paymentMethod: AnyCardPaymentMethod,
         context: AdyenContext,
         configuration: CardConfiguration = .init()
@@ -128,14 +127,14 @@ public class CardComponent: PresentableComponent,
 
     // MARK: - Presentable Component Protocol
 
-    public var viewController: UIViewController {
+    package var viewController: UIViewController {
         if let storedCardComponent {
             return storedCardComponent.viewController
         }
         return securedViewController
     }
 
-    public func stopLoading() {
+    package func stopLoading() {
         // since storedCardComponent is instantiated through this class
         // cardViewController should not be accessed when it's the storedCardComponent
         // we should separate stored card component logic into its own
@@ -168,11 +167,11 @@ public class CardComponent: PresentableComponent,
     /// Updates the visibility of the store payment method switch.
     ///
     /// - Parameter isVisible: Indicates whether to show the switch if `true` or to hide it if `false`.
-    public func update(storePaymentMethodFieldVisibility isVisible: Bool) {
+    package func update(storePaymentMethodFieldVisibility isVisible: Bool) {
         cardViewController.update(storePaymentMethodFieldVisibility: isVisible)
     }
 
-    public func update(storePaymentMethodFieldValue isOn: Bool) {
+    package func update(storePaymentMethodFieldValue isOn: Bool) {
         cardViewController.update(storePaymentMethodFieldValue: isOn)
     }
 
@@ -318,11 +317,11 @@ private extension CardConfiguration {
 
 extension CardComponent: SubmittableComponent {
 
-    public func submit() {
+    package func submit() {
         didSelectSubmitButton()
     }
 
-    public func validate() -> Bool {
+    package func validate() -> Bool {
         cardViewController.validate()
     }
 }

--- a/AdyenCard/Components/Card/CardComponentExtensions.swift
+++ b/AdyenCard/Components/Card/CardComponentExtensions.swift
@@ -72,10 +72,9 @@ extension CardComponent {
     }
 }
 
-@_spi(AdyenInternal)
 extension CardComponent: TrackableComponent {
     
-    public func sendDidLoadEvent() {
+    package func sendDidLoadEvent() {
         var infoEvent = AnalyticsEventInfo(component: paymentMethod.type.rawValue, type: .rendered)
         infoEvent.isStoredPaymentMethod = (paymentMethod is StoredPaymentMethod) ? true : nil
         infoEvent.brand = (paymentMethod as? StoredCardPaymentMethod)?.brand.rawValue
@@ -84,10 +83,9 @@ extension CardComponent: TrackableComponent {
     }
 }
 
-@_spi(AdyenInternal)
 extension CardComponent: ViewControllerDelegate {
 
-    public func viewDidLoad(viewController: UIViewController) {
+    package func viewDidLoad(viewController: UIViewController) {
         sendInitialAnalytics()
         sendDidLoadEvent()
     }

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent+Extensions.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent+Extensions.swift
@@ -7,13 +7,11 @@
 import Adyen
 import UIKit
 
-@_spi(AdyenInternal)
 extension GiftCardComponent: TrackableComponent {}
 
-@_spi(AdyenInternal)
 extension GiftCardComponent: ViewControllerDelegate {
 
-    public func viewDidLoad(viewController: UIViewController) {
+    package func viewDidLoad(viewController: UIViewController) {
         sendInitialAnalytics()
         sendDidLoadEvent()
     }

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -17,7 +17,7 @@ import UIKit
 
 /// A component that provides a form for gift card payments.
 @MainActor
-public final class GiftCardComponent: PresentableComponent,
+package final class GiftCardComponent: PresentableComponent,
     Localizable,
     LoadingComponent,
     AdyenObserver {
@@ -39,33 +39,32 @@ public final class GiftCardComponent: PresentableComponent,
     }
     
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
+    package let context: AdyenContext
+
     private let partialPaymentMethodType: PartialPaymentMethodType
 
     /// The gift card payment method.
-    public var paymentMethod: PaymentMethod {
+    package var paymentMethod: PaymentMethod {
         partialPaymentMethodType.partialPaymentMethod
     }
 
     /// Describes the component's UI style.
-    public let style: FormComponentStyle
+    package let style: FormComponentStyle
 
     /// A boolean value that determines whether the payment button is displayed. Defaults to `true`.
     internal let showsSubmitButton: Bool
 
     /// The delegate of the component.
-    public weak var delegate: PaymentComponentDelegate?
+    package weak var delegate: PaymentComponentDelegate?
 
     /// The partial payment component delegate.
-    public weak var partialPaymentDelegate: PartialPaymentDelegate?
+    package weak var partialPaymentDelegate: PartialPaymentDelegate?
 
     /// The delegate that handles shopper confirmation UI when the balance of the gift card is sufficient to pay.
-    public weak var readyToSubmitComponentDelegate: ReadyToSubmitPaymentComponentDelegate?
+    package weak var readyToSubmitComponentDelegate: ReadyToSubmitPaymentComponentDelegate?
 
     /// The localization parameters.
-    public var localizationParameters: LocalizationParameters?
+    package var localizationParameters: LocalizationParameters?
 
     /// Indicates whether to show the security code field at all.
     internal let showsSecurityCodeField: Bool
@@ -80,7 +79,7 @@ public final class GiftCardComponent: PresentableComponent,
     ///   - showsSubmitButton: Boolean value that determines whether the payment button is displayed.
     ///   Defaults to `true`.
     ///   - showsSecurityCodeField: Indicates whether to show the security code field at all.
-    public convenience init(
+    package convenience init(
         paymentMethod: GiftCardPaymentMethod,
         context: AdyenContext,
         amount: Amount,
@@ -108,7 +107,7 @@ public final class GiftCardComponent: PresentableComponent,
     ///   - showsSubmitButton: Boolean value that determines whether the payment button is displayed.
     ///   Defaults to `true`.
     ///   - showsSecurityCodeField: Indicates whether to show the security code field at all.
-    public convenience init(
+    package convenience init(
         paymentMethod: MealVoucherPaymentMethod,
         context: AdyenContext,
         amount: Amount,
@@ -144,7 +143,7 @@ public final class GiftCardComponent: PresentableComponent,
 
     // MARK: - Presentable Component Protocol
 
-    public lazy var viewController: UIViewController = SecuredViewController(child: formViewController, style: style)
+    package lazy var viewController: UIViewController = SecuredViewController(child: formViewController, style: style)
 
     private lazy var formViewController: FormViewController = {
 
@@ -247,7 +246,7 @@ public final class GiftCardComponent: PresentableComponent,
 
     // MARK: - Loading Component Protocol
 
-    public func stopLoading() {
+    package func stopLoading() {
         button.showsActivityIndicator = false
         viewController.view.isUserInteractionEnabled = true
     }
@@ -479,11 +478,11 @@ extension GiftCardComponent: PartialPaymentComponent {}
 
 extension GiftCardComponent: SubmittableComponent {
 
-    public func submit() {
+    package func submit() {
         didSelectSubmitButton()
     }
 
-    public func validate() -> Bool {
+    package func validate() -> Bool {
         formViewController.validate()
     }
 }

--- a/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewController.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewController.swift
@@ -11,7 +11,8 @@ import UIKit
 
 #if canImport(AdyenUI)
     import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormButton
+    @_spi(AdyenInternal) import class AdyenUI.FormTextItemView
+
 #endif
 
 internal class StoredCardInputViewController: UIViewController {

--- a/AdyenCard/Form/DualBrandAccessoryView.swift
+++ b/AdyenCard/Form/DualBrandAccessoryView.swift
@@ -119,7 +119,7 @@ extension FormCardNumberItemView {
             return imageView
         }
         
-        override public func didMoveToWindow() {
+        override package func didMoveToWindow() {
             super.didMoveToWindow()
             updateLogos()
         }

--- a/AdyenCard/Form/FormCardLogosItemView.swift
+++ b/AdyenCard/Form/FormCardLogosItemView.swift
@@ -133,7 +133,7 @@ extension FormCardLogosItemView {
             updateIcon()
         }
         
-        override public func didMoveToWindow() {
+        override package func didMoveToWindow() {
             super.didMoveToWindow()
             updateIcon()
         }

--- a/AdyenCard/Form/FormCardNumberContainerItem.swift
+++ b/AdyenCard/Form/FormCardNumberContainerItem.swift
@@ -15,7 +15,7 @@ import UIKit
 /// A form item which consists of card number item and the supported card icons below.
 internal final class FormCardNumberContainerItem: FormItem, AdyenObserver {
     
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
     
     /// The supported card type logos.
     internal let cardTypeLogos: [FormCardLogosItem.CardTypeLogo]

--- a/AdyenCard/Form/FormCardNumberContainerItem.swift
+++ b/AdyenCard/Form/FormCardNumberContainerItem.swift
@@ -15,8 +15,8 @@ import UIKit
 /// A form item which consists of card number item and the supported card icons below.
 internal final class FormCardNumberContainerItem: FormItem, AdyenObserver {
     
-    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
-    
+    internal var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
+
     /// The supported card type logos.
     internal let cardTypeLogos: [FormCardLogosItem.CardTypeLogo]
     

--- a/AdyenCard/Form/FormCardNumberItemView+ScanCard.swift
+++ b/AdyenCard/Form/FormCardNumberItemView+ScanCard.swift
@@ -13,7 +13,7 @@ extension FormCardNumberItemView {
         static let imageName = "camera.fill"
     }
 
-    func makeCardScanAccessoryView(title: String, _ selector: Selector) -> UIView {
+    internal func makeCardScanAccessoryView(title: String, _ selector: Selector) -> UIView {
         let accessoryView = UIInputView(frame: .zero, inputViewStyle: .keyboard)
         accessoryView.translatesAutoresizingMaskIntoConstraints = false
         accessoryView.heightAnchor.constraint(equalToConstant: 44).isActive = true

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -46,18 +46,18 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
         }
     }
 
-    override package func handleFormattedValueDidChange(_ newValue: String) {
+    override internal func handleFormattedValueDidChange(_ newValue: String) {
         textField.text = newValue
         updateValidation()
     }
 
-    override package func textDidChange(textField: UITextField) {
+    override internal func textDidChange(textField: UITextField) {
         // Overriding to not use the default behavior of the super class
         _ = item.textDidChange(value: textField.text ?? "")
         notifyDelegateOfMaxLengthIfNeeded()
     }
 
-    override package func textField(
+    override internal func textField(
         _ textField: UITextField,
         shouldChangeCharactersIn range: NSRange,
         replacementString string: String

--- a/AdyenCard/Form/FormCardNumberItemView.swift
+++ b/AdyenCard/Form/FormCardNumberItemView.swift
@@ -46,20 +46,18 @@ internal final class FormCardNumberItemView: FormTextItemView<FormCardNumberItem
         }
     }
 
-    override public func handleFormattedValueDidChange(_ newValue: String) {
+    override package func handleFormattedValueDidChange(_ newValue: String) {
         textField.text = newValue
         updateValidation()
     }
 
-    @_spi(AdyenInternal)
-    override public func textDidChange(textField: UITextField) {
+    override package func textDidChange(textField: UITextField) {
         // Overriding to not use the default behavior of the super class
         _ = item.textDidChange(value: textField.text ?? "")
         notifyDelegateOfMaxLengthIfNeeded()
     }
 
-    @_spi(AdyenInternal)
-    override public func textField(
+    override package func textField(
         _ textField: UITextField,
         shouldChangeCharactersIn range: NSRange,
         replacementString string: String

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -145,7 +145,7 @@ extension FormCardSecurityCodeItemView {
             )
         }
         
-        override public var accessibilityIdentifier: String? {
+        override package var accessibilityIdentifier: String? {
             didSet {
                 hintImage.accessibilityIdentifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "imageView")
             }

--- a/AdyenCardScanner/Sources/ROIView.swift
+++ b/AdyenCardScanner/Sources/ROIView.swift
@@ -15,8 +15,6 @@ internal class ROIView: UIView {
     private var borderColor: UIColor = .white
     private var cornerRadius: CGFloat = 12.0
 
-    // MARK: - Public
-
     override internal func draw(_ rect: CGRect) {
         super.draw(rect)
 

--- a/AdyenCashAppPay/CashAppPayComponent.swift
+++ b/AdyenCashAppPay/CashAppPayComponent.swift
@@ -287,10 +287,8 @@ extension CashAppPayComponent {
     }
 }
 
-@_spi(AdyenInternal)
 extension CashAppPayComponent: TrackableComponent {}
 
-@_spi(AdyenInternal)
 extension CashAppPayComponent: ViewControllerDelegate {}
 
 // MARK: - SubmitCustomizable

--- a/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent+Extensions.swift
+++ b/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent+Extensions.swift
@@ -14,7 +14,7 @@ import UIKit
 
 extension AbstractPersonalInformationComponent: LoadingComponent {
 
-    public func stopLoading() {
+    package func stopLoading() {
         button.showsActivityIndicator = false
         formViewController.view.isUserInteractionEnabled = true
     }
@@ -37,11 +37,9 @@ extension AbstractPersonalInformationComponent: LoadingComponent {
     }
 }
 
-@_spi(AdyenInternal)
 extension AbstractPersonalInformationComponent: TrackableComponent {}
 
-@_spi(AdyenInternal)
-public enum PersonalInformation: Equatable {
+package enum PersonalInformation: Equatable {
     case firstName
     case lastName
     case email
@@ -50,7 +48,7 @@ public enum PersonalInformation: Equatable {
     case deliveryAddress
     case custom(FormItemInjector)
 
-    public static func == (lhs: PersonalInformation, rhs: PersonalInformation) -> Bool {
+    package static func == (lhs: PersonalInformation, rhs: PersonalInformation) -> Bool {
         switch (lhs, rhs) {
         case (.firstName, .firstName),
              (.lastName, .lastName),

--- a/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
+++ b/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
@@ -16,28 +16,26 @@ import UIKit
 /// An abstract class that needs to be subclassed to abstract away any component
 /// who's form consists of a combination of personal information pieces like first name, last name, phone, email, and billing address.
 @MainActor
-open class AbstractPersonalInformationComponent: PaymentComponent, PresentableComponent {
+package class AbstractPersonalInformationComponent: PaymentComponent, PresentableComponent {
 
-    public typealias Configuration = PersonalInformationConfiguration
-    
+    package typealias Configuration = PersonalInformationConfiguration
+
     // MARK: - Properties
 
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
-    public let paymentMethod: PaymentMethod
+    package let context: AdyenContext
 
-    public weak var delegate: PaymentComponentDelegate?
+    package let paymentMethod: PaymentMethod
 
-    public lazy var viewController: UIViewController = SecuredViewController(
+    package weak var delegate: PaymentComponentDelegate?
+
+    package lazy var viewController: UIViewController = SecuredViewController(
         child: formViewController,
         style: configuration.style
     )
 
-    @_spi(AdyenInternal)
-    public var configuration: Configuration
-    
+    package var configuration: Configuration
+
     private let fields: [PersonalInformation]
 
     internal lazy var formViewController: FormViewController = {
@@ -62,8 +60,7 @@ open class AbstractPersonalInformationComponent: PaymentComponent, PresentableCo
     /// - Parameter context: The context object for this component.
     /// - Parameter fields: The component's fields.
     /// - Parameter configuration: The Component's configuration.
-    @_spi(AdyenInternal)
-    public init(
+    package init(
         paymentMethod: PaymentMethod,
         context: AdyenContext,
         fields: [PersonalInformation],
@@ -125,8 +122,7 @@ open class AbstractPersonalInformationComponent: PaymentComponent, PresentableCo
         return injector
     }()
 
-    @_spi(AdyenInternal)
-    public var firstNameItem: FormTextInputItem? {
+    package var firstNameItem: FormTextInputItem? {
         firstNameItemInjector?.item
     }
 
@@ -144,8 +140,7 @@ open class AbstractPersonalInformationComponent: PaymentComponent, PresentableCo
         return injector
     }()
 
-    @_spi(AdyenInternal)
-    public var lastNameItem: FormTextInputItem? {
+    package var lastNameItem: FormTextInputItem? {
         lastNameItemInjector?.item
     }
 
@@ -161,8 +156,7 @@ open class AbstractPersonalInformationComponent: PaymentComponent, PresentableCo
         return injector
     }()
 
-    @_spi(AdyenInternal)
-    public var emailItem: FormTextInputItem? {
+    package var emailItem: FormTextInputItem? {
         emailItemInjector?.item
     }
     
@@ -257,8 +251,7 @@ open class AbstractPersonalInformationComponent: PaymentComponent, PresentableCo
         Locale.current.regionCode ?? "US"
     }
     
-    @_spi(AdyenInternal)
-    public func showValidation() {
+    package func showValidation() {
         formViewController.showValidation()
     }
 
@@ -276,28 +269,26 @@ open class AbstractPersonalInformationComponent: PaymentComponent, PresentableCo
     }
 }
 
-@_spi(AdyenInternal)
 extension AbstractPersonalInformationComponent: ViewControllerPresenter {
     
-    public func presentViewController(_ viewController: UIViewController, animated: Bool) {
+    package func presentViewController(_ viewController: UIViewController, animated: Bool) {
         self.viewController.presentViewController(viewController, animated: animated)
     }
     
-    public func dismissViewController(animated: Bool) {
+    package func dismissViewController(animated: Bool) {
         self.viewController.dismissViewController(animated: animated)
     }
 }
 
-@_spi(AdyenInternal)
 extension AbstractPersonalInformationComponent: ViewControllerDelegate {
 
     // MARK: - ViewControllerDelegate
 
-    public func viewWillAppear(viewController: UIViewController) {
+    package func viewWillAppear(viewController: UIViewController) {
         populateFields()
     }
     
-    public func viewDidLoad(viewController: UIViewController) {
+    package func viewDidLoad(viewController: UIViewController) {
         sendInitialAnalytics()
         sendDidLoadEvent()
     }
@@ -307,11 +298,11 @@ extension AbstractPersonalInformationComponent: ViewControllerDelegate {
 
 extension AbstractPersonalInformationComponent: SubmittableComponent {
 
-    public func submit() {
+    package func submit() {
         didSelectSubmitButton()
     }
 
-    public func validate() -> Bool {
+    package func validate() -> Bool {
         formViewController.validate()
     }
 }

--- a/AdyenComponents/Affirm/AffirmComponent.swift
+++ b/AdyenComponents/Affirm/AffirmComponent.swift
@@ -13,11 +13,11 @@ import Adyen
 import UIKit
 
 /// A component that provides a form for Affirm payment.
-public final class AffirmComponent: AbstractPersonalInformationComponent {
-    
+package final class AffirmComponent: AbstractPersonalInformationComponent {
+
     /// Configuration for Affirm Component
-    public typealias Configuration = PersonalInformationConfiguration
-    
+    package typealias Configuration = PersonalInformationConfiguration
+
     private enum ViewIdentifier {
         static let billingAddress = "billingAddressItem"
         static let deliveryAddress = "deliveryAddressItem"
@@ -37,7 +37,7 @@ public final class AffirmComponent: AbstractPersonalInformationComponent {
     ///   - paymentMethod: The Affirm payment method.
     ///   - context: The context object for this component.
     ///   - configuration: The component's configuration.
-    public init(
+    package init(
         paymentMethod: PaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()
@@ -100,16 +100,14 @@ public final class AffirmComponent: AbstractPersonalInformationComponent {
         }
     }
     
-    // MARK: - Public
-    
-    @_spi(AdyenInternal)
-    override public func submitButtonTitle() -> String {
+    // MARK: - package
+
+    override package func submitButtonTitle() -> String {
         localizedString(.confirmPurchase, configuration.localizationParameters)
     }
     
-    @_spi(AdyenInternal)
-    override public func createPaymentDetails() throws -> PaymentMethodDetails {
-        
+    override package func createPaymentDetails() throws -> PaymentMethodDetails {
+
         guard let firstName = firstNameItem?.value,
               let lastName = lastNameItem?.value,
               let emailAddress = emailItem?.value,
@@ -131,8 +129,7 @@ public final class AffirmComponent: AbstractPersonalInformationComponent {
         )
     }
     
-    @_spi(AdyenInternal)
-    override public func phoneExtensions() -> [PhoneExtension] {
+    override package func phoneExtensions() -> [PhoneExtension] {
         let query = PhoneExtensionsQuery(paymentMethod: .generic)
         return PhoneExtensionsRepository.get(with: query)
     }

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -11,7 +11,7 @@ import PassKit
 
 /// A component that handles Apple Pay payments.
 @MainActor
-public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent, FinalizableComponent {
+package class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent, FinalizableComponent {
 
     /// The Apple Pay payment request. Kept on the configuration; exposed here as a
     /// convenience that returns the same `PKPaymentRequest` reference.
@@ -31,11 +31,10 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     internal var authorizationHandled = false
 
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
+    package let context: AdyenContext
 
     /// The Apple Pay payment method.
-    public var paymentMethod: PaymentMethod {
+    package var paymentMethod: PaymentMethod {
         applePayPaymentMethod
     }
 
@@ -44,8 +43,8 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     internal var paymentAuthorizationViewController: PKPaymentAuthorizationViewController?
 
     /// The delegate of the component.
-    public weak var delegate: PaymentComponentDelegate?
-    
+    package weak var delegate: PaymentComponentDelegate?
+
     /// Initializes the component.
     ///
     /// After the shopper authorizes payment, the component suspends the Apple Pay sheet
@@ -61,7 +60,7 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     /// if user can't make payments on any of the payment request’s supported networks.
     /// - Throws: `ApplePayComponent.Error.deviceDoesNotSupportApplePay` if the current device's hardware doesn't support ApplePay.
     /// - Throws: `ApplePayComponent.Error.userCannotMakePayment` if user can't make payments on any of the supported networks.
-    public init(
+    package init(
         paymentMethod: ApplePayPaymentMethod,
         context: AdyenContext,
         configuration: ApplePayConfiguration
@@ -96,7 +95,7 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     ///
     /// - Important: Do not access this property after the component has been used and dismissed.
     ///   Create a new `ApplePayComponent` instance for each payment attempt.
-    public var viewController: UIViewController {
+    package var viewController: UIViewController {
         guard let controller = paymentAuthorizationViewController else {
             preconditionFailure(
                 "The Apple Pay view controller is no longer available. "
@@ -136,11 +135,10 @@ public class ApplePayComponent: NSObject, PresentableComponent, PaymentComponent
     /// - Parameters:
     ///   - success: `true` if the payment succeeded, `false` otherwise.
     ///   - completion: Invoked once the continuation has been resumed.
-    public func didFinalize(with success: Bool, completion: (() -> Void)?) {
+    package func didFinalize(with success: Bool, completion: (() -> Void)?) {
         resumeContinuation(success: success)
         completion?()
     }
 }
 
-@_spi(AdyenInternal)
 extension ApplePayComponent: TrackableComponent {}

--- a/AdyenComponents/Atome/AtomeComponent.swift
+++ b/AdyenComponents/Atome/AtomeComponent.swift
@@ -15,10 +15,10 @@ import Adyen
 import UIKit
 
 /// A component that provides a form for Atome payment.
-public final class AtomeComponent: AbstractPersonalInformationComponent {
+package final class AtomeComponent: AbstractPersonalInformationComponent {
 
     /// Configuration for Atome Component
-    public typealias Configuration = PersonalInformationConfiguration
+    package typealias Configuration = PersonalInformationConfiguration
 
     private enum ViewIdentifier {
         static let billingAddress = "billingAddressItem"
@@ -35,7 +35,7 @@ public final class AtomeComponent: AbstractPersonalInformationComponent {
     ///   - paymentMethod: The Atome payment method.
     ///   - context: The context object for this component.
     ///   - configuration: The component's configuration.
-    public init(
+    package init(
         paymentMethod: PaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()

--- a/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
+++ b/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
@@ -20,32 +20,31 @@ internal protocol BACSDirectDebitRouterProtocol: AnyObject {
 
 /// A component that provides a form for BACS Direct Debit payments.
 @MainActor
-public final class BACSDirectDebitComponent: PaymentComponent, PresentableComponent {
+package final class BACSDirectDebitComponent: PaymentComponent, PresentableComponent {
 
     /// Configuration for BACS Direct Debit Component.
-    public typealias Configuration = BasicComponentConfiguration
-    
+    package typealias Configuration = BasicComponentConfiguration
+
     // MARK: - PresentableComponent
 
-    public let viewController: UIViewController
+    package let viewController: UIViewController
 
     /// The object that acts as the delegate of the component.
-    public weak var delegate: PaymentComponentDelegate?
+    package weak var delegate: PaymentComponentDelegate?
 
     /// The BACS Direct Debit payment method.
-    public var paymentMethod: PaymentMethod {
+    package var paymentMethod: PaymentMethod {
         bacsPaymentMethod
     }
 
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
+    package let context: AdyenContext
 
     /// The object that acts as the presentation delegate of the component.
-    public weak var presentationDelegate: PresentationDelegate?
-    
+    package weak var presentationDelegate: PresentationDelegate?
+
     /// Component's configuration
-    public var configuration: Configuration
+    package var configuration: Configuration
 
     // MARK: - Properties
 
@@ -65,7 +64,7 @@ public final class BACSDirectDebitComponent: PaymentComponent, PresentableCompon
     ///   - paymentMethod: The BACS Direct Debit payment method.
     ///   - context: The context object for this component.
     ///   - configuration: Configuration for the component.
-    public init(
+    package init(
         paymentMethod: BACSDirectDebitPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()
@@ -166,7 +165,7 @@ extension BACSDirectDebitComponent: BACSDirectDebitRouterProtocol {
 extension BACSDirectDebitComponent: LoadingComponent {
 
     /// Stops any processing animation that the component is running.
-    public func stopLoading() {
+    package func stopLoading() {
         confirmationPresenter?.stopLoading()
     }
 }
@@ -177,7 +176,7 @@ extension BACSDirectDebitComponent: LoadingComponent {
 extension BACSDirectDebitComponent: Cancellable {
 
     /// Called when the user cancels the component.
-    public func didCancel() {
+    package func didCancel() {
         if confirmationViewPresented == false {
             inputPresenter?.resetForm()
         } else {

--- a/AdyenComponents/BACS Direct Debit/Factories/BACSItemsFactory.swift
+++ b/AdyenComponents/BACS Direct Debit/Factories/BACSItemsFactory.swift
@@ -10,7 +10,6 @@ import Adyen
 #if canImport(AdyenUI)
     import AdyenUI
     @_spi(AdyenInternal) import class AdyenUI.FormTextInputItem
-    @_spi(AdyenInternal) import class AdyenUI.FormButtonItem
 #endif
 import Foundation
 

--- a/AdyenComponents/BLIK/BLIKComponent.swift
+++ b/AdyenComponents/BLIK/BLIKComponent.swift
@@ -15,25 +15,24 @@ import UIKit
 
 /// A component that provides a form for BLIK payments.
 @MainActor
-public final class BLIKComponent: PaymentComponent, PresentableComponent, LoadingComponent {
-    
+package final class BLIKComponent: PaymentComponent, PresentableComponent, LoadingComponent {
+
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
-    public var paymentMethod: PaymentMethod {
+    package let context: AdyenContext
+
+    package var paymentMethod: PaymentMethod {
         blikPaymentMethod
     }
 
-    public weak var delegate: PaymentComponentDelegate?
+    package weak var delegate: PaymentComponentDelegate?
 
-    public lazy var viewController: UIViewController = SecuredViewController(
+    package lazy var viewController: UIViewController = SecuredViewController(
         child: formViewController,
         theme: configuration.theme
     )
     
     /// Component's configuration
-    public var configuration: BLIKComponentConfiguration
+    package var configuration: BLIKComponentConfiguration
 
     private let blikPaymentMethod: BLIKPaymentMethod
 
@@ -42,7 +41,7 @@ public final class BLIKComponent: PaymentComponent, PresentableComponent, Loadin
     /// - Parameter paymentMethod: The BLIK payment method.
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The configuration for the component.
-    public init(
+    package init(
         paymentMethod: BLIKPaymentMethod,
         context: AdyenContext,
         configuration: BLIKComponentConfiguration = .init()
@@ -52,7 +51,7 @@ public final class BLIKComponent: PaymentComponent, PresentableComponent, Loadin
         self.configuration = configuration
     }
     
-    public func stopLoading() {
+    package func stopLoading() {
         button.showsActivityIndicator = false
         formViewController.view.isUserInteractionEnabled = true
     }
@@ -138,21 +137,19 @@ public final class BLIKComponent: PaymentComponent, PresentableComponent, Loadin
     }
 }
 
-@_spi(AdyenInternal)
 extension BLIKComponent: TrackableComponent {}
 
-@_spi(AdyenInternal)
 extension BLIKComponent: ViewControllerDelegate {}
 
 // MARK: - SubmitCustomizable
 
 extension BLIKComponent: SubmittableComponent {
 
-    public func submit() {
+    package func submit() {
         didSelectSubmitButton()
     }
 
-    public func validate() -> Bool {
+    package func validate() -> Bool {
         formViewController.validate()
     }
 }

--- a/AdyenComponents/BasicPersonalInfoFormComponent/BasicPersonalInfoFormComponent.swift
+++ b/AdyenComponents/BasicPersonalInfoFormComponent/BasicPersonalInfoFormComponent.swift
@@ -14,17 +14,17 @@ import Foundation
 import UIKit
 
 /// A component that provides a form consisting of first name, last name, phone, and email.
-public final class BasicPersonalInfoFormComponent: AbstractPersonalInformationComponent {
+package final class BasicPersonalInfoFormComponent: AbstractPersonalInformationComponent {
 
     /// Configuration for Basic Personal Information Component
-    public typealias Configuration = PersonalInformationConfiguration
-    
+    package typealias Configuration = PersonalInformationConfiguration
+
     /// Initializes the component.
     /// - Parameters:
     ///   - paymentMethod: The payment method.
     ///   - context: The context object for this component.
     ///   - configuration: The component's configuration.
-    public init(
+    package init(
         paymentMethod: PaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()
@@ -67,13 +67,13 @@ public final class BasicPersonalInfoFormComponent: AbstractPersonalInformationCo
 }
 
 /// Provides a form for personal information, required for E-context ATM  payments.
-public typealias EContextATMComponent = BasicPersonalInfoFormComponent
+package typealias EContextATMComponent = BasicPersonalInfoFormComponent
 
 /// Provides a form for personal information, required for E-context Store payments.
-public typealias EContextStoreComponent = BasicPersonalInfoFormComponent
+package typealias EContextStoreComponent = BasicPersonalInfoFormComponent
 
 /// Provides a form for personal information, required for E-context Online  payments.
-public typealias EContextOnlineComponent = BasicPersonalInfoFormComponent
+package typealias EContextOnlineComponent = BasicPersonalInfoFormComponent
 
 /// Provides a form for personal information, required for 7eleven  payments.
-public typealias SevenElevenComponent = BasicPersonalInfoFormComponent
+package typealias SevenElevenComponent = BasicPersonalInfoFormComponent

--- a/AdyenComponents/Boleto/BoletoComponent.swift
+++ b/AdyenComponents/Boleto/BoletoComponent.swift
@@ -15,24 +15,23 @@ import UIKit
 
 /// A component that provides a form for Boleto payment.
 @MainActor
-public final class BoletoComponent: PaymentComponent,
+package final class BoletoComponent: PaymentComponent,
     LoadingComponent,
     PresentableComponent,
     AdyenObserver {
 
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
+    package let context: AdyenContext
 
-    public weak var delegate: PaymentComponentDelegate?
-        
-    public var paymentMethod: PaymentMethod {
+    package weak var delegate: PaymentComponentDelegate?
+
+    package var paymentMethod: PaymentMethod {
         boletoPaymentMethod
     }
     
     /// The Component's configuration.
-    public var configuration: Configuration
-    
+    package var configuration: Configuration
+
     internal let boletoPaymentMethod: BoletoPaymentMethod
     
     /// Initializes the Boleto Component
@@ -40,7 +39,7 @@ public final class BoletoComponent: PaymentComponent,
     ///   - paymentMethod: Boleto Payment Method
     ///   - context: The context object for this component.
     ///   - configuration: The Component's configuration.
-    public init(
+    package init(
         paymentMethod: BoletoPaymentMethod,
         context: AdyenContext,
         configuration: Configuration
@@ -105,8 +104,8 @@ public final class BoletoComponent: PaymentComponent,
         return component
     }()
     
-    public lazy var viewController: UIViewController = formComponent.viewController
-    
+    package lazy var viewController: UIViewController = formComponent.viewController
+
     /// Constructs the fields for the form based on the configuration
     private var formFields: [PersonalInformation] {
         var fields: [PersonalInformation] = [
@@ -171,19 +170,17 @@ public final class BoletoComponent: PaymentComponent,
         return nil
     }
 
-    // MARK: - Public
-    
-    public func stopLoading() {
+    package func stopLoading() {
         formComponent.stopLoading()
     }
 }
 
 extension BoletoComponent: SubmittableComponent {
-    public func submit() {
+    package func submit() {
         formComponent.submit()
     }
     
-    public func validate() -> Bool {
+    package func validate() -> Bool {
         formComponent.validate()
     }
 }
@@ -191,27 +188,24 @@ extension BoletoComponent: SubmittableComponent {
 @_spi(AdyenInternal)
 extension BoletoComponent: TrackableComponent {}
 
-@_spi(AdyenInternal)
 extension BoletoComponent: ViewControllerDelegate {
     
-    public func viewWillAppear(viewController: UIViewController) {
+    package func viewWillAppear(viewController: UIViewController) {
         prefillFields(for: formComponent)
     }
 }
 
-@_spi(AdyenInternal)
 extension BoletoComponent: PaymentComponentDelegate {
     
-    public func didSubmit(_ data: PaymentComponentData, from component: PaymentComponent) {
+    package func didSubmit(_ data: PaymentComponentData, from component: PaymentComponent) {
         submit(data: data, component: self)
     }
     
-    public func didFail(with error: Error, from component: PaymentComponent) {
+    package func didFail(with error: Error, from component: PaymentComponent) {
         delegate?.didFail(with: error, from: self)
     }
 }
 
-@_spi(AdyenInternal)
 extension BoletoComponent {
     
     fileprivate final class FormComponent: AbstractPersonalInformationComponent {
@@ -235,13 +229,11 @@ extension BoletoComponent {
             )
         }
         
-        @_spi(AdyenInternal)
-        override public func submitButtonTitle() -> String {
+        override package func submitButtonTitle() -> String {
             localizedString(.boletobancarioBtnLabel, configuration.localizationParameters)
         }
         
-        @_spi(AdyenInternal)
-        override public func createPaymentDetails() -> PaymentMethodDetails {
+        override package func createPaymentDetails() -> PaymentMethodDetails {
             onCreatePaymentDetails() ?? InstantPaymentDetails(type: paymentMethod.type)
         }
     }

--- a/AdyenComponents/Doku/DokuComponent.swift
+++ b/AdyenComponents/Doku/DokuComponent.swift
@@ -15,11 +15,11 @@ import Foundation
 import UIKit
 
 /// A component that provides a form for Doku Wallet, Doku Alfamart, and Doku Indomaret  payments.
-public final class DokuComponent: AbstractPersonalInformationComponent {
+package final class DokuComponent: AbstractPersonalInformationComponent {
 
     /// Configuration for Doku Component
-    public typealias Configuration = PersonalInformationConfiguration
-    
+    package typealias Configuration = PersonalInformationConfiguration
+
     private let dokuPaymentMethod: DokuPaymentMethod
 
     /// Initializes the Doku component.
@@ -27,7 +27,7 @@ public final class DokuComponent: AbstractPersonalInformationComponent {
     ///   - paymentMethod: The Doku Wallet, Doku Alfamart, or Doku Indomaret payment method.
     ///   - context: The context object for this component.
     ///   - configuration: The component's configuration.
-    public init(
+    package init(
         paymentMethod: DokuPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()

--- a/AdyenComponents/Instant/InstantComponents.swift
+++ b/AdyenComponents/Instant/InstantComponents.swift
@@ -7,13 +7,13 @@
 import Adyen
 
 /// A payment method for OXXO.
-public typealias OXXOPaymentMethod = InstantPaymentMethod
+package typealias OXXOPaymentMethod = InstantPaymentMethod
 
 /// A component for handling OXXO payment.
-public typealias OXXOComponent = InstantPaymentComponent
+package typealias OXXOComponent = InstantPaymentComponent
 
 /// A  payment method for Multibanco.
-public typealias MultibancoPaymentMethod = InstantPaymentMethod
+package typealias MultibancoPaymentMethod = InstantPaymentMethod
 
 /// A component for handling Multibanco payment.
-public typealias MultibancoComponent = InstantPaymentComponent
+package typealias MultibancoComponent = InstantPaymentComponent

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -17,27 +17,26 @@ import UIKit
 /// A generic component for "issuer-based" payment methods, such as MOLPay.
 /// This component will provide a list in which the user can select their issuer.
 @MainActor
-public final class IssuerListComponent: PaymentComponent, PresentableComponent, LoadingComponent {
-    
+package final class IssuerListComponent: PaymentComponent, PresentableComponent, LoadingComponent {
+
     private enum Constants {
         static let searchDelay: TimeInterval = 1
     }
     
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
+    package let context: AdyenContext
+
     /// The issuer list payment method.
-    public var paymentMethod: PaymentMethod {
+    package var paymentMethod: PaymentMethod {
         issuerListPaymentMethod
     }
     
     /// The delegate of the component.
-    public weak var delegate: PaymentComponentDelegate?
-    
+    package weak var delegate: PaymentComponentDelegate?
+
     /// Component's configuration.
-    public var configuration: Configuration
-    
+    package var configuration: Configuration
+
     /// The title of the view controller
     private let title: String
     
@@ -48,7 +47,7 @@ public final class IssuerListComponent: PaymentComponent, PresentableComponent, 
     /// - Parameter paymentMethod: The issuer list payment method.
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The configuration for the component.
-    public init(
+    package init(
         paymentMethod: IssuerListPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()
@@ -63,7 +62,7 @@ public final class IssuerListComponent: PaymentComponent, PresentableComponent, 
 
     // MARK: - Presentable Component Protocol
     
-    public var viewController: UIViewController {
+    package var viewController: UIViewController {
         let viewController = searchViewController
         viewController.title = title
         return viewController
@@ -90,7 +89,7 @@ public final class IssuerListComponent: PaymentComponent, PresentableComponent, 
         return searchViewController
     }()
 
-    public func stopLoading() {
+    package func stopLoading() {
         searchViewController.resultsListViewController.stopLoading()
     }
 
@@ -166,27 +165,25 @@ public final class IssuerListComponent: PaymentComponent, PresentableComponent, 
     }
 }
 
-@_spi(AdyenInternal)
 extension IssuerListComponent: ViewControllerDelegate {}
 
-@_spi(AdyenInternal)
 extension IssuerListComponent: TrackableComponent {}
 
 extension IssuerListComponent {
     
     /// Configuration for Issuer List type components.
-    public struct Configuration {
-        
-        /// The UI style of the component.
-        public var style: ListComponentStyle
+    package struct Configuration {
 
-        public var localizationParameters: LocalizationParameters?
-        
+        /// The UI style of the component.
+        package var style: ListComponentStyle
+
+        package var localizationParameters: LocalizationParameters?
+
         /// Initializes the configuration for Issuer list type components.
         /// - Parameters:
         ///   - style: The UI style of the component.
         ///   - localizationParameters: Localization parameters.
-        public init(
+        package init(
             style: ListComponentStyle = .init(),
             localizationParameters: LocalizationParameters? = nil
         ) {
@@ -197,19 +194,19 @@ extension IssuerListComponent {
 }
 
 /// Provides an issuer selection list for MOLPay payments.
-public typealias MOLPayComponent = IssuerListComponent
+package typealias MOLPayComponent = IssuerListComponent
 
 /// Provides an issuer selection list for Dotpay payments.
-public typealias DotpayComponent = IssuerListComponent
+package typealias DotpayComponent = IssuerListComponent
 
 /// Provides an issuer selection list for EPS payments.
-public typealias EPSComponent = IssuerListComponent
+package typealias EPSComponent = IssuerListComponent
 
 /// Provides an issuer selection list for Entercash payments.
-public typealias EntercashComponent = IssuerListComponent
+package typealias EntercashComponent = IssuerListComponent
 
 /// Provides an issuer selection list for OpenBanking payments.
-public typealias OpenBankingComponent = IssuerListComponent
+package typealias OpenBankingComponent = IssuerListComponent
 
 /// Provides an issuer selection list for onlineBanking Poland .
-public typealias OnlineBankingPolandComponent = IssuerListComponent
+package typealias OnlineBankingPolandComponent = IssuerListComponent

--- a/AdyenComponents/MB Way/MBWayComponent.swift
+++ b/AdyenComponents/MB Way/MBWayComponent.swift
@@ -13,11 +13,11 @@ import Foundation
 import UIKit
 
 /// A component that provides a form for MB Way payments.
-public final class MBWayComponent: AbstractPersonalInformationComponent {
-    
+package final class MBWayComponent: AbstractPersonalInformationComponent {
+
     /// Configuration for MB Way Component
-    public typealias Configuration = PersonalInformationConfiguration
-    
+    package typealias Configuration = PersonalInformationConfiguration
+
     private let mbWayPaymentMethod: MBWayPaymentMethod
 
     /// Initializes the MB Way component.
@@ -25,7 +25,7 @@ public final class MBWayComponent: AbstractPersonalInformationComponent {
     ///   - paymentMethod: The MB Way payment method.
     ///   - context: The context object for this component.
     ///   - configuration: The component's configuration.
-    public init(
+    package init(
         paymentMethod: MBWayPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()

--- a/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
+++ b/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
@@ -14,7 +14,7 @@ import UIKit
 
 /// A component that provides a form for Online Banking payment.
 @MainActor
-public final class OnlineBankingComponent: PaymentComponent,
+package final class OnlineBankingComponent: PaymentComponent,
     PresentableComponent,
     LoadingComponent {
 
@@ -30,25 +30,25 @@ public final class OnlineBankingComponent: PaymentComponent,
     }
 
     /// Configuration for Online Banking Component.
-    public typealias Configuration = BasicComponentConfiguration
+    package typealias Configuration = BasicComponentConfiguration
 
     /// The context object for this component.
     @_spi(AdyenInternal)
     public var context: AdyenContext
 
-    public var paymentMethod: PaymentMethod {
+    package var paymentMethod: PaymentMethod {
         onlineBankingPaymentMethod
     }
 
-    public weak var delegate: PaymentComponentDelegate?
+    package weak var delegate: PaymentComponentDelegate?
 
-    public lazy var viewController: UIViewController = SecuredViewController(
+    package lazy var viewController: UIViewController = SecuredViewController(
         child: formViewController,
         style: configuration.style
     )
 
     /// Component's configuration
-    public var configuration: Configuration
+    package var configuration: Configuration
 
     private let onlineBankingPaymentMethod: OnlineBankingPaymentMethod
 
@@ -114,7 +114,7 @@ public final class OnlineBankingComponent: PaymentComponent,
     /// - Parameter paymentMethod: The Online Banking payment method.
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The configuration for the component.
-    public init(
+    package init(
         paymentMethod: OnlineBankingPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()
@@ -124,7 +124,7 @@ public final class OnlineBankingComponent: PaymentComponent,
         self.configuration = configuration
     }
 
-    public func stopLoading() {
+    package func stopLoading() {
         continueButton.showsActivityIndicator = false
         formViewController.view.isUserInteractionEnabled = true
     }
@@ -167,18 +167,17 @@ public final class OnlineBankingComponent: PaymentComponent,
 
 }
 
-@_spi(AdyenInternal)
 extension OnlineBankingComponent: AdyenObserver {}
 
 // MARK: - SubmitCustomizable
 
 extension OnlineBankingComponent: SubmittableComponent {
 
-    public func submit() {
+    package func submit() {
         didSelectContinueButton()
     }
 
-    public func validate() -> Bool {
+    package func validate() -> Bool {
         formViewController.validate()
     }
 }

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent.swift
@@ -9,24 +9,22 @@ import Adyen
 
 #if canImport(AdyenUI)
     import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormButton
 #endif
 import Foundation
 import UIKit
 
 /// A component that handles a Pay by Bank US payment.
 @MainActor
-public final class PayByBankUSComponent: PaymentComponent, PresentableComponent {
+package final class PayByBankUSComponent: PaymentComponent, PresentableComponent {
 
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
+    package let context: AdyenContext
 
     /// The payment method object for this component.
-    public let paymentMethod: PaymentMethod
-    
+    package let paymentMethod: PaymentMethod
+
     /// The ready to submit payment data.
-    public var paymentData: PaymentComponentData {
+    package var paymentData: PaymentComponentData {
         let details = InstantPaymentDetails(type: paymentMethod.type)
 
         return PaymentComponentData(
@@ -37,12 +35,12 @@ public final class PayByBankUSComponent: PaymentComponent, PresentableComponent 
     }
 
     /// Component's configuration
-    public var configuration: Configuration
+    package var configuration: Configuration
 
     /// The delegate of the component.
-    public weak var delegate: PaymentComponentDelegate?
-    
-    public var viewController: UIViewController {
+    package weak var delegate: PaymentComponentDelegate?
+
+    package var viewController: UIViewController {
         confirmationViewController
     }
     
@@ -70,7 +68,7 @@ public final class PayByBankUSComponent: PaymentComponent, PresentableComponent 
     /// - Parameter paymentMethod: The Pay by Bank US payment method.
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The configuration for the component.
-    public init(
+    package init(
         paymentMethod: PayByBankUSPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()
@@ -83,7 +81,7 @@ public final class PayByBankUSComponent: PaymentComponent, PresentableComponent 
     // MARK: - PaymentInitiable
 
     /// Generate the payment details and invoke PaymentsComponentDelegate method.
-    public func initiatePayment() {
+    package func initiatePayment() {
         submit(data: paymentData)
     }
 }
@@ -91,7 +89,7 @@ public final class PayByBankUSComponent: PaymentComponent, PresentableComponent 
 extension PayByBankUSComponent: TrackableComponent {}
 
 extension PayByBankUSComponent: LoadingComponent {
-    public func stopLoading() {
+    package func stopLoading() {
         confirmationViewController.submitButton.showsActivityIndicator = false
     }
 }

--- a/AdyenComponents/PayTo/PayToComponent.swift
+++ b/AdyenComponents/PayTo/PayToComponent.swift
@@ -15,23 +15,23 @@ import UIKit
 
 /// A component that provides PayTo flows for PayTo component.
 @MainActor
-public final class PayToComponent: PaymentComponent, PresentableComponent, AdyenObserver, LoadingComponent {
+package final class PayToComponent: PaymentComponent, PresentableComponent, AdyenObserver, LoadingComponent {
 
     /// Configuration for PayTo Component.
-    public typealias Configuration = BasicComponentConfiguration
+    package typealias Configuration = BasicComponentConfiguration
 
     /// The context object for this component.
     @_spi(AdyenInternal)
     public var context: AdyenContext
 
     /// The delegate of the component.
-    public weak var delegate: PaymentComponentDelegate?
+    package weak var delegate: PaymentComponentDelegate?
 
     /// Component's configuration
-    public var configuration: Configuration
+    package var configuration: Configuration
 
     /// The payment method object for this component.
-    public var paymentMethod: PaymentMethod {
+    package var paymentMethod: PaymentMethod {
         payToPaymentMethod
     }
 
@@ -47,7 +47,7 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
     }()
 
     /// The viewController for the component.
-    public lazy var viewController: UIViewController = SecuredViewController(
+    package lazy var viewController: UIViewController = SecuredViewController(
         child: formViewController,
         style: configuration.style
     )
@@ -94,7 +94,7 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
     /// - Parameter paymentMethod: The PayTo payment method.
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The configuration for the component.
-    public init(
+    package init(
         paymentMethod: PayToPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()
@@ -211,7 +211,7 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
         return formViewController
     }()
 
-    public func stopLoading() {
+    package func stopLoading() {
         continueButtonItem.showsActivityIndicator = false
         formViewController.view.isUserInteractionEnabled = true
     }
@@ -219,29 +219,26 @@ public final class PayToComponent: PaymentComponent, PresentableComponent, Adyen
 
 extension PayToComponent: SubmittableComponent {
 
-    public func submit() {
+    package func submit() {
         didSelectContinueButton()
     }
 
-    public func validate() -> Bool {
+    package func validate() -> Bool {
         formViewController.validate()
     }
 }
 
-@_spi(AdyenInternal)
 extension PayToComponent: ViewControllerDelegate {}
 
-@_spi(AdyenInternal)
 extension PayToComponent: TrackableComponent {}
 
-@_spi(AdyenInternal)
 extension PayToComponent: ViewControllerPresenter {
 
-    public func presentViewController(_ viewController: UIViewController, animated: Bool) {
+    package func presentViewController(_ viewController: UIViewController, animated: Bool) {
         self.viewController.presentViewController(viewController, animated: animated)
     }
 
-    public func dismissViewController(animated: Bool) {
+    package func dismissViewController(animated: Bool) {
         self.viewController.dismissViewController(animated: animated)
     }
 }

--- a/AdyenComponents/Qiwi Wallet/QiwiWalletComponent.swift
+++ b/AdyenComponents/Qiwi Wallet/QiwiWalletComponent.swift
@@ -13,11 +13,11 @@ import Adyen
 import UIKit
 
 /// A component that provides a form for Qiwi Wallet payments.
-public final class QiwiWalletComponent: AbstractPersonalInformationComponent {
-    
+package final class QiwiWalletComponent: AbstractPersonalInformationComponent {
+
     /// Configuration for Qiwi Wallet Component
-    public typealias Configuration = PersonalInformationConfiguration
-    
+    package typealias Configuration = PersonalInformationConfiguration
+
     private let qiwiWalletPaymentMethod: QiwiWalletPaymentMethod
     
     /// Initializes the Qiwi Wallet component.
@@ -26,7 +26,7 @@ public final class QiwiWalletComponent: AbstractPersonalInformationComponent {
     ///   - paymentMethod: The Qiwi Wallet payment method.
     ///   - context: The context object for this component.
     ///   - configuration: The component's configuration.
-    public init(
+    package init(
         paymentMethod: QiwiWalletPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()

--- a/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
+++ b/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
@@ -15,32 +15,31 @@ import UIKit
 
 /// A component that provides a form for SEPA Direct Debit payments.
 @MainActor
-public final class SEPADirectDebitComponent: PaymentComponent, PresentableComponent, LoadingComponent {
-    
+package final class SEPADirectDebitComponent: PaymentComponent, PresentableComponent, LoadingComponent {
+
     /// Configuration for SEPA Direct Debit Component
-    public typealias Configuration = BasicComponentConfiguration
-    
+    package typealias Configuration = BasicComponentConfiguration
+
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
-    
+    package let context: AdyenContext
+
     /// Component's configuration
-    public var configuration: Configuration
-    
+    package var configuration: Configuration
+
     /// The SEPA Direct Debit payment method.
-    public var paymentMethod: PaymentMethod {
+    package var paymentMethod: PaymentMethod {
         sepaDirectDebitPaymentMethod
     }
     
     /// The delegate of the component.
-    public weak var delegate: PaymentComponentDelegate?
-    
+    package weak var delegate: PaymentComponentDelegate?
+
     /// Initializes the SEPA Direct Debit component.
     ///
     /// - Parameter paymentMethod: The SEPA Direct Debit payment method.
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: Configuration for the component.
-    public init(
+    package init(
         paymentMethod: SEPADirectDebitPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()
@@ -54,12 +53,12 @@ public final class SEPADirectDebitComponent: PaymentComponent, PresentableCompon
     
     // MARK: - Presentable Component Protocol
     
-    public lazy var viewController: UIViewController = SecuredViewController(
+    package lazy var viewController: UIViewController = SecuredViewController(
         child: formViewController,
         style: configuration.style
     )
     
-    public func stopLoading() {
+    package func stopLoading() {
         button.showsActivityIndicator = false
         formViewController.view.isUserInteractionEnabled = true
     }
@@ -152,21 +151,19 @@ public final class SEPADirectDebitComponent: PaymentComponent, PresentableCompon
 
 }
 
-@_spi(AdyenInternal)
 extension SEPADirectDebitComponent: TrackableComponent {}
 
-@_spi(AdyenInternal)
 extension SEPADirectDebitComponent: ViewControllerDelegate {}
 
 // MARK: - SubmitCustomizable
 
 extension SEPADirectDebitComponent: SubmittableComponent {
 
-    public func submit() {
+    package func submit() {
         didSelectSubmitButton()
     }
 
-    public func validate() -> Bool {
+    package func validate() -> Bool {
         formViewController.validate()
     }
 }

--- a/AdyenComponents/UPI/UPIComponent.swift
+++ b/AdyenComponents/UPI/UPIComponent.swift
@@ -14,12 +14,12 @@ import UIKit
 
 /// A component that provides a upi flows for UPI component.
 @MainActor
-public final class UPIComponent: PaymentComponent,
+package final class UPIComponent: PaymentComponent,
     PresentableComponent,
     LoadingComponent {
     
     /// The flow types for UPI component.
-    public enum UPIFlowType: Int {
+    package enum UPIFlowType: Int {
 
         /// Transaction handled through UPI-enabled apps.
         case upiIntent = 0
@@ -51,43 +51,43 @@ public final class UPIComponent: PaymentComponent,
     }
     
     /// Configuration for UPI Component.
-    public typealias Configuration = BasicComponentConfiguration
-    
+    package typealias Configuration = BasicComponentConfiguration
+
     /// The context object for this component.
     @_spi(AdyenInternal)
     public var context: AdyenContext
-    
+
     /// The payment method object for this component.
-    public var paymentMethod: PaymentMethod {
+    package var paymentMethod: PaymentMethod {
         upiPaymentMethod
     }
     
     /// The delegate of the component.
-    public weak var delegate: PaymentComponentDelegate?
-    
+    package weak var delegate: PaymentComponentDelegate?
+
     /// The view controller for the component.
-    public lazy var viewController: UIViewController = SecuredViewController(
+    package lazy var viewController: UIViewController = SecuredViewController(
         child: formViewController,
         style: configuration.style
     )
     
     /// Component's configuration
-    public var configuration: Configuration
-    
+    package var configuration: Configuration
+
     private let upiPaymentMethod: UPIPaymentMethod
     
     internal private(set) var currentSelectedItemIdentifier: String?
     
     /// Represents the selected UPI (Unified Payments Interface) flow for the payment component.
     /// Determines the specific UPI transaction process to follow.
-    @AdyenObservable(.upiIntent) public private(set) var selectedUPIFlow: UPIFlowType
-    
+    @AdyenObservable(.upiIntent) package private(set) var selectedUPIFlow: UPIFlowType
+
     /// Initializes the UPI  component.
     ///
     /// - Parameter paymentMethod: The UPI payment method.
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The configuration for the component.
-    public init(
+    package init(
         paymentMethod: UPIPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()
@@ -101,7 +101,7 @@ public final class UPIComponent: PaymentComponent,
     
     // MARK: - LoadingComponent
     
-    public func stopLoading() {
+    package func stopLoading() {
         continueButton.showsActivityIndicator = false
         formViewController.view.isUserInteractionEnabled = true
     }
@@ -405,18 +405,17 @@ private extension UPIComponent {
     }
 }
 
-@_spi(AdyenInternal)
 extension UPIComponent: AdyenObserver {}
 
 // MARK: - SubmitCustomizable
 
 extension UPIComponent: SubmittableComponent {
     
-    public func submit() {
+    package func submit() {
         didSelectContinueButton()
     }
     
-    public func validate() -> Bool {
+    package func validate() -> Bool {
         formViewController.validate()
     }
 }

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -68,10 +68,10 @@ public final class DropInComponent: NSObject,
     internal var selectedPaymentComponent: PaymentComponent?
 
     /// The payment methods to display.
-    public internal(set) var paymentMethods: PaymentMethods
+    internal(set) var paymentMethods: PaymentMethods
 
     /// The title text on the first page of drop in component.
-    public let title: String
+    package let title: String
 
     /// The context object for this component.
     @_spi(AdyenInternal)
@@ -85,7 +85,7 @@ public final class DropInComponent: NSObject,
     ///   - configuration: The payment method specific configuration.
     ///   - title: Name of the application. To be displayed on a first payment page.
     ///            If no external value provided, the Main Bundle's name would be used.
-    public init(
+    package init(
         paymentMethods: PaymentMethods,
         context: AdyenContext,
         configuration: Configuration = .init(),
@@ -125,10 +125,10 @@ public final class DropInComponent: NSObject,
     public weak var delegate: DropInComponentDelegate?
 
     /// The partial payment flow delegate.
-    public weak var partialPaymentDelegate: PartialPaymentDelegate?
+    package weak var partialPaymentDelegate: PartialPaymentDelegate?
 
     /// The stored payment methods delegate.
-    public weak var storedPaymentMethodsDelegate: StoredPaymentMethodsDelegate? {
+    package weak var storedPaymentMethodsDelegate: StoredPaymentMethodsDelegate? {
         didSet {
             guard let sessionAsStoredPaymentMethodsDelegate else { return }
 
@@ -312,25 +312,22 @@ private extension Bundle {
 
 }
 
-@_spi(AdyenInternal)
 extension DropInComponent: AdyenSessionAware {
-    public var isSession: Bool {
+    package var isSession: Bool {
         delegate is AdyenSessionAware
     }
 }
 
-@_spi(AdyenInternal)
 extension DropInComponent: StorePaymentMethodFieldAware {
 
-    public var showStorePaymentMethodField: Bool? {
+    package var showStorePaymentMethodField: Bool? {
         (delegate as? StorePaymentMethodFieldAware)?.showStorePaymentMethodField
     }
 }
 
-@_spi(AdyenInternal)
 extension DropInComponent: InstallmentConfigurationAware {
 
-    public var installmentConfiguration: InstallmentConfiguration? {
+    package var installmentConfiguration: InstallmentConfiguration? {
         (delegate as? InstallmentConfigurationAware)?.installmentConfiguration
     }
 }

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -44,8 +44,7 @@ extension DropInComponent: FinalizableComponent {
 
 extension DropInComponent: ReadyToSubmitPaymentComponentDelegate {
 
-    @_spi(AdyenInternal)
-    public func showConfirmation(for component: InstantPaymentComponent, with order: PartialPaymentOrder?) {
+    package func showConfirmation(for component: InstantPaymentComponent, with order: PartialPaymentOrder?) {
 //        let newRootViewController = resolvePreselectedPaymentMethodView(
 //            for: component,
 //            onCancel: { [weak self] in

--- a/AdyenDropIn/Models/DropInComponentStyle.swift
+++ b/AdyenDropIn/Models/DropInComponentStyle.swift
@@ -14,30 +14,30 @@ import Adyen
 import Foundation
 import UIKit
 
-public extension DropInComponent {
-    
+package extension DropInComponent {
+
     /// Indicates the UI configuration of the drop in components.
     struct Style {
         
         /// Indicates any navigation style.
-        public var navigation = NavigationStyle()
-        
+        package var navigation = NavigationStyle()
+
         /// Indicates the UI configuration of any list component.
-        public var listComponent = ListComponentStyle()
-        
+        package var listComponent = ListComponentStyle()
+
         /// Indicates any form component UI style.
-        public var formComponent = FormComponentStyle()
-        
+        package var formComponent = FormComponentStyle()
+
         /// Indicates the UI configuration of Action Components
-        public var actionComponent = ActionComponentStyle()
-        
+        package var actionComponent = ActionComponentStyle()
+
         /// Indicates the UI configuration for the Apple Pay component.
-        public var applePay = ApplePayStyle()
-        
+        package var applePay = ApplePayStyle()
+
         /// The color for separator element.
         /// When set, updates separator colors for all underlying styles unless the value were set previously.
         /// If value is nil, the default color would be used.
-        public var separatorColor: UIColor? {
+        package var separatorColor: UIColor? {
             didSet {
                 formComponent.separatorColor = formComponent.separatorColor ?? separatorColor
                 navigation.separatorColor = navigation.separatorColor ?? separatorColor
@@ -45,10 +45,10 @@ public extension DropInComponent {
         }
         
         /// Initializes the instance of DropIn style with the default values.
-        public init() {}
-        
+        package init() {}
+
         /// Initializes the instance of DropIn style with the default values.
-        public init(tintColor: UIColor) {
+        package init(tintColor: UIColor) {
             formComponent = FormComponentStyle(tintColor: tintColor)
             navigation.tintColor = tintColor
         }

--- a/AdyenDropIn/Models/DropInConfiguration.swift
+++ b/AdyenDropIn/Models/DropInConfiguration.swift
@@ -21,62 +21,62 @@ import Foundation
 import PassKit
 
 // TODO: get rid of duplicate component configs inside dropin. they should be only one specified by merchant
-public extension DropInComponent {
-    
+package extension DropInComponent {
+
     /// Contains the configuration for the drop in component and the embedded payment method components.
     final class Configuration: AnyPersonalInformationConfiguration {
 
         /// Card component related configuration.
-        public var card = Card()
-        
+        package var card = Card()
+
         /// The Apple Pay configuration.
-        public var applePay: ApplePayConfiguration?
-        
+        package var applePay: ApplePayConfiguration?
+
         /// Payment methods list related configurations.
-        public var paymentMethodsList = PaymentMethodListConfiguration()
-        
+        package var paymentMethodsList = PaymentMethodListConfiguration()
+
         /// Action components related configurations.
-        public var actionComponent = ActionComponentConfiguration()
-        
+        package var actionComponent = ActionComponentConfiguration()
+
         /// Shopper related information
-        public var shopperInformation: PrefilledShopperInformation?
-        
+        package var shopperInformation: PrefilledShopperInformation?
+
         /// Indicates the localization parameters, leave it nil to use the default parameters.
-        public var localizationParameters: LocalizationParameters?
-        
+        package var localizationParameters: LocalizationParameters?
+
         /// Determines whether to enable skipping payment list step
         /// when there is only one non-instant payment method.
         /// Default value: `false`.
-        public var allowsSkippingPaymentList: Bool
+        package var allowsSkippingPaymentList: Bool
 
         /// Determines whether to enable preselected stored payment method view step.
         /// Default value: `true`.
-        public var allowPreselectedPaymentView: Bool
-        
+        package var allowPreselectedPaymentView: Bool
+
         /// Indicates the UI configuration of the drop in component.
-        public var style: DropInComponent.Style
+        package var style: DropInComponent.Style
 
         /// Indicates the UI style configuration of the drop in component.
-        public var theme: CheckoutTheme = .default
+        package var theme: CheckoutTheme = .default
 
         /// Boleto component configuration.
-        public var boleto: Boleto = .init()
+        package var boleto: Boleto = .init()
 
         /// Configuration for the Cash App Pay component
-        public var cashAppPay: CashAppPay?
+        package var cashAppPay: CashAppPay?
 
         /// The ACH Direct Debit configuration.
-        public var ach: ACH = .init()
+        package var ach: ACH = .init()
 
         /// Gift card component configuration
-        public var giftCard: GiftCard = .init()
+        package var giftCard: GiftCard = .init()
 
         /// Initializes the drop in configuration.
         /// - Parameters:
         ///   - style: The UI styles of the components.
         ///   - allowsSkippingPaymentList: Boolean to enable skipping payment list when there is only one one non-instant payment method.
         ///   - allowPreselectedPaymentView: Boolean to enable the preselected stored payment method view step.
-        public init(
+        package init(
             style: Style = Style(),
             theme: CheckoutTheme = .default,
             allowsSkippingPaymentList: Bool = false,
@@ -92,19 +92,19 @@ public extension DropInComponent {
     /// Action components related configurations.
     struct ActionComponentConfiguration {
         
-        public init() { /* Empty initializer */ }
-        
+        package init() { /* Empty initializer */ }
+
         /// Three DS configurations
-        public var authentication: AuthenticationConfiguration = .init()
+        package var authentication: AuthenticationConfiguration = .init()
 
         /// Twint configurations
-        public var twint: TwintActionConfiguration?
+        package var twint: TwintActionConfiguration?
     }
 
     /// Boleto component configuration.
     struct Boleto {
         /// Indicates whether to show sendCopyByEmail checkbox and email text field
-        public var showEmailAddress: Bool = true
+        package var showEmailAddress: Bool = true
     }
 
     /// ACH Component configuration specific to Drop In Component.
@@ -112,16 +112,16 @@ public extension DropInComponent {
         
         /// Indicates if the field for storing the card payment method should be displayed in the form.
         /// Defaults to `true`.
-        public var showsStorePaymentMethodField: Bool
-        
+        package var showsStorePaymentMethodField: Bool
+
         /// Determines whether the billing address should be displayed or not.
         /// Defaults to `true`.
-        public var showsBillingAddress: Bool
-        
+        package var showsBillingAddress: Bool
+
         /// List of ISO country codes that is supported for the billing address.
         /// Defaults to `["US", "PR"].
-        public var billingAddressCountryCodes: [String]
-        
+        package var billingAddressCountryCodes: [String]
+
         /// Configuration of the ACH component.
         ///
         /// - Parameters:
@@ -131,7 +131,7 @@ public extension DropInComponent {
         ///   Defaults to `true`.
         ///   - billingAddressCountryCodes: List of ISO country codes that is supported for the billing address.
         ///   Defaults to `["US", "PR"].
-        public init(
+        package init(
             showsStorePaymentMethodField: Bool = true,
             showsBillingAddress: Bool = true,
             billingAddressCountryCodes: [String] = ["US", "PR"]
@@ -145,7 +145,7 @@ public extension DropInComponent {
     /// Gift card component configuration.
     struct GiftCard {
         /// Indicates whether to show the security code field. Defaults to true.
-        public var showsSecurityCodeField: Bool = true
+        package var showsSecurityCodeField: Bool = true
     }
     
     // TODO: since these will be removed, changes on card config don't need to be added here
@@ -153,33 +153,33 @@ public extension DropInComponent {
     struct Card: AnyCardComponentConfiguration {
         
         /// Indicates if the field for entering the cardholder name should be displayed in the form. Defaults to false.
-        public var showCardholderName: Bool
+        package var showCardholderName: Bool
 
         /// Indicates if the field for storing the card payment method should be displayed in the form. Defaults to true.
-        public var showStorePaymentMethod: Bool
+        package var showStorePaymentMethod: Bool
 
         /// Indicates whether to show the security code field at all. Defaults to true.
-        public var showSecurityCode: Bool
+        package var showSecurityCode: Bool
 
         /// Indicates whether to show the security fields for South Korea issued cards. Defaults to `auto`.
         /// In AUTO mode the field will appear only for card issued in "KR" (South Korea).
-        public var koreanAuthenticationVisibility: CardConfiguration.FieldVisibility
+        package var koreanAuthenticationVisibility: CardConfiguration.FieldVisibility
 
         /// Indicates the visibility mode for the social security number field (CPF/CNPJ) for Brazilian cards. Defaults to `auto`.
         /// In `auto` mode the field will appear based on card bin lookup.
-        public var socialSecurityNumberVisibility: CardConfiguration.FieldVisibility
+        package var socialSecurityNumberVisibility: CardConfiguration.FieldVisibility
 
         /// Indicates whether to show the security code field for stored cards. Defaults to true.
-        public var showSecurityCodeForStoredCard: Bool
+        package var showSecurityCodeForStoredCard: Bool
 
         /// The list of supported card brands.  Defaults to nil.
         /// By default list of supported brands is extracted from component's `AnyCardPaymentMethod`.
         /// Use this property to enforce a custom collection of card brands.
-        public var supportedCardBrands: [CardType]?
+        package var supportedCardBrands: [CardType]?
 
         /// Installments options to present to the user.
-        public var installmentConfiguration: InstallmentConfiguration?
-        
+        package var installmentConfiguration: InstallmentConfiguration?
+
         /// Configuration of Card component.
         ///
         /// - Parameters:
@@ -196,7 +196,7 @@ public extension DropInComponent {
         ///   - supportedCardBrands: The enforced list of supported card brands.
         ///   - installmentConfiguration: Configuration for installments. Defaults to `nil`.
         ///   - billingAddress: Billing address fields configurations.
-        public init(
+        package init(
             showCardholderName: Bool = false,
             showStorePaymentMethod: Bool = true,
             showSecurityCode: Bool = true,
@@ -226,18 +226,18 @@ public extension DropInComponent {
     struct CashAppPay: AnyCashAppPayConfiguration {
 
         /// The URL for Cash App to call in order to redirect back to your application.
-        public let redirectURL: URL
+        package let redirectURL: URL
 
         /// A reference to your system (for example, a cart or checkout identifier).
-        public let referenceId: String?
+        package let referenceId: String?
 
         /// Indicates if the field for storing the payment method should be displayed in the form. Defaults to `true`.
-        public var showsStorePaymentMethodField: Bool
-        
+        package var showsStorePaymentMethodField: Bool
+
         /// Determines whether to store this payment method. Defaults to `false`.
         /// Ignored if `showsStorePaymentMethodField` is `true`.
-        public var storePaymentMethod: Bool
-        
+        package var storePaymentMethod: Bool
+
         /// Initializes an instance of `CashAppPayComponent.Configuration`
         ///
         /// - Parameters:
@@ -246,7 +246,7 @@ public extension DropInComponent {
         ///   - showsStorePaymentMethodField: Determines the visibility of the field for storing the payment method.
         ///   - storePaymentMethod: Determines whether to store this payment method.
         ///   Ignored if `showsStorePaymentMethodField` is `true`.
-        public init(
+        package init(
             redirectURL: URL,
             referenceId: String? = nil,
             showsStorePaymentMethodField: Bool = true,

--- a/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodViewController.swift
+++ b/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 
 #if canImport(AdyenUI)
     import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormButton
 #endif
 
 internal class PreselectedPaymentMethodViewController: UIViewController {

--- a/AdyenTwint/TwintComponent.swift
+++ b/AdyenTwint/TwintComponent.swift
@@ -14,20 +14,19 @@ import TwintSDK
 
 /// A component that handles a Twint payment.
 @MainActor
-public final class TwintComponent: InitiablePaymentComponent {
+package final class TwintComponent: InitiablePaymentComponent {
 
     /// Configuration for Twint Component.
-    public typealias Configuration = BasicComponentConfiguration
+    package typealias Configuration = BasicComponentConfiguration
 
     /// The context object for this component.
-    @_spi(AdyenInternal)
-    public let context: AdyenContext
+    package let context: AdyenContext
 
     /// The payment method object for this component.
-    public let paymentMethod: PaymentMethod
+    package let paymentMethod: PaymentMethod
 
     /// The ready to submit payment data.
-    public var paymentData: PaymentComponentData {
+    package var paymentData: PaymentComponentData {
         let details = TwintDetails(
             type: paymentMethod,
             subType: "sdk"
@@ -42,10 +41,10 @@ public final class TwintComponent: InitiablePaymentComponent {
     }
 
     /// Component's configuration
-    public var configuration: Configuration
+    package var configuration: Configuration
 
     /// The delegate of the component.
-    public weak var delegate: PaymentComponentDelegate?
+    package weak var delegate: PaymentComponentDelegate?
 
     // MARK: - Initializers
 
@@ -54,7 +53,7 @@ public final class TwintComponent: InitiablePaymentComponent {
     /// - Parameter paymentMethod: The Twint  payment method.
     /// - Parameter context: The context object for this component.
     /// - Parameter configuration: The configuration for the component.
-    public init(
+    package init(
         paymentMethod: TwintPaymentMethod,
         context: AdyenContext,
         configuration: Configuration = .init()
@@ -67,11 +66,10 @@ public final class TwintComponent: InitiablePaymentComponent {
     // MARK: - PaymentInitiable
 
     /// Generate the payment details and invoke PaymentsComponentDelegate method.
-    public func initiatePayment(delegate: PaymentComponentDelegate) {
+    package func initiatePayment(delegate: PaymentComponentDelegate) {
         self.delegate = delegate
         submit(data: paymentData)
     }
 }
 
-@_spi(AdyenInternal)
 extension TwintComponent: TrackableComponent {}

--- a/AdyenUI/UI/Dimensions.swift
+++ b/AdyenUI/UI/Dimensions.swift
@@ -8,20 +8,19 @@ import Adyen
 import Foundation
 import UIKit
 
-@_spi(AdyenInternal)
-public enum Dimensions {
+package enum Dimensions {
 
-    public static var leastPresentableScale: CGFloat = 0.25
+    package static var leastPresentableScale: CGFloat = 0.25
 
-    public static var greatestPresentableHeightScale: CGFloat = 0.9
+    package static var greatestPresentableHeightScale: CGFloat = 0.9
 
-    public static var maxAdaptiveWidth: CGFloat = 360
+    package static var maxAdaptiveWidth: CGFloat = 360
 
-    public static var greatestPresentableScale: CGFloat {
+    package static var greatestPresentableScale: CGFloat {
         UIDevice.current.userInterfaceIdiom == .phone && UIDevice.current.orientation.isLandscape ? 1 : greatestPresentableHeightScale
     }
 
-    public static func expectedWidth(for window: UIWindow? = nil) -> CGFloat {
+    package static func expectedWidth(for window: UIWindow? = nil) -> CGFloat {
         let containerSize = keyWindowSize(for: window)
         if UIDevice.current.userInterfaceIdiom == .pad {
             return min(containerSize.width * (1 - leastPresentableScale), maxAdaptiveWidth * UIScreen.main.scale)
@@ -30,7 +29,7 @@ public enum Dimensions {
         }
     }
 
-    public static func keyWindowSize(for window: UIWindow? = nil) -> CGRect {
+    package static func keyWindowSize(for window: UIWindow? = nil) -> CGRect {
         guard let window = window ?? UIApplication.shared.adyen.mainKeyWindow else {
             return UIScreen.main.bounds
         }

--- a/AdyenUI/UI/Form/FormViewController+ViewProtocol.swift
+++ b/AdyenUI/UI/Form/FormViewController+ViewProtocol.swift
@@ -6,23 +6,21 @@
 
 import Foundation
 
-@_spi(AdyenInternal)
-public protocol FormViewProtocol {
-    
+package protocol FormViewProtocol {
+
     func add(item: (some FormItem)?)
     
     func displayValidation()
 }
 
-@_spi(AdyenInternal)
 extension FormViewController: FormViewProtocol {
 
-    public func add(item: (some FormItem)?) {
+    package func add(item: (some FormItem)?) {
         guard let item else { return }
         append(item)
     }
 
-    public func displayValidation() {
+    package func displayValidation() {
         resignFirstResponder()
         showValidation()
     }

--- a/AdyenUI/UI/Form/Items/Address/AddressViewModel.swift
+++ b/AdyenUI/UI/Form/Items/Address/AddressViewModel.swift
@@ -8,8 +8,7 @@ import Adyen
 @_spi(AdyenInternal) import struct Adyen.LocalizationKey
 import UIKit
 
-@_spi(AdyenInternal)
-public enum AddressField: String, CaseIterable {
+package enum AddressField: String, CaseIterable {
     case street
     case houseNumberOrName
     case apartment
@@ -31,8 +30,7 @@ package enum AddressFormScheme {
     case split(AddressField, AddressField)
 }
 
-@_spi(AdyenInternal)
-public struct AddressViewModel {
+package struct AddressViewModel {
 
     internal var labels: [AddressField: LocalizationKey]
     internal var placeholder: [AddressField: LocalizationKey]

--- a/AdyenUI/UI/Form/Items/Address/DefaultAddressViewModelBuilder.swift
+++ b/AdyenUI/UI/Form/Items/Address/DefaultAddressViewModelBuilder.swift
@@ -8,14 +8,12 @@ import Adyen
 @_spi(AdyenInternal) import struct Adyen.LocalizationKey
 import Foundation
 
-@_spi(AdyenInternal)
-public struct AddressViewModelBuilderContext {
-    public var countryCode: String
-    public var isOptional: Bool
+package struct AddressViewModelBuilderContext {
+    package var countryCode: String
+    package var isOptional: Bool
 }
 
-@_spi(AdyenInternal)
-public protocol AddressViewModelBuilder {
+package protocol AddressViewModelBuilder {
     func build(context: AddressViewModelBuilderContext) -> AddressViewModel
 }
 

--- a/AdyenUI/UI/Form/Items/Basic Items/FormAttributedLabelItem.swift
+++ b/AdyenUI/UI/Form/Items/Basic Items/FormAttributedLabelItem.swift
@@ -8,14 +8,13 @@ import Adyen
 import UIKit
 
 /// Simple form item that represent a single attributed UILabel element.
-@_spi(AdyenInternal)
-public class FormAttributedLabelItem: FormItem {
+package class FormAttributedLabelItem: FormItem {
 
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
-    
-    public var subitems: [FormItem] = []
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
 
-    public init(
+    package var subitems: [FormItem] = []
+
+    package init(
         originalText: String,
         links: [String],
         style: TextStyle,
@@ -29,7 +28,7 @@ public class FormAttributedLabelItem: FormItem {
         self.links = links
     }
 
-    public var identifier: String?
+    package var identifier: String?
 
     /// The style of the label.
     private let style: TextStyle
@@ -43,7 +42,7 @@ public class FormAttributedLabelItem: FormItem {
     /// The links present in the label.
     private let links: [String]
 
-    public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         let label = LinkTextViewFormItem { [weak self] linkIndex in
             self?.handleLinkTapped(atIndex: linkIndex)
         }
@@ -71,7 +70,7 @@ public class FormAttributedLabelItem: FormItem {
 
 private class LinkTextViewFormItem: LinkTextView, AnyFormItemView {
     
-    public var childItemViews: [AnyFormItemView] {
+    package var childItemViews: [AnyFormItemView] {
         []
     }
 }

--- a/AdyenUI/UI/Form/Items/Basic Items/FormLabelItem.swift
+++ b/AdyenUI/UI/Form/Items/Basic Items/FormLabelItem.swift
@@ -13,7 +13,7 @@ import UIKit
 public class FormLabelItem: FormItem {
     
     public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
-    
+
     public var subitems: [FormItem] = []
 
     public init(text: String, style: TextStyle, identifier: String? = nil) {

--- a/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItemView.swift
@@ -8,9 +8,8 @@ import Adyen
 import UIKit
 
 /// The interface of the delegate of a text item view.
-@_spi(AdyenInternal)
-public protocol FormTextItemViewDelegate: AnyObject {
-    
+package protocol FormTextItemViewDelegate: AnyObject {
+
     /// Invoked when the text entered in the item view's text field has reached the maximum length.
     ///
     /// - Parameter itemView: The item view in which the maximum length was reached.
@@ -24,8 +23,7 @@ public protocol FormTextItemViewDelegate: AnyObject {
 }
 
 /// Defines any form text item view.
-@_spi(AdyenInternal)
-public protocol AnyFormTextItemView: AnyFormItemView {
+package protocol AnyFormTextItemView: AnyFormItemView {
 
     /// Delegate text related events.
     var delegate: FormTextItemViewDelegate? { get set }
@@ -99,8 +97,8 @@ open class FormTextItemView<ItemType: FormTextItem>: FormValidatableValueItemVie
     }
 
     /// Delegate text related events.
-    public weak var delegate: FormTextItemViewDelegate?
-    
+    package weak var delegate: FormTextItemViewDelegate?
+
     // MARK: - Stack View
     
     private lazy var textStackView: UIStackView = {

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController+EmptyView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController+EmptyView.swift
@@ -11,9 +11,9 @@ import UIKit
 extension FormPickerSearchViewController {
     
     /// The view that is shown when the form picker search result is empty
-    public class EmptyView: EmptyStateView<UILabel> {
-        
-        override public var searchTerm: String {
+    package class EmptyView: EmptyStateView<UILabel> {
+
+        override package var searchTerm: String {
             didSet { updateLabels() }
         }
         

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController+Style.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController+Style.swift
@@ -8,11 +8,11 @@ import UIKit
 
 extension FormPickerSearchViewController {
     
-    public struct Style: ViewStyle {
-        
-        public var backgroundColor: UIColor = .Adyen.componentBackground
-        public var emptyView: EmptyView.Style = .init()
-        
-        public init() {}
+    package struct Style: ViewStyle {
+
+        package var backgroundColor: UIColor = .Adyen.componentBackground
+        package var emptyView: EmptyView.Style = .init()
+
+        package init() {}
     }
 }

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController.swift
@@ -7,10 +7,9 @@
 import Adyen
 import UIKit
 
-@_spi(AdyenInternal)
-public final class FormPickerSearchViewController<Option: FormPickable>: UINavigationController {
-    
-    public init(
+package final class FormPickerSearchViewController<Option: FormPickable>: UINavigationController {
+
+    package init(
         localizationParameters: LocalizationParameters? = nil,
         style: Style = .init(),
         title: String?,
@@ -48,7 +47,7 @@ public final class FormPickerSearchViewController<Option: FormPickable>: UINavig
     }
     
     @available(*, unavailable)
-    public required init?(coder aDecoder: NSCoder) {
+    package required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     

--- a/AdyenUI/UI/List/ListCell.swift
+++ b/AdyenUI/UI/List/ListCell.swift
@@ -8,10 +8,9 @@ import Adyen
 import UIKit
 
 /// A cell in a ListViewController.
-@_spi(AdyenInternal)
-public final class ListCell: UITableViewCell {
-    
-    override public init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+package final class ListCell: UITableViewCell {
+
+    override package init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
         accessibilityTraits = .button
@@ -21,11 +20,11 @@ public final class ListCell: UITableViewCell {
     }
     
     @available(*, unavailable)
-    public required init?(coder aDecoder: NSCoder) {
+    package required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override public func setHighlighted(_ highlighted: Bool, animated: Bool) {
+    override package func setHighlighted(_ highlighted: Bool, animated: Bool) {
         super.setHighlighted(highlighted, animated: animated)
             
         guard let highlightedBackgroundColor = item?.style.highlightedBackgroundColor else {
@@ -38,7 +37,7 @@ public final class ListCell: UITableViewCell {
     // MARK: - Item
     
     /// The item displayed in the cell cell.
-    public var item: ListItem? {
+    package var item: ListItem? {
         didSet {
             itemView.item = item
             itemView.accessibilityIdentifier = item?.identifier.map { ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "itemView") }

--- a/AdyenUI/UI/List/ListItem+Icon.swift
+++ b/AdyenUI/UI/List/ListItem+Icon.swift
@@ -8,24 +8,24 @@ import UIKit
 
 extension ListItem {
 
-    public struct Icon: Hashable {
+    package struct Icon: Hashable {
 
-        public enum Location: Hashable {
+        package enum Location: Hashable {
             case local(image: UIImage)
             case remote(url: URL?)
         }
 
         /// The location of the icon image
-        public let location: Location
+        package let location: Location
         /// Whether or not the icon should be styled/altered
-        public let canBeModified: Bool
+        package let canBeModified: Bool
 
         /// Initializes the icon of the `ListItem`
         ///
         /// - Parameters:
         ///   - location: The location of the icon image
         ///   - canBeModified: Whether or not the icon should be styled/altered
-        public init(
+        package init(
             location: Location,
             canBeModified: Bool = true
         ) {
@@ -48,7 +48,7 @@ extension ListItem.Icon {
     }
 
     /// Convenience init to instantiate an ``ListItem.Icon`` with a remote ``URL``
-    public init(
+    package init(
         url: URL?,
         canBeModified: Bool = true
     ) {
@@ -59,7 +59,7 @@ extension ListItem.Icon {
     }
 
     /// Convenience init to instantiate an ``ListItem.Icon`` with a ``UIImage`` object
-    public init(
+    package init(
         image: UIImage,
         canBeModified: Bool = true
     ) {

--- a/AdyenUI/UI/List/ListItem.swift
+++ b/AdyenUI/UI/List/ListItem.swift
@@ -8,10 +8,9 @@ import Adyen
 import Foundation
 
 /// A selectable item displayed in the list.
-@_spi(AdyenInternal)
-public class ListItem: FormItem {
-    
-    public enum TrailingInfoType {
+package class ListItem: FormItem {
+
+    package enum TrailingInfoType {
         case text(String)
         case logos(urls: [URL], trailingText: String?)
         
@@ -23,37 +22,37 @@ public class ListItem: FormItem {
         }
     }
     
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
-    
-    public var subitems: [FormItem] = []
-    
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
+
+    package var subitems: [FormItem] = []
+
     /// The list item style.
-    public let style: ListItemStyle
-    
+    package let style: ListItemStyle
+
     /// The title of the item.
-    public var title: String
-    
+    package var title: String
+
     /// The subtitle of the item.
-    public var subtitle: String?
-    
+    package var subtitle: String?
+
     /// The icon to display
-    public var icon: Icon?
+    package var icon: Icon?
 
     /// The trailing text of the item.
-    public var trailingInfo: TrailingInfoType?
-    
+    package var trailingInfo: TrailingInfoType?
+
     /// The handler to invoke when the item is selected.
-    public var selectionHandler: (() -> Void)?
-    
+    package var selectionHandler: (() -> Void)?
+
     /// The handler to invoke when the item is deleted.
-    public var deletionHandler: ((IndexPath, @escaping Completion<Bool>) -> Void)?
-    
+    package var deletionHandler: ((IndexPath, @escaping Completion<Bool>) -> Void)?
+
     /// The `accessibilityIdentifier` to be used on the `ListItem`
-    public var identifier: String?
-    
+    package var identifier: String?
+
     /// The `accessibilityLabel` to be used on the ``ListItem`` or ``ListCell``
-    public let accessibilityLabel: String
-    
+    package let accessibilityLabel: String
+
     /// The closure for the ``ListViewController`` to assign, to listen to updates for its loading state
     ///
     /// See: ``ListItem/startLoading()`` & ``ListItem/stopLoading()``
@@ -70,7 +69,7 @@ public class ListItem: FormItem {
     ///   - identifier: The `accessibilityIdentifier` to be used on the `ListItem`
     ///   - selectionHandler: The closure to execute when an item is selected.
     ///   - accessibilityLabel: An optional custom `accessibilityLabel` to use. Defaults to title + subtitle + trailingText joined by a `, `
-    public init(
+    package init(
         title: String,
         subtitle: String? = nil,
         icon: Icon? = nil,
@@ -94,7 +93,7 @@ public class ListItem: FormItem {
         self.selectionHandler = selectionHandler
     }
     
-    public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
     
@@ -102,12 +101,12 @@ public class ListItem: FormItem {
     ///
     /// To stop the loading for the whole list either  call  ListViewController.``ListViewController/stopLoading()``
     /// or ListItem.``ListItem/stopLoading()``
-    public func startLoading() {
+    package func startLoading() {
         setLoading(true)
     }
     
     /// Indicate to the ``ListViewController`` to stop loading
-    public func stopLoading() {
+    package func stopLoading() {
         setLoading(false)
     }
     
@@ -127,14 +126,13 @@ public class ListItem: FormItem {
 
 // MARK: - Hashable & Equatable
 
-@_spi(AdyenInternal)
 extension ListItem: Hashable {
     
-    public func hash(into hasher: inout Hasher) {
+    package func hash(into hasher: inout Hasher) {
         hasher.combine(listIdentifier)
     }
     
-    public static func == (lhs: ListItem, rhs: ListItem) -> Bool {
+    package static func == (lhs: ListItem, rhs: ListItem) -> Bool {
         lhs.listIdentifier == rhs.listIdentifier
     }
 }

--- a/AdyenUI/UI/List/ListSection.swift
+++ b/AdyenUI/UI/List/ListSection.swift
@@ -7,26 +7,24 @@
 import Foundation
 
 /// The editing style.
-@_spi(AdyenInternal)
-public enum EditingStyle {
+package enum EditingStyle {
     case delete
     case none
 }
 
 /// A section of items in a ListViewController.
-@_spi(AdyenInternal)
-public struct ListSection: Hashable {
-    
+package struct ListSection: Hashable {
+
     /// The title of the section.
-    public let header: ListSectionHeader?
+    package let header: ListSectionHeader?
 
     /// The items inside the section.
-    public private(set) var items: [ListItem]
+    package private(set) var items: [ListItem]
 
     /// The footer title of the section.
-    public let footer: ListSectionFooter?
-    
-    public var isEditable: Bool {
+    package let footer: ListSectionFooter?
+
+    package var isEditable: Bool {
         header?.editingStyle != EditingStyle.none
     }
     
@@ -36,7 +34,7 @@ public struct ListSection: Hashable {
     ///   - header: The section header.
     ///   - items: The items inside the section.
     ///   - footer: The section footer.
-    public init(
+    package init(
         header: ListSectionHeader? = nil,
         items: [ListItem],
         footer: ListSectionFooter? = nil
@@ -54,13 +52,13 @@ public struct ListSection: Hashable {
         items.remove(at: index)
     }
     
-    public func hash(into hasher: inout Hasher) {
+    package func hash(into hasher: inout Hasher) {
         hasher.combine(identifier)
         hasher.combine(header)
         hasher.combine(footer)
     }
     
-    public static func == (lhs: ListSection, rhs: ListSection) -> Bool {
+    package static func == (lhs: ListSection, rhs: ListSection) -> Bool {
         lhs.header == rhs.header &&
             lhs.footer == rhs.footer &&
             lhs.identifier == rhs.identifier
@@ -69,59 +67,58 @@ public struct ListSection: Hashable {
 }
 
 /// A list section header.
-@_spi(AdyenInternal)
-public struct ListSectionHeader: Hashable {
+package struct ListSectionHeader: Hashable {
 
     /// The header title.
-    public var title: String
+    package var title: String
 
     /// The header style.
-    public var style: ListSectionHeaderStyle
-    
+    package var style: ListSectionHeaderStyle
+
     /// The editing style.
-    public var editingStyle: EditingStyle = .none
+    package var editingStyle: EditingStyle = .none
 
     /// - Parameters:
     ///   - title: The header title
     ///   - style: The UI style.
-    public init(title: String, editingStyle: EditingStyle = .none, style: ListSectionHeaderStyle) {
+    package init(title: String, editingStyle: EditingStyle = .none, style: ListSectionHeaderStyle) {
         self.title = title
         self.editingStyle = editingStyle
         self.style = style
     }
     
-    public func hash(into hasher: inout Hasher) {
+    package func hash(into hasher: inout Hasher) {
         hasher.combine(title)
         hasher.combine(editingStyle)
     }
     
-    public static func == (lhs: ListSectionHeader, rhs: ListSectionHeader) -> Bool {
+    package static func == (lhs: ListSectionHeader, rhs: ListSectionHeader) -> Bool {
         lhs.title == rhs.title && lhs.editingStyle == rhs.editingStyle
     }
 }
 
 /// A list section footer.
-public struct ListSectionFooter: Hashable {
+package struct ListSectionFooter: Hashable {
 
     /// The footer title.
-    public var title: String
+    package var title: String
 
     /// The footer style.
-    public var style: ListSectionFooterStyle
+    package var style: ListSectionFooterStyle
 
     /// - Parameters:
     ///   - title: The footer title
     ///   - style: The UI style.
-    public init(title: String, style: ListSectionFooterStyle) {
+    package init(title: String, style: ListSectionFooterStyle) {
         self.title = title
         self.style = style
     }
     
-    public func hash(into hasher: inout Hasher) {
+    package func hash(into hasher: inout Hasher) {
         hasher.combine(title)
     }
     
-    public static func == (lhs: ListSectionFooter, rhs: ListSectionFooter) -> Bool {
+    package static func == (lhs: ListSectionFooter, rhs: ListSectionFooter) -> Bool {
         lhs.title == rhs.title
     }
 }

--- a/AdyenUI/UI/ToolBar/ModalToolbar.swift
+++ b/AdyenUI/UI/ToolBar/ModalToolbar.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import protocol Adyen.AnyNavigationBar
+import Adyen
 import UIKit
 
 package class ModalToolbar: UIView, AnyNavigationBar {

--- a/AdyenUI/UI/ToolBar/ModalToolbar.swift
+++ b/AdyenUI/UI/ToolBar/ModalToolbar.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
+@_spi(AdyenInternal) import protocol Adyen.AnyNavigationBar
 import UIKit
 
 package class ModalToolbar: UIView, AnyNavigationBar {

--- a/AdyenUI/UI/View Controllers/SearchViewController/SearchViewController.swift
+++ b/AdyenUI/UI/View Controllers/SearchViewController/SearchViewController.swift
@@ -9,8 +9,7 @@ import UIKit
 
 /// Protocol specifying the interface of a view that is shown
 /// when the results of the ``SearchViewController`` are empty.
-@_spi(AdyenInternal)
-public protocol SearchResultsEmptyView: UIView {
+package protocol SearchResultsEmptyView: UIView {
     /// The searchTerm that caused the search results to be empty
     ///
     /// Use this value to update your messaging
@@ -18,9 +17,8 @@ public protocol SearchResultsEmptyView: UIView {
 }
 
 /// A view controller that shows search results in a ``ListViewController``
-@_spi(AdyenInternal)
-public class SearchViewController: UIViewController, AdyenObserver {
-    
+package class SearchViewController: UIViewController, AdyenObserver {
+
     internal lazy var keyboardObserver = KeyboardObserver()
     private var emptyViewBottomConstraint: NSLayoutConstraint?
 
@@ -37,7 +35,7 @@ public class SearchViewController: UIViewController, AdyenObserver {
     /// - Parameters:
     ///   - viewModel: The business logic of the search view controller
     ///   - emptyView: The view (conforming to ``SearchResultsEmptyView``) to show when the search results are empty.
-    public init(
+    package init(
         viewModel: ViewModel,
         emptyView: SearchResultsEmptyView
     ) {
@@ -68,7 +66,7 @@ public class SearchViewController: UIViewController, AdyenObserver {
         )
     }()
 
-    override public func viewDidLoad() {
+    override package func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = viewModel.style.backgroundColor
 
@@ -104,7 +102,7 @@ public class SearchViewController: UIViewController, AdyenObserver {
         viewModel.handleViewDidLoad()
     }
     
-    override public func viewWillAppear(_ animated: Bool) {
+    override package func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         delegate?.viewWillAppear(viewController: self)
@@ -194,7 +192,7 @@ public class SearchViewController: UIViewController, AdyenObserver {
         )
     }
 
-    override public var preferredContentSize: CGSize {
+    override package var preferredContentSize: CGSize {
         get {
             guard resultsListViewController.isViewLoaded else { return .zero }
             let innerSize = resultsListViewController.preferredContentSize
@@ -220,11 +218,11 @@ public class SearchViewController: UIViewController, AdyenObserver {
 
 extension SearchViewController: UISearchBarDelegate {
     
-    public func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+    package func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         viewModel.handleSearchTextDidChange(searchText)
     }
     
-    public func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+    package func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         searchBar.resignFirstResponder()
     }
 }

--- a/AdyenUI/UI/Views/CopyLabelView.swift
+++ b/AdyenUI/UI/Views/CopyLabelView.swift
@@ -8,10 +8,9 @@ import Adyen
 @_spi(AdyenInternal) import struct Adyen.LocalizationKey
 import UIKit
 
-@_spi(AdyenInternal)
-public final class CopyLabelView: UIView, Localizable {
+package final class CopyLabelView: UIView, Localizable {
 
-    public var localizationParameters: LocalizationParameters?
+    package var localizationParameters: LocalizationParameters?
 
     private let style: TextStyle
 
@@ -27,7 +26,7 @@ public final class CopyLabelView: UIView, Localizable {
         return label
     }()
 
-    public init(text: String, style: TextStyle) {
+    package init(text: String, style: TextStyle) {
         self.text = text
         self.style = style
         super.init(frame: .zero)
@@ -64,7 +63,7 @@ public final class CopyLabelView: UIView, Localizable {
         backgroundColor = UIColor.Adyen.lightGray
     }
 
-    override public var canBecomeFirstResponder: Bool {
+    override package var canBecomeFirstResponder: Bool {
         true
     }
 
@@ -79,7 +78,7 @@ public final class CopyLabelView: UIView, Localizable {
     }
 
     @discardableResult
-    override public func becomeFirstResponder() -> Bool {
+    override package func becomeFirstResponder() -> Bool {
         super.becomeFirstResponder()
     }
 

--- a/AdyenUI/UI/Views/EmptyStateView.swift
+++ b/AdyenUI/UI/Views/EmptyStateView.swift
@@ -22,14 +22,13 @@ public struct EmptyStateViewStyle: ViewStyle {
 }
 
 /// A generic empty view with title and generic subtitle
-@_spi(AdyenInternal)
-public class EmptyStateView<SubtitleLabel: UIView>: UIView, SearchResultsEmptyView {
-    
+package class EmptyStateView<SubtitleLabel: UIView>: UIView, SearchResultsEmptyView {
+
     internal let style: EmptyStateViewStyle
     internal let localizationParameters: LocalizationParameters?
     
-    public var searchTerm: String
-    
+    package var searchTerm: String
+
     internal lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.numberOfLines = 0

--- a/AdyenUI/UI/Views/FormButton.swift
+++ b/AdyenUI/UI/Views/FormButton.swift
@@ -8,8 +8,7 @@ import Adyen
 import UIKit
 
 /// A rounded button for use in forms.
-@_spi(AdyenInternal)
-public final class FormButton: UIControl {
+package final class FormButton: UIControl {
     private enum Constants {
         static let leadingImageWidth: CGFloat = 24
         static let leadingImageHeight: CGFloat = 24
@@ -21,7 +20,7 @@ public final class FormButton: UIControl {
     /// Initializes the form button.
     ///
     /// - Parameter style: The `FormButton` UI style.
-    public init(style: ButtonStyle) {
+    package init(style: ButtonStyle) {
         self.style = style
         super.init(frame: .zero)
         
@@ -41,7 +40,7 @@ public final class FormButton: UIControl {
     /// Initializes the form button.
     /// - Parameter buttonStyle: The  new `FormButton` UI style.
     /// - Parameter style: The  old `FormButton` UI style.
-    public init(
+    package init(
         theme: CheckoutTheme,
         style: ButtonStyle = .init(title: .init(font: .preferredFont(forTextStyle: .body), color: .red))
     ) {
@@ -82,7 +81,7 @@ public final class FormButton: UIControl {
     }
 
     @available(*, unavailable)
-    public required init?(coder aDecoder: NSCoder) {
+    package required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
@@ -101,7 +100,7 @@ public final class FormButton: UIControl {
     // MARK: - Title Label
      
     /// The title of the submit button.
-    public var title: String? {
+    package var title: String? {
         didSet {
             titleLabel.text = title
             accessibilityLabel = title
@@ -121,7 +120,7 @@ public final class FormButton: UIControl {
     // MARK: - Leading Image
     
     /// The optional leading image displayed to the left of the title.
-    public var leadingImage: UIImage? {
+    package var leadingImage: UIImage? {
         didSet {
             leadingImageView.image = leadingImage
             leadingImageView.isHidden = leadingImage == nil
@@ -149,7 +148,7 @@ public final class FormButton: UIControl {
         return stackView
     }()
     
-    override public var accessibilityIdentifier: String? {
+    override package var accessibilityIdentifier: String? {
         didSet {
             titleLabel.accessibilityIdentifier = accessibilityIdentifier.map {
                 ViewIdentifierBuilder.build(scopeInstance: $0, postfix: "titleLabel")
@@ -160,7 +159,7 @@ public final class FormButton: UIControl {
     // MARK: - Activity Indicator View
     
     /// Boolean value indicating whether an activity indicator should be shown.
-    public var showsActivityIndicator: Bool {
+    package var showsActivityIndicator: Bool {
         get {
             activityIndicatorView.isAnimating
         }
@@ -194,7 +193,7 @@ public final class FormButton: UIControl {
     
     // MARK: - Layout
     
-    override public func layoutSubviews() {
+    override package func layoutSubviews() {
         super.layoutSubviews()
         self.adyen.round(using: buttonStyle.cornerRadius ?? .fixed(AdyenUIConstants.defaultCornerRadius))
     }
@@ -227,7 +226,7 @@ public final class FormButton: UIControl {
     
     // MARK: - State
     
-    override public var isHighlighted: Bool {
+    override package var isHighlighted: Bool {
         didSet {
             backgroundView.isHighlighted = isHighlighted
         }

--- a/AdyenUI/UI/Views/LinkTextView.swift
+++ b/AdyenUI/UI/Views/LinkTextView.swift
@@ -10,16 +10,15 @@ import UIKit
 /// A text view that easily makes links - delimited with a `linkRangeDelimiter` - selectable
 ///
 /// Use ``update(text:style:linkRangeDelimiter:)`` to update the content
-@_spi(AdyenInternal)
-public class LinkTextView: UITextView {
-    
+package class LinkTextView: UITextView {
+
     private let linkSelectionHandler: (_ linkIndex: Int) -> Void
     
     /// Initializes a LinkTextView
     ///
     /// - Parameters:
     ///    - linkSelectionHandler: A closure that is called when a link is selected. Including the index of the link.
-    public init(linkSelectionHandler: @escaping (_ linkIndex: Int) -> Void) {
+    package init(linkSelectionHandler: @escaping (_ linkIndex: Int) -> Void) {
         self.linkSelectionHandler = linkSelectionHandler
         
         super.init(frame: .zero, textContainer: nil)
@@ -33,7 +32,7 @@ public class LinkTextView: UITextView {
     }
     
     @available(*, unavailable)
-    public required init?(coder: NSCoder) {
+    package required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
@@ -43,7 +42,7 @@ public class LinkTextView: UITextView {
     ///   - text: The text including the delimited links e.g. "Some text %#this is a link%#".
     ///   - style: The style of the text
     ///   - linkRangeDelimiter: The delimiter indicating the link range. Defaults to `%#`.
-    public func update(
+    package func update(
         text: String,
         style: TextStyle,
         linkRangeDelimiter: String = "%#"
@@ -80,7 +79,7 @@ public class LinkTextView: UITextView {
 
 extension LinkTextView: UITextViewDelegate {
     
-    public func textView(
+    package func textView(
         _ textView: UITextView,
         shouldInteractWith URL: URL,
         in characterRange: NSRange,

--- a/AdyenUI/UI/Views/SupportedPaymentMethodsView.swift
+++ b/AdyenUI/UI/Views/SupportedPaymentMethodsView.swift
@@ -8,13 +8,12 @@ import Adyen
 import AdyenNetworking
 import UIKit
 
-@_spi(AdyenInternal)
-public class SupportedPaymentMethodLogosView: UIView {
-    
-    public struct Style: ViewStyle {
-        public var backgroundColor: UIColor = .clear
-        
-        public var images: ImageStyle = .init(
+package class SupportedPaymentMethodLogosView: UIView {
+
+    package struct Style: ViewStyle {
+        package var backgroundColor: UIColor = .clear
+
+        package var images: ImageStyle = .init(
             borderColor: UIColor.Adyen.componentSeparator,
             borderWidth: 1.0 / UIScreen.main.nativeScale,
             cornerRadius: 3.0,
@@ -22,12 +21,12 @@ public class SupportedPaymentMethodLogosView: UIView {
             contentMode: .scaleAspectFit
         )
         
-        public var trailingText: TextStyle = .init(
+        package var trailingText: TextStyle = .init(
             font: .preferredFont(forTextStyle: .callout),
             color: UIColor.Adyen.componentSecondaryLabel
         )
         
-        public init() {}
+        package init() {}
     }
     
     internal let imageSize: CGSize
@@ -48,7 +47,7 @@ public class SupportedPaymentMethodLogosView: UIView {
     
     @AdyenDependency(\.imageLoader) private var imageLoader
     
-    public init(
+    package init(
         imageSize: CGSize = .init(width: 24, height: 16),
         imageUrls: [URL],
         trailingText: String?,
@@ -64,7 +63,7 @@ public class SupportedPaymentMethodLogosView: UIView {
         self.setContentHuggingPriority(.required, for: .horizontal)
     }
     
-    override public func willMove(toSuperview newSuperview: UIView?) {
+    override package func willMove(toSuperview newSuperview: UIView?) {
         super.willMove(toSuperview: newSuperview)
         
         if newSuperview != nil {

--- a/AdyenUI/UI/Views/UISearchBar+Prominent.swift
+++ b/AdyenUI/UI/Views/UISearchBar+Prominent.swift
@@ -6,8 +6,7 @@
 
 import UIKit
 
-@_spi(AdyenInternal)
-public extension UISearchBar {
+package extension UISearchBar {
     
     static func prominent(
         placeholder: String?,

--- a/AdyenUI/UI/Views/UIView+Accessibility.swift
+++ b/AdyenUI/UI/Views/UIView+Accessibility.swift
@@ -6,8 +6,7 @@
 
 import UIKit
 
-@_spi(AdyenInternal)
-public extension UIView {
+package extension UIView {
     
     /// Marks the element as selected/not-selected by inserting/removing `.selected` into/from the `accessibilityTraits`
     ///

--- a/Demo/Common/Configuration/CardComponentSettingsView.swift
+++ b/Demo/Common/Configuration/CardComponentSettingsView.swift
@@ -77,7 +77,7 @@ internal struct CardSettingsView: View {
 
 extension CardSettings.AddressFormType {
 
-    public var displayName: String {
+    internal var displayName: String {
         switch self {
         case .full: return "Full"
         case .lookup: return "Lookup (Dummy Data)"
@@ -90,7 +90,7 @@ extension CardSettings.AddressFormType {
 
 extension CardConfiguration.FieldVisibility {
 
-    public var displayName: String {
+    internal var displayName: String {
         self.rawValue.capitalized
     }
 }

--- a/Demo/Common/IntegrationExamples/ComponentCreationError.swift
+++ b/Demo/Common/IntegrationExamples/ComponentCreationError.swift
@@ -8,11 +8,11 @@ import Adyen
 import AdyenComponents
 import Foundation
 
-public enum IntegrationError: LocalizedError {
-    
+internal enum IntegrationError: LocalizedError {
+
     case paymentMethodNotAvailable(paymentMethod: PaymentMethod.Type)
     
-    public var errorDescription: String? {
+    internal var errorDescription: String? {
         switch self {
         case let .paymentMethodNotAvailable(paymentMethodType):
             return "\(String(describing: paymentMethodType)) is not available in payment methods response."

--- a/Demo/Common/IntegrationExamples/DemoAddressLookupProvider.swift
+++ b/Demo/Common/IntegrationExamples/DemoAddressLookupProvider.swift
@@ -9,8 +9,8 @@ import AdyenUI
 import Contacts
 
 /// Example implementation of an address lookup provider with debouncing and cancelling previous calls
-public class DemoAddressLookupProvider {
-    
+internal class DemoAddressLookupProvider {
+
     private struct AddressCompletionError: LocalizedError {
         var errorDescription: String? {
             "Could not complete address"
@@ -46,8 +46,8 @@ public class DemoAddressLookupProvider {
         }
     }
     
-    public func lookUp(searchTerm: String, resultHandler: @escaping ([AddressLookupResult]) -> Void) {
-        
+    internal func lookUp(searchTerm: String, resultHandler: @escaping ([AddressLookupResult]) -> Void) {
+
         // Nil-ing out the last search task which also cancels the previous task if applicable
         searchTask = nil
         
@@ -68,8 +68,8 @@ public class DemoAddressLookupProvider {
     }
     
     /// Optional implementation to fetch the full address for an incomplete version
-    public func complete(incompleteAddress: AddressLookupResult, resultHandler: @escaping (Result<PostalAddress, Error>) -> Void) {
-        
+    internal func complete(incompleteAddress: AddressLookupResult, resultHandler: @escaping (Result<PostalAddress, Error>) -> Void) {
+
         var dispatchWorkItem: DispatchWorkItem?
         
         dispatchWorkItem = DispatchWorkItem { [weak self] in

--- a/Demo/Common/IntegrationExamples/MapkitAddressLookupProvider.swift
+++ b/Demo/Common/IntegrationExamples/MapkitAddressLookupProvider.swift
@@ -11,10 +11,10 @@ import Foundation
 import MapKit
 
 /// Example implementation of an address lookup provider with debouncing and cancelling previous calls
-public class MapkitAddressLookupProvider {
-    
-    public init() {}
-    
+internal class MapkitAddressLookupProvider {
+
+    internal init() {}
+
     private let minDebounceDelay: TimeInterval = 0.3
     
     private var searchTask: DispatchWorkItem? {
@@ -31,8 +31,8 @@ public class MapkitAddressLookupProvider {
         }
     }
     
-    public func lookUp(searchTerm: String, resultHandler: @escaping ([AddressLookupResult]) -> Void) {
-        
+    internal func lookUp(searchTerm: String, resultHandler: @escaping ([AddressLookupResult]) -> Void) {
+
         // Nil-ing out the last search task which also cancels the previous task if applicable
         searchTask = nil
         

--- a/Demo/Common/Networking/APIRequest.swift
+++ b/Demo/Common/Networking/APIRequest.swift
@@ -14,19 +14,19 @@ internal protocol APIRequest: Request where ErrorResponseType == APIError {}
 internal struct APIError: ErrorResponse, LocalizedError {
     
     /// The status.
-    public let status: Int?
-    
+    internal let status: Int?
+
     /// The error code.
-    public let errorCode: String
-    
+    internal let errorCode: String
+
     /// The error message.
-    public let errorMessage: String
-    
+    internal let errorMessage: String
+
     /// The error type.
-    public let type: APIErrorType
-    
+    internal let type: APIErrorType
+
     /// The error human readable description.
-    public var errorDescription: String? {
+    internal var errorDescription: String? {
         errorMessage
     }
 

--- a/Demo/UIKit/UIView+Helpers.swift
+++ b/Demo/UIKit/UIView+Helpers.swift
@@ -102,16 +102,16 @@ extension UIView {
     /// Inset distances for views that can be nil.
     struct EdgeInsets {
 
-        public var top: CGFloat?
+        internal var top: CGFloat?
 
-        public var left: CGFloat?
+        internal var left: CGFloat?
 
-        public var bottom: CGFloat?
+        internal var bottom: CGFloat?
 
-        public var right: CGFloat?
-        
+        internal var right: CGFloat?
+
         /// Creates insets with 0 on all 4 values.
-        public static var zero: EdgeInsets {
+        internal static var zero: EdgeInsets {
             .init(top: 0, left: 0, bottom: 0, right: 0)
         }
         
@@ -122,7 +122,7 @@ extension UIView {
             right = edgeInsets.right
         }
         
-        public init(top: CGFloat? = nil, left: CGFloat? = nil, bottom: CGFloat? = nil, right: CGFloat? = nil) {
+        internal init(top: CGFloat? = nil, left: CGFloat? = nil, bottom: CGFloat? = nil, right: CGFloat? = nil) {
             self.top = top
             self.left = left
             self.bottom = bottom

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/ActionComponentDelegateMock.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/ActionComponentDelegateMock.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import AdyenActions
 @_spi(AdyenInternal) import Adyen
+import AdyenActions
 import Foundation
 
 final class ActionComponentDelegateMock: ActionComponentDelegate {

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/ActionConfigurationTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/ActionConfigurationTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import XCTest
 
 final class ActionConfigurationTests: XCTestCase {

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/CheckoutActionComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/CheckoutActionComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @_spi(AdyenInternal) @testable import AdyenUI
 import SafariServices
 import XCTest

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/Twint+Spy.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/Twint+Spy.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Foundation
-@testable @_spi(AdyenInternal) import Adyen
+@_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenActions
+import Foundation
 
 #if canImport(TwintSDK)
 

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Convenience.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Convenience.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenActions
 import XCTest
-@testable @_spi(AdyenInternal) import Adyen
-@testable @_spi(AdyenInternal) import AdyenActions
 
 #if canImport(TwintSDK)
     import TwintSDK

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Flows.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests+Flows.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenActions
 import XCTest
-@testable @_spi(AdyenInternal) import Adyen
-@testable @_spi(AdyenInternal) import AdyenActions
 
 #if canImport(TwintSDK)
     import TwintSDK

--- a/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/ActionComponent/Twint/TwintSDKActionTests.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenActions
 import XCTest
-@testable @_spi(AdyenInternal) import Adyen
-@testable @_spi(AdyenInternal) import AdyenActions
 
 #if canImport(TwintSDK)
     import TwintSDK

--- a/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Await/AwaitComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @testable import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest

--- a/Tests/IntegrationTests/Actions Tests/Await/PollingComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Await/PollingComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import AdyenNetworking
 import XCTest
 

--- a/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewControllerTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewControllerTests.swift
@@ -4,11 +4,11 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenActions
+@_spi(AdyenInternal) @testable import AdyenUI
 import UIKit
 import XCTest
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenUI
 
 final class QRCodeViewControllerTests: XCTestCase {
     

--- a/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewModelMock.swift
+++ b/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewModelMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
+@_spi(AdyenInternal) import Adyen
 @testable import AdyenActions
 import UIKit
 import XCTest

--- a/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewModelTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/QRCode/QRCodeViewModelTests.swift
@@ -4,10 +4,10 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenActions
 import UIKit
 import XCTest
-@_spi(AdyenInternal) @testable import Adyen
 
 @MainActor
 class QRCodeViewModelTests: XCTestCase {

--- a/Tests/IntegrationTests/Actions Tests/Redirect/RedirectComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Redirect/RedirectComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import AdyenNetworking
 import SafariServices
 import XCTest

--- a/Tests/IntegrationTests/Actions Tests/Redirect/RedirectDetailsTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Redirect/RedirectDetailsTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import XCTest
 
 class RedirectDetailsTests: XCTestCase {

--- a/Tests/IntegrationTests/Actions Tests/Redirect/RedirectListnerTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Redirect/RedirectListnerTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import XCTest
 
 class RedirectListenerTests: XCTestCase {

--- a/Tests/IntegrationTests/Actions Tests/Voucher/BoletoVoucherShareableVoucherViewProviderTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/BoletoVoucherShareableVoucherViewProviderTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @_spi(AdyenInternal) import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Actions Tests/Voucher/DokuVoucherUITests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/DokuVoucherUITests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Actions Tests/Voucher/EContextStoresVoucherViewControllerProviderTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/EContextStoresVoucherViewControllerProviderTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @_spi(AdyenInternal) @testable import AdyenUI
 import UIKit
 import XCTest

--- a/Tests/IntegrationTests/Actions Tests/Voucher/MultibancoShareableVoucherViewProviderTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/MultibancoShareableVoucherViewProviderTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Actions Tests/Voucher/OXXOShareableVoucherViewProviderTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/OXXOShareableVoucherViewProviderTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Actions Tests/Voucher/VoucherComponentTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/VoucherComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import UIKit
 import XCTest
 

--- a/Tests/IntegrationTests/Actions Tests/Voucher/VoucherViewTests.swift
+++ b/Tests/IntegrationTests/Actions Tests/Voucher/VoucherViewTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @_spi(AdyenInternal) @testable import AdyenUI
 import PassKit
 import UIKit

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/3DS2 Fingerprint Submitter/ThreeDS2FingerprintSubmitterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/3DS2 Fingerprint Submitter/ThreeDS2FingerprintSubmitterTests.swift
@@ -5,8 +5,8 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenActions
+@testable import AdyenCard
 import XCTest
 
 extension RedirectAction: Equatable {

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/AnyADYServiceMock.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/AnyADYServiceMock.swift
@@ -5,7 +5,7 @@
 //
 
 import Adyen3DS2
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import Foundation
 
 final class AnyADYServiceMock: AnyADYService {

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/AnyRedirectComponentMock.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/AnyRedirectComponentMock.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenActions
+@testable import AdyenCard
 import Foundation
 
 final class AnyRedirectComponentMock: AnyRedirectComponent {

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/AnyThreeDS2ActionHandlerMock.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/AnyThreeDS2ActionHandlerMock.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenActions
+@testable import AdyenCard
 import Foundation
 
 final class AnyThreeDS2ActionHandlerMock: AnyThreeDS2ActionHandler {

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/AnyThreeDS2FingerprintSubmitterMock.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/AnyThreeDS2FingerprintSubmitterMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import Foundation
 
 final class AnyThreeDS2FingerprintSubmitterMock: AnyThreeDS2FingerprintSubmitter {

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/AuthenticationComponent+FingerprintTokenTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/AuthenticationComponent+FingerprintTokenTests.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
-import XCTest
 @_spi(AdyenInternal) import Adyen
+@testable import AdyenActions
+import XCTest
 
 extension AuthenticationComponentTests {
     func testParsingTokenWithFeaturesInConfiguration() throws {

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/AuthenticationComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/AuthenticationComponentTests.swift
@@ -4,11 +4,11 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
-@testable @_spi(AdyenInternal) import AdyenCard
-import XCTest
 @_spi(AdyenInternal) import Adyen
+@testable import AdyenActions
+@testable import AdyenCard
 @_spi(AdyenInternal) import AdyenUI
+import XCTest
 
 @MainActor
 class AuthenticationComponentTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDS2CompactActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDS2CompactActionHandlerTests.swift
@@ -5,8 +5,8 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenActions
+@testable import AdyenCard
 import XCTest
 
 @MainActor

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDS2DAScreenPresenterMock.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDS2DAScreenPresenterMock.swift
@@ -7,8 +7,8 @@
 import Foundation
 
 #if canImport(AdyenAuthentication)
-    @_spi(AdyenInternal) @testable import Adyen
-    @_spi(AdyenInternal) @testable import AdyenActions
+    @testable import Adyen
+    @testable import AdyenActions
     import AdyenAuthentication
     import Foundation
     import UIKit

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDS2PlusDACoreActionHandlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDS2PlusDACoreActionHandlerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 #if canImport(AdyenAuthentication)
     @_spi(AdyenInternal) @testable import Adyen
-    @_spi(AdyenInternal) @testable import AdyenActions
+    @testable import AdyenActions
     import AdyenAuthentication
     import Foundation
     import UIKit

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDS2ServiceLegacyTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDS2ServiceLegacyTests.swift
@@ -6,8 +6,8 @@
 
 @_spi(AdyenInternal) @testable import Adyen
 import Adyen3DS2
-@_spi(AdyenInternal) @testable import AdyenActions
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenActions
+@testable import AdyenCard
 import XCTest
 
 final class ThreeDS2ServiceLegacyTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDSResultExtension.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDSResultExtension.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import Foundation
 
 extension ThreeDSResult: Equatable {

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDSServiceProviderTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDSServiceProviderTests.swift
@@ -4,10 +4,10 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
-@testable @_spi(AdyenInternal) import AdyenCard
-import XCTest
 @_spi(AdyenInternal) import Adyen
+@testable import AdyenActions
+@testable import AdyenCard
+import XCTest
 
 final class ThreeDSServiceProviderTests: XCTestCase {
     private let authenticationRequestParameters = AuthenticationRequestParametersMock(

--- a/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDSServiceableMock.swift
+++ b/Tests/IntegrationTests/Card Tests/Authentication Component/ThreeDSServiceableMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import Foundation
 
 final class ThreeDSServiceableMock: ThreeDSService {

--- a/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @testable import AdyenDropIn
 @testable import AdyenEncryption
 @_spi(AdyenInternal) @testable import AdyenUI

--- a/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerControllerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerControllerTests.swift
@@ -5,8 +5,8 @@
 //
 
 #if canImport(AdyenCardScanner)
+    import Adyen
     @testable import AdyenCard
-    @_spi(AdyenInternal) import Adyen
     @testable import AdyenCardScanner
     import XCTest
 

--- a/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerProviderDispatchOnceTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Card Scanner/CardScannerProviderDispatchOnceTests.swift
@@ -5,8 +5,8 @@
 //
 
 #if canImport(AdyenCardScanner)
+    @testable import AdyenCard
     import XCTest
-    @testable @_spi(AdyenInternal) import AdyenCard
 
     final class CardScannerProviderDispatchOnceTests: XCTestCase {
 

--- a/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentEventTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenCard
+@testable import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -5,10 +5,10 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenUI
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @testable import AdyenDropIn
 @testable import AdyenEncryption
+@_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
 @MainActor

--- a/Tests/IntegrationTests/Card Tests/CardComponentValidationTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentValidationTests.swift
@@ -5,11 +5,11 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenUI
-import XCTest
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @testable import AdyenDropIn
 @testable import AdyenEncryption
+@_spi(AdyenInternal) @testable import AdyenUI
+import XCTest
 
 @MainActor
 class CardComponentValidationTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/CardDetailsTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardDetailsTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @testable import AdyenEncryption
 import XCTest
 

--- a/Tests/IntegrationTests/Card Tests/DualBrandAccessoryViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/DualBrandAccessoryViewTests.swift
@@ -4,10 +4,10 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
+import XCTest
 
 final class DualBrandAccessoryViewTests: XCTestCase {
     var sut: FormCardNumberItemView.DualBrandAccessoryView!

--- a/Tests/IntegrationTests/Card Tests/FormViewControllerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/FormViewControllerTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 import AdyenNetworking
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest

--- a/Tests/IntegrationTests/Card Tests/Formatters/BrazilSocialSecurityNumberFormatterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Formatters/BrazilSocialSecurityNumberFormatterTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 import XCTest
 
 class BrazilSocialSecurityNumberFormatterTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Formatters/CardExpiryDateFormatterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Formatters/CardExpiryDateFormatterTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 import XCTest
 
 class CardExpiryDateFormatterTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Formatters/CardNumberFormatterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Formatters/CardNumberFormatterTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 import XCTest
 
 class CardNumberFormatterTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Formatters/CardSecurityCodeFormatterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Formatters/CardSecurityCodeFormatterTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 import XCTest
 
 class CardSecurityCodeFormatterTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemViewTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberValidationTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberValidationTests.swift
@@ -5,9 +5,9 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
-@testable @_spi(AdyenInternal) import AdyenCard
 
 /// Tests for card number validation display behavior.
 /// See FORM_VALIDATION_SPECS.md for use case definitions (UC5-UC9, UC13).

--- a/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Card Tests/Mocks/CardTypeProviderMock.swift
+++ b/Tests/IntegrationTests/Card Tests/Mocks/CardTypeProviderMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 
 final class BinInfoProviderMock: AnyBinInfoProvider {
     func provide(for bin: String, supportedTypes: [CardType], completion: @escaping (BinLookupResponse) -> Void) {

--- a/Tests/IntegrationTests/Card Tests/Mocks/OpenExternalAppDetector+Mock.swift
+++ b/Tests/IntegrationTests/Card Tests/Mocks/OpenExternalAppDetector+Mock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 
 struct MockOpenExternalAppDetector: OpenExternalAppDetecting {
     var didOpenExternalApp: Bool

--- a/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
@@ -5,8 +5,8 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
-@testable @_spi(AdyenInternal) import AdyenUI
+@testable import AdyenCard
+@_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
 @MainActor

--- a/Tests/IntegrationTests/Card Tests/StoredCardInputViewControllerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardInputViewControllerTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @testable import AdyenEncryption
 @_spi(AdyenInternal) @testable import AdyenUI
 import Combine

--- a/Tests/IntegrationTests/Card Tests/StoredCardInputViewModelTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardInputViewModelTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @testable import AdyenEncryption
 @_spi(AdyenInternal) @testable import AdyenUI
 import Combine

--- a/Tests/IntegrationTests/Card Tests/StoredPaymentMethodComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredPaymentMethodComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @testable import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest

--- a/Tests/IntegrationTests/Card Tests/Utilities/CardBrandProviderTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/CardBrandProviderTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 import XCTest
 
 class CardBrandProviderTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Utilities/CardEncryptorCardTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/CardEncryptorCardTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @testable import AdyenEncryption
 import XCTest
 

--- a/Tests/IntegrationTests/Card Tests/Utilities/CardTypeDetectorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/CardTypeDetectorTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenCard
 import XCTest
 
 class CardTypeDetectorTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Utilities/ThrottlerTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/ThrottlerTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenCard
 import XCTest
 
 class ThrottlerTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Validators/CardExpiryDateValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardExpiryDateValidatorTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
 @_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenCard
 import XCTest
 
 class CardExpiryDateValidatorTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Validators/CardHolderNameValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardHolderNameValidatorTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@_spi(AdyenInternal) @testable import AdyenCard
 import XCTest
 
 final class CardHolderNameValidatorTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Validators/CardKCPValidatorsTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardKCPValidatorsTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@_spi(AdyenInternal) @testable import AdyenCard
 import XCTest
 
 final class CardKCPValidatorsTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Validators/CardNumberValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardNumberValidatorTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
 @_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenCard
 import XCTest
 
 class CardNumberValidatorTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Validators/CardPublicKeyValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardPublicKeyValidatorTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 import XCTest
 
 class CardPublicKeyValidatorTests: XCTestCase {

--- a/Tests/IntegrationTests/Card Tests/Validators/CardSecurityCodeValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardSecurityCodeValidatorTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 import XCTest
 
 class CardSecurityCodeValidatorTests: XCTestCase {

--- a/Tests/IntegrationTests/Components Tests/Affirm/AffirmComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Affirm/AffirmComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
+@testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayPaymentMethodTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayPaymentMethodTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable import Adyen
+@_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenComponents
 import PassKit
 import XCTest

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/PreApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/PreApplePayComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
+@testable import AdyenComponents
 @testable import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import PassKit
@@ -68,7 +68,7 @@ class PreApplePayComponentTests: XCTestCase {
         let applePayConfiguration = try ApplePayConfiguration(
             paymentRequest: Dummy.createTestApplePayPaymentRequest()
         )
-            .allowOnboarding(false)
+        .allowOnboarding(false)
 
         // When / Then
         XCTAssertThrowsError(

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/DocumentComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/DocumentComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @testable import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest

--- a/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/DocumentActionViewDelegateMock.swift
+++ b/Tests/IntegrationTests/Components Tests/BACS Direct Debit/Mocks/DocumentActionViewDelegateMock.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 import Foundation
 
 internal final class DocumentActionViewDelegateMock: DocumentActionViewDelegate {

--- a/Tests/IntegrationTests/Components Tests/Boleto/BoletoComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Boleto/BoletoComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest

--- a/Tests/IntegrationTests/Components Tests/Doku/DokuComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Doku/DokuComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
+@testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Components Tests/Instant Payment/InstantPaymentComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Instant Payment/InstantPaymentComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 import XCTest
 
 @MainActor

--- a/Tests/IntegrationTests/Components Tests/MB Way/MBWayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/MB Way/MBWayComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
+@testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Components Tests/PayByBankUSComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayByBankUSComponentTests.swift
@@ -4,10 +4,10 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
-@testable @_spi(AdyenInternal) import Adyen
-@testable @_spi(AdyenInternal) import AdyenComponents
+@_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
+import XCTest
 
 @MainActor
 class PayByBankUSComponentTests: XCTestCase {

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
+@testable import AdyenComponents
+import XCTest
 
 @MainActor
 class PaymentComponentSubjectTests: XCTestCase {

--- a/Tests/IntegrationTests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Qiwi Wallet/QiwiWalletComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
+@testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Components Tests/Seven Eleven Component/BasicPersonalInfoFormComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Seven Eleven Component/BasicPersonalInfoFormComponentTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
+@testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/Components Tests/Twint/TwintComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Twint/TwintComponentTests.swift
@@ -6,7 +6,7 @@
 
 @_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenDropIn
-@testable @_spi(AdyenInternal) import AdyenTwint
+@testable import AdyenTwint
 import XCTest
 
 @MainActor

--- a/Tests/IntegrationTests/DropIn Tests/ComponentContainer/ComponentContainerRouterTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/ComponentContainer/ComponentContainerRouterTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable import Adyen
+@_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenActions
 @testable import AdyenDropIn
 import Testing

--- a/Tests/IntegrationTests/DropIn Tests/ComponentContainer/ComponentContainerViewControllerTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/ComponentContainer/ComponentContainerViewControllerTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable import Adyen
+@_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenActions
 @testable import AdyenDropIn
 import Testing

--- a/Tests/IntegrationTests/DropIn Tests/ComponentContainer/ComponentContainerViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/ComponentContainer/ComponentContainerViewModelTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable import Adyen
+@_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenActions
 @testable import AdyenDropIn
 @testable import AdyenEncryption

--- a/Tests/IntegrationTests/DropIn Tests/DropInActionTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/DropInActionTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) import AdyenActions
+import AdyenActions
 import AdyenDropIn
 import SafariServices
 import XCTest

--- a/Tests/IntegrationTests/DropIn Tests/DropInTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/DropInTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @testable import AdyenDropIn
 import SafariServices
 import XCTest

--- a/Tests/IntegrationTests/DropIn Tests/Mocks/DropInComponentDelegateMock.swift
+++ b/Tests/IntegrationTests/DropIn Tests/Mocks/DropInComponentDelegateMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable import Adyen
+@_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenActions
 @testable import AdyenDropIn
 

--- a/Tests/IntegrationTests/DropIn Tests/Mocks/PaymentMethodsMock.swift
+++ b/Tests/IntegrationTests/DropIn Tests/Mocks/PaymentMethodsMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable import Adyen
+@_spi(AdyenInternal) @testable import Adyen
 import Foundation
 
 enum PaymentMethodsMock {

--- a/Tests/IntegrationTests/DropIn Tests/ModalToolbarTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/ModalToolbarTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @testable import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest

--- a/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListRouterTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListRouterTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable import Adyen
+@_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenActions
 @testable import AdyenDropIn
 import Testing

--- a/Tests/IntegrationTests/Helpers/UIViewController+Search.swift
+++ b/Tests/IntegrationTests/Helpers/UIViewController+Search.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@_spi(AdyenInternal) @testable import Adyen
 import UIKit
 import XCTest
-@_spi(AdyenInternal) @testable import Adyen
 
 public extension UIViewController {
 

--- a/Tests/IntegrationTests/Helpers/XCTestCase+RootViewController.swift
+++ b/Tests/IntegrationTests/Helpers/XCTestCase+RootViewController.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@_spi(AdyenInternal) @testable import Adyen
 import Foundation
 import XCTest
-@_spi(AdyenInternal) @testable import Adyen
 
 extension XCTestCase {
     

--- a/Tests/IntegrationTests/Session Tests/SelfRetainingAPIClientTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SelfRetainingAPIClientTests.swift
@@ -4,10 +4,10 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@_spi(AdyenInternal) import Adyen
 import AdyenNetworking
 @testable import AdyenSession
 import XCTest
-@_spi(AdyenInternal) import Adyen
 
 extension SessionSetupResponse: Equatable {
     public static func == (lhs: SessionSetupResponse, rhs: SessionSetupResponse) -> Bool {

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -4,14 +4,14 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
-@_spi(AdyenInternal) @testable import AdyenSession
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import AdyenActions
 @testable import AdyenCard
 import AdyenComponents
 @testable import AdyenEncryption
 import AdyenNetworking
+@testable import AdyenSession
+import XCTest
 
 @MainActor
 class SessionTests: XCTestCase {

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Selectable/FormSelectableItemViewTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) import AdyenCard
+import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewDelegateMock.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewDelegateMock.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) import Adyen
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
 import Foundation
 

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Text/FormTextItemViewTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) import AdyenCard
+import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Validatable/FormValidatableItemViewTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Validatable/FormValidatableItemViewTests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) import AdyenCard
+import AdyenCard
 @_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 

--- a/Tests/IntegrationTests/UIKit/View Controllers/AddressInputFormViewControllerTests.swift
+++ b/Tests/IntegrationTests/UIKit/View Controllers/AddressInputFormViewControllerTests.swift
@@ -4,10 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Foundation
-
 @_spi(AdyenInternal) @testable import Adyen
 @_spi(AdyenInternal) @testable import AdyenUI
+import Foundation
 import XCTest
 
 class AddressInputFormViewControllerTests: XCTestCase {

--- a/Tests/SnapshotTests/Components/AffirmComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/AffirmComponentUITests.swift
@@ -4,10 +4,10 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
+@testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
+import XCTest
 
 @MainActor
 class AffirmComponentUITests: XCTestCase {

--- a/Tests/SnapshotTests/Components/AtomeComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/AtomeComponentUITests.swift
@@ -4,10 +4,10 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
 @_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenComponents
 @_spi(AdyenInternal) @testable import AdyenUI
+import XCTest
 
 @MainActor
 class AtomeComponentUITests: XCTestCase {

--- a/Tests/SnapshotTests/Components/CardComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/CardComponentUITests.swift
@@ -4,10 +4,10 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
 @_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenCard
 @testable import AdyenComponents
+import XCTest
 
 @MainActor
 class CardComponentUITests: XCTestCase {

--- a/Tests/SnapshotTests/Components/GiftCardComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/GiftCardComponentUITests.swift
@@ -5,7 +5,7 @@
 //
 
 @_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenCard
+@testable import AdyenCard
 @testable import AdyenComponents
 import AdyenDropIn
 @_spi(AdyenInternal) @testable import AdyenUI

--- a/Tests/SnapshotTests/UI/SecuredViewControllerUITests.swift
+++ b/Tests/SnapshotTests/UI/SecuredViewControllerUITests.swift
@@ -4,11 +4,11 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Foundation
-import XCTest
 @_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenCard
 @testable import AdyenComponents
+import Foundation
+import XCTest
 
 class SecuredViewControllerUITests: XCTestCase {
     

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -4,11 +4,11 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenCard
-@_spi(AdyenInternal) @testable import AdyenCheckout
-@_spi(AdyenInternal) @testable import AdyenComponents
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import Adyen
+@testable import AdyenCard
+@testable import AdyenCheckout
+@testable import AdyenComponents
+@testable import AdyenUI
 import PassKit
 import XCTest
 

--- a/Tests/UnitTests/AdyenCheckout/CheckoutConfiguration/CheckoutConfigurationTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutConfiguration/CheckoutConfigurationTests.swift
@@ -4,11 +4,11 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
-@_spi(AdyenInternal) @testable import AdyenCheckout
-@_spi(AdyenInternal) @testable import AdyenComponents
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import Adyen
+@testable import AdyenActions
+@testable import AdyenCheckout
+@testable import AdyenComponents
+@testable import AdyenUI
 import XCTest
 
 final class CheckoutConfigurationTests: XCTestCase {

--- a/Tests/UnitTests/AdyenCheckout/CheckoutProviderMock.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutProviderMock.swift
@@ -4,12 +4,12 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenCheckout
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenSession
-@_spi(AdyenInternal) @testable import AdyenDropIn
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import Adyen
+@testable import AdyenActions
+@testable import AdyenCheckout
+@testable import AdyenDropIn
 import AdyenNetworking
+@testable import AdyenSession
 
 internal class CheckoutProviderMock: CheckoutProviding {
     var setupSessionCalled = false

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -4,12 +4,12 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenCheckout
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenSession
-@_spi(AdyenInternal) @testable import AdyenDropIn
-@_spi(AdyenInternal) @testable import AdyenComponents
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import Adyen
+@testable import AdyenActions
+@testable import AdyenCheckout
+@testable import AdyenComponents
+@testable import AdyenDropIn
+@testable import AdyenSession
 import UIKit
 import XCTest
 

--- a/Tests/UnitTests/AdyenCheckout/Component Factory Tests/ACHDirectDebitComponentFactoryTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/Component Factory Tests/ACHDirectDebitComponentFactoryTests.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import Adyen
+@testable import AdyenComponents
+@testable import AdyenUI
 import XCTest
 
 final class ACHDirectDebitComponentFactoryTests: XCTestCase {

--- a/Tests/UnitTests/AdyenCheckout/Component Factory Tests/ApplePayComponentFactoryTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/Component Factory Tests/ApplePayComponentFactoryTests.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import Adyen
+@testable import AdyenComponents
+@testable import AdyenUI
 import PassKit
 import XCTest
 

--- a/Tests/UnitTests/AdyenCheckout/Component Factory Tests/BLIKComponentFactoryTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/Component Factory Tests/BLIKComponentFactoryTests.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenComponents
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import Adyen
+@testable import AdyenComponents
+@testable import AdyenUI
 import XCTest
 
 @MainActor

--- a/Tests/UnitTests/AdyenUI/Assets/AdyenUIAssetsAccessTests.swift
+++ b/Tests/UnitTests/AdyenUI/Assets/AdyenUIAssetsAccessTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import AdyenUI
 import Testing
 import UIKit
 

--- a/Tests/UnitTests/AdyenUI/Form/TextFieldTests.swift
+++ b/Tests/UnitTests/AdyenUI/Form/TextFieldTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import Adyen
+@testable import AdyenUI
 import XCTest
 
 final class TextField_AdyenLabelStyle_Tests: XCTestCase {

--- a/Tests/UnitTests/AdyenUI/Helpers/AdyenStyleAssertions.swift
+++ b/Tests/UnitTests/AdyenUI/Helpers/AdyenStyleAssertions.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import AdyenUI
 import XCTest
 
 extension XCTestCase {

--- a/Tests/UnitTests/AdyenUI/Helpers/UILabelApplyStyleTests.swift
+++ b/Tests/UnitTests/AdyenUI/Helpers/UILabelApplyStyleTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import AdyenUI
 import XCTest
 
 final class UILabelApplyStyleTests: XCTestCase {

--- a/Tests/UnitTests/AdyenUI/UI/Views/CardImageViewTests.swift
+++ b/Tests/UnitTests/AdyenUI/UI/Views/CardImageViewTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import Adyen
+@testable import AdyenUI
 import Testing
 import UIKit
 

--- a/Tests/UnitTests/Analytics/AnalyticsEventDataSourceTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsEventDataSourceTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@testable import Adyen
 import XCTest
-@_spi(AdyenInternal) @testable import Adyen
 
 final class AnalyticsEventDataSourceTests: XCTestCase {
     

--- a/Tests/UnitTests/Analytics/AnalyticsEventTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsEventTests.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 @testable import AdyenNetworking
+import XCTest
 
 class AnalyticsEventTests: XCTestCase {
 

--- a/Tests/UnitTests/Analytics/AnalyticsFlavorTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsFlavorTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@testable import Adyen
 import XCTest
-@_spi(AdyenInternal) @testable import Adyen
 
 class AnalyticsFlavorTests: XCTestCase {
 

--- a/Tests/UnitTests/Analytics/AnalyticsProviderMock.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsProviderMock.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@testable import Adyen
 import Foundation
-@_spi(AdyenInternal) @testable import Adyen
 
 class AnalyticsProviderMock: AnyAnalyticsProvider {
     static let testCheckoutAttemptId = "testCheckoutAttemptId"

--- a/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
+++ b/Tests/UnitTests/Analytics/AnalyticsProviderTests.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 @testable import AdyenNetworking
+import XCTest
 
 class AnalyticsProviderTests: XCTestCase {
     

--- a/Tests/UnitTests/Analytics/CheckoutAttemptIdProviderTests.swift
+++ b/Tests/UnitTests/Analytics/CheckoutAttemptIdProviderTests.swift
@@ -4,10 +4,10 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenCheckout
+@testable import Adyen
+@testable import AdyenCheckout
 import AdyenNetworking
-@_spi(AdyenInternal) @testable import AdyenSession
+@testable import AdyenSession
 import XCTest
 
 final class CheckoutAttemptIdProviderTests: XCTestCase {

--- a/Tests/UnitTests/Analytics/EventAnalyticsProviderTests.swift
+++ b/Tests/UnitTests/Analytics/EventAnalyticsProviderTests.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 @testable import AdyenNetworking
+import XCTest
 
 final class EventAnalyticsProviderTests: XCTestCase {
     

--- a/Tests/UnitTests/Assets/AssetsAccessTests.swift
+++ b/Tests/UnitTests/Assets/AssetsAccessTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import Adyen
+@testable import AdyenActions
 import XCTest
 
 class AssetsAccessTests: XCTestCase {

--- a/Tests/UnitTests/Core/APIContextTests.swift
+++ b/Tests/UnitTests/Core/APIContextTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class APIContextTests: XCTestCase {

--- a/Tests/UnitTests/Core/ActionTests.swift
+++ b/Tests/UnitTests/Core/ActionTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenActions
+@testable import Adyen
+@testable import AdyenActions
 import XCTest
 
 class ActionTests: XCTestCase {

--- a/Tests/UnitTests/Core/AdyenContextTests.swift
+++ b/Tests/UnitTests/Core/AdyenContextTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import Adyen
-@_spi(AdyenInternal) @testable import AdyenCheckout
+@testable import Adyen
+@testable import AdyenCheckout
 @testable import AdyenEncryption
 @testable import AdyenNetworking
 import Testing

--- a/Tests/UnitTests/Core/AdyenSessionMock.swift
+++ b/Tests/UnitTests/Core/AdyenSessionMock.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import AdyenSession
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
+@testable import AdyenSession
 
 public final class AdyenSessionMock: SessionProtocol {
     public var state: Session.State

--- a/Tests/UnitTests/Core/BackoffSchedulerTests.swift
+++ b/Tests/UnitTests/Core/BackoffSchedulerTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 @testable import AdyenNetworking
 import XCTest
 

--- a/Tests/UnitTests/Core/BankDetailsEncryptorTests.swift
+++ b/Tests/UnitTests/Core/BankDetailsEncryptorTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import AdyenCard
+@testable import AdyenCard
 @testable import AdyenEncryption
 import XCTest
 

--- a/Tests/UnitTests/Core/CheckoutPlatformParamsTests.swift
+++ b/Tests/UnitTests/Core/CheckoutPlatformParamsTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import XCTest
 @_spi(AdyenInternal) @testable import Adyen
+import XCTest
 
 class CheckoutPlatformParamsTests: XCTestCase {
 

--- a/Tests/UnitTests/Core/ImageLoaderTests.swift
+++ b/Tests/UnitTests/Core/ImageLoaderTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import Adyen
+@testable import Adyen
 import XCTest
 
 class ImageLoaderTests: XCTestCase {

--- a/Tests/UnitTests/Core/ListItemTests.swift
+++ b/Tests/UnitTests/Core/ListItemTests.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@testable import Adyen
+@testable import AdyenUI
 import XCTest
-@testable @_spi(AdyenInternal) import Adyen
-@_spi(AdyenInternal) @testable import AdyenUI
 
 final class ListItemTests: XCTestCase {
     /// Checks COIOS-797: NSInternalInconsistencyException 1008: Item identifiers are not unique

--- a/Tests/UnitTests/Core/OpenExternalAppDetectorTests.swift
+++ b/Tests/UnitTests/Core/OpenExternalAppDetectorTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@testable @_spi(AdyenInternal) import Adyen
+@testable import Adyen
 @testable import AdyenActions
 import XCTest
 

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -4,8 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal)
-@testable import Adyen
+@_spi(AdyenInternal) @testable import Adyen
 import AdyenComponents
 import XCTest
 

--- a/Tests/UnitTests/Core/PerformAsyncTests.swift
+++ b/Tests/UnitTests/Core/PerformAsyncTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
+import Adyen
 @testable import AdyenNetworking
 import XCTest
 

--- a/Tests/UnitTests/Core/SimpleSchedulerTests.swift
+++ b/Tests/UnitTests/Core/SimpleSchedulerTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import AdyenNetworking
 import XCTest
 

--- a/Tests/UnitTests/Extension/KeyedDecodingContainerExtensionsTests.swift
+++ b/Tests/UnitTests/Extension/KeyedDecodingContainerExtensionsTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class KeyedDecodingContainerExtensions: XCTestCase {

--- a/Tests/UnitTests/Extension/StringExtensionsTests.swift
+++ b/Tests/UnitTests/Extension/StringExtensionsTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class StringExtensionsTests: XCTestCase {

--- a/Tests/UnitTests/Extension/TimeIntervalExtensionsTests.swift
+++ b/Tests/UnitTests/Extension/TimeIntervalExtensionsTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class TimeIntervalExtensionsTests: XCTestCase {

--- a/Tests/UnitTests/Extension/UIButtonHelpersTests.swift
+++ b/Tests/UnitTests/Extension/UIButtonHelpersTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import Adyen
+@testable import AdyenUI
 import XCTest
 
 class UIButtonHelperTests: XCTestCase {

--- a/Tests/UnitTests/Extension/UILabelHelpersTests.swift
+++ b/Tests/UnitTests/Extension/UILabelHelpersTests.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import Adyen
+@testable import AdyenUI
 import XCTest
 
 class UILabelHelpersTests: XCTestCase {

--- a/Tests/UnitTests/Extension/URLExtensionsTest.swift
+++ b/Tests/UnitTests/Extension/URLExtensionsTest.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class URLExtensionsTests: XCTestCase {

--- a/Tests/UnitTests/Helpers/XCTestCase+Coder.swift
+++ b/Tests/UnitTests/Helpers/XCTestCase+Coder.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import AdyenComponents
 import XCTest
 

--- a/Tests/UnitTests/Mocks/ActionHandlingComponentMock.swift
+++ b/Tests/UnitTests/Mocks/ActionHandlingComponentMock.swift
@@ -4,9 +4,9 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+import Adyen
+import AdyenActions
 import Foundation
-@_spi(AdyenInternal) import Adyen
-@_spi(AdyenInternal) import AdyenActions
 
 internal final class ActionHandlingComponentMock: ActionHandlingComponent {
 

--- a/Tests/UnitTests/Mocks/AppLauncherMock.swift
+++ b/Tests/UnitTests/Mocks/AppLauncherMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import Foundation
 
 final class AppLauncherMock: AnyAppLauncher {

--- a/Tests/UnitTests/Mocks/CancellableMock.swift
+++ b/Tests/UnitTests/Mocks/CancellableMock.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@testable import Adyen
 import Foundation
-@_spi(AdyenInternal) @testable import Adyen
 
 class CancellableMock: AdyenCancellable {
     

--- a/Tests/UnitTests/Mocks/DummyData/Dummy.swift
+++ b/Tests/UnitTests/Mocks/DummyData/Dummy.swift
@@ -4,11 +4,11 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import AdyenActions
 import AdyenComponents
 import AdyenEncryption
-@_spi(AdyenInternal) @testable import AdyenUI
+@testable import AdyenUI
 import Foundation
 import PassKit
 

--- a/Tests/UnitTests/Mocks/FormatterMock.swift
+++ b/Tests/UnitTests/Mocks/FormatterMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
+import Adyen
 import Foundation
 
 final class FormatterMock: Adyen.Formatter {

--- a/Tests/UnitTests/Mocks/ImageLoaderMock.swift
+++ b/Tests/UnitTests/Mocks/ImageLoaderMock.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@testable import Adyen
 import UIKit
-@testable @_spi(AdyenInternal) import Adyen
 
 class ImageLoaderMock: ImageLoading {
 

--- a/Tests/UnitTests/Mocks/MockAddressLookupProvider.swift
+++ b/Tests/UnitTests/Mocks/MockAddressLookupProvider.swift
@@ -4,8 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
-@_spi(AdyenInternal) @testable import AdyenUI
+import Adyen
+@testable import AdyenUI
 import XCTest
 
 class MockAddressLookupProvider: AddressLookupProvider {

--- a/Tests/UnitTests/Mocks/PaymentComponentDelegateMock.swift
+++ b/Tests/UnitTests/Mocks/PaymentComponentDelegateMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 
 final class PaymentComponentDelegateMock: PaymentComponentDelegate {
 

--- a/Tests/UnitTests/Mocks/PostalAddressMocks.swift
+++ b/Tests/UnitTests/Mocks/PostalAddressMocks.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
+import Adyen
 
 enum PostalAddressMocks {
     

--- a/Tests/UnitTests/Mocks/PresentationDelegateMock.swift
+++ b/Tests/UnitTests/Mocks/PresentationDelegateMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
+import Adyen
 @testable import AdyenDropIn
 import Foundation
 import XCTest

--- a/Tests/UnitTests/Mocks/PresenterMock.swift
+++ b/Tests/UnitTests/Mocks/PresenterMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
+import Adyen
 import UIKit
 
 class PresenterMock: ViewControllerPresenter {

--- a/Tests/UnitTests/Mocks/ValidatorMock.swift
+++ b/Tests/UnitTests/Mocks/ValidatorMock.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
+import Adyen
 import Foundation
 
 final class ValidatorMock: Validator {

--- a/Tests/UnitTests/Utilities/AdyenCoderTests.swift
+++ b/Tests/UnitTests/Utilities/AdyenCoderTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class AdyenCoderTests: XCTestCase {

--- a/Tests/UnitTests/Utilities/AmountFormatterTests.swift
+++ b/Tests/UnitTests/Utilities/AmountFormatterTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class AmountFormatterTests: XCTestCase {

--- a/Tests/UnitTests/Utilities/BalanceCheckerTests.swift
+++ b/Tests/UnitTests/Utilities/BalanceCheckerTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class BalanceCheckerTests: XCTestCase {

--- a/Tests/UnitTests/Utilities/DateValidationTests.swift
+++ b/Tests/UnitTests/Utilities/DateValidationTests.swift
@@ -4,9 +4,8 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
+@testable import Adyen
 import Foundation
-
-@_spi(AdyenInternal) @testable import Adyen
 import XCTest
 
 class DateValidationTests: XCTestCase {

--- a/Tests/UnitTests/Utilities/KeyboardObserverTests.swift
+++ b/Tests/UnitTests/Utilities/KeyboardObserverTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class KeyboardObserverTests: XCTestCase, AdyenObserver {

--- a/Tests/UnitTests/Utilities/LazyOptionalTests.swift
+++ b/Tests/UnitTests/Utilities/LazyOptionalTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class LazyOptionalTests: XCTestCase {

--- a/Tests/UnitTests/Utilities/LengthValidatorTests.swift
+++ b/Tests/UnitTests/Utilities/LengthValidatorTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class LengthValidatorTests: XCTestCase {

--- a/Tests/UnitTests/Utilities/PhoneExtensionsRepositoryTests.swift
+++ b/Tests/UnitTests/Utilities/PhoneExtensionsRepositoryTests.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) @testable import Adyen
+@testable import Adyen
 import XCTest
 
 class PhoneExtensionsRepositoryTests: XCTestCase {


### PR DESCRIPTION
# Summary [Required]
1. All individual "public" components have been made package.
2. Test target - did a clean up to remove as much as possilbe spi import with the current state. 

<ticket>
COSDK-470
</ticket>

Remaining:
1. PresentableComponent has `navBarType` - I'm not even sure how & where this is used. But i can't remove the `@spi` there.
2. We need to remove buildComponent(using: Builder) from `PaymentMethod` protocol to make the PaymentComponent protocol package & remove `@spi` from each of the paymentMethods. The PR is open.
3. Remove `defaultDisplayInformation(using` from PaymentMethod.
4. Not sure if i can remove PaymentMethodDetails.checkoutAttemptId.
5. FormTextItem, FormItemView is `open` ACL, can't make that package unless i move the ones inheriting like SecurityCodeInputView to `Adyen`.

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
