### PR TITLE
Localization: Make checkout localizationProvider checkout-wide

### DIFF
--- a/Adyen/Core/Components/StoredPaymentMethodComponent.swift
+++ b/Adyen/Core/Components/StoredPaymentMethodComponent.swift
@@ -10,7 +10,7 @@ import UIKit
 // TODO: Fix Stored PM UI
 ///  A component that handle stored payment methods.
 @MainActor
-public final class StoredPaymentMethodComponent: StoredPaymentComponent {
+public final class StoredPaymentMethodComponent: StoredPaymentComponent, Localizable {
 
     package var localizationParameters: LocalizationParameters?
 

--- a/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewModel.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardInputView/StoredCardInputViewModel.swift
@@ -96,7 +96,7 @@ internal final class StoredCardInputViewModel: StoredCardInputViewModelProtocol 
     }()
 
     internal lazy var securityCodeItem: FormCardSecurityCodeItem = {
-        let item = FormCardSecurityCodeItem()
+        let item = FormCardSecurityCodeItem(localizationParameters: localizationParameters)
         item.identifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "securityCodeItem")
         return item
     }()

--- a/AdyenCheckout/CheckoutConfiguration/CheckoutConfiguration.swift
+++ b/AdyenCheckout/CheckoutConfiguration/CheckoutConfiguration.swift
@@ -134,6 +134,16 @@ public struct CheckoutConfiguration {
         configurations[.action(actionType)] as? T
     }
 
+    internal func resolvedLocalizationParameters(
+        merging base: LocalizationParameters? = nil
+    ) -> LocalizationParameters? {
+        guard let localizationProvider else {
+            return base
+        }
+
+        return (base ?? LocalizationParameters()).withProvider(localizationProvider)
+    }
+
     // TODO: Robert: Make public to private.
     // This public is not needed, but it currently supports providing
     // analyticsAPIContext in the Integration Examples.

--- a/AdyenCheckout/CheckoutConfiguration/CheckoutConfiguration.swift
+++ b/AdyenCheckout/CheckoutConfiguration/CheckoutConfiguration.swift
@@ -134,8 +134,13 @@ public struct CheckoutConfiguration {
         configurations[.action(actionType)] as? T
     }
 
