### PR TITLE
public types to package / @_spi(AdyenInternal) (4/4)

### DIFF
--- a/Adyen/Core/Components/AnyCashAppPayConfiguration.swift
+++ b/Adyen/Core/Components/AnyCashAppPayConfiguration.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Describes any configuration for the Cash App Pay component.
-public protocol AnyCashAppPayConfiguration {
+package protocol AnyCashAppPayConfiguration {
 
     /// The URL for Cash App to call in order to redirect back to your application.
     var redirectURL: URL { get }

--- a/Adyen/Core/Components/Base/PartialPaymentError.swift
+++ b/Adyen/Core/Components/Base/PartialPaymentError.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Indicates a partial payment related errors.
-public enum PartialPaymentError: LocalizedError {
+package enum PartialPaymentError: LocalizedError {
 
     /// Indicates that there is zero remaining amount to be paid.
     case zeroRemainingAmount
@@ -18,7 +18,7 @@ public enum PartialPaymentError: LocalizedError {
     /// Indicates that the partial payment flow is not supported with the current component.
     case notSupportedForComponent
 
-    public var errorDescription: String? {
+    package var errorDescription: String? {
         switch self {
         case .zeroRemainingAmount:
             return "There is no remaining amount to be paid."

--- a/Adyen/Core/Core Protocols/DeviceDependent.swift
+++ b/Adyen/Core/Core Protocols/DeviceDependent.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Represents any structure/object whose behavior is device dependent.
-public protocol DeviceDependent {
+package protocol DeviceDependent {
     
     /// Decides whether current device is supported.
     static func isDeviceSupported() -> Bool

--- a/Adyen/Core/Core Protocols/LoadingComponent.swift
+++ b/Adyen/Core/Core Protocols/LoadingComponent.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Any `Component` that show a loading state of some kind
-public protocol LoadingComponent {
+package protocol LoadingComponent {
     /// Stops any processing animation that the view controller is running.
     ///
     func stopLoading()

--- a/Adyen/Core/Core Protocols/PaymentAwareComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentAwareComponent.swift
@@ -7,17 +7,16 @@
 import Foundation
 
 /// Any component with a partial payment property.
-public protocol PartialPaymentOrderAware {
+package protocol PartialPaymentOrderAware {
 
     /// The partial payment order if any.
     var order: PartialPaymentOrder? { get set }
 
 }
 
-@_spi(AdyenInternal)
 extension PartialPaymentOrderAware {
 
-    public var order: PartialPaymentOrder? {
+    package var order: PartialPaymentOrder? {
         get {
             objc_getAssociatedObject(self, &AssociatedKeys.order) as? PartialPaymentOrder
         }

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Any Object that is aware of a `PaymentMethod`.
-public protocol PaymentMethodAware {
+package protocol PaymentMethodAware {
 
     /// The payment method for which to gather payment details.
     var paymentMethod: PaymentMethod { get }

--- a/Adyen/Core/Core Protocols/PaymentMethod.swift
+++ b/Adyen/Core/Core Protocols/PaymentMethod.swift
@@ -58,8 +58,7 @@ public protocol StoredPaymentMethod: PaymentMethod {
     
 }
 
-@_spi(AdyenInternal)
-public func == (lhs: StoredPaymentMethod, rhs: StoredPaymentMethod) -> Bool {
+package func == (lhs: StoredPaymentMethod, rhs: StoredPaymentMethod) -> Bool {
     lhs.type == rhs.type &&
         lhs.name == rhs.name &&
         lhs.identifier == rhs.identifier &&
@@ -67,19 +66,16 @@ public func == (lhs: StoredPaymentMethod, rhs: StoredPaymentMethod) -> Bool {
         String(describing: type(of: lhs)) == String(describing: type(of: rhs))
 }
 
-@_spi(AdyenInternal)
-public func != (lhs: StoredPaymentMethod, rhs: StoredPaymentMethod) -> Bool {
+package func != (lhs: StoredPaymentMethod, rhs: StoredPaymentMethod) -> Bool {
     !(lhs == rhs)
 }
 
-@_spi(AdyenInternal)
-public func == (lhs: PaymentMethod, rhs: PaymentMethod) -> Bool {
+package func == (lhs: PaymentMethod, rhs: PaymentMethod) -> Bool {
     lhs.type == rhs.type &&
         lhs.name == rhs.name &&
         String(describing: type(of: lhs)) == String(describing: type(of: rhs))
 }
 
-@_spi(AdyenInternal)
-public func != (lhs: PaymentMethod, rhs: PaymentMethod) -> Bool {
+package func != (lhs: PaymentMethod, rhs: PaymentMethod) -> Bool {
     !(lhs == rhs)
 }

--- a/Adyen/Core/Core Protocols/PresentableComponent.swift
+++ b/Adyen/Core/Core Protocols/PresentableComponent.swift
@@ -15,7 +15,7 @@ package protocol Localizable {
 }
 
 /// Represents any object than can handle a cancel event.
-public protocol Cancellable: AnyObject {
+package protocol Cancellable: AnyObject {
     
     /// Called when the user cancels the component.
     func didCancel()

--- a/Adyen/Core/Core Protocols/StoredPaymentMethodsDelegate.swift
+++ b/Adyen/Core/Core Protocols/StoredPaymentMethodsDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// Describes the methods a delegate of stored payment methods needs to implement.
 @MainActor
-public protocol StoredPaymentMethodsDelegate: AnyObject {
+package protocol StoredPaymentMethodsDelegate: AnyObject {
 
     /// Invoked when shopper wants to delete a stored payment method.
     ///

--- a/Adyen/Core/Errors/AppleWalletError.swift
+++ b/Adyen/Core/Errors/AppleWalletError.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// An error that occurred during adding a pass to apple wallet.
-public enum AppleWalletError: LocalizedError {
+package enum AppleWalletError: LocalizedError {
 
     /// Indicates adding the pass to apple wallet failed.
     case failedToAddToAppleWallet

--- a/Adyen/Core/Errors/ComponentError.swift
+++ b/Adyen/Core/Errors/ComponentError.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// An error that occurred during the use of a component.
-public enum ComponentError: Error {
+package enum ComponentError: Error {
 
     /// Indicates the component was cancelled by the user.
     case cancelled

--- a/Adyen/Core/Models/DisplayInformation.swift
+++ b/Adyen/Core/Models/DisplayInformation.swift
@@ -7,10 +7,9 @@
 import Foundation
 
 /// Describes a payment method display information.
-public struct DisplayInformation: Equatable {
+package struct DisplayInformation: Equatable {
 
-    @_spi(AdyenInternal)
-    public enum TrailingInfoType: Equatable {
+    package enum TrailingInfoType: Equatable {
         case text(String)
         case logos(named: [String], trailingText: String?)
         
@@ -25,28 +24,24 @@ public struct DisplayInformation: Equatable {
     /// The title for the payment method, adapted for displaying in a list.
     /// In the case of stored payment methods, this will include information identifying the stored payment method.
     /// For example, this could be the last 4 digits of the card number, or the used email address.
-    public let title: String
+    package let title: String
 
     /// The subtitle for the payment method, adapted for displaying in a list.
     /// This property represents optional data that can help identify a payment method.
     /// For example, this could be the expiration date of a stored credit card.
-    public let subtitle: String?
+    package let subtitle: String?
 
     /// The name of the logo resource.
-    @_spi(AdyenInternal)
-    public let logoName: String
+    package let logoName: String
 
     /// The trailing info element
-    @_spi(AdyenInternal)
-    public let trailingInfo: TrailingInfoType?
+    package let trailingInfo: TrailingInfoType?
 
     /// The footnote if any.
-    @_spi(AdyenInternal)
-    public let footnoteText: String?
-    
+    package let footnoteText: String?
+
     /// An optional custom `accessibilityLabel` to use.
-    @_spi(AdyenInternal)
-    public let accessibilityLabel: String?
+    package let accessibilityLabel: String?
 
     /// Initializes a `DisplayInformation`
     ///
@@ -57,7 +52,7 @@ public struct DisplayInformation: Equatable {
     /// - Parameter footnoteText: The footnote text if any.
     /// - Parameter accessibilityLabel: An optional custom `accessibilityLabel` to use.
     /// Set this if the title / subtitle might not be sufficient enough to provide a good accessibility
-    public init(
+    package init(
         title: String,
         subtitle: String?,
         logoName: String,
@@ -75,8 +70,7 @@ public struct DisplayInformation: Equatable {
         )
     }
     
-    @_spi(AdyenInternal)
-    public init(
+    package init(
         title: String,
         subtitle: String?,
         logoName: String,

--- a/Adyen/Core/Payment Methods/PayByBankUSPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/PayByBankUSPaymentMethod.swift
@@ -11,9 +11,8 @@ public struct PayByBankUSPaymentMethod: PaymentMethod, PaymentMethodDisplayOverr
     public let type: PaymentMethodType
     
     public var name: String
-    
-    @_spi(AdyenInternal)
-    public static var logoNames: [String] {
+
+    package static var logoNames: [String] {
         ["US-1", "US-2", "US-3", "US-4"]
     }
     

--- a/Adyen/Formatters/Formatter.swift
+++ b/Adyen/Formatters/Formatter.swift
@@ -7,8 +7,8 @@
 import Foundation
 
 /// Formats a value for display purposes.
-public protocol Formatter: Sanitizer {
-    
+package protocol Formatter: Sanitizer {
+
     /// Formats the given value.
     ///
     /// - Parameter value: The value to format.
@@ -19,7 +19,7 @@ public protocol Formatter: Sanitizer {
 
 // Sanitizes (removes any illegal character)  string values.
 
-public protocol Sanitizer {
+package protocol Sanitizer {
 
     /// Sanitizes (removes any illegal character) the given value.
     ///

--- a/Adyen/Model/Balance.swift
+++ b/Adyen/Model/Balance.swift
@@ -7,14 +7,14 @@
 import Foundation
 
 /// Describes an account balance.
-public struct Balance {
+package struct Balance {
 
     /// Indicates the available balance.
-    public let availableAmount: Amount
+    package let availableAmount: Amount
 
     /// Indicates the maximum spendable balance for a single transaction,
     /// as mandated by the account issuer, regardless of the account balance.
-    public let transactionLimit: Amount?
+    package let transactionLimit: Amount?
 
     /// Initializes a Balance.
     ///
@@ -22,7 +22,7 @@ public struct Balance {
     ///   - availableAmount: The available balance.
     ///   - transactionLimit: The maximum spendable balance for a single transaction as mandated by the account issuer,
     ///    regardless of the account balance.
-    public init(availableAmount: Amount, transactionLimit: Amount?) {
+    package init(availableAmount: Amount, transactionLimit: Amount?) {
         self.availableAmount = availableAmount
         self.transactionLimit = transactionLimit
     }

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -67,7 +67,7 @@ public struct PaymentComponentData {
         return shopperInfo.socialSecurityNumber
     }
     
-    public var delegatedAuthenticationData: DelegatedAuthenticationData? {
+    package var delegatedAuthenticationData: DelegatedAuthenticationData? {
         guard let paymentMethod = paymentMethod as? DelegatedAuthenticationAware else { return nil }
         return paymentMethod.delegatedAuthenticationData
     }

--- a/Adyen/Model/SDKData.swift
+++ b/Adyen/Model/SDKData.swift
@@ -6,23 +6,21 @@
 
 import Foundation
 
-// TODO: - Convert into package once PaymentComponent is ready
-@_spi(AdyenInternal)
-public struct SDKData: Codable {
+package struct SDKData: Codable {
 
     internal struct Analytics: Codable {
         internal let checkoutAttemptId: String
     }
 
-    public struct Authentication: Codable {
+    package struct Authentication: Codable {
         internal let threeDS2SdkVersion: String
 
-        public init(threeDS2SdkVersion: String) {
+        package init(threeDS2SdkVersion: String) {
             self.threeDS2SdkVersion = threeDS2SdkVersion
         }
     }
 
-    public enum PaymentMethodBehavior: String, Codable {
+    package enum PaymentMethodBehavior: String, Codable {
         /// Indicates that the SDK has a specific component for this payment method.
         case nativeComponent
 
@@ -42,8 +40,7 @@ public struct SDKData: Codable {
     private let platform: String = checkoutPlatformParams.platform.rawValue
     private let sdkVersion: String = checkoutPlatformParams.version
 
-    @_spi(AdyenInternal)
-    public var encodedValue: String? {
+    package var encodedValue: String? {
         try? AdyenCoder.encodeBase64(self)
     }
 
@@ -74,8 +71,7 @@ public struct SDKData: Codable {
     }
 }
 
-@_spi(AdyenInternal)
-public protocol SDKDataAuthenticationProvider {
+package protocol SDKDataAuthenticationProvider {
     var authentication: SDKData.Authentication { get }
 }
 

--- a/Adyen/Model/ShopperInformation.swift
+++ b/Adyen/Model/ShopperInformation.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Any object that holds shopper personal information.
-public protocol ShopperInformation {
+package protocol ShopperInformation {
 
     /// Shopper name.
     var shopperName: ShopperName? { get }
@@ -29,9 +29,8 @@ public protocol ShopperInformation {
 
 }
 
-@_spi(AdyenInternal)
-public extension ShopperInformation {
-    
+package extension ShopperInformation {
+
     var shopperName: ShopperName? {
         nil
     }

--- a/Adyen/Utilities/Completion.swift
+++ b/Adyen/Utilities/Completion.swift
@@ -7,8 +7,8 @@
 import Foundation
 
 /// Alias for a completion handler with a single parameter of type T.
-public typealias Completion<T> = (T) -> Void
+package typealias Completion<T> = (T) -> Void
 
 /// Alias for a completion handler with no parameters.
 /// Note i cannot use the Completion<T> type as Completion<Void> as that would make the call site become completion(Void) or completion(())
-public typealias VoidCompletion = () -> Void
+package typealias VoidCompletion = () -> Void

--- a/Adyen/Utilities/Debugging/Assertion.swift
+++ b/Adyen/Utilities/Debugging/Assertion.swift
@@ -7,8 +7,7 @@
 import Foundation
 
 /// A typealias for a closure that handles a URL through which the application was opened.
-@_spi(AdyenInternal)
-public typealias AssertionListener = (String) -> Void
+package typealias AssertionListener = (String) -> Void
 
 package enum AdyenAssertion {
 

--- a/Adyen/Utilities/Observable/AdyenObserver.swift
+++ b/Adyen/Utilities/Observable/AdyenObserver.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Conforming to the Observer protocol will make the observe and binding functions available for use.
-public protocol AdyenObserver: AnyObject {}
+package protocol AdyenObserver: AnyObject {}
 
 package extension AdyenObserver {
 

--- a/Adyen/Validators/Validator.swift
+++ b/Adyen/Validators/Validator.swift
@@ -41,7 +41,7 @@ package func && (lhs: Validator, rhs: Validator) -> Validator {
 }
 
 /// Interface to allow for two validators.
-public protocol CombinedValidator: Validator {
+package protocol CombinedValidator: Validator {
     var firstValidator: Validator { get }
     var secondValidator: Validator { get }
 }

--- a/AdyenActions/CheckoutActionComponent.swift
+++ b/AdyenActions/CheckoutActionComponent.swift
@@ -5,7 +5,6 @@
 //
 
 import Adyen
-@_spi(AdyenInternal) import protocol Adyen.Component
 import Foundation
 import UIKit
 

--- a/AdyenActions/Components/Authentication/3DS2 SDK Adapters/LegacySDK/ADYAppearanceConfigurationBuilder.swift
+++ b/AdyenActions/Components/Authentication/3DS2 SDK Adapters/LegacySDK/ADYAppearanceConfigurationBuilder.swift
@@ -6,7 +6,7 @@
 
 import Adyen3DS2
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import Foundation
 

--- a/AdyenActions/Components/Authentication/Action handlers/AnyThreeDS2ActionHandler.swift
+++ b/AdyenActions/Components/Authentication/Action handlers/AnyThreeDS2ActionHandler.swift
@@ -5,8 +5,6 @@
 //
 
 import Adyen
-@_spi(AdyenInternal) import protocol Adyen.Component
-
 #if canImport(AdyenUI)
     import AdyenUI
 #endif

--- a/AdyenActions/Components/Authentication/AuthenticationComponent.swift
+++ b/AdyenActions/Components/Authentication/AuthenticationComponent.swift
@@ -5,7 +5,6 @@
 //
 
 import Adyen
-@_spi(AdyenInternal) import protocol Adyen.Component
 import Foundation
 
 internal protocol AnyRedirectComponent: ActionComponent {

--- a/AdyenActions/Components/Await/AwaitComponent.swift
+++ b/AdyenActions/Components/Await/AwaitComponent.swift
@@ -4,8 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
-@_spi(AdyenInternal) import protocol Adyen.Component
+@_spi(AdyenInternal) import Adyen
 import Foundation
 
 /// A component that handles Await action's.

--- a/AdyenActions/Components/Await/PollingComponent.swift
+++ b/AdyenActions/Components/Await/PollingComponent.swift
@@ -4,8 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
-@_spi(AdyenInternal) import protocol Adyen.Component
+@_spi(AdyenInternal) import Adyen
 import AdyenNetworking
 import Foundation
 

--- a/AdyenActions/Components/Base/AnyWeChatPaySDKActionComponent.swift
+++ b/AdyenActions/Components/Base/AnyWeChatPaySDKActionComponent.swift
@@ -8,7 +8,7 @@ import Adyen
 import Foundation
 
 /// Represents any structure/class that can be initialized without any parameters.
-public protocol APIContextInitializable {
+package protocol APIContextInitializable {
     /// Initializer that takes an `APIContext`.
     init(context: AdyenContext)
 }

--- a/AdyenActions/Components/Redirect/BrowserComponent.swift
+++ b/AdyenActions/Components/Redirect/BrowserComponent.swift
@@ -4,8 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
-@_spi(AdyenInternal) import protocol Adyen.PresentableComponent
+@_spi(AdyenInternal) import Adyen
 import SafariServices
 import UIKit
 

--- a/AdyenActions/Components/Redirect/RedirectComponent.swift
+++ b/AdyenActions/Components/Redirect/RedirectComponent.swift
@@ -4,8 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
-@_spi(AdyenInternal) import protocol Adyen.Component
+@_spi(AdyenInternal) import Adyen
 import AdyenNetworking
 import UIKit
 

--- a/AdyenActions/Components/Voucher/VoucherComponent.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponent.swift
@@ -4,8 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-import Adyen
-@_spi(AdyenInternal) import protocol Adyen.Component
+@_spi(AdyenInternal) import Adyen
 import AdyenNetworking
 #if canImport(AdyenUI)
     @_spi(AdyenInternal) import AdyenUI

--- a/AdyenActions/Components/Voucher/VoucherComponent.swift
+++ b/AdyenActions/Components/Voucher/VoucherComponent.swift
@@ -8,7 +8,7 @@ import Adyen
 @_spi(AdyenInternal) import protocol Adyen.Component
 import AdyenNetworking
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import PassKit
 import UIKit

--- a/AdyenActions/UI/UI Style/ActionComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/ActionComponentStyle.swift
@@ -8,22 +8,22 @@ import Adyen
 import UIKit
 
 /// /// Contains the styling customization options for various Action Components.
-public struct ActionComponentStyle {
-    
+package struct ActionComponentStyle {
+
     /// Indicates the UI configuration of the redirect component.
-    public var redirectComponentStyle: RedirectComponentStyle
-    
+    package var redirectComponentStyle: RedirectComponentStyle
+
     /// Indicates the UI configuration of the await component.
-    public var awaitComponentStyle: AwaitComponentStyle
-    
+    package var awaitComponentStyle: AwaitComponentStyle
+
     /// Indicates the UI configuration of the voucher component.
-    public var voucherComponentStyle: VoucherComponentStyle
-    
+    package var voucherComponentStyle: VoucherComponentStyle
+
     /// Indicates the UI configuration of the QR code component.
-    public var qrCodeComponentStyle: QRCodeComponentStyle
-    
+    package var qrCodeComponentStyle: QRCodeComponentStyle
+
     /// Indicates the UI configuration of the document action component.
-    public var documentActionComponentStyle: DocumentComponentStyle
+    package var documentActionComponentStyle: DocumentComponentStyle
 
     /// Initializes the
     /// - Parameters:
@@ -32,7 +32,7 @@ public struct ActionComponentStyle {
     ///   - voucherComponentStyle: The UI configuration of the voucher component.
     ///   - qrCodeComponentStyle: The UI configuration of the QR code component.
     ///   - documentActionComponentStyle: The UI configuration of the document action component.
-    public init(
+    package init(
         redirectComponentStyle: RedirectComponentStyle = RedirectComponentStyle(),
         awaitComponentStyle: AwaitComponentStyle = AwaitComponentStyle(),
         voucherComponentStyle: VoucherComponentStyle = VoucherComponentStyle(),

--- a/AdyenActions/UI/UI Style/AwaitComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/AwaitComponentStyle.swift
@@ -6,16 +6,16 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import Foundation
 import UIKit
 
 /// Contains the styling customization options for the await component.
-public struct AwaitComponentStyle: ViewStyle {
-    
+package struct AwaitComponentStyle: ViewStyle {
+
     /// The image style.
-    public var image = ImageStyle(
+    package var image = ImageStyle(
         borderColor: nil,
         borderWidth: 0,
         cornerRadius: 0,
@@ -24,20 +24,20 @@ public struct AwaitComponentStyle: ViewStyle {
     )
     
     /// The style of message label.
-    public var message = TextStyle(
+    package var message = TextStyle(
         font: .preferredFont(forTextStyle: .callout),
         color: UIColor.Adyen.componentLabel
     )
     
     /// The style of the spinner title label.
-    public var spinnerTitle = TextStyle(
+    package var spinnerTitle = TextStyle(
         font: .preferredFont(forTextStyle: .footnote),
         color: UIColor.Adyen.componentLoadingMessageColor,
         textAlignment: .left
     )
     
-    public var backgroundColor = UIColor.Adyen.componentBackground
-    
+    package var backgroundColor = UIColor.Adyen.componentBackground
+
     /// Initializes the await component style with the default style.
-    public init() {}
+    package init() {}
 }

--- a/AdyenActions/UI/UI Style/DelegatedAuthenticationComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/DelegatedAuthenticationComponentStyle.swift
@@ -6,19 +6,18 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import UIKit
 
-// TODO: make package
 /// Contains the styling customization options for Delegated Authentication Screens(Registration & Approval)
-public struct DelegatedAuthenticationComponentStyle {
+package struct DelegatedAuthenticationComponentStyle {
     
     /// The background color of the approval and the register screen
-    public var backgroundColor = UIColor.Adyen.componentBackground
+    package var backgroundColor = UIColor.Adyen.componentBackground
 
     /// The Image style of the approval and the register screen
-    public var imageStyle: ImageStyle = .init(
+    package var imageStyle: ImageStyle = .init(
         borderColor: nil,
         borderWidth: 0.0,
         cornerRadius: 0.0,
@@ -26,28 +25,28 @@ public struct DelegatedAuthenticationComponentStyle {
         contentMode: .scaleAspectFit
     )
     /// The text style of the header of the approval and the register screen
-    public var headerTextStyle = TextStyle(
+    package var headerTextStyle = TextStyle(
         font: .systemFont(ofSize: 24, weight: .bold),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .center
     )
     
     /// The text style of the description of the approval and the register screen
-    public var descriptionTextStyle = TextStyle(
+    package var descriptionTextStyle = TextStyle(
         font: .preferredFont(forTextStyle: .body),
         color: UIColor.Adyen.componentSecondaryLabel,
         textAlignment: .center
     )
     
     /// The text style of the amount of the approval
-    public var amountTextStyle = TextStyle(
+    package var amountTextStyle = TextStyle(
         font: .systemFont(ofSize: 32),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .center
     )
     
     /// The card type image style of the approval and the register screen
-    public var cardImageStyle: ImageStyle = .init(
+    package var cardImageStyle: ImageStyle = .init(
         borderColor: nil,
         borderWidth: 0.0,
         cornerRadius: 0.0,
@@ -56,14 +55,14 @@ public struct DelegatedAuthenticationComponentStyle {
     )
     
     /// The card number style of the approval and the register screen
-    public var cardNumberTextStyle = TextStyle(
+    package var cardNumberTextStyle = TextStyle(
         font: .systemFont(ofSize: 24, weight: .bold),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .center
     )
     
     /// The image style of the register screen for the additional info section
-    public var infoImageStyle: ImageStyle = .init(
+    package var infoImageStyle: ImageStyle = .init(
         borderColor: nil,
         borderWidth: 0.0,
         cornerRadius: 0.0,
@@ -72,17 +71,17 @@ public struct DelegatedAuthenticationComponentStyle {
     )
     
     /// The text style of the register screen for the additional info section
-    public var additionalInformationTextStyle = TextStyle(
+    package var additionalInformationTextStyle = TextStyle(
         font: .preferredFont(forTextStyle: .caption1),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .center
     )
     
     /// The background color of the approval and the register screen
-    public var errorBackgroundColor = UIColor.Adyen.componentBackground
+    package var errorBackgroundColor = UIColor.Adyen.componentBackground
 
     /// The image style for the error screen
-    public var errorImageStyle: ImageStyle = .init(
+    package var errorImageStyle: ImageStyle = .init(
         borderColor: nil,
         borderWidth: 0.0,
         cornerRadius: 0.0,
@@ -91,35 +90,35 @@ public struct DelegatedAuthenticationComponentStyle {
     )
     
     /// The error title style for the error screen
-    public var errorTitleStyle = TextStyle(
+    package var errorTitleStyle = TextStyle(
         font: .preferredFont(forTextStyle: .title1),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .center
     )
     
     /// The error description style for the error screen
-    public var errorDescription = TextStyle(
+    package var errorDescription = TextStyle(
         font: .preferredFont(forTextStyle: .body),
         color: UIColor.Adyen.componentSecondaryLabel,
         textAlignment: .center
     )
     
     /// The title style for the troubleshooting message
-    public var troubleshootingTitleStyle = TextStyle(
+    package var troubleshootingTitleStyle = TextStyle(
         font: .preferredFont(forTextStyle: .subheadline),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .center
     )
     
     /// The description style for the troubleshooting message
-    public var troubleshootingDescriptionStyle = TextStyle(
+    package var troubleshootingDescriptionStyle = TextStyle(
         font: .preferredFont(forTextStyle: .caption1),
         color: UIColor.Adyen.componentSecondaryLabel,
         textAlignment: .center
     )
     
     /// The button style for the troubleshooting message
-    public var troubleshootingButtonStyle = ButtonStyle(
+    package var troubleshootingButtonStyle = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .headline),
             color: UIColor.Adyen.defaultBlue
@@ -129,7 +128,7 @@ public struct DelegatedAuthenticationComponentStyle {
     )
 
     /// The primary button style for the register & approve screens.
-    public var primaryButton = ButtonStyle(
+    package var primaryButton = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .headline),
             color: .white
@@ -139,7 +138,7 @@ public struct DelegatedAuthenticationComponentStyle {
     )
 
     /// The secondary button style for the register & approve screens.
-    public var secondaryButton = ButtonStyle(
+    package var secondaryButton = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .headline),
             color: UIColor.Adyen.defaultBlue
@@ -149,7 +148,7 @@ public struct DelegatedAuthenticationComponentStyle {
     )
     
     /// The primary button style for the error screen.
-    public var errorButton = ButtonStyle(
+    package var errorButton = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .headline),
             color: .white
@@ -159,7 +158,7 @@ public struct DelegatedAuthenticationComponentStyle {
     )
 
     /// Creates a component style with the default styling
-    public init() {
+    package init() {
         imageStyle.tintColor = .systemGray
     }
 }

--- a/AdyenActions/UI/UI Style/DocumentComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/DocumentComponentStyle.swift
@@ -6,15 +6,15 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import UIKit
 
 /// Contains the styling customization options for the document action component.
-public struct DocumentComponentStyle {
+package struct DocumentComponentStyle {
     
     /// The image style.
-    public var image = ImageStyle(
+    package var image = ImageStyle(
         borderColor: nil,
         borderWidth: 0,
         cornerRadius: 8,
@@ -23,7 +23,7 @@ public struct DocumentComponentStyle {
     )
     
     /// The done button style.
-    public var doneButton = ButtonStyle(
+    package var doneButton = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .headline),
             color: UIColor.Adyen.defaultBlue
@@ -33,7 +33,7 @@ public struct DocumentComponentStyle {
     )
     
     /// The main button style.
-    public var mainButton = ButtonStyle(
+    package var mainButton = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .headline),
             color: UIColor.Adyen.defaultBlue
@@ -43,14 +43,14 @@ public struct DocumentComponentStyle {
     )
     
     /// The message label style.
-    public var messageLabel = TextStyle(
+    package var messageLabel = TextStyle(
         font: .preferredFont(forTextStyle: .callout),
         color: UIColor.Adyen.componentLabel
     )
     
     /// The background color of the document action view.
-    public var backgroundColor = UIColor.Adyen.componentBackground
+    package var backgroundColor = UIColor.Adyen.componentBackground
     
     /// Initializes the document component style with the default style.
-    public init() {}
+    package init() {}
 }

--- a/AdyenActions/UI/UI Style/QRCodeComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/QRCodeComponentStyle.swift
@@ -7,49 +7,49 @@
 import Adyen
 import UIKit
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 
 /// Contains the styling customization options for the QR code component.
-public struct QRCodeComponentStyle: ViewStyle {
+package struct QRCodeComponentStyle: ViewStyle {
     
     /// The copy button style.
-    public var copyCodeButton = ButtonStyle(
+    package var copyCodeButton = ButtonStyle(
         title: TextStyle(font: .preferredFont(forTextStyle: .headline), color: .white),
         cornerRadius: 8,
         background: UIColor.Adyen.defaultBlue
     )
 
     /// The save as image button style.
-    public var saveAsImageButton = ButtonStyle(
+    package var saveAsImageButton = ButtonStyle(
         title: TextStyle(font: .preferredFont(forTextStyle: .headline), color: .white),
         cornerRadius: 8,
         background: UIColor.Adyen.defaultBlue
     )
     
     /// The instruction label style.
-    public var instructionLabel = TextStyle(font: .preferredFont(forTextStyle: .subheadline), color: UIColor.Adyen.componentLabel)
+    package var instructionLabel = TextStyle(font: .preferredFont(forTextStyle: .subheadline), color: UIColor.Adyen.componentLabel)
     
     /// The amount to pay label style.
-    public var amountToPayLabel = TextStyle(
+    package var amountToPayLabel = TextStyle(
         font: .preferredFont(forTextStyle: .callout).adyen.font(with: .bold),
         color: UIColor.Adyen.componentLabel
     )
 
     /// The progress view style.
-    public var progressView = ProgressViewStyle(
+    package var progressView = ProgressViewStyle(
         progressTintColor: UIColor.Adyen.defaultBlue,
         trackTintColor: UIColor.Adyen.lightGray
     )
     
     /// The expiration label style.
-    public var expirationLabel = TextStyle(font: .preferredFont(forTextStyle: .footnote), color: UIColor.Adyen.componentSecondaryLabel)
+    package var expirationLabel = TextStyle(font: .preferredFont(forTextStyle: .footnote), color: UIColor.Adyen.componentSecondaryLabel)
     
     /// The corner rounding for the logo
-    public var logoCornerRounding: CornerRounding = .fixed(5)
+    package var logoCornerRounding: CornerRounding = .fixed(5)
         
-    public var backgroundColor = UIColor.Adyen.componentBackground
+    package var backgroundColor = UIColor.Adyen.componentBackground
     
     /// Initializes the QR code component style with the default style
-    public init() {}
+    package init() {}
 }

--- a/AdyenActions/UI/UI Style/VoucherComponentStyle.swift
+++ b/AdyenActions/UI/UI Style/VoucherComponentStyle.swift
@@ -6,28 +6,28 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import Foundation
 import UIKit
 
 /// Contains the styling customization options for the voucher component.
-public struct VoucherComponentStyle: ViewStyle {
+package struct VoucherComponentStyle: ViewStyle {
     
     /// The amount label style.
-    public var amountLabel = TextStyle(
+    package var amountLabel = TextStyle(
         font: .preferredFont(forTextStyle: .largeTitle),
         color: UIColor.Adyen.componentLabel
     )
     
     /// The currency label style.
-    public var currencyLabel = TextStyle(
+    package var currencyLabel = TextStyle(
         font: .preferredFont(forTextStyle: .headline),
         color: UIColor.Adyen.componentLabel
     )
     
     /// The edit button style.
-    public var editButton = ButtonStyle(
+    package var editButton = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .headline),
             color: UIColor.Adyen.defaultBlue
@@ -37,7 +37,7 @@ public struct VoucherComponentStyle: ViewStyle {
     )
     
     /// The done button style.
-    public var doneButton = ButtonStyle(
+    package var doneButton = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .headline),
             color: UIColor.Adyen.defaultBlue
@@ -47,7 +47,7 @@ public struct VoucherComponentStyle: ViewStyle {
     )
 
     /// The main button style.
-    public var mainButton = ButtonStyle(
+    package var mainButton = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .headline),
             color: .white
@@ -57,7 +57,7 @@ public struct VoucherComponentStyle: ViewStyle {
     )
 
     /// The secondary button style.
-    public var secondaryButton = ButtonStyle(
+    package var secondaryButton = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .headline),
             color: UIColor.Adyen.defaultBlue
@@ -67,10 +67,10 @@ public struct VoucherComponentStyle: ViewStyle {
     )
     
     /// The secondary button copy code confirmation color
-    public var codeConfirmationColor = UIColor.Adyen.green40
+    package var codeConfirmationColor = UIColor.Adyen.green40
 
-    public var backgroundColor = UIColor.Adyen.componentBackground
+    package var backgroundColor = UIColor.Adyen.componentBackground
 
     /// Initializes the voucher component style with the default style.
-    public init() {}
+    package init() {}
 }

--- a/AdyenActions/UI/View Controllers/Await/AwaitView.swift
+++ b/AdyenActions/UI/View Controllers/Await/AwaitView.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import Foundation
 import UIKit

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UIImageViewHelper.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UIImageViewHelper.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import UIKit
 

--- a/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UILabelHelper.swift
+++ b/AdyenActions/UI/View Controllers/DelegatedAuthentication/ViewHelpers/UILabelHelper.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import UIKit
 

--- a/AdyenActions/UI/View Controllers/Document/DocumentActionView.swift
+++ b/AdyenActions/UI/View Controllers/Document/DocumentActionView.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import Foundation
 import SwiftUI

--- a/AdyenActions/UI/View Controllers/QR Code/Models/QRCodeViewStyle.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/Models/QRCodeViewStyle.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import Foundation
 import UIKit

--- a/AdyenActions/UI/View Controllers/QR Code/QRCodeViewController.swift
+++ b/AdyenActions/UI/View Controllers/QR Code/QRCodeViewController.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import Foundation
 import UIKit

--- a/AdyenActions/UI/View Controllers/Voucher/ShareableVoucherView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/ShareableVoucherView.swift
@@ -8,7 +8,7 @@ import Adyen
 import PassKit
 import UIKit
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 
 internal class ShareableVoucherView: UIView, Localizable {

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherSeparatorView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherSeparatorView.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import CoreGraphics
 import QuartzCore

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherView.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherView.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import PassKit
 import UIKit

--- a/AdyenActions/UI/View Controllers/Voucher/VoucherViewModel.swift
+++ b/AdyenActions/UI/View Controllers/Voucher/VoucherViewModel.swift
@@ -7,7 +7,7 @@
 import Adyen
 import UIKit
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 
 extension VoucherView {

--- a/AdyenCard/Components/Card/CardComponentExtensions.swift
+++ b/AdyenCard/Components/Card/CardComponentExtensions.swift
@@ -5,7 +5,6 @@
 //
 
 import Adyen
-@_spi(AdyenInternal) import protocol Adyen.PaymentComponent
 #if canImport(AdyenEncryption)
     import AdyenEncryption
 #endif

--- a/AdyenCard/Components/Card/CardConfiguration.swift
+++ b/AdyenCard/Components/Card/CardConfiguration.swift
@@ -234,7 +234,7 @@ extension CardConfiguration {
 }
 
 /// Describes any configuration for the card component.
-public protocol AnyCardComponentConfiguration {
+package protocol AnyCardComponentConfiguration {
     
     /// Indicates if the field for entering the cardholder name should be displayed in the form. Defaults to false.
     var showCardholderName: Bool { get }

--- a/AdyenCard/Components/Card/CardDetails.swift
+++ b/AdyenCard/Components/Card/CardDetails.swift
@@ -156,9 +156,8 @@ public struct CardDetails: PaymentMethodDetails, ShopperInformation {
 @_spi(AdyenInternal)
 extension CardDetails: DelegatedAuthenticationAware {}
 
-@_spi(AdyenInternal)
 extension CardDetails: SDKDataAuthenticationProvider {
-    public var authentication: SDKData.Authentication {
+    package var authentication: SDKData.Authentication {
         .init(threeDS2SdkVersion: threeDS2SdkVersion)
     }
 }

--- a/AdyenCard/Form/FormCardNumberContainerItem.swift
+++ b/AdyenCard/Form/FormCardNumberContainerItem.swift
@@ -6,9 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
-    @_spi(AdyenInternal) import protocol AdyenUI.FormItem
-    @_spi(AdyenInternal) import class AdyenUI.FormItemView
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import UIKit
 

--- a/AdyenCard/Form/FormCoBadgedCardItem.swift
+++ b/AdyenCard/Form/FormCoBadgedCardItem.swift
@@ -6,8 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
-    @_spi(AdyenInternal) import protocol AdyenUI.FormItem
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import UIKit
 

--- a/AdyenCard/Form/FormCoBadgedCardItemStyle.swift
+++ b/AdyenCard/Form/FormCoBadgedCardItemStyle.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import UIKit
 

--- a/AdyenCard/Validators/CardKCPValidators.swift
+++ b/AdyenCard/Validators/CardKCPValidators.swift
@@ -9,23 +9,22 @@ import Adyen
 import Foundation
 
 /// Validates birthdate (YYMMDD) or the Corporate registration number (10 digits) for KCP.
-@_spi(AdyenInternal)
-public final class CardKCPFieldValidator: CombinedValidator, StatusValidator {
-    
+package final class CardKCPFieldValidator: CombinedValidator, StatusValidator {
+
     private enum Constants {
         static let exactLength = 10
     }
     
-    public let firstValidator: Validator
-    
-    public let secondValidator: Validator
-    
-    public init() {
+    package let firstValidator: Validator
+
+    package let secondValidator: Validator
+
+    package init() {
         self.firstValidator = NumericStringValidator(exactLength: Constants.exactLength)
         self.secondValidator = DateValidator(format: DateValidator.Format.kcpFormat)
     }
     
-    public func validate(_ value: String) -> ValidationStatus {
+    package func validate(_ value: String) -> ValidationStatus {
         if value.isEmpty {
             return .invalid(CardValidationError.kcpFieldEmpty)
         }
@@ -40,23 +39,22 @@ public final class CardKCPFieldValidator: CombinedValidator, StatusValidator {
         return .valid
     }
     
-    public func isValid(_ value: String) -> Bool {
+    package func isValid(_ value: String) -> Bool {
         validate(value).isValid
     }
 }
 
-@_spi(AdyenInternal)
-public final class CardKCPPasswordValidator: LengthValidator, StatusValidator {
-    
+package final class CardKCPPasswordValidator: LengthValidator, StatusValidator {
+
     private enum Constants {
         static let exactLength = 2
     }
     
-    public init() {
+    package init() {
         super.init(exactLength: Constants.exactLength)
     }
     
-    public func validate(_ value: String) -> ValidationStatus {
+    package func validate(_ value: String) -> ValidationStatus {
         if super.isValid(value) {
             return .valid
         }
@@ -68,7 +66,7 @@ public final class CardKCPPasswordValidator: LengthValidator, StatusValidator {
         return .invalid(CardValidationError.kcpPasswordPartial)
     }
     
-    override public func isValid(_ value: String) -> Bool {
+    override package func isValid(_ value: String) -> Bool {
         validate(value).isValid
     }
     

--- a/AdyenCard/Validators/CardNumberValidator.swift
+++ b/AdyenCard/Validators/CardNumberValidator.swift
@@ -74,10 +74,9 @@ public final class CardNumberValidator: Validator {
     }
 }
 
-@_spi(AdyenInternal)
 extension CardNumberValidator: StatusValidator {
     
-    public func validate(_ value: String) -> ValidationStatus {
+    package func validate(_ value: String) -> ValidationStatus {
         // order of checks are important to return the correct error.
         
         if value.isEmpty {

--- a/AdyenCashAppPay/CashAppPayButton/CashAppPayButtonItem.swift
+++ b/AdyenCashAppPay/CashAppPayButton/CashAppPayButtonItem.swift
@@ -6,9 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
-    @_spi(AdyenInternal) import protocol AdyenUI.FormItem
-    @_spi(AdyenInternal) import class AdyenUI.FormItemView
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import Foundation
 import UIKit

--- a/AdyenCashAppPay/CashAppPayConfiguration.swift
+++ b/AdyenCashAppPay/CashAppPayConfiguration.swift
@@ -11,23 +11,23 @@ import Adyen
 import Foundation
 
 /// Configuration for Cash App Pay Component.
-public struct CashAppPayConfiguration: AnyCashAppPayConfiguration {
+package struct CashAppPayConfiguration: AnyCashAppPayConfiguration {
 
     /// The URL for Cash App to call in order to redirect back to your application.
-    public let redirectURL: URL
+    package let redirectURL: URL
 
     /// A reference to your system (for example, a cart or checkout identifier).
-    public let referenceId: String?
+    package let referenceId: String?
 
     /// Indicates if the field for storing the payment method should be displayed in the form. Defaults to `true`.
-    public var showsStorePaymentMethodField: Bool
-    
+    package var showsStorePaymentMethodField: Bool
+
     /// Determines whether to store this payment method. Defaults to `false`.
     /// Ignored if `showsStorePaymentMethodField` is `true`.
-    public var storePaymentMethod: Bool
+    package var storePaymentMethod: Bool
 
     /// Describes the component's UI style.
-    public var style: FormComponentStyle
+    package var style: FormComponentStyle
 
     /// A boolean value that determines whether the payment button is displayed. Defaults to `true`.
     internal let showsSubmitButton: Bool
@@ -47,7 +47,7 @@ public struct CashAppPayConfiguration: AnyCashAppPayConfiguration {
     ///   - showsSubmitButton: Boolean value that determines whether the payment button is displayed.
     ///   Defaults to `true`.
     ///   - localizationParameters: The localization parameters, leave it nil to use the default parameters.
-    public init(
+    package init(
         redirectURL: URL,
         referenceId: String? = nil,
         showsStorePaymentMethodField: Bool = true,

--- a/AdyenCheckout/Core/CheckoutCore+PaymentComponentDelegate.swift
+++ b/AdyenCheckout/Core/CheckoutCore+PaymentComponentDelegate.swift
@@ -4,7 +4,7 @@
 // This file is open source and available under the MIT license. See the LICENSE file for more info.
 //
 
-@_spi(AdyenInternal) import Adyen
+import Adyen
 import Foundation
 
 // MARK: - PaymentComponentDelegate

--- a/AdyenCheckout/Core/CheckoutCore+StoredPaymentMethodsDelegate.swift
+++ b/AdyenCheckout/Core/CheckoutCore+StoredPaymentMethodsDelegate.swift
@@ -6,7 +6,7 @@
 
 @_spi(AdyenInternal) import Adyen
 #if canImport(AdyenSession)
-    @_spi(AdyenInternal) import AdyenSession
+    import AdyenSession
 #endif
 import UIKit
 

--- a/AdyenComponents/AbstractPersonalInformationComponent/FormItemInjector.swift
+++ b/AdyenComponents/AbstractPersonalInformationComponent/FormItemInjector.swift
@@ -11,26 +11,24 @@
 import Foundation
 
 /// Builds a `FormItem` and injects it into a `FormViewController`.
-@_spi(AdyenInternal)
-public protocol FormItemInjector {
+package protocol FormItemInjector {
 
     func inject(into formViewController: FormViewController)
     
 }
 
 /// Injects a custom `FormItem` into a `FormViewController`.
-@_spi(AdyenInternal)
-public struct CustomFormItemInjector<T: FormItem>: FormItemInjector {
-    
+package struct CustomFormItemInjector<T: FormItem>: FormItemInjector {
+
     private let item: T
     
     /// Initializes a `CustomFormItemInjector` with a custom `FormItem`
     /// - Parameter item: `FormItem` to be injected
-    public init(item: T) {
+    package init(item: T) {
         self.item = item
     }
     
-    public func inject(into formViewController: FormViewController) {
+    package func inject(into formViewController: FormViewController) {
         formViewController.append(item)
     }
     

--- a/AdyenComponents/Affirm/AffirmComponent.swift
+++ b/AdyenComponents/Affirm/AffirmComponent.swift
@@ -7,8 +7,7 @@
 import Adyen
 @_spi(AdyenInternal) import struct Adyen.LocalizationKey
 #if canImport(AdyenUI)
-    import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormLabelItem
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import UIKit
 

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -5,7 +5,6 @@
 //
 
 import Adyen
-@_spi(AdyenInternal) import protocol Adyen.PaymentComponent
 import Foundation
 import PassKit
 

--- a/AdyenComponents/Atome/AtomeComponent.swift
+++ b/AdyenComponents/Atome/AtomeComponent.swift
@@ -8,9 +8,7 @@ import Adyen
 @_spi(AdyenInternal) import struct Adyen.LocalizationKey
 
 #if canImport(AdyenUI)
-    import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormLabelItem
-    @_spi(AdyenInternal) import protocol AdyenUI.AddressViewModelBuilder
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import UIKit
 
@@ -68,15 +66,11 @@ package final class AtomeComponent: AbstractPersonalInformationComponent {
         phoneItem?.title = localizedString(.phoneNumberTitle, configuration.localizationParameters)
     }
 
-    // MARK: - Public
-
-    @_spi(AdyenInternal)
-    override public func submitButtonTitle() -> String {
+    override package func submitButtonTitle() -> String {
         localizedString(.continueTitle, configuration.localizationParameters)
     }
 
-    @_spi(AdyenInternal)
-    override public func createPaymentDetails() throws -> PaymentMethodDetails {
+    override package func createPaymentDetails() throws -> PaymentMethodDetails {
         guard let firstName = firstNameItem?.value,
               let lastName = lastNameItem?.value,
               let telephoneNumber = phoneItem?.phoneNumber,
@@ -93,14 +87,12 @@ package final class AtomeComponent: AbstractPersonalInformationComponent {
         )
     }
 
-    @_spi(AdyenInternal)
-    override public func phoneExtensions() -> [PhoneExtension] {
+    override package func phoneExtensions() -> [PhoneExtension] {
         let query = PhoneExtensionsQuery(paymentMethod: .generic)
         return PhoneExtensionsRepository.get(with: query)
     }
-    
-    @_spi(AdyenInternal)
-    override public func addressViewModelBuilder() -> AddressViewModelBuilder {
+
+    override package func addressViewModelBuilder() -> AddressViewModelBuilder {
         AtomeAddressViewModelBuilder()
     }
 

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent+Style.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent+Style.swift
@@ -6,7 +6,7 @@
 
 import Adyen
 #if canImport(AdyenUI)
-    import AdyenUI
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import Foundation
 import UIKit

--- a/AdyenComponents/PayTo/PayToItemsProvider.swift
+++ b/AdyenComponents/PayTo/PayToItemsProvider.swift
@@ -8,8 +8,7 @@ import Adyen
 @_spi(AdyenInternal) import struct Adyen.LocalizationKey
 
 #if canImport(AdyenUI)
-    import AdyenUI
-    @_spi(AdyenInternal) import class AdyenUI.FormLabelItem
+    @_spi(AdyenInternal) import AdyenUI
 #endif
 import UIKit
 

--- a/AdyenComponents/Qiwi Wallet/QiwiWalletComponent.swift
+++ b/AdyenComponents/Qiwi Wallet/QiwiWalletComponent.swift
@@ -40,18 +40,15 @@ package final class QiwiWalletComponent: AbstractPersonalInformationComponent {
         )
     }
 
-    @_spi(AdyenInternal)
-    override public func submitButtonTitle() -> String {
+    override package func submitButtonTitle() -> String {
         localizedString(.continueTo, configuration.localizationParameters, paymentMethod.name)
     }
 
-    @_spi(AdyenInternal)
-    override public func phoneExtensions() -> [PhoneExtension] {
+    override package func phoneExtensions() -> [PhoneExtension] {
         qiwiWalletPaymentMethod.phoneExtensions
     }
 
-    @_spi(AdyenInternal)
-    override public func createPaymentDetails() throws -> PaymentMethodDetails {
+    override package func createPaymentDetails() throws -> PaymentMethodDetails {
         guard let phoneItem else {
             throw UnknownError(errorDescription: "There seems to be an error in the BasicPersonalInfoFormComponent configuration.")
         }

--- a/AdyenComponents/UPI/UPIComponent.swift
+++ b/AdyenComponents/UPI/UPIComponent.swift
@@ -223,7 +223,7 @@ package final class UPIComponent: PaymentComponent,
     
     internal lazy var errorItem: FormErrorItem = {
         let errorMessage = localizedString(LocalizationKey.upiErrorNoAppSelected, configuration.localizationParameters)
-        let item = FormErrorItem(message: errorMessage, iconName: Images.errorIcon)
+        let item = FormErrorItem(message: errorMessage, iconName: Images.errorIcon, style: FormErrorItemStyle())
         item.identifier = ViewIdentifierBuilder.build(
             scopeInstance: self,
             postfix: ViewIdentifier.errorItem

--- a/AdyenDropIn/Modules/DropInFlowManager.swift
+++ b/AdyenDropIn/Modules/DropInFlowManager.swift
@@ -5,7 +5,6 @@
 //
 
 import Adyen
-@_spi(AdyenInternal) import protocol Adyen.PaymentComponent
 #if canImport(AdyenActions)
     import AdyenActions
 #endif

--- a/AdyenEncryption/JOSE/Encryption Algorithms/Content Encryption Algorithms/JWAEncryptionAlgorithm.swift
+++ b/AdyenEncryption/JOSE/Encryption Algorithms/Content Encryption Algorithms/JWAEncryptionAlgorithm.swift
@@ -36,7 +36,7 @@ internal struct JWAInput {
 }
 
 /// Indicates encryption related errors.
-public enum EncryptionError: LocalizedError {
+package enum EncryptionError: LocalizedError {
 
     /// Indicates a problem with the key
     case invalidKey
@@ -59,7 +59,7 @@ public enum EncryptionError: LocalizedError {
     /// Any other error.
     case other(Error)
     
-    public var errorDescription: String? {
+    package var errorDescription: String? {
         switch self {
         case .invalidKey:
             return "Key is invalid."

--- a/AdyenTwint/TwintComponent.swift
+++ b/AdyenTwint/TwintComponent.swift
@@ -5,8 +5,6 @@
 //
 
 import Adyen
-@_spi(AdyenInternal) import protocol Adyen.PaymentComponent
-
 #if canImport(AdyenUI)
     import AdyenUI
 #endif

--- a/AdyenUI/CheckoutConfiguration/CheckoutConfigurable.swift
+++ b/AdyenUI/CheckoutConfiguration/CheckoutConfigurable.swift
@@ -30,8 +30,8 @@ package protocol CheckoutComponentConfiguration: CheckoutConfigurable {
     var theme: CheckoutTheme { get set }
 }
 
-public extension CheckoutConfigurable {
-    
+package extension CheckoutConfigurable {
+
     // TODO: add descriptions
     // having this function here instead of re writing it for all configurations
     // prevents duplication, but the returned value will be seen as CheckoutConfigurable

--- a/AdyenUI/Styles/CornerRadiusStyle.swift
+++ b/AdyenUI/Styles/CornerRadiusStyle.swift
@@ -8,8 +8,8 @@ import Foundation
 import UIKit
 
 /// The size of corner rounding.
-public enum CornerRounding {
-    
+@_spi(AdyenInternal) public enum CornerRounding {
+
     /// No rounding.
     case none
     

--- a/AdyenUI/UI/Form/Items/Address/AddressStyle.swift
+++ b/AdyenUI/UI/Form/Items/Address/AddressStyle.swift
@@ -8,30 +8,30 @@ import Foundation
 import UIKit
 
 /// The style of form address
-public struct AddressStyle: FormValueItemStyle {
+package struct AddressStyle: FormValueItemStyle {
 
     /// The section header style.
-    public var title = TextStyle(
+    package var title = TextStyle(
         font: .preferredFont(forTextStyle: .headline),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .natural
     )
 
     /// The text field style.
-    public var textField = FormTextItemStyle()
+    package var textField = FormTextItemStyle()
 
     /// The tint color of the view.
-    public var tintColor: UIColor? {
+    package var tintColor: UIColor? {
         didSet {
             textField.tintColor = tintColor
         }
     }
 
     /// The background color of the view.
-    public var backgroundColor: UIColor = .clear
+    package var backgroundColor: UIColor = .clear
 
     /// The color of form view item's separator line.
-    public var separatorColor: UIColor? {
+    package var separatorColor: UIColor? {
         textField.separatorColor
     }
     
@@ -41,7 +41,7 @@ public struct AddressStyle: FormValueItemStyle {
     ///   - textField: The text field style.
     ///   - tintColor: The tint color of the view.
     ///   - backgroundColor: The background color of the view.
-    public init(
+    package init(
         title: TextStyle,
         textField: FormTextItemStyle,
         tintColor: UIColor? = nil,
@@ -54,5 +54,5 @@ public struct AddressStyle: FormValueItemStyle {
     }
     
     /// Initializes the form address item configuration with default values
-    public init() {}
+    package init() {}
 }

--- a/AdyenUI/UI/Form/Items/Basic Items/FormContainerItem.swift
+++ b/AdyenUI/UI/Form/Items/Basic Items/FormContainerItem.swift
@@ -8,19 +8,18 @@ import Adyen
 import UIKit
 
 /// Simple form item to wrap another item and provide padding around it.
-@_spi(AdyenInternal)
-public class FormContainerItem<ContentItem: FormItem>: FormItem {
+package class FormContainerItem<ContentItem: FormItem>: FormItem {
 
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
 
-    public var subitems: [FormItem] {
+    package var subitems: [FormItem] {
         [content]
     }
 
-    public var identifier: String?
+    package var identifier: String?
 
     /// The content of container.
-    public let content: ContentItem
+    package let content: ContentItem
 
     /// The margin around content.
     private let padding: UIEdgeInsets?
@@ -31,7 +30,7 @@ public class FormContainerItem<ContentItem: FormItem>: FormItem {
     ///   - content: The Form item to wrap.
     ///   - padding: The padding around `content`.
     ///   - identifier: The optional accessibility identifier for FormView.
-    public init(
+    package init(
         content: ContentItem,
         padding: UIEdgeInsets? = nil,
         identifier: String? = nil
@@ -41,7 +40,7 @@ public class FormContainerItem<ContentItem: FormItem>: FormItem {
         self.identifier = identifier
     }
 
-    public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         let container = FormContainerItemView()
         let contentView = content.build(with: builder)
         container.accessibilityIdentifier = identifier
@@ -78,9 +77,8 @@ private class FormContainerItemView: UIView, AnyFormItemView {
 
 // MARK: - Convenience extension
 
-@_spi(AdyenInternal)
-public extension FormItem {
-    
+package extension FormItem {
+
     /// Adds padding around the form item
     ///
     /// If no padding is provided it uses the superview layout margins to specify the amount of padding around the item

--- a/AdyenUI/UI/Form/Items/Basic Items/FormLabelItem.swift
+++ b/AdyenUI/UI/Form/Items/Basic Items/FormLabelItem.swift
@@ -9,14 +9,13 @@ import Foundation
 import UIKit
 
 /// Simple form item that represent a single UILabel element.
-@_spi(AdyenInternal)
-public class FormLabelItem: FormItem {
-    
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
+package class FormLabelItem: FormItem {
 
-    public var subitems: [FormItem] = []
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
 
-    public init(text: String, style: TextStyle, identifier: String? = nil) {
+    package var subitems: [FormItem] = []
+
+    package init(text: String, style: TextStyle, identifier: String? = nil) {
         self.identifier = identifier
         self.style = style
         self.text = text
@@ -35,18 +34,18 @@ public class FormLabelItem: FormItem {
         self.style = TextStyle(font: .preferredFont(forTextStyle: .title1), color: .red)
     }
 
-    public var identifier: String?
+    package var identifier: String?
 
     /// The style of the label.
-    public var style: TextStyle
+    package var style: TextStyle
 
     /// The text of the label.
-    public var text: String
+    package var text: String
 
     /// The labelStyle from the adyen theme
     internal var labelStyle: AdyenLabelStyle = .init()
 
-    public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         FormLabelItemView(item: self, theme: builder.theme)
     }
 }

--- a/AdyenUI/UI/Form/Items/Button/FormButtonItem.swift
+++ b/AdyenUI/UI/Form/Items/Button/FormButtonItem.swift
@@ -8,33 +8,32 @@ import Adyen
 import Foundation
 
 /// A form item that represents a single button with a spinner.
-@_spi(AdyenInternal)
-public final class FormButtonItem: FormItem {
+package final class FormButtonItem: FormItem {
 
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
-    
-    public var subitems: [FormItem] = []
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
 
-    public var style: FormButtonItemStyle
+    package var subitems: [FormItem] = []
+
+    package var style: FormButtonItemStyle
 
     /// Indicates the item's UI styling.
     internal var buttonStyle: AdyenButtonStyle = AdyenButtonStyles.default.primary
 
-    public var identifier: String?
-    
-    /// The title of the button.
-    @AdyenObservable(nil) public var title: String?
-    
-    /// The observable of the button indicator activity.
-    @AdyenObservable(false) public var showsActivityIndicator: Bool
-    
-    /// The observable of the button's availability status.
-    @AdyenObservable(true) public var enabled: Bool
-    
-    /// A closure that will be invoked when a button is selected.
-    public var buttonSelectionHandler: (() -> Void)?
+    package var identifier: String?
 
-    public init(style: FormButtonItemStyle) {
+    /// The title of the button.
+    @AdyenObservable(nil) package var title: String?
+
+    /// The observable of the button indicator activity.
+    @AdyenObservable(false) package var showsActivityIndicator: Bool
+
+    /// The observable of the button's availability status.
+    @AdyenObservable(true) package var enabled: Bool
+
+    /// A closure that will be invoked when a button is selected.
+    package var buttonSelectionHandler: (() -> Void)?
+
+    package init(style: FormButtonItemStyle) {
         self.style = style
     }
 
@@ -46,7 +45,7 @@ public final class FormButtonItem: FormItem {
         self.style = .init(button: .init(title: .init(font: .preferredFont(forTextStyle: .body), color: .red)))
     }
     
-    public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
     

--- a/AdyenUI/UI/Form/Items/Button/FormButtonItemStyle.swift
+++ b/AdyenUI/UI/Form/Items/Button/FormButtonItemStyle.swift
@@ -8,24 +8,24 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for a form button item.
-public struct FormButtonItemStyle: ViewStyle {
-    
+package struct FormButtonItemStyle: ViewStyle {
+
     /// The font used to display the text.
-    public var button: ButtonStyle
-    
+    package var button: ButtonStyle
+
     /// The background of the view.
-    public var backgroundColor: UIColor = .clear
-    
+    package var backgroundColor: UIColor = .clear
+
     /// Initializes the secondary button style.
     ///
     /// - Parameter font: The font of a title.
-    public init(button: ButtonStyle) {
+    package init(button: ButtonStyle) {
         self.button = button
     }
     
     /// Initializes the button style.
     ///
-    public init(button: ButtonStyle, background: UIColor) {
+    package init(button: ButtonStyle, background: UIColor) {
         self.button = button
         self.backgroundColor = background
     }
@@ -36,7 +36,7 @@ public struct FormButtonItemStyle: ViewStyle {
     ///   - textColor: The color of button's title.
     ///   - mainColor: The filling color of a button..
     ///   - cornerRadius: The corner radius of the button.
-    public static func main(font: UIFont, textColor: UIColor, mainColor: UIColor, cornerRadius: CGFloat) -> FormButtonItemStyle {
+    package static func main(font: UIFont, textColor: UIColor, mainColor: UIColor, cornerRadius: CGFloat) -> FormButtonItemStyle {
         FormButtonItemStyle(button: ButtonStyle(
             title: TextStyle(font: font, color: textColor),
             cornerRadius: cornerRadius,
@@ -49,7 +49,7 @@ public struct FormButtonItemStyle: ViewStyle {
     ///   - font: The font of button's title.
     ///   - textColor: The color of button's title.
     ///   - mainColor: The filling color of a button..
-    public static func main(font: UIFont, textColor: UIColor, mainColor: UIColor) -> FormButtonItemStyle {
+    package static func main(font: UIFont, textColor: UIColor, mainColor: UIColor) -> FormButtonItemStyle {
         FormButtonItemStyle(button: ButtonStyle(
             title: TextStyle(font: font, color: textColor),
             cornerRounding: .fixed(8),
@@ -63,7 +63,7 @@ public struct FormButtonItemStyle: ViewStyle {
     ///   - textColor: The color of button's title.
     ///   - mainColor: The filling color of a button..
     ///   - cornerRounding: The corner style of the button.
-    public static func main(font: UIFont, textColor: UIColor, mainColor: UIColor, cornerRounding: CornerRounding) -> FormButtonItemStyle {
+    package static func main(font: UIFont, textColor: UIColor, mainColor: UIColor, cornerRounding: CornerRounding) -> FormButtonItemStyle {
         FormButtonItemStyle(button: ButtonStyle(
             title: TextStyle(font: font, color: textColor),
             cornerRounding: cornerRounding,
@@ -75,7 +75,7 @@ public struct FormButtonItemStyle: ViewStyle {
     /// - Parameters:
     ///   - font: The font of button's title.
     ///   - textColor: The color of button's title.
-    public static func secondary(font: UIFont, textColor: UIColor) -> FormButtonItemStyle {
+    package static func secondary(font: UIFont, textColor: UIColor) -> FormButtonItemStyle {
         FormButtonItemStyle(button: ButtonStyle(
             title: TextStyle(font: font, color: textColor),
             cornerRadius: 0,

--- a/AdyenUI/UI/Form/Items/Button/SearchButton/FormSearchButtonItem.swift
+++ b/AdyenUI/UI/Form/Items/Button/SearchButton/FormSearchButtonItem.swift
@@ -7,30 +7,29 @@
 import Adyen
 
 /// A form item that represents a search bar button.
-@_spi(AdyenInternal)
-public final class FormSearchButtonItem: FormItem {
+package final class FormSearchButtonItem: FormItem {
 
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
-    
-    public var subitems: [FormItem] = []
-    
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
+
+    package var subitems: [FormItem] = []
+
     /// Indicates the item's UI styling.
-    public let style: ViewStyle
-    
-    public var identifier: String?
-    
+    package let style: ViewStyle
+
+    package var identifier: String?
+
     /// The title of the button.
-    @AdyenObservable(nil) public var placeholder: String?
-    
+    @AdyenObservable(nil) package var placeholder: String?
+
     /// A closure that will be invoked when a button is selected.
-    public let selectionHandler: () -> Void
-    
+    package let selectionHandler: () -> Void
+
     /// Initializes the button item.
     ///
     /// - Parameter placeholder: The search bar placeholder
     /// - Parameter style: The style of the search bar
     /// - Parameter selectionHandler: A closure that will be invoked when a button is selected.
-    public init(
+    package init(
         placeholder: String,
         style: ViewStyle,
         identifier: String,
@@ -42,7 +41,7 @@ public final class FormSearchButtonItem: FormItem {
         self.placeholder = placeholder
     }
     
-    public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
     

--- a/AdyenUI/UI/Form/Items/Error/FormErrorItem.swift
+++ b/AdyenUI/UI/Form/Items/Error/FormErrorItem.swift
@@ -8,36 +8,30 @@ import Adyen
 import Foundation
 
 /// A form item that represents an error.
-@_spi(AdyenInternal)
-public final class FormErrorItem: FormItem {
+package final class FormErrorItem: FormItem {
 
     /// Indicates the error message.
-    @AdyenObservable(nil) public var message: String?
+    @AdyenObservable(nil) package var message: String?
 
     /// The error icon name.
-    public let iconName: String
+    package let iconName: String
 
     /// The error item style.
-    public let style: FormErrorItemStyle
+    package let style: FormErrorItemStyle
 
-    public var identifier: String?
+    package var identifier: String?
 
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(true)
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(true)
 
-    public var subitems: [FormItem] = []
+    package var subitems: [FormItem] = []
 
-    /// Initializes the separator item.
-    ///
-    /// - Parameter message: The message.
-    /// - Parameter iconName: The icon name.
-    /// - Parameter style: a `FormErrorItemStyle` UI style.
-    public init(message: String? = nil, iconName: String = "error", style: FormErrorItemStyle = FormErrorItemStyle()) {
+    package init(message: String? = nil, iconName: String = "error", style: FormErrorItemStyle = FormErrorItemStyle()) {
         self.iconName = iconName
         self.style = style
         self.message = message
     }
 
-    public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
 

--- a/AdyenUI/UI/Form/Items/Error/FormErrorItemStyle.swift
+++ b/AdyenUI/UI/Form/Items/Error/FormErrorItemStyle.swift
@@ -7,27 +7,27 @@
 import UIKit
 
 /// Contains the styling customization options for an error item in a form.
-public struct FormErrorItemStyle: ViewStyle {
+package struct FormErrorItemStyle: ViewStyle {
 
     /// The message style.
-    public var message = TextStyle(
+    package var message = TextStyle(
         font: .preferredFont(forTextStyle: .callout),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .natural
     )
 
     /// The corners style of the text item.
-    public var cornerRounding: CornerRounding = .fixed(6)
+    package var cornerRounding: CornerRounding = .fixed(6)
 
-    public var backgroundColor = UIColor.Adyen.errorRed.withAlphaComponent(0.1)
+    package var backgroundColor = UIColor.Adyen.errorRed.withAlphaComponent(0.1)
 
     /// Initializes the form error item style.
     ///
     /// - Parameter message: The message style.
-    public init(message: TextStyle) {
+    package init(message: TextStyle) {
         self.message = message
     }
 
     /// Initializes the form error item style with the default style.
-    public init() {}
+    package init() {}
 }

--- a/AdyenUI/UI/Form/Items/FormItemView.swift
+++ b/AdyenUI/UI/Form/Items/FormItemView.swift
@@ -55,8 +55,7 @@ public protocol AnyFormItemView: UIView {
     var childItemViews: [AnyFormItemView] { get }
 }
 
-@_spi(AdyenInternal)
-public protocol AppearanceChangeRefreshable: AnyObject {
+package protocol AppearanceChangeRefreshable: AnyObject {
     func refreshAppearance(with traitCollection: UITraitCollection)
 }
 

--- a/AdyenUI/UI/Form/Items/Separator/FormSeparatorItem.swift
+++ b/AdyenUI/UI/Form/Items/Separator/FormSeparatorItem.swift
@@ -8,27 +8,25 @@ import Adyen
 import UIKit
 
 /// A form item that represents a separator line.
-@_spi(AdyenInternal)
-public final class FormSeparatorItem: FormItem {
+package final class FormSeparatorItem: FormItem {
 
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
-    
-    public var subitems: [FormItem] = []
-    
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
+
+    package var subitems: [FormItem] = []
+
     /// Indicates the line color.
-    public let color: UIColor
-    
-    public var identifier: String?
-    
+    package let color: UIColor
+
+    package var identifier: String?
+
     /// Initializes the separator item.
     ///
     /// - Parameter style: Any `ViewStyle` UI style.
-    public init(color: UIColor) {
+    package init(color: UIColor) {
         self.color = color
     }
     
-    @_spi(AdyenInternal)
-    public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
     

--- a/AdyenUI/UI/Form/Items/Spacer/FormSpacerItem.swift
+++ b/AdyenUI/UI/Form/Items/Spacer/FormSpacerItem.swift
@@ -8,26 +8,25 @@ import Adyen
 import Foundation
 
 /// A space form item in terms of number of layout margins.
-@_spi(AdyenInternal)
-public final class FormSpacerItem: FormItem {
+package final class FormSpacerItem: FormItem {
 
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
-    
-    public var identifier: String?
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
 
-    public let subitems: [FormItem] = []
+    package var identifier: String?
+
+    package let subitems: [FormItem] = []
 
     /// Indicates number of layout margins.
-    public let standardSpaceMultiplier: Int
+    package let standardSpaceMultiplier: Int
 
     /// Initializes a `FormSpacerItem`.
     ///
     /// - Parameter standardSpaceMultiplier: The number of layout margins.
-    public init(numberOfSpaces: Int = 1) {
+    package init(numberOfSpaces: Int = 1) {
         self.standardSpaceMultiplier = numberOfSpaces
     }
 
-    public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
 }

--- a/AdyenUI/UI/Form/Items/Spacer/FormSpacerItemView.swift
+++ b/AdyenUI/UI/Form/Items/Spacer/FormSpacerItemView.swift
@@ -8,8 +8,7 @@ import Adyen
 import UIKit
 
 /// A space form item in terms of number of layout margins.
-@_spi(AdyenInternal)
-public final class FormSpacerItemView: FormItemView<FormSpacerItem> {
+package final class FormSpacerItemView: FormItemView<FormSpacerItem> {
 
     /// Initializes the spacer item view.
     ///

--- a/AdyenUI/UI/Form/Items/Split/FormSplitItem.swift
+++ b/AdyenUI/UI/Form/Items/Split/FormSplitItem.swift
@@ -8,21 +8,20 @@ import Adyen
 import Foundation
 
 /// A form item in which two items are shown side-by-side horizontally.
-@_spi(AdyenInternal)
-public final class FormSplitItem: FormItem {
+package final class FormSplitItem: FormItem {
 
-    public var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
-    
+    package var isHidden: AdyenObservable<Bool> = AdyenObservable(false)
+
     internal var leftItem: FormItem
 
     internal var rightItem: FormItem
     
     /// Indicates the `FormSplitItemView` UI styling.
-    public let style: ViewStyle
-    
-    public var identifier: String?
-    
-    public var subitems: [FormItem] {
+    package let style: ViewStyle
+
+    package var identifier: String?
+
+    package var subitems: [FormItem] {
         [leftItem, rightItem]
     }
     
@@ -30,14 +29,14 @@ public final class FormSplitItem: FormItem {
     ///
     /// - Parameter items: The items displayed side-by-side. Must be two.
     /// - Parameter style: The `FormSplitItemView` UI style.
-    public init(items: FormItem..., style: ViewStyle) {
+    package init(items: FormItem..., style: ViewStyle) {
         assert(items.count == 2)
         self.leftItem = items[0]
         self.rightItem = items[1]
         self.style = style
     }
     
-    public func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
+    package func build(with builder: FormItemViewBuilder) -> AnyFormItemView {
         builder.build(with: self)
     }
     

--- a/AdyenUI/UI/Form/Items/Text/FormTextItem.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItem.swift
@@ -18,7 +18,7 @@ open class FormTextItem: FormValidatableValueItem<String>, InputViewRequiringFor
     }
 
     /// The formatter to use for formatting the text in the text field.
-    public var formatter: Adyen.Formatter?
+    package var formatter: Adyen.Formatter?
 
     /// The validator to use for validating the text in the text field.
     package var validator: Validator?

--- a/AdyenUI/UI/Form/Items/Text/FormTextItemStyle.swift
+++ b/AdyenUI/UI/Form/Items/Text/FormTextItemStyle.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for a text item in a form.
-public struct FormTextItemStyle: FormValueItemStyle {
+@_spi(AdyenInternal) public struct FormTextItemStyle: FormValueItemStyle {
     
     /// The title style.
     public var title = TextStyle(
@@ -28,7 +28,7 @@ public struct FormTextItemStyle: FormValueItemStyle {
     public var placeholderText: TextStyle?
     
     /// The icons' style.
-    public var icon = ImageStyle(
+    package var icon = ImageStyle(
         borderColor: UIColor.Adyen.componentSeparator,
         borderWidth: 1.0 / UIScreen.main.nativeScale,
         cornerRadius: 4.0,

--- a/AdyenUI/UI/Form/Items/Toggle/FormToggleItemStyle.swift
+++ b/AdyenUI/UI/Form/Items/Toggle/FormToggleItemStyle.swift
@@ -8,31 +8,31 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for a switch item in a form.
-public struct FormToggleItemStyle: FormValueItemStyle {
-    
+package struct FormToggleItemStyle: FormValueItemStyle {
+
     /// The title style.
-    public var title = TextStyle(
+    package var title = TextStyle(
         font: .preferredFont(forTextStyle: .body),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .natural
     )
     
     /// The color of `onTintColor` of switch.
-    public var tintColor: UIColor?
-    
+    package var tintColor: UIColor?
+
     /// The color for separator element.
     /// If value is nil, the default color would be used.
-    public var separatorColor: UIColor?
-    
-    public var backgroundColor: UIColor = .clear
-    
+    package var separatorColor: UIColor?
+
+    package var backgroundColor: UIColor = .clear
+
     /// Initializes the form switch item style.
     ///
     /// - Parameter title: The title style.
-    public init(title: TextStyle) {
+    package init(title: TextStyle) {
         self.title = title
     }
     
     /// Initializes the form switch item style with the default style.
-    public init() {}
+    package init() {}
 }

--- a/AdyenUI/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItem.swift
+++ b/AdyenUI/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItem.swift
@@ -14,6 +14,7 @@ package protocol PickerElement: Equatable, CustomStringConvertible {
     var identifier: String { get }
 }
 
+@_spi(AdyenInternal)
 public struct BasePickerElement<ElementType: CustomStringConvertible>: PickerElement {
 
     /// Picker item identifier.

--- a/AdyenUI/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItem.swift
+++ b/AdyenUI/UI/Form/Items/Value Pickers/Abstract/BaseFormPickerItem.swift
@@ -8,14 +8,12 @@ import Adyen
 import UIKit
 
 /// Picker item identifier.
-@_spi(AdyenInternal)
-public protocol PickerElement: Equatable, CustomStringConvertible {
+package protocol PickerElement: Equatable, CustomStringConvertible {
 
     /// Picker item identifier.
     var identifier: String { get }
 }
 
-@_spi(AdyenInternal)
 public struct BasePickerElement<ElementType: CustomStringConvertible>: PickerElement {
 
     /// Picker item identifier.

--- a/AdyenUI/UI/Form/Items/Value Pickers/Abstract/BasePickerInputControl.swift
+++ b/AdyenUI/UI/Form/Items/Value Pickers/Abstract/BasePickerInputControl.swift
@@ -8,6 +8,7 @@ import Adyen
 import UIKit
 
 /// Interface for a basic picker input control.
+@_spi(AdyenInternal)
 public protocol PickerTextInputControl: UIView {
 
     /// Executed when the view resigns as first responder.

--- a/AdyenUI/UI/Form/Items/Value Pickers/Abstract/BasePickerInputControl.swift
+++ b/AdyenUI/UI/Form/Items/Value Pickers/Abstract/BasePickerInputControl.swift
@@ -8,7 +8,6 @@ import Adyen
 import UIKit
 
 /// Interface for a basic picker input control.
-@_spi(AdyenInternal)
 public protocol PickerTextInputControl: UIView {
 
     /// Executed when the view resigns as first responder.

--- a/AdyenUI/UI/Form/Items/Value/FormValueItem.swift
+++ b/AdyenUI/UI/Form/Items/Value/FormValueItem.swift
@@ -8,7 +8,7 @@ import Adyen
 import UIKit
 
 /// A style of form elements in which a value can be entered.
-public protocol FormValueItemStyle: TintableStyle {
+@_spi(AdyenInternal) public protocol FormValueItemStyle: TintableStyle {
     
     /// The color of bottom line separating form elements.
     var separatorColor: UIColor? { get }

--- a/AdyenUI/UI/Form/Items/Value/FormValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/FormValueItemView.swift
@@ -80,8 +80,7 @@ open class FormValueItemView<ValueType, Style, ItemType: FormValueItem<ValueType
 }
 
 /// A type-erased form value item view.
-@_spi(AdyenInternal)
-public protocol AnyFormValueItemView: AnyFormItemView {
+package protocol AnyFormValueItemView: AnyFormItemView {
     
     /// Indicates if the item is currently being edited.
     var isEditing: Bool { get set }

--- a/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Validatable/FormValidatableValueItemView.swift
@@ -127,8 +127,7 @@ open class FormValidatableValueItemView<ValueType, ItemType: FormValidatableValu
 }
 
 /// A type-erased form value item view that provides a validation check
-@_spi(AdyenInternal)
-public protocol AnyFormValidatableValueItemView: AnyFormValueItemView {
+package protocol AnyFormValidatableValueItemView: AnyFormValueItemView {
 
     /// Invoke validation check. Performs all necessary UI transformations based on a validation result.
     func showValidation()

--- a/AdyenUI/UI/List/ListItemStyle.swift
+++ b/AdyenUI/UI/List/ListItemStyle.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for an item in a list.
-public struct ListItemStyle: ViewStyle {
+@_spi(AdyenInternal) public struct ListItemStyle: ViewStyle {
     
     /// The title style.
     public var title = TextStyle(

--- a/AdyenUI/UI/List/ListItemStyle.swift
+++ b/AdyenUI/UI/List/ListItemStyle.swift
@@ -8,31 +8,31 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for an item in a list.
-@_spi(AdyenInternal) public struct ListItemStyle: ViewStyle {
-    
+package struct ListItemStyle: ViewStyle {
+
     /// The title style.
-    public var title = TextStyle(
+    package var title = TextStyle(
         font: .preferredFont(forTextStyle: .body),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .natural
     )
     
     /// The subtitle style.
-    public var subtitle = TextStyle(
+    package var subtitle = TextStyle(
         font: .preferredFont(forTextStyle: .footnote),
         color: UIColor.Adyen.componentSecondaryLabel,
         textAlignment: .natural
     )
 
     /// The trailing title style.
-    public var trailingText = TextStyle(
+    package var trailingText = TextStyle(
         font: .preferredFont(forTextStyle: .body),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .natural
     )
     
     /// The image style.
-    public var image = ImageStyle(
+    package var image = ImageStyle(
         borderColor: UIColor.Adyen.componentSeparator,
         borderWidth: 1.0 / UIScreen.main.nativeScale,
         cornerRadius: 4.0,
@@ -40,30 +40,30 @@ import UIKit
         contentMode: .scaleAspectFit
     )
     
-    public var backgroundColor = UIColor.Adyen.componentBackground
-    
+    package var backgroundColor = UIColor.Adyen.componentBackground
+
     /// Background color when highlighted (tapped).
-    public var highlightedBackgroundColor: UIColor?
-    
+    package var highlightedBackgroundColor: UIColor?
+
     /// Initializes the list item style.
     ///
     /// - Parameter title: The title style.
     /// - Parameter subtitle: The subtitle style.
     /// - Parameter image: The image style.
-    public init(title: TextStyle, subtitle: TextStyle, image: ImageStyle) {
+    package init(title: TextStyle, subtitle: TextStyle, image: ImageStyle) {
         self.title = title
         self.subtitle = subtitle
         self.image = image
     }
     
     /// Initializes the list item style with the default style.
-    public init() {}
-    
+    package init() {}
+
 }
 
 extension ListItemStyle: Equatable {
     
-    public static func == (lhs: ListItemStyle, rhs: ListItemStyle) -> Bool {
+    package static func == (lhs: ListItemStyle, rhs: ListItemStyle) -> Bool {
         lhs.title == rhs.title &&
             lhs.subtitle == rhs.subtitle &&
             lhs.image == rhs.image &&

--- a/AdyenUI/UI/List/ListSectionFooterStyle.swift
+++ b/AdyenUI/UI/List/ListSectionFooterStyle.swift
@@ -8,10 +8,10 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for a list section footer.
-public struct ListSectionFooterStyle: ViewStyle {
+package struct ListSectionFooterStyle: ViewStyle {
 
     /// The title style.
-    public var title = TextStyle(
+    package var title = TextStyle(
         font: .preferredFont(forTextStyle: .footnote),
         color: UIColor.Adyen.paidSectionFooterTitleColor,
         textAlignment: .center,
@@ -20,18 +20,18 @@ public struct ListSectionFooterStyle: ViewStyle {
     )
 
     /// Separator Color.
-    public var separatorColor = UIColor.Adyen.componentSeparator
+    package var separatorColor = UIColor.Adyen.componentSeparator
 
-    public var backgroundColor = UIColor.Adyen.componentBackground
+    package var backgroundColor = UIColor.Adyen.componentBackground
 
     /// Initializes the list header style.
     ///
     /// - Parameter title: The title style.
-    public init(title: TextStyle) {
+    package init(title: TextStyle) {
         self.title = title
     }
 
     /// Initializes the list header style with the default style.
-    public init() {}
+    package init() {}
 
 }

--- a/AdyenUI/UI/List/ListSectionHeaderStyle.swift
+++ b/AdyenUI/UI/List/ListSectionHeaderStyle.swift
@@ -8,17 +8,17 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for a list section header.
-public struct ListSectionHeaderStyle: ViewStyle {
-    
+package struct ListSectionHeaderStyle: ViewStyle {
+
     /// The title style.
-    public var title = TextStyle(
+    package var title = TextStyle(
         font: .preferredFont(forTextStyle: .subheadline),
         color: UIColor.Adyen.componentSecondaryLabel,
         textAlignment: .natural
     )
     
     /// The trailing button style.
-    public var trailingButton = ButtonStyle(
+    package var trailingButton = ButtonStyle(
         title: TextStyle(
             font: .preferredFont(forTextStyle: .body),
             color: UIColor.Adyen.defaultBlue
@@ -27,16 +27,16 @@ public struct ListSectionHeaderStyle: ViewStyle {
         background: UIColor.clear
     )
     
-    public var backgroundColor = UIColor.Adyen.componentBackground
-    
+    package var backgroundColor = UIColor.Adyen.componentBackground
+
     /// Initializes the list header style.
     ///
     /// - Parameter title: The title style.
-    public init(title: TextStyle) {
+    package init(title: TextStyle) {
         self.title = title
     }
     
     /// Initializes the list header style with the default style.
-    public init() {}
+    package init() {}
     
 }

--- a/AdyenUI/UI/Styles/ApplePayStyle.swift
+++ b/AdyenUI/UI/Styles/ApplePayStyle.swift
@@ -9,22 +9,22 @@ import PassKit
 import UIKit
 
 ///  Contains the styling options for Apple Pay components.
-public struct ApplePayStyle {
-    
+package struct ApplePayStyle {
+
     /// Style of the payment button. When nil, it's set to automatic based on Dark or Light Mode.
-    public var paymentButtonStyle: PKPaymentButtonStyle?
-    
+    package var paymentButtonStyle: PKPaymentButtonStyle?
+
     /// Type of the Apple Pay payment button. Default is `.inStore`
-    public var paymentButtonType: PKPaymentButtonType
-    
+    package var paymentButtonType: PKPaymentButtonType
+
     /// Corner radius for the payment button. iOS 12 or above. Defaults to 4 points.
-    public var cornerRadius: CGFloat
-    
+    package var cornerRadius: CGFloat
+
     /// Background color for the Apple Pay component.
-    public var backgroundColor: UIColor
-    
+    package var backgroundColor: UIColor
+
     /// Stying for the label that contains the formatted amount text.
-    public var hintLabel: TextStyle
+    package var hintLabel: TextStyle
 
     /// Initializes an Apple Pay style instance with default values.
     /// - Parameters:
@@ -33,7 +33,7 @@ public struct ApplePayStyle {
     ///   - cornerRadius: Corner radius for the payment button. iOS 12 or above. Defaults to 4 points.
     ///   - backgroundColor: Background color for the Apple Pay component.
     ///   - hintLabel: Stying for the label that contains the formatted amount text.
-    public init(
+    package init(
         paymentButtonStyle: PKPaymentButtonStyle? = nil,
         paymentButtonType: PKPaymentButtonType = .inStore,
         cornerRadius: CGFloat = 4,

--- a/AdyenUI/UI/Styles/ButtonStyle.swift
+++ b/AdyenUI/UI/Styles/ButtonStyle.swift
@@ -8,26 +8,26 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for any buttons.
-public struct ButtonStyle: ViewStyle, Equatable {
-    
+package struct ButtonStyle: ViewStyle, Equatable {
+
     /// The title style.
-    public var title: TextStyle
-    
+    package var title: TextStyle
+
     /// The corners style of the button.
-    public var cornerRounding: CornerRounding = .fixed(8)
+    package var cornerRounding: CornerRounding = .fixed(8)
 
     /// The color of the Button's border.
-    public var borderColor: UIColor?
+    package var borderColor: UIColor?
 
     /// The width of the Button's border.
-    public var borderWidth: CGFloat = 0
-    
-    public var backgroundColor = UIColor.Adyen.defaultBlue
-    
+    package var borderWidth: CGFloat = 0
+
+    package var backgroundColor = UIColor.Adyen.defaultBlue
+
     /// Initializes the button style.
     ///
     /// - Parameter title: The title style.
-    public init(title: TextStyle) {
+    package init(title: TextStyle) {
         self.title = title
     }
     
@@ -35,7 +35,7 @@ public struct ButtonStyle: ViewStyle, Equatable {
     ///
     /// - Parameter title: The title style.
     /// - Parameter cornerRadius: The corner radius of the button.
-    public init(title: TextStyle, cornerRadius: CGFloat) {
+    package init(title: TextStyle, cornerRadius: CGFloat) {
         self.title = title
         self.cornerRounding = .fixed(cornerRadius)
     }
@@ -44,7 +44,7 @@ public struct ButtonStyle: ViewStyle, Equatable {
     ///
     /// - Parameter title: The title style.
     /// - Parameter cornerRounding: The corner radius of the button style.
-    public init(title: TextStyle, cornerRounding: CornerRounding) {
+    package init(title: TextStyle, cornerRounding: CornerRounding) {
         self.title = title
         self.cornerRounding = cornerRounding
     }
@@ -54,7 +54,7 @@ public struct ButtonStyle: ViewStyle, Equatable {
     /// - Parameter title: The button title text style.
     /// - Parameter cornerRadius: The button corner radius.
     /// - Parameter background: Color to fill button's background.
-    public init(title: TextStyle, cornerRadius: CGFloat, background: UIColor) {
+    package init(title: TextStyle, cornerRadius: CGFloat, background: UIColor) {
         self.title = title
         self.cornerRounding = .fixed(cornerRadius)
         self.backgroundColor = background
@@ -65,7 +65,7 @@ public struct ButtonStyle: ViewStyle, Equatable {
     /// - Parameter title: The button title text style.
     /// - Parameter cornerRounding: The button corner radius style.
     /// - Parameter background: Color to fill button's background.
-    public init(title: TextStyle, cornerRounding: CornerRounding, background: UIColor) {
+    package init(title: TextStyle, cornerRounding: CornerRounding, background: UIColor) {
         self.title = title
         self.cornerRounding = cornerRounding
         self.backgroundColor = background

--- a/AdyenUI/UI/Styles/FormComponentStyle.swift
+++ b/AdyenUI/UI/Styles/FormComponentStyle.swift
@@ -8,12 +8,12 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for any form-based component.
-public struct FormComponentStyle: TintableStyle {
-    
-    public var backgroundColor = UIColor.Adyen.componentBackground
+package struct FormComponentStyle: TintableStyle {
+
+    package var backgroundColor = UIColor.Adyen.componentBackground
 
     /// The section header style.
-    public var sectionHeader = TextStyle(
+    package var sectionHeader = TextStyle(
         font: .preferredFont(forTextStyle: .headline),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .natural
@@ -24,51 +24,51 @@ public struct FormComponentStyle: TintableStyle {
     }
     
     /// The text field style.
-    public var textField = FormTextItemStyle() {
+    package var textField = FormTextItemStyle() {
         didSet {
             addressStyle.textField = textField
         }
     }
     
     /// The toggle style.
-    public var toggle = FormToggleItemStyle()
+    package var toggle = FormToggleItemStyle()
 
     /// The helper message style.
-    public var hintLabel = TextStyle(
+    package var hintLabel = TextStyle(
         font: .preferredFont(forTextStyle: .body),
         color: UIColor.Adyen.componentLabel,
         textAlignment: .natural
     )
 
     /// The foot note text style.
-    public var footnoteLabel = TextStyle(
+    package var footnoteLabel = TextStyle(
         font: .preferredFont(forTextStyle: .footnote),
         color: UIColor.Adyen.componentSecondaryLabel,
         textAlignment: .center
     )
 
     /// The link text style.
-    public var linkTextLabel = TextStyle(
+    package var linkTextLabel = TextStyle(
         font: .preferredFont(forTextStyle: .footnote),
         color: UIColor.Adyen.defaultBlue,
         textAlignment: .center
     )
     
     /// The main button style.
-    public var mainButtonItem: FormButtonItemStyle = .main(
+    package var mainButtonItem: FormButtonItemStyle = .main(
         font: .preferredFont(forTextStyle: .headline),
         textColor: .white,
         mainColor: UIColor.Adyen.defaultBlue
     )
     
     /// The secondary button style.
-    public var secondaryButtonItem: FormButtonItemStyle = .secondary(
+    package var secondaryButtonItem: FormButtonItemStyle = .secondary(
         font: .preferredFont(forTextStyle: .body),
         textColor: UIColor.Adyen.defaultBlue
     )
 
     /// The  segmented control  style.
-    public var segmentedControlStyle: SegmentedControlStyle = .init(
+    package var segmentedControlStyle: SegmentedControlStyle = .init(
         textStyle: TextStyle(
             font: .preferredFont(forTextStyle: .subheadline),
             color: UIColor.Adyen.componentBackground
@@ -76,15 +76,15 @@ public struct FormComponentStyle: TintableStyle {
     )
 
     /// The address style generated based on other field's value.
-    public var addressStyle: AddressStyle
+    package var addressStyle: AddressStyle
 
     /// The error message indicator style.
-    public var errorStyle = FormErrorItemStyle()
+    package var errorStyle = FormErrorItemStyle()
 
     /// Set tint color of form.
     /// When set, updates tint colors for all underlying styles.
     /// If value is nil, the default color would be used.
-    public var tintColor: UIColor? {
+    package var tintColor: UIColor? {
         didSet {
             setTintColor(tintColor)
         }
@@ -93,7 +93,7 @@ public struct FormComponentStyle: TintableStyle {
     /// The color for separator element.
     /// When set, updates separator colors for all underlying styles unless the value were set previously.
     /// If value is nil, the default color would be used.
-    public var separatorColor: UIColor? {
+    package var separatorColor: UIColor? {
         didSet {
             textField.separatorColor = textField.separatorColor ?? separatorColor
             toggle.separatorColor = toggle.separatorColor ?? separatorColor
@@ -108,7 +108,7 @@ public struct FormComponentStyle: TintableStyle {
     /// - Parameter secondaryButton: The secondary button style.
     /// - Parameter helper: The helper message style.
     /// - Parameter sectionHeader: The section header style.
-    public init(
+    package init(
         textField: FormTextItemStyle,
         toggle: FormToggleItemStyle,
         mainButton: FormButtonItemStyle,
@@ -131,7 +131,7 @@ public struct FormComponentStyle: TintableStyle {
     /// - Parameter toggle: The toggle style.
     /// - Parameter mainButton: The main button style.
     /// - Parameter secondaryButton: The secondary button style.
-    public init(
+    package init(
         textField: FormTextItemStyle,
         toggle: FormToggleItemStyle,
         mainButton: ButtonStyle,
@@ -146,13 +146,13 @@ public struct FormComponentStyle: TintableStyle {
     
     /// Initializes the form style with the default style and custom tint for all elements.
     /// - Parameter tintColor: The color for tinting buttons. textfields, icons and switches.
-    public init(tintColor: UIColor) {
+    package init(tintColor: UIColor) {
         self.addressStyle = .init(title: sectionHeader, textField: textField)
         setTintColor(tintColor)
     }
     
     /// Initializes the form style with the default style.
-    public init() {
+    package init() {
         self.addressStyle = .init(title: sectionHeader, textField: textField)
     }
 

--- a/AdyenUI/UI/Styles/ImageStyle.swift
+++ b/AdyenUI/UI/Styles/ImageStyle.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 /// Contains the styling customization options for any images.
-public struct ImageStyle: TintableStyle {
+@_spi(AdyenInternal) public struct ImageStyle: TintableStyle {
     
     /// The color of the image's border.
     public var borderColor: UIColor?

--- a/AdyenUI/UI/Styles/ListComponentStyle.swift
+++ b/AdyenUI/UI/Styles/ListComponentStyle.swift
@@ -8,24 +8,24 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for any list-based component.
-public struct ListComponentStyle: ViewStyle {
-    
+package struct ListComponentStyle: ViewStyle {
+
     /// The style of any of the items in the list.
-    public var listItem = ListItemStyle()
-    
+    package var listItem = ListItemStyle()
+
     /// The style of any of the section headers in the list.
-    public var sectionHeader = ListSectionHeaderStyle()
+    package var sectionHeader = ListSectionHeaderStyle()
 
     /// The style of partial payment section footer.
-    public var partialPaymentSectionFooter = ListSectionFooterStyle()
-    
-    public var backgroundColor = UIColor.Adyen.componentBackground
-    
+    package var partialPaymentSectionFooter = ListSectionFooterStyle()
+
+    package var backgroundColor = UIColor.Adyen.componentBackground
+
     /// Initializes the list component style.
     ///
     /// - Parameter listItem: The style of any of the items in the list.
     /// - Parameter sectionHeader: The style of any of the section headers in the list.
-    public init(
+    package init(
         listItem: ListItemStyle,
         sectionHeader: ListSectionHeaderStyle
     ) {
@@ -34,5 +34,5 @@ public struct ListComponentStyle: ViewStyle {
     }
     
     /// Initializes the list component style with the default style.
-    public init() {}
+    package init() {}
 }

--- a/AdyenUI/UI/Styles/NavigationStyle.swift
+++ b/AdyenUI/UI/Styles/NavigationStyle.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// The style of "Cancel" button.
-public enum CancelButtonStyle {
+package enum CancelButtonStyle {
 
     /// Default system style. Cross icon for iOS 13, system button "Cancel" for prior versions.
     case system
@@ -21,7 +21,7 @@ public enum CancelButtonStyle {
 }
 
 /// Modes for toolbar layout.
-public enum ToolbarMode {
+package enum ToolbarMode {
 
     /// Cancel button visually left aligned.
     case leftCancel
@@ -35,35 +35,35 @@ public enum ToolbarMode {
 }
 
 /// Indicates the navigation level style.
-public struct NavigationStyle: TintableStyle {
-    
+package struct NavigationStyle: TintableStyle {
+
     /// Indicates the navigation bar background color.
-    public var backgroundColor = UIColor.Adyen.componentBackground
-    
+    package var backgroundColor = UIColor.Adyen.componentBackground
+
     /// The color of the thin line at the bottom of the navigation bar.
     /// If value is nil, the default color would be used.
-    public var separatorColor: UIColor?
-    
+    package var separatorColor: UIColor?
+
     /// Indicates the navigation bar tint color.
-    public var tintColor: UIColor?
-    
+    package var tintColor: UIColor?
+
     /// Indicates the corner radius of navigation bar top corners.
-    public var cornerRadius: CGFloat = 10
-    
+    package var cornerRadius: CGFloat = 10
+
     /// Indicates the bar title text style.
-    public var barTitle = TextStyle(
+    package var barTitle = TextStyle(
         font: UIFont.AdyenCore.barTitle,
         color: UIColor.Adyen.componentLabel,
         textAlignment: .natural
     )
 
     /// The style of cancelButton. This property is not applicable to SFViewController in redirect component.
-    public var cancelButton = CancelButtonStyle.system
+    package var cancelButton = CancelButtonStyle.system
 
     /// The mode for toolbar layout. Defines positions cancel button.
-    public var toolbarMode = ToolbarMode.natural
-    
+    package var toolbarMode = ToolbarMode.natural
+
     /// Initializes the navigation style.
-    public init() {}
-    
+    package init() {}
+
 }

--- a/AdyenUI/UI/Styles/ProgressViewStyle.swift
+++ b/AdyenUI/UI/Styles/ProgressViewStyle.swift
@@ -7,22 +7,22 @@
 import UIKit
 
 /// Contains the styling customization options for any progress views
-public struct ProgressViewStyle: ViewStyle {
-    
+package struct ProgressViewStyle: ViewStyle {
+
     /// The color shown for the portion of the progress bar that is filled
-    public let progressTintColor: UIColor
-    
+    package let progressTintColor: UIColor
+
     /// The color shown for the portion of the progress bar that is not filled.
-    public let trackTintColor: UIColor
-    
-    public var backgroundColor = UIColor.clear
-    
+    package let trackTintColor: UIColor
+
+    package var backgroundColor = UIColor.clear
+
     /// Initializes the progress view style
     ///
     /// - Parameters:
     ///   - progressTintColor: The color shown for the portion of the progress bar that is filled
     ///   - trackTintColor: The color shown for the portion of the progress bar that is not filled.
-    public init(progressTintColor: UIColor, trackTintColor: UIColor) {
+    package init(progressTintColor: UIColor, trackTintColor: UIColor) {
         self.progressTintColor = progressTintColor
         self.trackTintColor = trackTintColor
     }

--- a/AdyenUI/UI/Styles/SegmentedControlStyle.swift
+++ b/AdyenUI/UI/Styles/SegmentedControlStyle.swift
@@ -8,23 +8,23 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for any segmented control.
-public struct SegmentedControlStyle: TintableStyle {
+package struct SegmentedControlStyle: TintableStyle {
 
     /// The textStyle used to customize the text
-    public var textStyle: TextStyle
+    package var textStyle: TextStyle
 
     /// The background color of segmented control.
-    public var backgroundColor: UIColor
+    package var backgroundColor: UIColor
 
     /// The tintColor used to changes the selected segment tint color.
-    public var tintColor: UIColor?
+    package var tintColor: UIColor?
 
     /// Initializes the segmented control style.
     ///
     /// - Parameter textStyle: the style of the text
     /// - Parameter backgroundColor: The background color.
     /// -  Parameter tintColor: The background color of the selected segment.
-    public init(
+    package init(
         textStyle: TextStyle,
         backgroundColor: UIColor = .clear,
         tintColor: UIColor = .white

--- a/AdyenUI/UI/Styles/TextStyle.swift
+++ b/AdyenUI/UI/Styles/TextStyle.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Contains the styling customization options for any labels.
-public struct TextStyle: ViewStyle {
+@_spi(AdyenInternal) public struct TextStyle: ViewStyle {
     
     /// The font used to display the text.
     public var font: UIFont

--- a/AdyenUI/UI/View Controllers/AddressLookup/Form/AddressInputFormViewController.swift
+++ b/AdyenUI/UI/View Controllers/AddressLookup/Form/AddressInputFormViewController.swift
@@ -9,12 +9,11 @@ import Adyen
 import UIKit
 
 /// A ``FormViewController`` with a ``FormAddressItem`` and optional ``FormSearchButtonItem``
-@_spi(AdyenInternal)
-public class AddressInputFormViewController: FormViewController {
-    
+package class AddressInputFormViewController: FormViewController {
+
     private let viewModel: ViewModel
     
-    public init(viewModel: ViewModel) {
+    package init(viewModel: ViewModel) {
         self.viewModel = viewModel
         
         super.init(
@@ -36,7 +35,7 @@ public class AddressInputFormViewController: FormViewController {
         setupNavigationItems()
     }
     
-    override public func viewDidLoad() {
+    override package func viewDidLoad() {
         super.viewDidLoad()
         
         // The done button should only be enabled once at least one field is filled in.

--- a/AdyenUI/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController+Style.swift
+++ b/AdyenUI/UI/View Controllers/AddressLookup/Search/AddressLookupSearchViewController+Style.swift
@@ -7,17 +7,17 @@
 import UIKit
 
 /// The style of the search screen for address lookup
-public struct AddressLookupSearchStyle: ViewStyle {
-    
-    public var backgroundColor: UIColor = .Adyen.componentBackground
-    
-    public var manualEntryListItem: ListItemStyle = {
+package struct AddressLookupSearchStyle: ViewStyle {
+
+    package var backgroundColor: UIColor = .Adyen.componentBackground
+
+    package var manualEntryListItem: ListItemStyle = {
         var listItemStyle = ListItemStyle()
         listItemStyle.title.color = .Adyen.defaultBlue
         return listItemStyle
     }()
     
-    public var emptyView: EmptyStateViewStyle = .init()
-    
-    public init() {}
+    package var emptyView: EmptyStateViewStyle = .init()
+
+    package init() {}
 }

--- a/AdyenUI/UI/Views/EmptyStateView.swift
+++ b/AdyenUI/UI/Views/EmptyStateView.swift
@@ -8,17 +8,17 @@ import Adyen
 import UIKit
 
 /// The style of the empty state view
-public struct EmptyStateViewStyle: ViewStyle {
-    
-    public var title: TextStyle = .init(
+package struct EmptyStateViewStyle: ViewStyle {
+
+    package var title: TextStyle = .init(
         font: .preferredFont(forTextStyle: .headline),
         color: .Adyen.componentLabel
     )
-    public var subtitle: TextStyle = .init(
+    package var subtitle: TextStyle = .init(
         font: .preferredFont(forTextStyle: .subheadline),
         color: .Adyen.componentSecondaryLabel
     )
-    public var backgroundColor: UIColor = .Adyen.componentBackground
+    package var backgroundColor: UIColor = .Adyen.componentBackground
 }
 
 /// A generic empty view with title and generic subtitle

--- a/AdyenWeChatPay/WeChatPayActionComponent/WeChatPayActionComponent.swift
+++ b/AdyenWeChatPay/WeChatPayActionComponent/WeChatPayActionComponent.swift
@@ -8,7 +8,6 @@
     import AdyenActions
 #endif
 import Adyen
-@_spi(AdyenInternal) import protocol Adyen.Component
 import Foundation
 
 #if !targetEnvironment(simulator) && canImport(AdyenWeChatPayInternal)

--- a/AdyenWeChatPay/WeChatPayActionComponent/WeChatPayActionComponent.swift
+++ b/AdyenWeChatPay/WeChatPayActionComponent/WeChatPayActionComponent.swift
@@ -7,7 +7,7 @@
 #if canImport(AdyenActions)
     import AdyenActions
 #endif
-import Adyen
+@_spi(AdyenInternal) import Adyen
 import Foundation
 
 #if !targetEnvironment(simulator) && canImport(AdyenWeChatPayInternal)

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Error Item/FormErrorItemTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Error Item/FormErrorItemTests.swift
@@ -17,7 +17,7 @@ class FormErrorItemTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "Dummy Expectation")
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            let errorItem = FormErrorItem(message: "Error Message", iconName: "error")
+            let errorItem = FormErrorItem(message: "Error Message", iconName: "error", style: FormErrorItemStyle())
             errorItem.identifier = "errorItem"
             formViewController.append(errorItem)
 

--- a/Tests/UnitTests/Extension/UIButtonHelpersTests.swift
+++ b/Tests/UnitTests/Extension/UIButtonHelpersTests.swift
@@ -5,7 +5,7 @@
 //
 
 @testable import Adyen
-@testable import AdyenUI
+@_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
 class UIButtonHelperTests: XCTestCase {

--- a/Tests/UnitTests/Extension/UILabelHelpersTests.swift
+++ b/Tests/UnitTests/Extension/UILabelHelpersTests.swift
@@ -5,7 +5,7 @@
 //
 
 @testable import Adyen
-@testable import AdyenUI
+@_spi(AdyenInternal) @testable import AdyenUI
 import XCTest
 
 class UILabelHelpersTests: XCTestCase {


### PR DESCRIPTION
## Summary

My last effort to this end, the leftovers have some dependency on some `open` type or requires some refactor. 
Public to `package` or to `@_spi(AdyenInternal)` 

<ticket> 
COSDK-470
 </ticket>

## Visibility Changes

### `public` → `package`

| Category | Types |
|---|---|
| **Action Styles** | `ActionComponentStyle`, `AwaitComponentStyle`, `DelegatedAuthenticationComponentStyle`, `DocumentComponentStyle`, `QRCodeComponentStyle`, `VoucherComponentStyle` |
| **UI Styles** | `AddressLookupSearchStyle`, `AddressStyle`, `ApplePayStyle`, `ButtonStyle`, `CancelButtonStyle`, `EmptyStateViewStyle`, `FormButtonItemStyle`, `FormComponentStyle`, `FormErrorItemStyle`, `FormToggleItemStyle`, `ListComponentStyle`, `ListSectionFooterStyle`, `ListSectionHeaderStyle`, `NavigationStyle`, `ProgressViewStyle`, `SegmentedControlStyle`, `ToolbarMode` |
| **Form Items** | `FormButtonItem`, `FormContainerItem`, `FormErrorItem`, `FormLabelItem`, `FormSearchButtonItem`, `FormSeparatorItem`, `FormSpacerItem`, `FormSpacerItemView`, `FormSplitItem` |
| **Form / UI Protocols** | `AnyFormValidatableValueItemView`, `AnyFormValueItemView`, `AppearanceChangeRefreshable`, `FormItemInjector`, `PickerElement` |
| **Component / View Controllers** | `AddressInputFormViewController`, `CustomFormItemInjector` |
| **Component Lifecycle Protocols** | `Cancellable`, `DeviceDependent`, `LoadingComponent`, `PartialPaymentOrderAware`, `PaymentMethodAware`, `StoredPaymentMethodsDelegate` |
| **SDK-Internal Protocols** | `AdyenObserver`, `AnyCashAppPayConfiguration`, `AnyCardComponentConfiguration`, `APIContextInitializable`, `SDKDataAuthenticationProvider`, `ShopperInformation` |
| **Validation Protocols** | `CombinedValidator`, `Formatter`, `Sanitizer` |
| **Core / SDK Types** | `Balance`, `DisplayInformation`, `SDKData` |
| **Errors** | `AppleWalletError`, `ComponentError`, `EncryptionError`, `PartialPaymentError` |
| **Payment Component Configs** | `CashAppPayConfiguration` |
| **Card Validators** | `CardKCPFieldValidator`, `CardKCPPasswordValidator` |

### `public` → `@_spi(AdyenInternal)`

| Category | Types | Reason |
|---|---|---|
| **UI Styles** | `CornerRounding`, `ImageStyle`, `TextStyle` | Connects to open `FormTextItem` |
| **Form Style Protocols** | `FormValueItemStyle` | Depended on by open `FormTextItem` |
| **Form Item Styles** | `FormTextItemStyle` | Cannot narrow further due to `FormTextItem` being `open` |


## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
