### PR TITLE
Session Patching/onBeforeSubmit

### DIFF
--- a/Adyen.xcodeproj/project.pbxproj
+++ b/Adyen.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		A01B13782FBC89390081DA79 /* ActionOnlyCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01B13732FBC89390081DA79 /* ActionOnlyCheckout.swift */; };
 		A01B137A2FBC89430081DA79 /* PaymentCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01B13792FBC89430081DA79 /* PaymentCheckout.swift */; };
 		A01B137C2FBC89580081DA79 /* SessionCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01B137B2FBC89580081DA79 /* SessionCheckout.swift */; };
+		A01B13A12FBCACB30081DA79 /* BeforeSubmitResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01B13A02FBCACAB0081DA79 /* BeforeSubmitResult.swift */; };
 		A01DCF0B26BD67BB00BC35B3 /* FormCardExpiryDateItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01DCF0A26BD67BB00BC35B3 /* FormCardExpiryDateItem.swift */; };
 		A01DFBBF2BA887BF00205881 /* ThreadSafeAnalyticsEventDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01DFBBE2BA887BF00205881 /* ThreadSafeAnalyticsEventDataSource.swift */; };
 		A01DFBC52BB6F9FA00205881 /* ValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01DFBC42BB6F9FA00205881 /* ValidationError.swift */; };
@@ -2181,6 +2182,7 @@
 		A01B13752FBC89390081DA79 /* BaseCheckout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCheckout.swift; sourceTree = "<group>"; };
 		A01B13792FBC89430081DA79 /* PaymentCheckout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentCheckout.swift; sourceTree = "<group>"; };
 		A01B137B2FBC89580081DA79 /* SessionCheckout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCheckout.swift; sourceTree = "<group>"; };
+		A01B13A02FBCACAB0081DA79 /* BeforeSubmitResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeforeSubmitResult.swift; sourceTree = "<group>"; };
 		A01D775529B250C10075BD70 /* CashAppPayDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashAppPayDetails.swift; sourceTree = "<group>"; };
 		A01DCF0A26BD67BB00BC35B3 /* FormCardExpiryDateItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCardExpiryDateItem.swift; sourceTree = "<group>"; };
 		A01DFBBE2BA887BF00205881 /* ThreadSafeAnalyticsEventDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeAnalyticsEventDataSource.swift; sourceTree = "<group>"; };
@@ -3990,6 +3992,7 @@
 		A01948532D91AD7500AA27AC /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				A01B13A02FBCACAB0081DA79 /* BeforeSubmitResult.swift */,
 				81AA3B332ACD9CE800F5719D /* AddressLookupProvider.swift */,
 				A080E3E62EDC5F000031B09A /* AsyncAddressLookupProvider.swift */,
 				A0A26BF92DC101B600DB5B4E /* CheckoutBaseCallbacks.swift */,
@@ -8619,6 +8622,7 @@
 				A013F98126AFF72D00602633 /* BrazilSocialSecurityNumberFormatter.swift in Sources */,
 				A0A26BFA2DC101B800DB5B4E /* CheckoutBaseCallbacks.swift in Sources */,
 				A0A26C032DC101B800DB5B4E /* SubmitResult.swift in Sources */,
+				A01B13A12FBCACB30081DA79 /* BeforeSubmitResult.swift in Sources */,
 				A0A26C052DC101B800DB5B4E /* AdditionalDetailsResult.swift in Sources */,
 				E97B972322B238C400505476 /* Analytics.swift in Sources */,
 				A0BDF3EE2BD285E5001FF7E5 /* PostalCodeValidator.swift in Sources */,