-    internal func resolvedLocalizationParameters(
-        merging base: LocalizationParameters? = nil
+    /// Resolves runtime localization parameters from the checkout-wide provider only.
+    ///
+    /// Checkout flows do not define component-level localization-provider precedence.
+    /// Merchants configure provider-based overrides exclusively through
+    /// `CheckoutConfiguration.localizationProvider(...)`.
+    internal func resolvedCheckoutLocalizationParameters(
+        mergingExistingParameters base: LocalizationParameters? = nil
     ) -> LocalizationParameters? {
         guard let localizationProvider else {
             return base
@@ -180,6 +185,10 @@ extension CheckoutConfiguration {
     /// The provider is called for each string the SDK renders. Return a non-`nil` value
     /// to override the default, or return `nil` to let the SDK's standard localization
     /// fallback chain handle the key (app bundle → SDK bundle → English).
+    ///
+    /// In checkout flows, this is the only merchant-facing provider override. Checkout
+    /// resolves it into internal runtime localization parameters before constructing
+    /// payment and action components.
     ///
     /// - Note: To add support for a *completely new language*, place a `.strings` or
     ///   `.xcstrings` file with `adyen.*` keys in your app bundle instead of using this provider.

--- a/AdyenCheckout/Component/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/Component/CheckoutComponentBuilder.swift
@@ -81,24 +81,21 @@ internal enum CheckoutComponentBuilder {
         configuration: CheckoutConfiguration,
         context: AdyenContext
     ) -> PaymentComponent {
-        
-        // TODO: stored components requires no configuration
-        // (when new localization is implemented, see if this needs to updated
-        
         switch storedPaymentMethod {
-            
+
         #if canImport(AdyenCard)
             case let storedCard as StoredCardPaymentMethod:
-                StoredCardComponent(
-                    storedCardPaymentMethod: storedCard,
-                    context: context,
-                    theme: configuration.theme
+                return createStoredCardComponent(
+                    storedPaymentMethod: storedCard,
+                    configuration: configuration,
+                    context: context
                 )
         #endif
-            
+
         default:
-            StoredPaymentMethodComponent(
-                paymentMethod: storedPaymentMethod,
+            return createStoredPaymentMethodComponent(
+                storedPaymentMethod: storedPaymentMethod,
+                configuration: configuration,
                 context: context
             )
         }
@@ -129,13 +126,45 @@ internal enum CheckoutComponentBuilder {
 
         componentConfiguration.showsSubmitButton = configuration.showsSubmitButton
         componentConfiguration.theme = configuration.theme
-        // Component-level provider wins; fall back to the global one only if unset.
-        componentConfiguration.localizationProvider = componentConfiguration.localizationProvider ?? configuration.localizationProvider
+        componentConfiguration.localizationParameters = configuration.resolvedLocalizationParameters(
+            merging: componentConfiguration.localizationParameters
+        )
 
         return try factory.create(
             with: paymentMethod,
             context: context,
             configuration: componentConfiguration
         )
+    }
+
+    @MainActor
+    private static func createStoredCardComponent(
+        storedPaymentMethod: StoredCardPaymentMethod,
+        configuration: CheckoutConfiguration,
+        context: AdyenContext
+    ) -> PaymentComponent {
+        var component = StoredCardComponent(
+            storedCardPaymentMethod: storedPaymentMethod,
+            context: context,
+            theme: configuration.theme
+        )
+        component.localizationParameters = configuration.resolvedLocalizationParameters()
+
+        return component
+    }
+
+    @MainActor
+    private static func createStoredPaymentMethodComponent(
+        storedPaymentMethod: StoredPaymentMethod,
+        configuration: CheckoutConfiguration,
+        context: AdyenContext
+    ) -> PaymentComponent {
+        var component = StoredPaymentMethodComponent(
+            paymentMethod: storedPaymentMethod,
+            context: context
+        )
+        component.localizationParameters = configuration.resolvedLocalizationParameters()
+
+        return component
     }
 }

--- a/AdyenCheckout/Component/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/Component/CheckoutComponentBuilder.swift
@@ -126,8 +126,8 @@ internal enum CheckoutComponentBuilder {
 
         componentConfiguration.showsSubmitButton = configuration.showsSubmitButton
         componentConfiguration.theme = configuration.theme
-        componentConfiguration.localizationParameters = configuration.resolvedLocalizationParameters(
-            merging: componentConfiguration.localizationParameters
+        componentConfiguration.localizationParameters = configuration.resolvedCheckoutLocalizationParameters(
+            mergingExistingParameters: componentConfiguration.localizationParameters
         )
 
         return try factory.create(
@@ -148,7 +148,7 @@ internal enum CheckoutComponentBuilder {
             context: context,
             theme: configuration.theme
         )
-        component.localizationParameters = configuration.resolvedLocalizationParameters()
+        component.localizationParameters = configuration.resolvedCheckoutLocalizationParameters()
 
         return component
     }
@@ -163,7 +163,7 @@ internal enum CheckoutComponentBuilder {
             paymentMethod: storedPaymentMethod,
             context: context
         )
-        component.localizationParameters = configuration.resolvedLocalizationParameters()
+        component.localizationParameters = configuration.resolvedCheckoutLocalizationParameters()
 
         return component
     }

--- a/AdyenCheckout/Core/CheckoutCore.swift
+++ b/AdyenCheckout/Core/CheckoutCore.swift
@@ -51,12 +51,12 @@ package final class CheckoutCore: CheckoutCoreProtocol {
             for: .threeDS2,
             defaultValue: AuthenticationConfiguration(theme: configuration.theme)
         )
-        authenticationConfiguration.localizationParameters = configuration.resolvedLocalizationParameters(
-            merging: authenticationConfiguration.localizationParameters
+        authenticationConfiguration.localizationParameters = configuration.resolvedCheckoutLocalizationParameters(
+            mergingExistingParameters: authenticationConfiguration.localizationParameters
         )
 
         let actionConfig = CheckoutActionComponent.Configuration(
-            localizationParameters: configuration.resolvedLocalizationParameters(),
+            localizationParameters: configuration.resolvedCheckoutLocalizationParameters(),
             authentication: authenticationConfiguration,
             twint: configuration.configuration(for: .twint)
         )

--- a/AdyenCheckout/Core/CheckoutCore.swift
+++ b/AdyenCheckout/Core/CheckoutCore.swift
@@ -47,16 +47,18 @@ package final class CheckoutCore: CheckoutCoreProtocol {
     package let callbackHandler: any CheckoutCallbackHandling
 
     internal lazy var actionHandlingComponent: ActionHandlingComponent = {
-        let authenticationConfiguration: AuthenticationConfiguration = configuration.configuration(
+        var authenticationConfiguration: AuthenticationConfiguration = configuration.configuration(
             for: .threeDS2,
             defaultValue: AuthenticationConfiguration(theme: configuration.theme)
         )
-
-        let twintConfig: TwintActionConfiguration? = configuration.configuration(for: .twint)
+        authenticationConfiguration.localizationParameters = configuration.resolvedLocalizationParameters(
+            merging: authenticationConfiguration.localizationParameters
+        )
 
         let actionConfig = CheckoutActionComponent.Configuration(
+            localizationParameters: configuration.resolvedLocalizationParameters(),
             authentication: authenticationConfiguration,
-            twint: twintConfig
+            twint: configuration.configuration(for: .twint)
         )
 
         let handler = CheckoutActionComponent(

--- a/AdyenUI/CheckoutConfiguration/CheckoutConfigurable.swift
+++ b/AdyenUI/CheckoutConfiguration/CheckoutConfigurable.swift
@@ -18,8 +18,8 @@ package protocol CheckoutComponentConfiguration: CheckoutConfigurable {
     
     var showsSubmitButton: Bool { get set }
     
-    // These are here  to work with the current way,
-    // to be changed with new styling/localization
+    // Internal runtime localization state. Merchant-facing checkout flows configure
+    // localization through `CheckoutConfiguration.localizationProvider(...)`.
 
     var localizationParameters: LocalizationParameters? { get set }
 

--- a/AdyenUI/CheckoutConfiguration/CheckoutConfigurable.swift
+++ b/AdyenUI/CheckoutConfiguration/CheckoutConfigurable.swift
@@ -21,7 +21,7 @@ package protocol CheckoutComponentConfiguration: CheckoutConfigurable {
     // These are here  to work with the current way,
     // to be changed with new styling/localization
 
-    var localizationParameters: LocalizationParameters? { get }
+    var localizationParameters: LocalizationParameters? { get set }
 
     var localizationProvider: (any CheckoutLocalizationProvider)? { get set }
 

--- a/Tests/IntegrationTests/Card Tests/CardComponentLocalizationFlowTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentLocalizationFlowTests.swift
@@ -58,22 +58,6 @@ final class CardComponentLocalizationFlowTests: XCTestCase {
         )
     }
 
-    func test_cardComponent_builtFromCheckoutConfiguration_withComponentLevelProvider_shouldPreferComponentProviderForVisibleCardStrings() throws {
-        let globalProvider = CardComponentLocalizationFlowProviderMock(values: [.cardNumber: "Global number"])
-        let componentProvider = CardComponentLocalizationFlowProviderMock(values: [.cardNumber: "Component number"])
-
-        let sut = try makeSUT(
-            globalProvider: globalProvider,
-            componentProvider: componentProvider
-        )
-
-        expectVisibleTitles(
-            of: sut,
-            numberTitle: "Component number",
-            securityCodeTitle: localizedString(.cardCvcItemTitle, nil)
-        )
-    }
-
     func test_cardComponent_builtFromCheckoutConfiguration_withoutProvider_shouldUseSDKDefaultLocalization() throws {
         let sut = try makeSUT()
 
@@ -84,13 +68,23 @@ final class CardComponentLocalizationFlowTests: XCTestCase {
         )
     }
 
+    func test_cardComponent_builtFromCheckoutConfiguration_withGlobalProvider_shouldRenderCoBadgedSelectorStrings() throws {
+        let provider = CardComponentLocalizationFlowProviderMock(values: [
+            .cardDualBrandSelectorTitle: "Pick your card",
+            .cardDualBrandSelectorDescription: "Choose the brand for this payment"
+        ])
+
+        let sut = try makeSUT(globalProvider: provider)
+
+        XCTAssertEqual(sut.cardViewController.items.coBadgedCardItem.title, "Pick your card")
+        XCTAssertEqual(sut.cardViewController.items.coBadgedCardItem.subtitle, "Choose the brand for this payment")
+    }
+
     private func makeSUT(
         globalProvider: (any CheckoutLocalizationProvider)? = nil,
-        componentProvider: (any CheckoutLocalizationProvider)? = nil,
         localizationParameters: LocalizationParameters? = nil
     ) throws -> CardComponent {
         var cardConfiguration = CardConfiguration()
-        cardConfiguration.localizationProvider = componentProvider
         cardConfiguration.localizationParameters = localizationParameters
 
         var checkoutConfiguration = makeCheckoutConfiguration(

--- a/Tests/IntegrationTests/Card Tests/StoredCardInputViewModelTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardInputViewModelTests.swift
@@ -281,6 +281,18 @@ struct StoredCardInputViewModelTests {
         #expect(sut.submitButtonTitle == expectedSubmitButtonTitle)
     }
 
+    @Test
+    func securityCodeItem_usesProviderBackedLocalizationParameters() {
+        // Given
+        let localizationParameters = LocalizationParameters().withProvider(
+            StoredCardLocalizationProviderMock(values: [.cardSecurityCode: "Stored security code"])
+        )
+        let sut = makeSUT(localizationParameters: localizationParameters)
+
+        // Then
+        #expect(sut.securityCodeItem.title == "Stored security code")
+    }
+
     // MARK: - Helpers
 
     private func makeSUT(
@@ -315,6 +327,19 @@ struct StoredCardInputViewModelTests {
             localizationParameters: localizationParameters,
             cardBrand: brand
         )
+    }
+}
+
+private final class StoredCardLocalizationProviderMock: CheckoutLocalizationProvider {
+
+    private let values: [CheckoutLocalizationKey: String]
+
+    init(values: [CheckoutLocalizationKey: String]) {
+        self.values = values
+    }
+
+    func localizedString(_ key: CheckoutLocalizationKey, locale: Locale) -> String? {
+        values[key]
     }
 }
 

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -249,7 +249,7 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         XCTAssertEqual(component.paymentMethod.type, .blik)
     }
 
-    func test_cardComponent_withLocalizationProviderOnCheckoutConfiguration_shouldReceiveProvider() throws {
+    func test_cardComponent_withLocalizationProviderOnCheckoutConfiguration_shouldAttachProviderBackedLocalizationParameters() throws {
         // Given
         let paymentMethod = try XCTUnwrap(createCardPaymentMethod())
         let provider = CheckoutLocalizationProviderMock(result: "Localized card number")
@@ -267,15 +267,14 @@ final class CheckoutComponentBuilderTests: XCTestCase {
             XCTFail("Component should be CardComponent")
             return
         }
-        guard let localizationProvider = cardComponent.configuration.localizationProvider else {
-            XCTFail("Localization provider should be propagated to the card configuration")
+
+        guard let localizationParameters = cardComponent.configuration.localizationParameters else {
+            XCTFail("Localization parameters should be resolved on the card configuration")
             return
         }
 
-        let locale = Locale(identifier: "nl-NL")
-        XCTAssertEqual(localizationProvider.localizedString(CheckoutLocalizationKey.cardNumber, locale: locale), "Localized card number")
+        XCTAssertEqual(localizedString(.cardNumberItemTitle, localizationParameters), "Localized card number")
         XCTAssertEqual(provider.recordedCalls.count, 1)
-        XCTAssertEqual(provider.recordedCalls.first?.locale.identifier, locale.identifier)
         XCTAssertTrue(provider.recordedCalls.contains { $0.key == CheckoutLocalizationKey.cardNumber })
     }
 
@@ -298,31 +297,6 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         XCTAssertTrue(provider.recordedCalls.contains { $0.key == CheckoutLocalizationKey.cardNumber })
     }
 
-    func test_cardComponent_withComponentLevelLocalizationProvider_shouldOverrideCheckoutConfigurationProvider() throws {
-        // Given
-        let paymentMethod = try XCTUnwrap(createCardPaymentMethod())
-        let globalProvider = CheckoutLocalizationProviderMock(result: "Global number")
-        let componentProvider = CheckoutLocalizationProviderMock(result: "Component number")
-        var cardConfiguration = CardConfiguration()
-        cardConfiguration.localizationProvider = componentProvider
-        checkoutConfiguration = makeCheckoutConfiguration(
-            configurations: [.payment(.scheme): cardConfiguration]
-        ).localizationProvider(globalProvider)
-
-        // When
-        let component = try CheckoutComponentBuilder.build(
-            for: paymentMethod,
-            configuration: checkoutConfiguration,
-            context: context
-        )
-
-        // Then
-        let cardComponent = try XCTUnwrap(component as? CardComponent)
-        XCTAssertEqual(cardComponent.cardViewController.items.numberContainerItem.numberItem.title, "Component number")
-        XCTAssertTrue(componentProvider.recordedCalls.contains { $0.key == CheckoutLocalizationKey.cardNumber })
-        XCTAssertTrue(globalProvider.recordedCalls.isEmpty)
-    }
-    
     // MARK: - ACH Direct Debit Component Tests
 
     func test_build_withACHPaymentMethod_returnsACHComponent() throws {
@@ -402,6 +376,48 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         )
     }
 
+    func test_build_withCheckoutLocalizationProvider_resolvesLocalizationParametersForBLIKComponent() throws {
+        // Given
+        let paymentMethod = try XCTUnwrap(createBLIKPaymentMethod())
+        let provider = CheckoutLocalizationProviderMock(values: [.blikCode: "Custom BLIK code"])
+        checkoutConfiguration = makeCheckoutConfiguration().localizationProvider(provider)
+
+        // When
+        let component = try CheckoutComponentBuilder.build(
+            for: paymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+
+        // Then
+        let blikComponent = try XCTUnwrap(component as? BLIKComponent)
+        let localizationParameters = try XCTUnwrap(blikComponent.configuration.localizationParameters)
+        XCTAssertEqual(localizedString(.blikCode, localizationParameters), "Custom BLIK code")
+        XCTAssertTrue(provider.recordedCalls.contains { $0.key == .blikCode })
+    }
+
+    func test_build_withoutCheckoutLocalizationProvider_keepsExistingLocalizationParametersForBLIKComponent() throws {
+        // Given
+        let paymentMethod = try XCTUnwrap(createBLIKPaymentMethod())
+        let localizationParameters = LocalizationParameters(enforcedLocale: "it-IT")
+        var blikConfiguration = BLIKComponentConfiguration()
+        blikConfiguration.localizationParameters = localizationParameters
+        checkoutConfiguration = makeCheckoutConfiguration(
+            configurations: [.payment(.blik): blikConfiguration]
+        )
+
+        // When
+        let component = try CheckoutComponentBuilder.build(
+            for: paymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+
+        // Then
+        let blikComponent = try XCTUnwrap(component as? BLIKComponent)
+        XCTAssertEqual(blikComponent.configuration.localizationParameters, localizationParameters)
+    }
+
     // MARK: - Stored Payment Method Tests
     
     func test_build_withStoredCardPaymentMethod_returnsStoredCardComponent() throws {
@@ -443,6 +459,26 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         XCTAssertEqual(component.context.amount?.value, 1000)
         XCTAssertEqual(component.context.amount?.currencyCode, "EUR")
     }
+
+    func test_build_withStoredCardPaymentMethod_resolvesLocalizationParametersFromCheckoutConfiguration() throws {
+        // Given
+        let storedPaymentMethod = try XCTUnwrap(createStoredCardPaymentMethod())
+        let provider = CheckoutLocalizationProviderMock(values: [.cardSecurityCode: "Stored security code"])
+        checkoutConfiguration = makeCheckoutConfiguration().localizationProvider(provider)
+
+        // When
+        let component = CheckoutComponentBuilder.build(
+            for: storedPaymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+
+        // Then
+        let storedCardComponent = try XCTUnwrap(component as? StoredCardComponent)
+        let localizationParameters = try XCTUnwrap(storedCardComponent.localizationParameters)
+        XCTAssertEqual(localizedString(.cardCvcItemTitle, localizationParameters), "Stored security code")
+        XCTAssertTrue(provider.recordedCalls.contains { $0.key == .cardSecurityCode })
+    }
     
     func test_build_withGenericStoredPaymentMethod_returnsStoredPaymentMethodComponent() throws {
         // Given
@@ -458,6 +494,26 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         // Then
         XCTAssertEqual(component.paymentMethod.type, .payPal)
         XCTAssertTrue(component is StoredPaymentMethodComponent, "Component should be StoredPaymentMethodComponent")
+    }
+
+    func test_build_withGenericStoredPaymentMethod_resolvesLocalizationParametersFromCheckoutConfiguration() throws {
+        // Given
+        let storedPaymentMethod = try XCTUnwrap(createStoredPayPalPaymentMethod())
+        let provider = CheckoutLocalizationProviderMock(values: [.generalCancel: "Cancel payment"])
+        checkoutConfiguration = makeCheckoutConfiguration().localizationProvider(provider)
+
+        // When
+        let component = CheckoutComponentBuilder.build(
+            for: storedPaymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+
+        // Then
+        let storedPaymentMethodComponent = try XCTUnwrap(component as? StoredPaymentMethodComponent)
+        let localizationParameters = try XCTUnwrap(storedPaymentMethodComponent.localizationParameters)
+        XCTAssertEqual(localizedString(.cancelButton, localizationParameters), "Cancel payment")
+        XCTAssertTrue(provider.recordedCalls.contains { $0.key == .generalCancel })
     }
     
     func test_build_withStoredBCMCPaymentMethod_returnsStoredPaymentMethodComponent() throws {
@@ -616,14 +672,18 @@ final class CheckoutComponentBuilderTests: XCTestCase {
 private final class CheckoutLocalizationProviderMock: CheckoutLocalizationProvider {
     private(set) var recordedCalls: [(locale: Locale, key: CheckoutLocalizationKey)] = []
 
-    private let result: String?
+    private let values: [CheckoutLocalizationKey: String]
 
     init(result: String? = nil) {
-        self.result = result
+        self.values = result.map { [.cardNumber: $0] } ?? [:]
+    }
+
+    init(values: [CheckoutLocalizationKey: String]) {
+        self.values = values
     }
 
     func localizedString(_ key: CheckoutLocalizationKey, locale: Locale) -> String? {
         recordedCalls.append((locale, key))
-        return result
+        return values[key]
     }
 }

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -47,6 +47,25 @@ final class CheckoutTests: XCTestCase {
         paymentMethods = try! AdyenCoder.decode(paymentMethodsDictionary) as PaymentMethods
     }
 
+    func test_actionHandlingComponent_withCheckoutLocalizationProvider_shouldResolveLocalizationParametersForActionAndAuthenticationConfigurations() throws {
+        // Given
+        let provider = CheckoutLocalizationProviderMock(values: [
+            .awaitLoading: "Await custom",
+            .cardNumber: "Card number"
+        ])
+        configuration = configuration.localizationProvider(provider)
+        let sut = makeActionOnlyCheckoutCore()
+
+        // When
+        let actionComponent = try XCTUnwrap(sut.actionHandlingComponent as? CheckoutActionComponent)
+
+        // Then
+        let actionLocalizationParameters = try XCTUnwrap(actionComponent.configuration.localizationParameters)
+        let authenticationLocalizationParameters = try XCTUnwrap(actionComponent.configuration.authentication.localizationParameters)
+        XCTAssertEqual(localizedString(.awaitWaitForConfirmation, actionLocalizationParameters), "Await custom")
+        XCTAssertEqual(localizedString(.cardNumberItemTitle, authenticationLocalizationParameters), "Card number")
+    }
+
     func testSetupWithSession_Success() async throws {
         let expectedSession = AdyenSessionMock(state: .init(
             data: "test_session_data",
@@ -867,4 +886,17 @@ struct TestError: Error {}
 private final class ActionComponentMock: ActionComponent {
     var context: AdyenContext = Dummy.context
     var delegate: ActionComponentDelegate?
+}
+
+private final class CheckoutLocalizationProviderMock: CheckoutLocalizationProvider {
+
+    private let values: [CheckoutLocalizationKey: String]
+
+    init(values: [CheckoutLocalizationKey: String]) {
+        self.values = values
+    }
+
+    func localizedString(_ key: CheckoutLocalizationKey, locale: Locale) -> String? {
+        values[key]
+    }
 }


### PR DESCRIPTION
# Summary
This PR makes `CheckoutConfiguration.localizationProvider(...)` checkout-wide by resolving provider-backed localization parameters for checkout-built payment, stored-payment, and action flows. It also adds focused regression coverage for stored card, BLIK, action, and co-badged selector localization.

## Technical Information 
- resolve checkout-level provider overrides through `CheckoutConfiguration.resolvedLocalizationParameters(merging:)`
- keep stored and action wiring explicit and aligned with current checkout flows

## Ticket 
<ticket>
COSDK-1240
</ticket>

## Checklist [Required]
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
