### PR TITLE
fix: Remove restored checkout callbacks from configuration

### DIFF
--- a/AdyenCheckout/CheckoutConfiguration/CheckoutConfiguration.swift
+++ b/AdyenCheckout/CheckoutConfiguration/CheckoutConfiguration.swift
@@ -38,14 +38,6 @@ public struct CheckoutConfiguration {
     // TODO: how we store configurations may change
     package var configurations: [CheckoutComponentType: CheckoutComponentConfiguration]
     
-    package var onSubmit: SubmitHandler?
-    
-    package var onAdditionalDetails: AdditionalDetailsHandler?
-    
-    package var onError: CheckoutErrorHandler?
-    
-    package var onComplete: CheckoutSuccessHandler?
-
     package var localizationProvider: (any CheckoutLocalizationProvider)?
     package var theme: CheckoutTheme
 


### PR DESCRIPTION
## Summary
- remove the callback stored properties that were mistakenly restored in `CheckoutConfiguration`
- keep the checkout-wide localization provider changes intact
- restore `CheckoutConfiguration.swift` to the expected post-callback-removal state
