### PR TITLE
PaymentMethodList - Wrap presented components in navigation controller with close button

### DIFF
--- a/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListRouter.swift
+++ b/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListRouter.swift
@@ -103,16 +103,21 @@ internal class PaymentMethodListRouter: Router, PaymentMethodListRouting {
         let componentContainerViewController = componentContainerViewController(for: component)
         setupCloseButton(controller: componentContainerViewController)
         let modalNavigationController = UINavigationController(rootViewController: componentContainerViewController)
-        viewController.present(modalNavigationController, animated: true)
+        navigationController.present(modalNavigationController, animated: true)
     }
 
     private func setupCloseButton(controller: UIViewController) {
-        let closeButton = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(closeTappedOnComponentContainerViewController))
+        let closeButton = UIBarButtonItem(
+            barButtonSystemItem: .close,
+            target: self,
+            action: #selector(closeTappedOnComponentContainerViewController)
+        )
         controller.navigationItem.leftBarButtonItem = closeButton
     }
 
     @objc private func closeTappedOnComponentContainerViewController() {
-        viewController.dismiss(animated: true)
+        navigationController.dismiss(animated: true)
+        childRouter = nil
     }
 
     private func componentContainerViewController(

--- a/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListRouter.swift
+++ b/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListRouter.swift
@@ -103,7 +103,7 @@ internal class PaymentMethodListRouter: Router, PaymentMethodListRouting {
         let componentContainerViewController = componentContainerViewController(for: component)
         setupCloseButton(controller: componentContainerViewController)
         let modalNavigationController = UINavigationController(rootViewController: componentContainerViewController)
-        navigationController.present(modalNavigationController, animated: true)
+        rootViewController.present(modalNavigationController, animated: true)
     }
 
     private func setupCloseButton(controller: UIViewController) {
@@ -116,7 +116,7 @@ internal class PaymentMethodListRouter: Router, PaymentMethodListRouting {
     }
 
     @objc private func closeTappedOnComponentContainerViewController() {
-        navigationController.dismiss(animated: true)
+        rootViewController.dismiss(animated: true)
         childRouter = nil
     }
 

--- a/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListRouter.swift
+++ b/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListRouter.swift
@@ -101,7 +101,18 @@ internal class PaymentMethodListRouter: Router, PaymentMethodListRouting {
         with component: PresentableComponent
     ) {
         let componentContainerViewController = componentContainerViewController(for: component)
-        rootViewController.present(componentContainerViewController, animated: true)
+        setupCloseButton(controller: componentContainerViewController)
+        let modalNavigationController = UINavigationController(rootViewController: componentContainerViewController)
+        viewController.present(modalNavigationController, animated: true)
+    }
+
+    private func setupCloseButton(controller: UIViewController) {
+        let closeButton = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(closeTappedOnComponentContainerViewController))
+        controller.navigationItem.leftBarButtonItem = closeButton
+    }
+
+    @objc private func closeTappedOnComponentContainerViewController() {
+        viewController.dismiss(animated: true)
     }
 
     private func componentContainerViewController(


### PR DESCRIPTION
# Summary [Required]
PaymentMethodList - Wrap presented components in navigation controller with close button. 
- Even though this issue is not part of the v6 alpha scope. This part is one of the consumers of the StoredCardInputView. Wanted to get this out of the way. 

# Demo [Required for UI changes]
<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-03 at 10 54 58" src="https://github.com/user-attachments/assets/6b30cc48-dcab-4db8-b6cd-01232089eff6" />


## Checklist [Required]
- [x] Tested changes locally
- [x] Verified against acceptance criteria
