### PR TITLE
Add MOCKING.md and improve TESTING.md

### DIFF
--- a/MOCKING.md
+++ b/MOCKING.md
@@ -1,12 +1,8 @@
 # Mocking Guide
 
-This file provides guidance for generating and using mocks in the Adyen iOS SDK.
+The project uses [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to auto-generate mock implementations from protocols.
 
-## Generating Mocks with Sourcery
-
-The project uses [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to auto-generate mock implementations from protocols. Generated mocks are output to `Tests/GeneratedMocks/`.
-
-### Running the Generator
+## Running the Generator
 
 Build the `GenerateSourcery` scheme to regenerate mocks:
 
@@ -14,47 +10,8 @@ Build the `GenerateSourcery` scheme to regenerate mocks:
 xcodebuild -project Adyen.xcodeproj -scheme GenerateSourcery build
 ```
 
-### Marking Protocols as AutoMockable
+## Adding a New Mock
 
-Add the `// sourcery: AutoMockable` annotation above any protocol to generate a mock:
+Add `// sourcery: AutoMockable` above any protocol (see [`StoredCardInputViewModelProtocol`](AdyenCard/Components/Stored%20Card/StoredCardInputView/StoredCardInputViewModel.swift) for an example).
 
-```swift
-// sourcery: AutoMockable
-protocol MyProtocol {
-    func doSomething()
-}
-```
-
-After running the generator, a `MyProtocolMock` class will be created in `Tests/GeneratedMocks/`.
-
-### Generated Mock Features
-
-Each generated mock includes:
-- **Call tracking**: `<methodName>CallsCount`, `<methodName>Called`
-- **Argument capture**: `<methodName>ReceivedArguments`, `<methodName>ReceivedInvocations`
-- **Return value stubbing**: `<methodName>ReturnValue`
-- **Closure injection**: `<methodName>Closure` for custom behavior
-- **Error stubbing**: `<methodName>ThrowableError` for throwing methods
-
-### Example Usage
-
-```swift
-// Given a protocol:
-// sourcery: AutoMockable
-protocol PaymentHandler {
-    func process(payment: Payment) throws -> Result
-}
-
-// The generated mock can be used as:
-let mock = PaymentHandlerMock()
-mock.processPaymentReturnValue = .success
-
-let result = try sut.handle(with: mock)
-
-XCTAssertTrue(mock.processPaymentCalled)
-XCTAssertEqual(mock.processPaymentReceivedPayment?.amount, expectedAmount)
-```
-
-### Configuration
-
-Sourcery configuration is located at `Tools/Sourcery/.sourcery.yml`. The template (`AutoMockable.stencil`) automatically adds `@testable import` for the SDK modules (including `Adyen`, `AdyenCard`, `AdyenCheckout`, `AdyenDropIn`, and `AdyenUI`).
+Generated mocks are output to [`Tests/GeneratedMocks/`](Tests/GeneratedMocks/). Configuration: [`Tools/Sourcery/.sourcery.yml`](Tools/Sourcery/.sourcery.yml).

--- a/MOCKING.md
+++ b/MOCKING.md
@@ -57,4 +57,4 @@ XCTAssertEqual(mock.processPaymentReceivedPayment?.amount, expectedAmount)
 
 ### Configuration
 
-Sourcery configuration is located at `Tools/Sourcery/.sourcery.yml`. The template (`AutoMockable.stencil`) automatically adds `@testable import` for `Adyen` and `AdyenDropIn` modules.
+Sourcery configuration is located at `Tools/Sourcery/.sourcery.yml`. The template (`AutoMockable.stencil`) automatically adds `@testable import` for the SDK modules (including `Adyen`, `AdyenCard`, `AdyenCheckout`, `AdyenDropIn`, and `AdyenUI`).

--- a/MOCKING.md
+++ b/MOCKING.md
@@ -1,0 +1,60 @@
+# Mocking Guide
+
+This file provides guidance for generating and using mocks in the Adyen iOS SDK.
+
+## Generating Mocks with Sourcery
+
+The project uses [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to auto-generate mock implementations from protocols. Generated mocks are output to `Tests/GeneratedMocks/`.
+
+### Running the Generator
+
+Build the `GenerateSourcery` target to regenerate mocks:
+
+```bash
+xcodebuild -project Adyen.xcodeproj -scheme GenerateSourcery build
+```
+
+### Marking Protocols as AutoMockable
+
+Add the `// sourcery: AutoMockable` annotation above any protocol to generate a mock:
+
+```swift
+// sourcery: AutoMockable
+protocol MyProtocol {
+    func doSomething()
+}
+```
+
+After running the generator, a `MyProtocolMock` class will be created in `Tests/GeneratedMocks/`.
+
+### Generated Mock Features
+
+Each generated mock includes:
+- **Call tracking**: `<methodName>CallsCount`, `<methodName>Called`
+- **Argument capture**: `<methodName>ReceivedArguments`, `<methodName>ReceivedInvocations`
+- **Return value stubbing**: `<methodName>ReturnValue`
+- **Closure injection**: `<methodName>Closure` for custom behavior
+- **Error stubbing**: `<methodName>ThrowableError` for throwing methods
+
+### Example Usage
+
+```swift
+// Given a protocol:
+// sourcery: AutoMockable
+protocol PaymentHandler {
+    func process(payment: Payment) throws -> Result
+}
+
+// The generated mock can be used as:
+let mock = PaymentHandlerMock()
+mock.processPaymentReturnValue = .success
+
+let result = try sut.handle(with: mock)
+
+XCTAssertTrue(mock.processPaymentCalled)
+XCTAssertEqual(mock.processPaymentReceivedPayment?.amount, expectedAmount)
+```
+
+### Configuration
+
+Sourcery configuration is located at `Tools/Sourcery/.sourcery.yml`. The template (`AutoMockable.stencil`) automatically adds `@testable import` for `Adyen` and `AdyenDropIn` modules.

--- a/MOCKING.md
+++ b/MOCKING.md
@@ -8,7 +8,7 @@ The project uses [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to au
 
 ### Running the Generator
 
-Build the `GenerateSourcery` target to regenerate mocks:
+Build the `GenerateSourcery` scheme to regenerate mocks:
 
 ```bash
 xcodebuild -project Adyen.xcodeproj -scheme GenerateSourcery build

--- a/TESTING.md
+++ b/TESTING.md
@@ -326,4 +326,4 @@ This helper method pattern makes tests **~70% more concise** while maintaining c
 
 ## Mocking
 
-For guidance on generating and using mocks with Sourcery, see [MOCKING.md](MOCKING.md).
+When testing tasks require creating/updating a mock, refer to [MOCKING.md](MOCKING.md) for details.

--- a/TESTING.md
+++ b/TESTING.md
@@ -172,6 +172,14 @@ func test_submit_withValidPaymentData_shouldSucceed()
 
 ## Running Tests
 
+### Default Test Scheme
+
+**Use the `UnitTests` scheme** for running tests. This is the primary test target located at `Tests/UnitTests/`.
+
+Other test schemes (`IntegrationUIKitTests`, `SnapshotTests`) are available but consume more resources and are typically run in CI or when specifically needed.
+
+### Simulator Setup
+
 **List available simulators:**
 ```bash
 xcrun simctl list devices available
@@ -179,26 +187,19 @@ xcrun simctl list devices available
 
 Choose an available simulator name from the output (e.g., "iPhone 15 Pro", "iPhone 16", etc.) and use it in the commands below by replacing `<SIMULATOR_NAME>`.
 
-**Run unit tests:**
+### Running Tests
+
+**Run all unit tests:**
 ```bash
-# Option 1: Use a standard iPhone simulator (recommended)
 xcodebuild test -project Adyen.xcodeproj -scheme UnitTests -destination 'platform=iOS Simulator,name=<SIMULATOR_NAME>'
-
-# Option 2: Use specific device by ID (most reliable)
-xcodebuild test -project Adyen.xcodeproj -scheme UnitTests -destination 'platform=iOS Simulator,id=<DEVICE_ID>'
 ```
 
-**Run integration tests:**
-```bash
-xcodebuild test -project Adyen.xcodeproj -scheme IntegrationUIKitTests -destination 'platform=iOS Simulator,name=<SIMULATOR_NAME>'
-```
-
-**Run single test:**
+**Run a single test:**
 ```bash
 xcodebuild test -project Adyen.xcodeproj -scheme UnitTests -destination 'platform=iOS Simulator,name=<SIMULATOR_NAME>' -only-testing:UnitTests/TestClassName/testMethodName
 ```
 
-**Note:** Do not use `swift test` - it doesn't work well with the Xcode project structure. The `SnapshotTests` target is primarily for CI and not typically run during local development.
+**Note:** Do not use `swift test` - it doesn't work well with the Xcode project structure.
 
 ## Testing Form Views
 
@@ -322,3 +323,7 @@ private func getContainerView(from sut: FormTextItemView<FormTextInputItem>) -> 
 ### Benefits
 
 This helper method pattern makes tests **~70% more concise** while maintaining clarity and proper error reporting. Tests read like specifications rather than imperative code.
+
+## Mocking
+
+For guidance on generating and using mocks with Sourcery, see [MOCKING.md](MOCKING.md).


### PR DESCRIPTION
## Summary

- **New [MOCKING.md](cci:7://file:///Users/naufal/Documents/Adyen/adyen-checkout-sdk-meta/sdks/adyen-ios/MOCKING.md:0:0-0:0)**: Documents Sourcery mock generation via `GenerateSourcery` scheme, `// sourcery: AutoMockable` annotation, and generated mock features
- **Updated [TESTING.md](cci:7://file:///Users/naufal/Documents/Adyen/adyen-checkout-sdk-meta/sdks/adyen-ios/TESTING.md:0:0-0:0)**: Simplified to focus on `UnitTests` as the default test scheme; references [MOCKING.md](cci:7://file:///Users/naufal/Documents/Adyen/adyen-checkout-sdk-meta/sdks/adyen-ios/MOCKING.md:0:0-0:0) for mock guidance

## Why

- Clear guidance on default test target (`UnitTests`) for developers and LLM agents
- Reduces overhead by not recommending `IntegrationUIKitTests` by default