### PR TITLE
[v6] (3/5) Non-UI components: Implement `submit` in `StoredCardComponent`

### DIFF
--- a/AdyenCard/Components/Stored Card/StoredCardComponent.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardComponent.swift
@@ -16,22 +16,20 @@ import UIKit
 @MainActor
 package final class StoredCardComponent: StoredPaymentComponent, Localizable {
 
-    /// The context object for this component.
+    // MARK: - Properties
+
     package let context: AdyenContext
-    
-    /// The card payment method.
     package var paymentMethod: PaymentMethod {
         storedCardPaymentMethod
     }
-    
-    /// The delegate of the component.
-    package weak var delegate: PaymentComponentDelegate?
-    
-    package var localizationParameters: LocalizationParameters?
-        
-    private let storedCardPaymentMethod: StoredCardPaymentMethod
 
+    package weak var delegate: PaymentComponentDelegate?
+    package var localizationParameters: LocalizationParameters?
+
+    private let storedCardPaymentMethod: StoredCardPaymentMethod
     private let theme: CheckoutTheme
+
+    // MARK: - Initializers
 
     package init(
         storedCardPaymentMethod: StoredCardPaymentMethod,
@@ -42,8 +40,8 @@ package final class StoredCardComponent: StoredPaymentComponent, Localizable {
         self.context = context
         self.theme = theme
     }
-    
-    package lazy var viewController: UIViewController = {
+
+    private lazy var viewModel: StoredCardInputViewModel = {
         let viewModel = StoredCardInputViewModel(
             theme: theme,
             storedCardPaymentMethod: storedCardPaymentMethod,
@@ -54,34 +52,38 @@ package final class StoredCardComponent: StoredPaymentComponent, Localizable {
             localizationParameters: localizationParameters,
             cardBrand: storedCardPaymentMethod.brand
         )
+        viewModel.cardDetailsCompletionHandler = makeCompletionHandler()
+        return viewModel
+    }()
 
-        viewModel.cardDetailsCompletionHandler = { [weak self] result in
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                switch result {
-                case let .success(details):
-                    self.submit(
-                        data: PaymentComponentData(
-                            paymentMethodDetails: details,
-                            amount: context.amount,
-                            order: order
-                        )
-                    )
-                case let .failure(error):
-                    delegate?.didFail(with: error, from: self)
-                }
-            }
-        }
-
-        self.sendInitialAnalytics()
-
+    package lazy var viewController: UIViewController = {
+        sendInitialAnalytics()
         return StoredCardInputViewController(viewModel: viewModel)
     }()
 
     package func submit() {
-        // TODO: - Naufal: Implement submit logic in  StoredCardComponent
+        Task { await viewModel.submit() }
+    }
+
+    // MARK: - Private
+
+    private func makeCompletionHandler() -> (Result<CardDetails, Error>) -> Void {
+        { [weak self] result in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                switch result {
+                case let .success(details):
+                    self.submit(data: PaymentComponentData(
+                        paymentMethodDetails: details,
+                        amount: self.context.amount,
+                        order: self.order
+                    ))
+                case let .failure(error):
+                    self.delegate?.didFail(with: error, from: self)
+                }
+            }
+        }
     }
 }
 
-/// :nodoc:
 extension StoredCardComponent: TrackableComponent {}

--- a/AdyenCard/Components/Stored Card/StoredCardComponent.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardComponent.swift
@@ -62,7 +62,9 @@ package final class StoredCardComponent: StoredPaymentComponent, Localizable {
     }()
 
     package func submit() {
-        Task { await viewModel.submit() }
+        Task { [weak self] in
+            await self?.viewModel.submit()
+        }
     }
 
     // MARK: - Private

--- a/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
@@ -64,6 +64,36 @@ class StoredCardComponentTests: XCTestCase {
         XCTAssertFalse(proxy.isPayButtonEnabled)
     }
 
+    func testSubmitShouldCallPaymentDelegateDidSubmit() throws {
+        // Given
+        let sut = makeSUT()
+        let proxy = StoredCardComponentProxy(component: sut, testCase: self)
+        let delegate = PaymentComponentDelegateMock()
+        sut.delegate = delegate
+
+        let submitExpectation = expectation(description: "Expect didSubmit to be called")
+        delegate.onDidSubmit = { _, _ in submitExpectation.fulfill() }
+        delegate.onDidFail = { _, _ in XCTFail("didFail should not be called") }
+
+        proxy.present()
+        proxy.enterText("737")
+
+        // When
+        sut.submit()
+
+        // Then
+        waitForExpectations(timeout: 1)
+
+        let args = try XCTUnwrap(delegate.didSubmitReceivedArguments)
+        XCTAssertTrue(args.component === sut)
+
+        let cardDetails = try XCTUnwrap(args.data.paymentMethod as? CardDetails)
+        XCTAssertNotNil(cardDetails.encryptedSecurityCode)
+        XCTAssertNil(cardDetails.encryptedCardNumber)
+        XCTAssertNil(cardDetails.encryptedExpiryYear)
+        XCTAssertNil(cardDetails.encryptedExpiryMonth)
+    }
+
     /// Verifies that encryption failure with an invalid public key calls didFail on the delegate.
     func testPaymentSubmitWithInvalidPublicKey() throws {
         // Given


### PR DESCRIPTION
# Summary

This PR adds the `submit` implementation to `StoredCardComponent`:
- **Extract completion handler:** Moved the `cardDetailsCompletionHandler` closure out of init into a dedicated `makeCompletionHandler()` method to reduce initializer complexity.
- **Defer side-effectful work to lazy properties:** Init now only assigns stored properties; ViewModel setup is deferred to its lazy declaration.
- Implement submit(): Invoke the `submit` function within the ViewModel

## Ticket
<ticket>
COSDK-1103
</ticket>

## Checklist
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