--- a/Adyen/Core/Configuration/BeforeSubmitResult.swift
+++ b/Adyen/Core/Configuration/BeforeSubmitResult.swift
@@ -12,7 +12,8 @@ public enum BeforeSubmitResult: Sendable {
     /// Continue the submission flow with the provided data.
     /// - Parameters:
     ///   - data: The submit data (pass back unchanged if unmodified).
-    ///   - sessionData: Optional. Pass the sessionData you received from your server's `PATCH` request.
+    ///   - sessionData: Optional. Pass the sessionData you received from your server's `PATCH` request
+    ///     so the SDK can update the current session state data before continuing.
     case proceed(data: BeforeSubmitData, sessionData: String?)
     
     /// Stop the submission and reset the state.

--- a/Adyen/Core/Configuration/BeforeSubmitResult.swift
+++ b/Adyen/Core/Configuration/BeforeSubmitResult.swift
@@ -23,18 +23,18 @@ public enum BeforeSubmitResult: Sendable {
 public struct BeforeSubmitData: Sendable {
     
     /// Billing address of the shopper.
-    public var billingAddress: PostalAddress?
+    public private(set) var billingAddress: PostalAddress?
     
     /// Delivery address of the shopper.
-    public var deliveryAddress: PostalAddress?
+    public private(set) var deliveryAddress: PostalAddress?
     
     /// Name of the shopper.
-    public var shopperName: ShopperName?
+    public private(set) var shopperName: ShopperName?
     
     /// Email address of the shopper.
-    public var shopperEmail: String?
+    public private(set) var shopperEmail: String?
     
-    public init(
+    package init(
         billingAddress: PostalAddress? = nil,
         deliveryAddress: PostalAddress? = nil,
         shopperName: ShopperName? = nil,
@@ -44,5 +44,29 @@ public struct BeforeSubmitData: Sendable {
         self.deliveryAddress = deliveryAddress
         self.shopperName = shopperName
         self.shopperEmail = shopperEmail
+    }
+
+    public func replacing(billingAddress: PostalAddress) -> BeforeSubmitData {
+        var copy = self
+        copy.billingAddress = billingAddress
+        return copy
+    }
+
+    public func replacing(deliveryAddress: PostalAddress) -> BeforeSubmitData {
+        var copy = self
+        copy.deliveryAddress = deliveryAddress
+        return copy
+    }
+
+    public func replacing(shopperName: ShopperName) -> BeforeSubmitData {
+        var copy = self
+        copy.shopperName = shopperName
+        return copy
+    }
+
+    public func replacing(shopperEmail: String) -> BeforeSubmitData {
+        var copy = self
+        copy.shopperEmail = shopperEmail
+        return copy
     }
 }

--- a/Adyen/Core/Configuration/BeforeSubmitResult.swift
+++ b/Adyen/Core/Configuration/BeforeSubmitResult.swift
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+/// Result returned by `onBeforeSubmit` callback in the session flow.
+public enum BeforeSubmitResult: Sendable {
+    
+    /// Continue the submission flow with the provided data.
+    /// - Parameters:
+    ///   - data: The submit data (pass back unchanged if unmodified).
+    ///   - sessionData: Optional. Pass the sessionData you received from your server's `PATCH` request.
+    case proceed(data: BeforeSubmitData, sessionData: String?)
+    
+    /// Stop the submission and reset the state.
+    case abort
+}
+
+public struct BeforeSubmitData: Sendable {
+    
+    /// Billing address of the shopper.
+    public var billingAddress: PostalAddress?
+    
+    /// Delivery address of the shopper.
+    public var deliveryAddress: PostalAddress?
+    
+    /// Name of the shopper.
+    public var shopperName: ShopperName?
+    
+    /// Email address of the shopper.
+    public var shopperEmail: String?
+    
+    public init(
+        billingAddress: PostalAddress? = nil,
+        deliveryAddress: PostalAddress? = nil,
+        shopperName: ShopperName? = nil,
+        shopperEmail: String? = nil
+    ) {
+        self.billingAddress = billingAddress
+        self.deliveryAddress = deliveryAddress
+        self.shopperName = shopperName
+        self.shopperEmail = shopperEmail
+    }
+}

--- a/Adyen/Core/Configuration/CheckoutBaseCallbacks.swift
+++ b/Adyen/Core/Configuration/CheckoutBaseCallbacks.swift
@@ -9,5 +9,5 @@ import Foundation
 public typealias SubmitHandler = @MainActor @Sendable (_ data: PaymentComponentData) async throws -> SubmitResult
 public typealias AdditionalDetailsHandler = @MainActor @Sendable (_ data: ActionComponentData) async throws -> AdditionalDetailsResult
 public typealias BeforeSubmitHandler = @MainActor @Sendable (_ data: BeforeSubmitData) async throws -> BeforeSubmitResult
-public typealias CheckoutErrorHandler = (_ error: Error) -> Void
-public typealias CheckoutSuccessHandler = (_ result: CheckoutResult) -> Void
+public typealias CheckoutErrorHandler = @MainActor (_ error: Error) -> Void
+public typealias CheckoutSuccessHandler = @MainActor (_ result: CheckoutResult) -> Void

--- a/Adyen/Core/Configuration/CheckoutBaseCallbacks.swift
+++ b/Adyen/Core/Configuration/CheckoutBaseCallbacks.swift
@@ -8,17 +8,6 @@ import Foundation
 
 public typealias SubmitHandler = @MainActor @Sendable (_ data: PaymentComponentData) async throws -> SubmitResult
 public typealias AdditionalDetailsHandler = @MainActor @Sendable (_ data: ActionComponentData) async throws -> AdditionalDetailsResult
+public typealias BeforeSubmitHandler = @MainActor @Sendable (_ data: BeforeSubmitData) async throws -> BeforeSubmitResult
 public typealias CheckoutErrorHandler = (_ error: Error) -> Void
 public typealias CheckoutSuccessHandler = (_ result: CheckoutResult) -> Void
-
-/// Basic callbacks for all components.
-package protocol CheckoutBaseCallbacks {
-    
-    var onSubmit: SubmitHandler? { get set }
-    
-    var onAdditionalDetails: AdditionalDetailsHandler? { get set }
-    
-    var onError: CheckoutErrorHandler? { get set }
-    
-    var onComplete: CheckoutSuccessHandler? { get set }
-}

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -160,7 +160,7 @@ public struct PaymentComponentData {
         )
     }
 
-    package func applying(_ beforeSubmitData: BeforeSubmitData) -> PaymentComponentData {
+    package func replacing(beforeSubmitData: BeforeSubmitData) -> PaymentComponentData {
         var copy = self
         copy.beforeSubmitData = beforeSubmitData
         return copy

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -29,16 +29,17 @@ public struct PaymentComponentData {
     /// The installments object.
     public let installments: Installments?
     
+    /// Data applied via onBeforeSubmit callback. Takes priority for its fields.
+    private var beforeSubmitData: BeforeSubmitData?
+    
     /// Shopper name.
     public var shopperName: ShopperName? {
-        guard let shopperInfo = paymentMethod as? ShopperInformation else { return nil }
-        return shopperInfo.shopperName
+        beforeSubmitData?.shopperName ?? (paymentMethod as? ShopperInformation)?.shopperName
     }
 
     /// The email address.
     public var emailAddress: String? {
-        guard let shopperInfo = paymentMethod as? ShopperInformation else { return nil }
-        return shopperInfo.emailAddress
+        beforeSubmitData?.shopperEmail ?? (paymentMethod as? ShopperInformation)?.emailAddress
     }
 
     /// The telephone number.
@@ -52,14 +53,12 @@ public struct PaymentComponentData {
 
     /// The billing address information.
     public var billingAddress: PostalAddress? {
-        guard let shopperInfo = paymentMethod as? ShopperInformation else { return nil }
-        return shopperInfo.billingAddress
+        beforeSubmitData?.billingAddress ?? (paymentMethod as? ShopperInformation)?.billingAddress
     }
     
     /// The delivery address information.
     public var deliveryAddress: PostalAddress? {
-        guard let shopperInfo = paymentMethod as? ShopperInformation else { return nil }
-        return shopperInfo.deliveryAddress
+        beforeSubmitData?.deliveryAddress ?? (paymentMethod as? ShopperInformation)?.deliveryAddress
     }
     
     /// The social security number.
@@ -159,5 +158,11 @@ public struct PaymentComponentData {
             browserInfo: browserInfo,
             installments: installments
         )
+    }
+
+    package func applying(_ beforeSubmitData: BeforeSubmitData) -> PaymentComponentData {
+        var copy = self
+        copy.beforeSubmitData = beforeSubmitData
+        return copy
     }
 }

--- a/AdyenCheckout/Callbacks/CallbackError.swift
+++ b/AdyenCheckout/Callbacks/CallbackError.swift
@@ -4,17 +4,13 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-//
-// Copyright (c) 2025 Adyen N.V.
-//
-// This file is open source and available under the MIT license. See the LICENSE file for more info.
-//
 import Foundation
 
 internal enum CallbackError: LocalizedError {
     case missingSubmitHandler
     case missingAdditionalDetailsHandler
     case unsupportedSubmit
+    case beforeSubmitAborted
 
     internal var errorDescription: String? {
         switch self {
@@ -24,6 +20,8 @@ internal enum CallbackError: LocalizedError {
             "Checkout requires `onAdditionalDetails` to submit additional details."
         case .unsupportedSubmit:
             "Action-only checkout cannot submit payment data."
+        case .beforeSubmitAborted:
+            "Submission was aborted by the `onBeforeSubmit` callback."
         }
     }
 }

--- a/AdyenCheckout/Callbacks/CheckoutCallbackHandlers.swift
+++ b/AdyenCheckout/Callbacks/CheckoutCallbackHandlers.swift
@@ -38,6 +38,51 @@ package final class SessionCallbackHandler: CheckoutCallbackHandling {
 }
 
 @MainActor
+package final class BeforeSubmitCallbackHandler: CheckoutCallbackHandling {
+
+    private let innerHandler: any CheckoutCallbackHandling
+    private let session: SessionProtocol
+    private let callbackStore: SessionCheckoutCallbackStore
+
+    package init(
+        inner: any CheckoutCallbackHandling,
+        session: SessionProtocol,
+        callbackStore: SessionCheckoutCallbackStore
+    ) {
+        self.innerHandler = inner
+        self.session = session
+        self.callbackStore = callbackStore
+    }
+
+    package func handleSubmit(_ data: PaymentComponentData) async throws -> SubmitResult {
+        var submitData = data
+        if let onBeforeSubmit = callbackStore.onBeforeSubmit {
+            let inputData = BeforeSubmitData(
+                billingAddress: data.billingAddress,
+                deliveryAddress: data.deliveryAddress,
+                shopperName: data.shopperName,
+                shopperEmail: data.emailAddress
+            )
+            let result = try await onBeforeSubmit(inputData)
+            switch result {
+            case let .proceed(modifiedData, sessionData):
+                if let sessionData {
+                    try await session.refreshSessionState(with: sessionData)
+                }
+                submitData = data.applying(modifiedData)
+            case .abort:
+                throw CallbackError.beforeSubmitAborted
+            }
+        }
+        return try await innerHandler.handleSubmit(submitData)
+    }
+
+    package func handleAdditionalDetails(_ data: ActionComponentData) async throws -> AdditionalDetailsResult {
+        try await innerHandler.handleAdditionalDetails(data)
+    }
+}
+
+@MainActor
 package final class AdvancedCallbackHandler: CheckoutCallbackHandling {
     private let callbackStore: AdvancedCheckoutCallbackStore
 

--- a/AdyenCheckout/Callbacks/CheckoutCallbackHandlers.swift
+++ b/AdyenCheckout/Callbacks/CheckoutCallbackHandlers.swift
@@ -40,45 +40,51 @@ package final class SessionCallbackHandler: CheckoutCallbackHandling {
 @MainActor
 package final class BeforeSubmitCallbackHandler: CheckoutCallbackHandling {
 
-    private let innerHandler: any CheckoutCallbackHandling
+    private let handler: any CheckoutCallbackHandling
     private let session: SessionProtocol
     private let callbackStore: SessionCheckoutCallbackStore
 
     package init(
-        inner: any CheckoutCallbackHandling,
+        handler: any CheckoutCallbackHandling,
         session: SessionProtocol,
         callbackStore: SessionCheckoutCallbackStore
     ) {
-        self.innerHandler = inner
+        self.handler = handler
         self.session = session
         self.callbackStore = callbackStore
     }
 
     package func handleSubmit(_ data: PaymentComponentData) async throws -> SubmitResult {
-        var submitData = data
-        if let onBeforeSubmit = callbackStore.onBeforeSubmit {
-            let inputData = BeforeSubmitData(
-                billingAddress: data.billingAddress,
-                deliveryAddress: data.deliveryAddress,
-                shopperName: data.shopperName,
-                shopperEmail: data.emailAddress
-            )
-            let result = try await onBeforeSubmit(inputData)
-            switch result {
-            case let .proceed(modifiedData, sessionData):
-                if let sessionData {
-                    try await session.refreshSessionState(with: sessionData)
-                }
-                submitData = data.applying(modifiedData)
-            case .abort:
-                throw CallbackError.beforeSubmitAborted
-            }
-        }
-        return try await innerHandler.handleSubmit(submitData)
+        let submitData = try await handleBeforeSubmit(for: data)
+        return try await handler.handleSubmit(submitData)
     }
 
     package func handleAdditionalDetails(_ data: ActionComponentData) async throws -> AdditionalDetailsResult {
-        try await innerHandler.handleAdditionalDetails(data)
+        try await handler.handleAdditionalDetails(data)
+    }
+
+    private func handleBeforeSubmit(for data: PaymentComponentData) async throws -> PaymentComponentData {
+        guard let onBeforeSubmit = callbackStore.onBeforeSubmit else {
+            return data
+        }
+
+        let inputData = BeforeSubmitData(
+            billingAddress: data.billingAddress,
+            deliveryAddress: data.deliveryAddress,
+            shopperName: data.shopperName,
+            shopperEmail: data.emailAddress
+        )
+        let result = try await onBeforeSubmit(inputData)
+
+        switch result {
+        case let .proceed(modifiedData, sessionData):
+            if let sessionData {
+                try await session.refreshSessionState(with: sessionData)
+            }
+            return data.replacing(beforeSubmitData: modifiedData)
+        case .abort:
+            throw CallbackError.beforeSubmitAborted
+        }
     }
 }
 

--- a/AdyenCheckout/Callbacks/CheckoutResultCallbackStore.swift
+++ b/AdyenCheckout/Callbacks/CheckoutResultCallbackStore.swift
@@ -14,6 +14,8 @@ package protocol CheckoutResultCallbackStore: AnyObject {
 }
 
 package final class SessionCheckoutCallbackStore: CheckoutResultCallbackStore {
+    package var onBeforeSubmit: BeforeSubmitHandler?
+
     package var onComplete: CheckoutSuccessHandler?
 
     package var onError: CheckoutErrorHandler?

--- a/AdyenCheckout/Core/CheckoutCore+Orchestration.swift
+++ b/AdyenCheckout/Core/CheckoutCore+Orchestration.swift
@@ -58,6 +58,11 @@ internal extension CheckoutCore {
                 let submitResult = try await onSubmit()
                 guard !Task.isCancelled else { return }
                 self?.handle(submitResult: submitResult, source: source)
+            } catch CallbackError.beforeSubmitAborted {
+                // catch beforeSubmit abort here and reset the component UI
+                guard !Task.isCancelled else { return }
+                source.paymentComponent.stopLoading()
+                self?.pendingPaymentComponent = nil
             } catch {
                 // Ignore if this was a cancellation (task superseded or Checkout torn down).
                 guard !(error is CancellationError), !Task.isCancelled else { return }

--- a/AdyenCheckout/Core/CheckoutCore+Orchestration.swift
+++ b/AdyenCheckout/Core/CheckoutCore+Orchestration.swift
@@ -36,6 +36,10 @@ internal enum CheckoutCallbackSource {
             dropInComponent
         }
     }
+    
+    internal func stopLoading() {
+        paymentComponent.stopLoading()
+    }
 }
 
 internal extension CheckoutCore {
@@ -61,7 +65,7 @@ internal extension CheckoutCore {
             } catch CallbackError.beforeSubmitAborted {
                 // catch beforeSubmit abort here and reset the component UI
                 guard !Task.isCancelled else { return }
-                source.paymentComponent.stopLoading()
+                source.stopLoading()
                 self?.pendingPaymentComponent = nil
             } catch {
                 // Ignore if this was a cancellation (task superseded or Checkout torn down).

--- a/AdyenCheckout/Flows/ActionOnlyCheckout.swift
+++ b/AdyenCheckout/Flows/ActionOnlyCheckout.swift
@@ -19,6 +19,9 @@ public final class ActionOnlyCheckout: BaseCheckout {
     }
 
     /// Sets the callback invoked when additional action details are submitted.
+    /// - Parameter handler: Callback invoked when an action component provides data for `/payments/details`.
+    ///   - data: The `ActionComponentData` containing the action `details` and optional `paymentData` returned by the previous `/payments` response.
+    /// - Returns: An `AdditionalDetailsResult` describing how checkout should continue after the details are submitted.
     public func onAdditionalDetails(_ handler: @escaping AdditionalDetailsHandler) -> Self {
         callbackStore.onAdditionalDetails = handler
         return self

--- a/AdyenCheckout/Flows/AdvancedCheckout.swift
+++ b/AdyenCheckout/Flows/AdvancedCheckout.swift
@@ -19,12 +19,18 @@ public final class AdvancedCheckout: PaymentCheckout {
     }
 
     /// Sets the callback invoked when payment data is submitted.
+    /// - Parameter handler: Callback invoked when a payment component submits payment data.
+    ///   - data: The `PaymentComponentData` containing the selected payment method details and any shopper or browser information collected by the component.
+    /// - Returns: A `SubmitResult` describing how checkout should continue, such as completion, presenting an action, retry, or partial payment handling.
     public func onSubmit(_ handler: @escaping SubmitHandler) -> Self {
         callbackStore.onSubmit = handler
         return self
     }
 
     /// Sets the callback invoked when additional action details are submitted.
+    /// - Parameter handler: Callback invoked when an action component provides data for `/payments/details`.
+    ///   - data: The `ActionComponentData` containing the action `details` and optional `paymentData` returned by the previous `/payments` response.
+    /// - Returns: An `AdditionalDetailsResult` describing how checkout should continue after the details are submitted.
     public func onAdditionalDetails(_ handler: @escaping AdditionalDetailsHandler) -> Self {
         callbackStore.onAdditionalDetails = handler
         return self

--- a/AdyenCheckout/Flows/BaseCheckout.swift
+++ b/AdyenCheckout/Flows/BaseCheckout.swift
@@ -30,12 +30,16 @@ public class BaseCheckout {
     }
 
     /// Sets the callback invoked when checkout completes successfully.
+    /// - Parameter handler: Callback invoked with the final checkout result.
+    ///   - result: The `CheckoutResult` containing the payment `resultCode` and, for session flows, an optional `sessionResult` that can be used on your server to retrieve the payment outcome.
     public func onComplete(_ handler: @escaping CheckoutSuccessHandler) -> Self {
         resultCallbacks.onComplete = handler
         return self
     }
 
     /// Sets the callback invoked when checkout fails.
+    /// - Parameter handler: Callback invoked with the checkout failure.
+    ///   - error: The `Error` describing why the checkout flow failed.
     public func onError(_ handler: @escaping CheckoutErrorHandler) -> Self {
         resultCallbacks.onError = handler
         return self

--- a/AdyenCheckout/Flows/SessionCheckout.swift
+++ b/AdyenCheckout/Flows/SessionCheckout.swift
@@ -17,4 +17,11 @@ public final class SessionCheckout: PaymentCheckout {
         self.callbackStore = callbackStore
         super.init(core: core, resultCallbacks: callbackStore)
     }
+
+    /// Sets the callback invoked before payment data is submitted to the session.
+    /// Use this to inspect or modify payment data, or to abort the submission.
+    public func onBeforeSubmit(_ handler: @escaping BeforeSubmitHandler) -> Self {
+        callbackStore.onBeforeSubmit = handler
+        return self
+    }
 }

--- a/AdyenCheckout/Flows/SessionCheckout.swift
+++ b/AdyenCheckout/Flows/SessionCheckout.swift
@@ -25,7 +25,8 @@ public final class SessionCheckout: PaymentCheckout {
     /// in `.proceed(data:sessionData:)` so the SDK can refresh the session state before continuing.
     /// - Parameter handler: Callback invoked before the session performs the `/payments` call.
     ///   - data: The `BeforeSubmitData` containing shopper fields that can be validated, modified, or passed back unchanged.
-    /// - Returns: A `BeforeSubmitResult`. Return `.proceed(data:sessionData:)` to continue or `.abort` to stop the flow and reset the component state.
+    /// - Returns: A `BeforeSubmitResult`. Return `.proceed(data:sessionData:)` to continue or `.abort`
+    /// to stop the flow and reset the component state.
     public func onBeforeSubmit(_ handler: @escaping BeforeSubmitHandler) -> Self {
         callbackStore.onBeforeSubmit = handler
         return self

--- a/AdyenCheckout/Flows/SessionCheckout.swift
+++ b/AdyenCheckout/Flows/SessionCheckout.swift
@@ -19,7 +19,13 @@ public final class SessionCheckout: PaymentCheckout {
     }
 
     /// Sets the callback invoked before payment data is submitted to the session.
-    /// Use this to inspect or modify payment data, or to abort the submission.
+    /// Use this to inspect or modify payment data, patch the session on your server, or abort the submission.
+    ///
+    /// If you patch the session on your server during this callback, pass the returned `sessionData`
+    /// in `.proceed(data:sessionData:)` so the SDK can refresh the session state before continuing.
+    /// - Parameter handler: Callback invoked before the session performs the `/payments` call.
+    ///   - data: The `BeforeSubmitData` containing shopper fields that can be validated, modified, or passed back unchanged.
+    /// - Returns: A `BeforeSubmitResult`. Return `.proceed(data:sessionData:)` to continue or `.abort` to stop the flow and reset the component state.
     public func onBeforeSubmit(_ handler: @escaping BeforeSubmitHandler) -> Self {
         callbackStore.onBeforeSubmit = handler
         return self

--- a/AdyenCheckout/Flows/SessionCheckout.swift
+++ b/AdyenCheckout/Flows/SessionCheckout.swift
@@ -22,7 +22,7 @@ public final class SessionCheckout: PaymentCheckout {
     /// Use this to inspect or modify payment data, patch the session on your server, or abort the submission.
     ///
     /// If you patch the session on your server during this callback, pass the returned `sessionData`
-    /// in `.proceed(data:sessionData:)` so the SDK can refresh the session state before continuing.
+    /// in `.proceed(data:sessionData:)` so the SDK can update the session state data before continuing.
     /// - Parameter handler: Callback invoked before the session performs the `/payments` call.
     ///   - data: The `BeforeSubmitData` containing shopper fields that can be validated, modified, or passed back unchanged.
     /// - Returns: A `BeforeSubmitResult`. Return `.proceed(data:sessionData:)` to continue or `.abort`

--- a/AdyenCheckout/Setup/CheckoutProvider.swift
+++ b/AdyenCheckout/Setup/CheckoutProvider.swift
@@ -49,7 +49,11 @@ internal class CheckoutProvider: CheckoutProviding {
             adyenContext: adyenContext,
             presentationDelegate: presentationDelegate,
             resultCallbacks: callbackStore,
-            callbackHandler: SessionCallbackHandler(session: session)
+            callbackHandler: BeforeSubmitCallbackHandler(
+                inner: SessionCallbackHandler(session: session),
+                session: session,
+                callbackStore: callbackStore
+            )
         )
     }
     

--- a/AdyenCheckout/Setup/CheckoutProvider.swift
+++ b/AdyenCheckout/Setup/CheckoutProvider.swift
@@ -50,7 +50,7 @@ internal class CheckoutProvider: CheckoutProviding {
             presentationDelegate: presentationDelegate,
             resultCallbacks: callbackStore,
             callbackHandler: BeforeSubmitCallbackHandler(
-                inner: SessionCallbackHandler(session: session),
+                handler: SessionCallbackHandler(session: session),
                 session: session,
                 callbackStore: callbackStore
             )

--- a/AdyenSession/Session.swift
+++ b/AdyenSession/Session.swift
@@ -124,7 +124,7 @@ extension Session {
 extension Session {
     
     package func refreshSessionState(with sessionData: String) async throws {
-        state = try await refreshedState(using: sessionData)
+        state.data = sessionData
     }
     
     package func performSubmit(_ data: PaymentComponentData) async throws -> SubmitResult {
@@ -213,18 +213,6 @@ private extension Session {
         newState.resultCode = result.resultCode
         newState.sessionResult = result.sessionResult
         return newState
-    }
-    
-    func refreshedState(using sessionData: String) async throws -> State {
-        let initialInfo = SessionResponse(
-            id: state.identifier,
-            sessionData: sessionData
-        )
-        return try await Self.makeSetupCall(
-            with: initialInfo,
-            baseAPIClient: apiClient,
-            order: nil
-        )
     }
     
     func updateSession(with data: SessionDataAware) {

--- a/AdyenSession/Session.swift
+++ b/AdyenSession/Session.swift
@@ -124,8 +124,7 @@ extension Session {
 extension Session {
     
     package func refreshSessionState(with sessionData: String) async throws {
-        state.data = sessionData
-        state = try await refreshedState()
+        state = try await refreshedState(using: sessionData)
     }
     
     package func performSubmit(_ data: PaymentComponentData) async throws -> SubmitResult {
@@ -216,10 +215,10 @@ private extension Session {
         return newState
     }
     
-    func refreshedState() async throws -> State {
+    func refreshedState(using sessionData: String) async throws -> State {
         let initialInfo = SessionResponse(
             id: state.identifier,
-            sessionData: state.data
+            sessionData: sessionData
         )
         return try await Self.makeSetupCall(
             with: initialInfo,

--- a/AdyenSession/Session.swift
+++ b/AdyenSession/Session.swift
@@ -123,6 +123,11 @@ extension Session {
 
 extension Session {
     
+    package func refreshSessionState(with sessionData: String) async throws {
+        state.data = sessionData
+        state = try await refreshedState()
+    }
+    
     package func performSubmit(_ data: PaymentComponentData) async throws -> SubmitResult {
         let request = PaymentsRequest(
             sessionId: state.identifier,
@@ -209,6 +214,18 @@ private extension Session {
         newState.resultCode = result.resultCode
         newState.sessionResult = result.sessionResult
         return newState
+    }
+    
+    func refreshedState() async throws -> State {
+        let initialInfo = SessionResponse(
+            id: state.identifier,
+            sessionData: state.data
+        )
+        return try await Self.makeSetupCall(
+            with: initialInfo,
+            baseAPIClient: apiClient,
+            order: nil
+        )
     }
     
     func updateSession(with data: SessionDataAware) {

--- a/AdyenSession/SessionProtocol.swift
+++ b/AdyenSession/SessionProtocol.swift
@@ -29,4 +29,5 @@ package protocol SessionProtocol: AnyObject {
     
     func disable(storedPaymentMethod: StoredPaymentMethod) async throws
     
+    func refreshSessionState(with sessionData: String) async throws
 }

--- a/Demo/Common/Assets/Localizable.xcstrings
+++ b/Demo/Common/Assets/Localizable.xcstrings
@@ -100,6 +100,9 @@
     "Korean Authentication Mode" : {
 
     },
+    "onBeforeSubmit" : {
+
+    },
     "Return success from didAuthorize" : {
 
     },
@@ -107,6 +110,9 @@
 
     },
     "Security Code" : {
+
+    },
+    "Session Callbacks" : {
 
     },
     "Set to country currency" : {

--- a/Demo/Common/Configuration/ApplePaySettingsView.swift
+++ b/Demo/Common/Configuration/ApplePaySettingsView.swift
@@ -33,10 +33,28 @@ internal struct ApplePaySettingsView: View {
                             .font(.footnote)
                     }
                 }
+                Section(header: Text("Session Callbacks")) {
+                    Picker("onBeforeSubmit", selection: $viewModel.applePayOnBeforeSubmitMode) {
+                        ForEach(ApplePaySettings.OnBeforeSubmitMode.allCases, id: \.self) {
+                            Text($0.displayName)
+                        }
+                    }
+                }
             }
             .navigationBarTitle("")
             .navigationBarHidden(true)
         }
         .navigationViewStyle(.stack)
+    }
+}
+
+extension ApplePaySettings.OnBeforeSubmitMode {
+
+    public var displayName: String {
+        switch self {
+        case .updateData: return "Update data"
+        case .abort: return "Abort"
+        case .patchSession: return "Patch session"
+        }
     }
 }

--- a/Demo/Common/Configuration/ConfigurationView.swift
+++ b/Demo/Common/Configuration/ConfigurationView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 internal struct ConfigurationView: View {
     
     private enum ConfigurationSection: String, CaseIterable {
-        case apiVersion = "Api Version"
         case merchantAccount = "Merchant Account"
         case region = "Region"
         case payment = "Payment"
@@ -46,7 +45,6 @@ internal struct ConfigurationView: View {
     internal var body: some View {
         NavigationView {
             Form {
-                apiVersionSection
                 merchantAccountSection
                 regionSection
                 wrapInSection(view: paymentSection, section: .payment)
@@ -72,15 +70,6 @@ internal struct ConfigurationView: View {
         section: ConfigurationSection
     ) -> some View {
         Section(header: Text(section.rawValue.uppercased())) { view }
-    }
-    
-    private var apiVersionSection: some View {
-        TextFieldItemView(
-            title: "API Version",
-            value: $viewModel.apiVersion,
-            placeholder: ConfigurationSection.apiVersion.rawValue,
-            keyboardType: .numberPad
-        )
     }
     
     private var merchantAccountSection: some View {

--- a/Demo/Common/Configuration/ConfigurationViewModel.swift
+++ b/Demo/Common/Configuration/ConfigurationViewModel.swift
@@ -12,7 +12,6 @@ internal final class ConfigurationViewModel: ObservableObject {
     @Published internal var countryCode: String = ""
     @Published internal var currencyCode: String = ""
     @Published internal var value: String = ""
-    @Published internal var apiVersion: String = ""
     @Published internal var merchantAccount: String = ""
     @Published internal var showCardholderName = false
     @Published internal var showStorePaymentMethod = true
@@ -31,6 +30,7 @@ internal final class ConfigurationViewModel: ObservableObject {
     @Published internal var applePayMerchantIdentifier: String = ""
     @Published internal var applePayDidAuthorizeSuccessful: Bool = true
     @Published internal var allowOnboarding: Bool = false
+    @Published internal var applePayOnBeforeSubmitMode: ApplePaySettings.OnBeforeSubmitMode = .updateData
     @Published internal var analyticsIsEnabled: Bool = true
     @Published internal var installmentsEnabled: Bool = false
     @Published internal var showInstallmentAmount: Bool = false
@@ -53,7 +53,6 @@ internal final class ConfigurationViewModel: ObservableObject {
         self.countryCode = configuration.countryCode
         self.currencyCode = configuration.currencyCode
         self.value = configuration.value.description
-        self.apiVersion = configuration.apiVersion.description
         self.merchantAccount = configuration.merchantAccount
         self.showCardholderName = configuration.cardSettings.showCardholderName
         self.showStorePaymentMethod = configuration.cardSettings.showStorePaymentMethod
@@ -69,6 +68,7 @@ internal final class ConfigurationViewModel: ObservableObject {
         self.applePayMerchantIdentifier = configuration.applePaySettings.merchantIdentifier
         self.allowOnboarding = configuration.applePaySettings.allowOnboarding
         self.applePayDidAuthorizeSuccessful = configuration.applePaySettings.didAuthorizeSuccessful
+        self.applePayOnBeforeSubmitMode = configuration.applePaySettings.onBeforeSubmitMode
         self.analyticsIsEnabled = configuration.analyticsSettings.isEnabled
         self.installmentsEnabled = configuration.cardSettings.enableInstallments
         self.showInstallmentAmount = configuration.cardSettings.showsInstallmentAmount
@@ -88,7 +88,6 @@ internal final class ConfigurationViewModel: ObservableObject {
             countryCode: countryCode,
             value: Int(value) ?? configuration.value,
             currencyCode: currencyCode,
-            apiVersion: Int(apiVersion) ?? configuration.apiVersion,
             merchantAccount: merchantAccount,
             cardSettings: CardSettings(
                 showCardholderName: showCardholderName,
@@ -112,7 +111,8 @@ internal final class ConfigurationViewModel: ObservableObject {
             applePaySettings: ApplePaySettings(
                 merchantIdentifier: applePayMerchantIdentifier,
                 allowOnboarding: allowOnboarding,
-                didAuthorizeSuccessful: applePayDidAuthorizeSuccessful
+                didAuthorizeSuccessful: applePayDidAuthorizeSuccessful,
+                onBeforeSubmitMode: applePayOnBeforeSubmitMode
             ),
             analyticsSettings: AnalyticsSettings(isEnabled: analyticsIsEnabled),
             themeSettings: ThemeSettings(selectedTheme: selectedTheme.rawValue)

--- a/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
+++ b/Demo/Common/IntegrationExamples/Protocols/InitialDataFlowProtocol.swift
@@ -46,8 +46,8 @@ extension InitialDataFlowProtocol {
         )
     }
     
-    internal func requestSessionInitialInfo() async throws -> SessionResponse {
-        let request = SessionRequest()
+    internal func requestSessionInitialInfo(payable: Bool = true) async throws -> SessionResponse {
+        let request = SessionRequest(payable: payable)
         return try await withCheckedThrowingContinuation { continuation in
             apiClient.perform(request) { result in
                 continuation.resume(with: result)

--- a/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
@@ -132,9 +132,9 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
 
             switch ConfigurationConstants.current.applePaySettings.onBeforeSubmitMode {
             case .updateData:
-                var updatedData = data
-                updatedData.shopperName = ShopperName(firstName: "Demo", lastName: "Shopper")
-                updatedData.shopperEmail = "updatedForDemo-\(ConfigurationConstants.shopperEmail)"
+                let updatedData = data
+                    .replacing(shopperName: ShopperName(firstName: "Demo", lastName: "Shopper"))
+                    .replacing(shopperEmail: "updatedForDemo-\(ConfigurationConstants.shopperEmail)")
                 return .proceed(data: updatedData, sessionData: nil)
             case .abort:
                 return .abort
@@ -225,7 +225,8 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
         )
     }
     
-    // MARK: - Backend 
+    // MARK: - Backend
+
     private func patchSession(using sessionResponse: SessionResponse) async throws -> SessionPatchResponse {
         let request = SessionPatchRequest(
             sessionId: sessionResponse.id,

--- a/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
@@ -68,55 +68,52 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
                         return PKPaymentAuthorizationResult(status: .failure, errors: [postalCodeError])
                     }
                 }.onShippingContactChange { contact, summaryItems in
-                    var items = summaryItems
-                    if let last = items.last {
-                        items = items.dropLast()
-                        let cityLabel = contact.postalAddress?.city ?? "Somewhere"
-                        items.append(.init(
-                            label: "Shipping \(cityLabel)",
-                            amount: NSDecimalNumber(value: 5.0)
-                        ))
-                        items.append(.init(label: last.label, amount: NSDecimalNumber(value: last.amount.floatValue + 5.0)))
-                    }
+                    let cityLabel = contact.postalAddress?.city ?? "Somewhere"
+                    let items = self.updatedSummaryItems(
+                        from: summaryItems,
+                        appendedItems: [
+                            .init(
+                                label: "Shipping \(cityLabel)",
+                                amount: NSDecimalNumber(value: 5.0)
+                            )
+                        ],
+                        totalAmountDelta: 5.0
+                    )
                     self.updateLatestApplePayAmount(using: items)
                     return PKPaymentRequestShippingContactUpdate(paymentSummaryItems: items)
                 }
                 .onShippingMethodChange { shippingMethod, summaryItems in
-                    var items = summaryItems
-                    if let last = items.last {
-                        items = items.dropLast()
-                        items.append(shippingMethod)
-                        items.append(.init(
-                            label: last.label,
-                            amount: NSDecimalNumber(value: last.amount.floatValue + shippingMethod.amount.floatValue)
-                        ))
-                    }
+                    let items = self.updatedSummaryItems(
+                        from: summaryItems,
+                        appendedItems: [shippingMethod],
+                        totalAmountDelta: shippingMethod.amount.doubleValue
+                    )
                     self.updateLatestApplePayAmount(using: items)
                     return PKPaymentRequestShippingMethodUpdate(paymentSummaryItems: items)
                 }
                 .onCouponCodeChange { _, summaryItems in
-                    var items = summaryItems
-                    if let last = items.last {
-                        items = items.dropLast()
-                        // make sure your backend's amount and apple pay sheet amount are the same
-                        items.append(.init(label: "Coupon", amount: NSDecimalNumber(value: -5.0)))
-                        items.append(.init(label: last.label, amount: NSDecimalNumber(value: last.amount.floatValue - 5.0)))
-                    }
+                    // make sure your backend's amount and apple pay sheet amount are the same
+                    let items = self.updatedSummaryItems(
+                        from: summaryItems,
+                        appendedItems: [.init(label: "Coupon", amount: NSDecimalNumber(value: -5.0))],
+                        totalAmountDelta: -5.0
+                    )
                     self.updateLatestApplePayAmount(using: items)
                     return PKPaymentRequestCouponCodeUpdate(paymentSummaryItems: items)
                 }
                 .onPaymentMethodChange { paymentMethod, summaryItems in
                     // Example: Add a processing fee based on card type
-                    var items = summaryItems
-                    if let last = items.last {
-                        items = items.dropLast()
-                        let cardType = paymentMethod.displayName ?? "Card"
-                        items.append(.init(
-                            label: "Processing Fee (\(cardType))",
-                            amount: NSDecimalNumber(value: 1.0)
-                        ))
-                        items.append(.init(label: last.label, amount: NSDecimalNumber(value: last.amount.floatValue + 1.0)))
-                    }
+                    let cardType = paymentMethod.displayName ?? "Card"
+                    let items = self.updatedSummaryItems(
+                        from: summaryItems,
+                        appendedItems: [
+                            .init(
+                                label: "Processing Fee (\(cardType))",
+                                amount: NSDecimalNumber(value: 1.0)
+                            )
+                        ],
+                        totalAmountDelta: 1.0
+                    )
                     self.updateLatestApplePayAmount(using: items)
                     return PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: items)
                 }
@@ -190,13 +187,24 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
         }
     }
 
-    private func patchSession(using sessionResponse: SessionResponse) async throws -> SessionPatchResponse {
-        let request = SessionPatchRequest(
-            sessionId: sessionResponse.id,
-            sessionData: sessionResponse.sessionData,
-            amount: latestApplePayAmount
+    private func updatedSummaryItems(
+        from summaryItems: [PKPaymentSummaryItem],
+        appendedItems: [PKPaymentSummaryItem],
+        totalAmountDelta: Double
+    ) -> [PKPaymentSummaryItem] {
+        guard let total = summaryItems.last else {
+            return summaryItems
+        }
+
+        var updatedItems = Array(summaryItems.dropLast())
+        updatedItems.append(contentsOf: appendedItems)
+        updatedItems.append(
+            .init(
+                label: total.label,
+                amount: NSDecimalNumber(value: total.amount.doubleValue + totalAmountDelta)
+            )
         )
-        return try await asyncApiClient.performAsync(request)
+        return updatedItems
     }
 
     private func updateLatestApplePayAmount(using summaryItems: [PKPaymentSummaryItem]) {
@@ -215,6 +223,16 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
             currencyCode: currentAmount.currencyCode,
             localeIdentifier: currentAmount.localeIdentifier
         )
+    }
+    
+    // MARK: - Backend 
+    private func patchSession(using sessionResponse: SessionResponse) async throws -> SessionPatchResponse {
+        let request = SessionPatchRequest(
+            sessionId: sessionResponse.id,
+            sessionData: sessionResponse.sessionData,
+            amount: latestApplePayAmount
+        )
+        return try await asyncApiClient.performAsync(request)
     }
 }
 

--- a/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
@@ -17,8 +17,10 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
 
     private var checkout: SessionCheckout?
     private var adyenComponent: CheckoutPaymentComponent?
+    private var latestApplePayAmount = ConfigurationConstants.current.amount
 
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
+    private lazy var asyncApiClient = ApiClientHelper.generateAsyncApiClient()
 
     /// comes from demo app protocol, unused on new structure
     internal var context: AdyenContext?
@@ -27,10 +29,12 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
 
     internal func start() {
         startLoading()
+        latestApplePayAmount = ConfigurationConstants.current.amount
 
         Task {
             do {
-                let sessionResponse = try await requestSessionInitialInfo()
+                let patchableSession = ConfigurationConstants.current.applePaySettings.onBeforeSubmitMode == .patchSession
+                let sessionResponse = try await requestSessionInitialInfo(payable: !patchableSession)
                 let component = try await applePayComponent(from: sessionResponse)
                 self.adyenComponent = component
                 hideLoading()
@@ -52,7 +56,7 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
             )
         ) {
             try ConfigurationConstants.current
-                .applePayConfiguration(using: .demo)
+                .applePayConfiguration(using: .demoWithShippingFields)
                 .onAuthorize { payment in
                     if ConfigurationConstants.current.applePaySettings.didAuthorizeSuccessful {
                         return PKPaymentAuthorizationResult(status: .success, errors: nil)
@@ -63,6 +67,58 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
                         )
                         return PKPaymentAuthorizationResult(status: .failure, errors: [postalCodeError])
                     }
+                }.onShippingContactChange { contact, summaryItems in
+                    var items = summaryItems
+                    if let last = items.last {
+                        items = items.dropLast()
+                        let cityLabel = contact.postalAddress?.city ?? "Somewhere"
+                        items.append(.init(
+                            label: "Shipping \(cityLabel)",
+                            amount: NSDecimalNumber(value: 5.0)
+                        ))
+                        items.append(.init(label: last.label, amount: NSDecimalNumber(value: last.amount.floatValue + 5.0)))
+                    }
+                    self.updateLatestApplePayAmount(using: items)
+                    return PKPaymentRequestShippingContactUpdate(paymentSummaryItems: items)
+                }
+                .onShippingMethodChange { shippingMethod, summaryItems in
+                    var items = summaryItems
+                    if let last = items.last {
+                        items = items.dropLast()
+                        items.append(shippingMethod)
+                        items.append(.init(
+                            label: last.label,
+                            amount: NSDecimalNumber(value: last.amount.floatValue + shippingMethod.amount.floatValue)
+                        ))
+                    }
+                    self.updateLatestApplePayAmount(using: items)
+                    return PKPaymentRequestShippingMethodUpdate(paymentSummaryItems: items)
+                }
+                .onCouponCodeChange { _, summaryItems in
+                    var items = summaryItems
+                    if let last = items.last {
+                        items = items.dropLast()
+                        // make sure your backend's amount and apple pay sheet amount are the same
+                        items.append(.init(label: "Coupon", amount: NSDecimalNumber(value: -5.0)))
+                        items.append(.init(label: last.label, amount: NSDecimalNumber(value: last.amount.floatValue - 5.0)))
+                    }
+                    self.updateLatestApplePayAmount(using: items)
+                    return PKPaymentRequestCouponCodeUpdate(paymentSummaryItems: items)
+                }
+                .onPaymentMethodChange { paymentMethod, summaryItems in
+                    // Example: Add a processing fee based on card type
+                    var items = summaryItems
+                    if let last = items.last {
+                        items = items.dropLast()
+                        let cardType = paymentMethod.displayName ?? "Card"
+                        items.append(.init(
+                            label: "Processing Fee (\(cardType))",
+                            amount: NSDecimalNumber(value: 1.0)
+                        ))
+                        items.append(.init(label: last.label, amount: NSDecimalNumber(value: last.amount.floatValue + 1.0)))
+                    }
+                    self.updateLatestApplePayAmount(using: items)
+                    return PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: items)
                 }
         }
 
@@ -71,6 +127,25 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
             configuration: configuration,
             presentationDelegate: self
         )
+        .onBeforeSubmit { data in
+            print("onBeforeSubmit: shopperName: \(String(describing: data.shopperName))")
+            print("onBeforeSubmit: shopperEmail: \(String(describing: data.shopperEmail))")
+            print("onBeforeSubmit: billingAddress: \(String(describing: data.billingAddress))")
+            print("onBeforeSubmit: deliveryAddress: \(String(describing: data.deliveryAddress))")
+
+            switch ConfigurationConstants.current.applePaySettings.onBeforeSubmitMode {
+            case .updateData:
+                var updatedData = data
+                updatedData.shopperName = ShopperName(firstName: "Demo", lastName: "Shopper")
+                updatedData.shopperEmail = "updatedForDemo-\(ConfigurationConstants.shopperEmail)"
+                return .proceed(data: updatedData, sessionData: nil)
+            case .abort:
+                return .abort
+            case .patchSession:
+                let patchedSession = try await self.patchSession(using: sessionResponse)
+                return .proceed(data: data, sessionData: patchedSession.sessionData)
+            }
+        }
         .onComplete { [weak self] result in
             self?.dismissAndShowAlert(
                 result.resultCode.isSuccess,
@@ -113,6 +188,33 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
             let title = success ? "Success" : "Error"
             self.presenter?.presentAlert(withTitle: title, message: message)
         }
+    }
+
+    private func patchSession(using sessionResponse: SessionResponse) async throws -> SessionPatchResponse {
+        let request = SessionPatchRequest(
+            sessionId: sessionResponse.id,
+            sessionData: sessionResponse.sessionData,
+            amount: latestApplePayAmount
+        )
+        return try await asyncApiClient.performAsync(request)
+    }
+
+    private func updateLatestApplePayAmount(using summaryItems: [PKPaymentSummaryItem]) {
+        guard let total = summaryItems.last else {
+            return
+        }
+
+        let currentAmount = ConfigurationConstants.current.amount
+        let updatedValue = AmountFormatter.minorUnitAmount(
+            from: total.amount.decimalValue,
+            currencyCode: currentAmount.currencyCode,
+            localeIdentifier: currentAmount.localeIdentifier
+        )
+        latestApplePayAmount = Amount(
+            value: updatedValue,
+            currencyCode: currentAmount.currencyCode,
+            localeIdentifier: currentAmount.localeIdentifier
+        )
     }
 }
 

--- a/Demo/Common/Networking/Environment.swift
+++ b/Demo/Common/Networking/Environment.swift
@@ -28,6 +28,10 @@ internal struct DemoAPIContext: AnyAPIContext {
 internal enum DemoCheckoutAPIEnvironment: String, AnyAPIEnvironment, CaseIterable {
     
     case test, local
+
+    private enum Constants {
+        static let localCheckoutAPIVersion = 72
+    }
     
     internal var baseURL: URL {
         switch self {
@@ -39,24 +43,22 @@ internal enum DemoCheckoutAPIEnvironment: String, AnyAPIEnvironment, CaseIterabl
     }
     
     internal var version: Int {
-        ConfigurationConstants.current.apiVersion
-    }
-    
-}
-
-internal enum DemoClassicAPIEnvironment: String, AnyAPIEnvironment, CaseIterable {
-    
-    case beta, test, local
-    
-    internal var baseURL: URL {
         switch self {
-        case .beta:
-            return URL(string: "https://pal-beta.adyen.com/pal/servlet/")!
         case .test:
-            return URL(string: "https://pal-test.adyen.com/pal/servlet/")!
+            // The test Checkout API version is taken from MERCHANT_SERVER_HOST in Demo/Secrets*.xcconfig.
+            return checkoutAPIVersion(from: ConfigurationConstants.serverUrl) ?? Constants.localCheckoutAPIVersion
         case .local:
-            return URL(string: "http://localhost:8080/pal/servlet/")!
+            return Constants.localCheckoutAPIVersion
         }
+    }
+
+    private func checkoutAPIVersion(from serverURL: String) -> Int? {
+        guard let match = serverURL.range(of: #"/checkout/v(\d+)"#, options: .regularExpression) else {
+            return nil
+        }
+
+        let versionComponent = serverURL[match].split(separator: "v").last
+        return versionComponent.flatMap { Int($0) }
     }
     
 }

--- a/Demo/Common/Networking/SessionRequest.swift
+++ b/Demo/Common/Networking/SessionRequest.swift
@@ -16,6 +16,8 @@ internal struct SessionRequest: APIRequest {
     
     internal let path = "sessions"
     
+    internal let payable: Bool
+    
     internal var counter: UInt = 0
     
     internal var method: HTTPMethod = .post
@@ -24,11 +26,16 @@ internal struct SessionRequest: APIRequest {
     
     internal var queryParameters: [URLQueryItem] = []
     
+    internal init(payable: Bool = true) {
+        self.payable = payable
+    }
+    
     internal func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         
         let currentConfiguration = ConfigurationConstants.current
         
+        try container.encode(payable, forKey: .payable)
         try container.encode(currentConfiguration.countryCode, forKey: .countryCode)
         try container.encode(Locale.current.identifier, forKey: .shopperLocale)
         try container.encode(ConfigurationConstants.shopperEmail, forKey: .shopperEmail)
@@ -57,7 +64,7 @@ internal struct SessionRequest: APIRequest {
         if ConfigurationConstants.current.cardSettings.showStorePaymentMethod {
             AdyenAssertion.assert(
                 message: "API version should be v70 or above to apply card component's store payment method field",
-                condition: ConfigurationConstants.current.apiVersion < 70
+                condition: ConfigurationConstants.demoServerEnvironment.version < 70
             )
             try container.encode("enabled", forKey: .storePaymentMethodMode)
             try container.encode(ConfigurationConstants.recurringProcessingModel, forKey: .recurringProcessingModel)
@@ -80,6 +87,7 @@ internal struct SessionRequest: APIRequest {
         case merchantAccount
         case amount
         case order
+        case payable
         case returnUrl
         case reference
         case shopperLocale
@@ -99,7 +107,54 @@ internal struct SessionRequest: APIRequest {
     
 }
 
-extension SessionResponse: @retroactive Response {}
+internal struct SessionPatchRequest: APIRequest {
+    
+    internal typealias ResponseType = SessionPatchResponse
+    
+    internal let sessionId: String
+    
+    internal let sessionData: String
+    
+    internal let amount: Amount
+    
+    internal let payable = true
+    
+    internal var path: String {
+        "sessions/\(sessionId)"
+    }
+    
+    internal var counter: UInt = 0
+    
+    internal var method: HTTPMethod = .patch
+    
+    internal var headers: [String: String] = [:]
+    
+    internal var queryParameters: [URLQueryItem] = []
+    
+    internal func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sessionData, forKey: .sessionData)
+        try container.encode(amount, forKey: .amount)
+        try container.encode(payable, forKey: .payable)
+    }
+    
+    internal enum CodingKeys: CodingKey {
+        case sessionData
+        case amount
+        case payable
+    }
+}
+
+extension SessionResponse: Response {}
+
+internal struct SessionPatchResponse: Response {
+    
+    internal let sessionData: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case sessionData
+    }
+}
 
 private struct AuthenticationData: Encodable {
     struct ThreeDSRequestData: Encodable {

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -111,6 +111,7 @@ internal struct CardSettings: Codable {
     internal var koreanAuthenticationVisibility: CardConfiguration.FieldVisibility = .auto
     internal var enableInstallments = false
     internal var showsInstallmentAmount = false
+    internal var onBeforeSubmitSuccessful = true
     
     internal enum AddressFormType: String, Codable, CaseIterable {
         case lookup
@@ -204,7 +205,8 @@ internal struct DemoAppSettings: Codable {
         socialSecurityNumberVisibility: .auto,
         koreanAuthenticationVisibility: .auto,
         enableInstallments: false,
-        showsInstallmentAmount: false
+        showsInstallmentAmount: false,
+        onBeforeSubmitSuccessful: true
     )
 
     internal static let defaultDropInSettings = DropInSettings(

--- a/Demo/Configuration.swift
+++ b/Demo/Configuration.swift
@@ -22,8 +22,6 @@ internal enum ConfigurationConstants {
     /// Please use your own web server between your app and adyen checkout API.
     static let demoServerEnvironment = DemoCheckoutAPIEnvironment.test
     
-    static let classicAPIEnvironment = DemoClassicAPIEnvironment.test
-    
     static let componentsEnvironment = Environment.test
     
     static let appName = "Adyen Demo"
@@ -111,7 +109,6 @@ internal struct CardSettings: Codable {
     internal var koreanAuthenticationVisibility: CardConfiguration.FieldVisibility = .auto
     internal var enableInstallments = false
     internal var showsInstallmentAmount = false
-    internal var onBeforeSubmitSuccessful = true
     
     internal enum AddressFormType: String, Codable, CaseIterable {
         case lookup
@@ -136,6 +133,13 @@ internal struct ApplePaySettings: Codable {
     internal var merchantIdentifier: String
     internal var allowOnboarding: Bool = false
     internal var didAuthorizeSuccessful: Bool = true
+    internal var onBeforeSubmitMode: OnBeforeSubmitMode = .updateData
+
+    internal enum OnBeforeSubmitMode: String, Codable, CaseIterable {
+        case updateData
+        case abort
+        case patchSession
+    }
 }
 
 internal struct AnalyticsSettings: Codable {
@@ -156,7 +160,6 @@ internal struct DemoAppSettings: Codable {
     internal var countryCode: String
     internal let value: Int
     internal var currencyCode: String
-    internal let apiVersion: Int
     internal let merchantAccount: String
     internal let cardSettings: CardSettings
     internal let dropInSettings: DropInSettings
@@ -186,7 +189,6 @@ internal struct DemoAppSettings: Codable {
         countryCode: "NL",
         value: 17408,
         currencyCode: "EUR",
-        apiVersion: 71,
         merchantAccount: ConfigurationConstants.merchantAccount,
         cardSettings: defaultCardSettings,
         dropInSettings: defaultDropInSettings,
@@ -205,8 +207,7 @@ internal struct DemoAppSettings: Codable {
         socialSecurityNumberVisibility: .auto,
         koreanAuthenticationVisibility: .auto,
         enableInstallments: false,
-        showsInstallmentAmount: false,
-        onBeforeSubmitSuccessful: true
+        showsInstallmentAmount: false
     )
 
     internal static let defaultDropInSettings = DropInSettings(
@@ -222,7 +223,8 @@ internal struct DemoAppSettings: Codable {
     internal static let defaultApplePaySettings = ApplePaySettings(
         merchantIdentifier: ConfigurationConstants.applePayMerchantIdentifier,
         allowOnboarding: false,
-        didAuthorizeSuccessful: true
+        didAuthorizeSuccessful: true,
+        onBeforeSubmitMode: .updateData
     )
 
     internal static let defaultAnalyticsSettings = AnalyticsSettings(isEnabled: true)

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -432,6 +432,50 @@ class SessionTests: XCTestCase {
         }
     }
 
+    func test_refreshSessionState_withSuccess_shouldReplaceState() async throws {
+        let apiClient = APIClientMock()
+        apiClient.mockedResults = [.success(SessionSetupResponse(
+            countryCode: "NL",
+            shopperLocale: "nl_NL",
+            paymentMethods: expectedPaymentMethods,
+            amount: .init(value: 500, currencyCode: "EUR"),
+            sessionData: "session_data_2",
+            configuration: .init(installmentOptions: nil, enableStoreDetails: false)
+        ))]
+        sut = initializeSession(expectedPaymentMethods: expectedPaymentMethods, apiClient: apiClient)
+
+        try await sut.refreshSessionState(with: "patched_session_data")
+
+        XCTAssertEqual(sut.state.data, "session_data_2")
+        XCTAssertEqual(sut.state.countryCode, "NL")
+        XCTAssertEqual(sut.state.shopperLocale, "nl_NL")
+        XCTAssertEqual(sut.state.amount, .init(value: 500, currencyCode: "EUR"))
+        XCTAssertFalse(sut.state.responseConfiguration.enableStoreDetails)
+    }
+
+    func test_refreshSessionState_withFailure_shouldNotMutateCurrentState() async {
+        let apiClient = APIClientMock()
+        apiClient.mockedResults = [.failure(Dummy.error)]
+        sut = initializeSession(expectedPaymentMethods: expectedPaymentMethods, apiClient: apiClient)
+
+        let previousState = sut.state
+
+        do {
+            try await sut.refreshSessionState(with: "patched_session_data")
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(error is Dummy)
+        }
+
+        XCTAssertEqual(sut.state.data, previousState.data)
+        XCTAssertEqual(sut.state.identifier, previousState.identifier)
+        XCTAssertEqual(sut.state.countryCode, previousState.countryCode)
+        XCTAssertEqual(sut.state.shopperLocale, previousState.shopperLocale)
+        XCTAssertEqual(sut.state.amount, previousState.amount)
+        XCTAssertEqual(sut.state.paymentMethods, previousState.paymentMethods)
+        XCTAssertEqual(sut.state.responseConfiguration.enableStoreDetails, previousState.responseConfiguration.enableStoreDetails)
+    }
+
     // MARK: - requestOrder
 
     func test_requestOrder_withSuccess_shouldReturnOrder() async throws {

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -432,48 +432,22 @@ class SessionTests: XCTestCase {
         }
     }
 
-    func test_refreshSessionState_withSuccess_shouldReplaceState() async throws {
+    func test_refreshSessionState_shouldOnlyUpdateSessionData() async throws {
         let apiClient = APIClientMock()
-        apiClient.mockedResults = [.success(SessionSetupResponse(
-            countryCode: "NL",
-            shopperLocale: "nl_NL",
-            paymentMethods: expectedPaymentMethods,
-            amount: .init(value: 500, currencyCode: "EUR"),
-            sessionData: "session_data_2",
-            configuration: .init(installmentOptions: nil, enableStoreDetails: false)
-        ))]
-        sut = initializeSession(expectedPaymentMethods: expectedPaymentMethods, apiClient: apiClient)
-
-        try await sut.refreshSessionState(with: "patched_session_data")
-
-        XCTAssertEqual(sut.state.data, "session_data_2")
-        XCTAssertEqual(sut.state.countryCode, "NL")
-        XCTAssertEqual(sut.state.shopperLocale, "nl_NL")
-        XCTAssertEqual(sut.state.amount, .init(value: 500, currencyCode: "EUR"))
-        XCTAssertFalse(sut.state.responseConfiguration.enableStoreDetails)
-    }
-
-    func test_refreshSessionState_withFailure_shouldNotMutateCurrentState() async {
-        let apiClient = APIClientMock()
-        apiClient.mockedResults = [.failure(Dummy.error)]
         sut = initializeSession(expectedPaymentMethods: expectedPaymentMethods, apiClient: apiClient)
 
         let previousState = sut.state
 
-        do {
-            try await sut.refreshSessionState(with: "patched_session_data")
-            XCTFail("Expected error to be thrown")
-        } catch {
-            XCTAssertTrue(error is Dummy)
-        }
+        try await sut.refreshSessionState(with: "patched_session_data")
 
-        XCTAssertEqual(sut.state.data, previousState.data)
+        XCTAssertEqual(sut.state.data, "patched_session_data")
         XCTAssertEqual(sut.state.identifier, previousState.identifier)
         XCTAssertEqual(sut.state.countryCode, previousState.countryCode)
         XCTAssertEqual(sut.state.shopperLocale, previousState.shopperLocale)
         XCTAssertEqual(sut.state.amount, previousState.amount)
         XCTAssertEqual(sut.state.paymentMethods, previousState.paymentMethods)
         XCTAssertEqual(sut.state.responseConfiguration.enableStoreDetails, previousState.responseConfiguration.enableStoreDetails)
+        XCTAssertEqual(apiClient.counter, 0)
     }
 
     // MARK: - requestOrder

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -247,9 +247,9 @@ final class CheckoutTests: XCTestCase {
         
         let modifiedName = ShopperName(firstName: "Modified", lastName: "Name")
         callbackStore.onBeforeSubmit = { data in
-            var modified = data
-            modified.shopperName = modifiedName
-            modified.shopperEmail = "modified@test.com"
+            let modified = data
+                .updating(shopperName: modifiedName)
+                .updating(shopperEmail: "modified@test.com")
             return .proceed(data: modified, sessionData: nil)
         }
         callbackStore.onComplete = { _ in
@@ -359,11 +359,15 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(original.deliveryAddress)
         
         let overrides = BeforeSubmitData(
-            billingAddress: PostalAddress(city: "Amsterdam", country: "NL"),
-            deliveryAddress: PostalAddress(city: "Berlin", country: "DE"),
-            shopperName: ShopperName(firstName: "John", lastName: "Doe"),
-            shopperEmail: "john@example.com"
+            billingAddress: nil,
+            deliveryAddress: nil,
+            shopperName: nil,
+            shopperEmail: nil
         )
+        .updating(billingAddress: PostalAddress(city: "Amsterdam", country: "NL"))
+        .updating(deliveryAddress: PostalAddress(city: "Berlin", country: "DE"))
+        .updating(shopperName: ShopperName(firstName: "John", lastName: "Doe"))
+        .updating(shopperEmail: "john@example.com")
         
         let updated = original.replacing(beforeSubmitData: overrides)
         

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -247,9 +247,9 @@ final class CheckoutTests: XCTestCase {
         
         let modifiedName = ShopperName(firstName: "Modified", lastName: "Name")
         callbackStore.onBeforeSubmit = { data in
-            var modified = data
-            modified.shopperName = modifiedName
-            modified.shopperEmail = "modified@test.com"
+            let modified = data
+                .replacing(shopperName: modifiedName)
+                .replacing(shopperEmail: "modified@test.com")
             return .proceed(data: modified, sessionData: nil)
         }
         callbackStore.onComplete = { _ in
@@ -359,11 +359,15 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(original.deliveryAddress)
         
         let overrides = BeforeSubmitData(
-            billingAddress: PostalAddress(city: "Amsterdam", country: "NL"),
-            deliveryAddress: PostalAddress(city: "Berlin", country: "DE"),
-            shopperName: ShopperName(firstName: "John", lastName: "Doe"),
-            shopperEmail: "john@example.com"
+            billingAddress: nil,
+            deliveryAddress: nil,
+            shopperName: nil,
+            shopperEmail: nil
         )
+        .replacing(billingAddress: PostalAddress(city: "Amsterdam", country: "NL"))
+        .replacing(deliveryAddress: PostalAddress(city: "Berlin", country: "DE"))
+        .replacing(shopperName: ShopperName(firstName: "John", lastName: "Doe"))
+        .replacing(shopperEmail: "john@example.com")
         
         let updated = original.replacing(beforeSubmitData: overrides)
         

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -345,7 +345,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertFalse(session.performSubmitCalled)
     }
     
-    func test_paymentComponentData_applying_shouldOverrideShopperFields() throws {
+    func test_paymentComponentData_replacingBeforeSubmitData_shouldOverrideShopperFields() throws {
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let original = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
@@ -365,7 +365,7 @@ final class CheckoutTests: XCTestCase {
             shopperEmail: "john@example.com"
         )
         
-        let updated = original.applying(overrides)
+        let updated = original.replacing(beforeSubmitData: overrides)
         
         XCTAssertEqual(updated.shopperName, ShopperName(firstName: "John", lastName: "Doe"))
         XCTAssertEqual(updated.emailAddress, "john@example.com")
@@ -811,7 +811,7 @@ final class CheckoutTests: XCTestCase {
             presentationDelegate: nil,
             resultCallbacks: callbackStore,
             callbackHandler: BeforeSubmitCallbackHandler(
-                inner: SessionCallbackHandler(session: session),
+                handler: SessionCallbackHandler(session: session),
                 session: session,
                 callbackStore: callbackStore
             )

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -208,6 +208,171 @@ final class CheckoutTests: XCTestCase {
         XCTAssertFalse(session.didSubmitCalled)
     }
     
+    // MARK: - onBeforeSubmit
+    
+    func test_didSubmit_withNoOnBeforeSubmit_shouldPerformSubmitDirectly() async throws {
+        let callbackStore = SessionCheckoutCallbackStore()
+        let onCompleteExpectation = expectation(description: "onComplete called")
+        let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
+        let paymentData = PaymentComponentData(
+            paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
+            amount: nil,
+            order: nil
+        )
+        let session = makeSessionMock()
+        session.performSubmitResult = .success(.completion(resultCode: CheckoutResultCode.authorised.rawValue))
+        callbackStore.onComplete = { _ in
+            onCompleteExpectation.fulfill()
+        }
+        let sut = makeSessionCheckoutCore(session: session, callbackStore: callbackStore)
+        
+        sut.didSubmit(paymentData, from: PaymentComponentMock(paymentMethod: blik))
+        await fulfillment(of: [onCompleteExpectation], timeout: 1)
+        
+        XCTAssertTrue(session.performSubmitCalled)
+        XCTAssertFalse(session.refreshSessionStateCalled)
+    }
+    
+    func test_didSubmit_withOnBeforeSubmitProceed_shouldApplyModifiedData() async throws {
+        let callbackStore = SessionCheckoutCallbackStore()
+        let onCompleteExpectation = expectation(description: "onComplete called")
+        let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
+        let paymentData = PaymentComponentData(
+            paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
+            amount: nil,
+            order: nil
+        )
+        let session = makeSessionMock()
+        session.performSubmitResult = .success(.completion(resultCode: CheckoutResultCode.authorised.rawValue))
+        
+        let modifiedName = ShopperName(firstName: "Modified", lastName: "Name")
+        callbackStore.onBeforeSubmit = { data in
+            var modified = data
+            modified.shopperName = modifiedName
+            modified.shopperEmail = "modified@test.com"
+            return .proceed(data: modified, sessionData: nil)
+        }
+        callbackStore.onComplete = { _ in
+            onCompleteExpectation.fulfill()
+        }
+        let sut = makeSessionCheckoutCore(session: session, callbackStore: callbackStore)
+        
+        sut.didSubmit(paymentData, from: PaymentComponentMock(paymentMethod: blik))
+        await fulfillment(of: [onCompleteExpectation], timeout: 1)
+        
+        XCTAssertTrue(session.performSubmitCalled)
+        XCTAssertFalse(session.refreshSessionStateCalled)
+    }
+    
+    func test_didSubmit_withOnBeforeSubmitProceedAndSessionData_shouldRefreshSession() async throws {
+        let callbackStore = SessionCheckoutCallbackStore()
+        let onCompleteExpectation = expectation(description: "onComplete called")
+        let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
+        let paymentData = PaymentComponentData(
+            paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
+            amount: nil,
+            order: nil
+        )
+        let session = makeSessionMock()
+        session.performSubmitResult = .success(.completion(resultCode: CheckoutResultCode.authorised.rawValue))
+        
+        callbackStore.onBeforeSubmit = { data in
+            .proceed(data: data, sessionData: "patched_session_data")
+        }
+        callbackStore.onComplete = { _ in
+            onCompleteExpectation.fulfill()
+        }
+        let sut = makeSessionCheckoutCore(session: session, callbackStore: callbackStore)
+        
+        sut.didSubmit(paymentData, from: PaymentComponentMock(paymentMethod: blik))
+        await fulfillment(of: [onCompleteExpectation], timeout: 1)
+        
+        XCTAssertTrue(session.refreshSessionStateCalled)
+        XCTAssertEqual(session.refreshSessionStateData, "patched_session_data")
+        XCTAssertTrue(session.performSubmitCalled)
+    }
+    
+    func test_didSubmit_withOnBeforeSubmitAbort_shouldStopLoadingAndNotCallOnError() async throws {
+        let callbackStore = SessionCheckoutCallbackStore()
+        let onErrorExpectation = expectation(description: "onError should NOT be called")
+        onErrorExpectation.isInverted = true
+        let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
+        let paymentData = PaymentComponentData(
+            paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
+            amount: nil,
+            order: nil
+        )
+        let session = makeSessionMock()
+        
+        callbackStore.onBeforeSubmit = { _ in
+            .abort
+        }
+        callbackStore.onError = { _ in
+            onErrorExpectation.fulfill()
+        }
+        let component = PresentableComponentMock(paymentMethod: blik, viewController: UIViewController())
+        let sut = makeSessionCheckoutCore(session: session, callbackStore: callbackStore)
+        
+        sut.didSubmit(paymentData, from: component)
+        await fulfillment(of: [onErrorExpectation], timeout: 0.5)
+        
+        XCTAssertTrue(component.stopLoadingCalled)
+        XCTAssertFalse(session.performSubmitCalled)
+    }
+    
+    func test_didSubmit_withOnBeforeSubmitThrowing_shouldCallOnError() async throws {
+        let callbackStore = SessionCheckoutCallbackStore()
+        let onErrorExpectation = expectation(description: "onError called")
+        let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
+        let paymentData = PaymentComponentData(
+            paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
+            amount: nil,
+            order: nil
+        )
+        let session = makeSessionMock()
+        
+        callbackStore.onBeforeSubmit = { _ in
+            throw TestError()
+        }
+        callbackStore.onError = { _ in
+            onErrorExpectation.fulfill()
+        }
+        let sut = makeSessionCheckoutCore(session: session, callbackStore: callbackStore)
+        
+        sut.didSubmit(paymentData, from: PaymentComponentMock(paymentMethod: blik))
+        await fulfillment(of: [onErrorExpectation], timeout: 1)
+        
+        XCTAssertFalse(session.performSubmitCalled)
+    }
+    
+    func test_paymentComponentData_applying_shouldOverrideShopperFields() throws {
+        let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
+        let original = PaymentComponentData(
+            paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
+            amount: nil,
+            order: nil
+        )
+        
+        XCTAssertNil(original.shopperName)
+        XCTAssertNil(original.emailAddress)
+        XCTAssertNil(original.billingAddress)
+        XCTAssertNil(original.deliveryAddress)
+        
+        let overrides = BeforeSubmitData(
+            billingAddress: PostalAddress(city: "Amsterdam", country: "NL"),
+            deliveryAddress: PostalAddress(city: "Berlin", country: "DE"),
+            shopperName: ShopperName(firstName: "John", lastName: "Doe"),
+            shopperEmail: "john@example.com"
+        )
+        
+        let updated = original.applying(overrides)
+        
+        XCTAssertEqual(updated.shopperName, ShopperName(firstName: "John", lastName: "Doe"))
+        XCTAssertEqual(updated.emailAddress, "john@example.com")
+        XCTAssertEqual(updated.billingAddress?.city, "Amsterdam")
+        XCTAssertEqual(updated.deliveryAddress?.city, "Berlin")
+    }
+    
     func test_didSubmit_callsOnSubmit_whenSet() async throws {
         let callbackStore = AdvancedCheckoutCallbackStore()
         let expectation = expectation(description: "onSubmit called")

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -645,7 +645,11 @@ final class CheckoutTests: XCTestCase {
             adyenContext: Dummy.context,
             presentationDelegate: nil,
             resultCallbacks: callbackStore,
-            callbackHandler: SessionCallbackHandler(session: session)
+            callbackHandler: BeforeSubmitCallbackHandler(
+                inner: SessionCallbackHandler(session: session),
+                session: session,
+                callbackStore: callbackStore
+            )
         )
     }
 

--- a/Tests/UnitTests/Core/AdyenSessionMock.swift
+++ b/Tests/UnitTests/Core/AdyenSessionMock.swift
@@ -34,6 +34,12 @@ public final class AdyenSessionMock: SessionProtocol {
         self.presentationDelegate = presentationDelegate
     }
     
+    var refreshSessionStateCalled = false
+    
+    public func refreshSessionState(with sessionData: String) async throws {
+        refreshSessionStateCalled = true
+    }
+    
     public func performSubmit(_ data: PaymentComponentData) async throws -> SubmitResult {
         performSubmitCalled = true
         guard let performSubmitResult else { throw AdyenSessionMockError.missingResult }

--- a/Tests/UnitTests/Core/AdyenSessionMock.swift
+++ b/Tests/UnitTests/Core/AdyenSessionMock.swift
@@ -35,9 +35,11 @@ public final class AdyenSessionMock: SessionProtocol {
     }
     
     var refreshSessionStateCalled = false
+    var refreshSessionStateData: String?
     
     public func refreshSessionState(with sessionData: String) async throws {
         refreshSessionStateCalled = true
+        refreshSessionStateData = sessionData
     }
     
     public func performSubmit(_ data: PaymentComponentData) async throws -> SubmitResult {


### PR DESCRIPTION
Introduces the `onBeforeSubmit` callback for the session flow, allowing merchants to get access to some of the payment data and modify them if needed while also giving them the opportunity to update the `amount` via patching the session (v72+) and returning a new sessionData.

- onBeforeSubmit public callback
- BeforeSubmitCallbackHandler with composition to handle its result.
- If aborted, reset component UI and don’t call onSubmit

## Ticket [Optional]
<ticket>
COSDK-907
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
