### PR TITLE
COSDK-1127: [v6] Remove `amount` from `PaymentComponentData`

### DIFF
--- a/Adyen/Core/Components/InstantPaymentComponent.swift
+++ b/Adyen/Core/Components/InstantPaymentComponent.swift
@@ -61,7 +61,6 @@ package final class InstantPaymentComponent: InitiablePaymentComponent {
         let details = InstantPaymentDetails(type: paymentMethod.type)
         self.paymentData = PaymentComponentData(
             paymentMethodDetails: details,
-            amount: context.amount,
             order: order
         )
     }

--- a/Adyen/Core/Components/StoredPaymentMethodComponent.swift
+++ b/Adyen/Core/Components/StoredPaymentMethodComponent.swift
@@ -74,7 +74,6 @@ package final class StoredPaymentMethodComponent: StoredPaymentComponent, Locali
             let details = StoredPaymentDetails(paymentMethod: self.storedPaymentMethod)
             self.submit(data: PaymentComponentData(
                 paymentMethodDetails: details,
-                amount: self.context.amount,
                 order: self.order
             ))
         }

--- a/Adyen/Model/PaymentComponentData.swift
+++ b/Adyen/Model/PaymentComponentData.swift
@@ -14,9 +14,6 @@ import Foundation
  */
 public struct PaymentComponentData {
 
-    /// The payment amount.
-    public let amount: Amount?
-    
     /// The payment method details submitted by the payment component.
     public let paymentMethod: PaymentMethodDetails
     
@@ -77,7 +74,6 @@ public struct PaymentComponentData {
     ///
     /// - Parameters:
     ///   - paymentMethodDetails: The payment method details submitted from the payment component.
-    ///   - amount: The payment amount.
     ///   - order: The partial payment order if any.
     ///   - storePaymentMethod: Whether the user has chosen to store the payment method.
     ///   - browserInfo: The device default browser info.
@@ -86,13 +82,11 @@ public struct PaymentComponentData {
     ///   - sdkData: The encoded SDK data if specified.
     package init(
         paymentMethodDetails: some PaymentMethodDetails,
-        amount: Amount?,
         order: PartialPaymentOrder?,
         storePaymentMethod: Bool? = nil,
         browserInfo: BrowserInfo? = nil,
         installments: Installments? = nil
     ) {
-        self.amount = amount
         self.paymentMethod = paymentMethodDetails
         self.order = order
         self.storePaymentMethod = storePaymentMethod
@@ -105,7 +99,6 @@ public struct PaymentComponentData {
         paymentMethodDetails.sdkData = sdkData.encodedValue
         return PaymentComponentData(
             paymentMethodDetails: paymentMethodDetails,
-            amount: amount,
             order: order,
             storePaymentMethod: storePaymentMethod,
             browserInfo: browserInfo,
@@ -116,18 +109,6 @@ public struct PaymentComponentData {
     package func replacing(order: PartialPaymentOrder) -> PaymentComponentData {
         PaymentComponentData(
             paymentMethodDetails: paymentMethod,
-            amount: amount,
-            order: order,
-            storePaymentMethod: storePaymentMethod,
-            browserInfo: browserInfo,
-            installments: installments
-        )
-    }
-
-    package func replacing(amount: Amount) -> PaymentComponentData {
-        PaymentComponentData(
-            paymentMethodDetails: paymentMethod,
-            amount: amount,
             order: order,
             storePaymentMethod: storePaymentMethod,
             browserInfo: browserInfo,
@@ -141,7 +122,6 @@ public struct PaymentComponentData {
         paymentMethod.checkoutAttemptId = checkoutAttemptId
         return PaymentComponentData(
             paymentMethodDetails: paymentMethod,
-            amount: amount,
             order: order,
             storePaymentMethod: storePaymentMethod,
             browserInfo: browserInfo,
@@ -152,7 +132,6 @@ public struct PaymentComponentData {
     package func replacing(browserInfo: BrowserInfo?) -> PaymentComponentData {
         PaymentComponentData(
             paymentMethodDetails: paymentMethod,
-            amount: amount,
             order: order,
             storePaymentMethod: storePaymentMethod,
             browserInfo: browserInfo,

--- a/AdyenCard/Components/Card/CardComponentExtensions.swift
+++ b/AdyenCard/Components/Card/CardComponentExtensions.swift
@@ -43,7 +43,6 @@ extension CardComponent {
             
             let data = PaymentComponentData(
                 paymentMethodDetails: details,
-                amount: context.amount,
                 order: order,
                 storePaymentMethod: cardViewController.storePayment,
                 installments: cardViewController.installments

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -309,8 +309,7 @@ extension GiftCardComponent {
                             paymentData: paymentData
                         )
                     } else {
-                        let newPaymentData = paymentData.replacing(amount: balanceCheckResult.amountToPay)
-                        return self.startPartialPaymentFlow(paymentData: newPaymentData)
+                        return self.startPartialPaymentFlow(paymentData: paymentData)
                     }
                 }
                 .handle(success: { /* Do nothing.*/ }, failure: { self.handle(error: $0) })
@@ -452,7 +451,6 @@ extension GiftCardComponent {
 
             return .success(PaymentComponentData(
                 paymentMethodDetails: details,
-                amount: amount,
                 order: order,
                 storePaymentMethod: false
             ))

--- a/AdyenCard/Components/Stored Card/StoredCardComponent.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardComponent.swift
@@ -63,7 +63,6 @@ package final class StoredCardComponent: StoredPaymentComponent, Localizable {
                     self.submit(
                         data: PaymentComponentData(
                             paymentMethodDetails: details,
-                            amount: context.amount,
                             order: order
                         )
                     )

--- a/AdyenCashAppPay/CashAppPayComponent.swift
+++ b/AdyenCashAppPay/CashAppPayComponent.swift
@@ -213,7 +213,6 @@ package final class CashAppPayComponent: PaymentComponent,
             let details = try cashAppPayDetails(from: grants, customerProfile: profile)
             submit(data: PaymentComponentData(
                 paymentMethodDetails: details,
-                amount: context.amount,
                 order: order,
                 storePaymentMethod: storePayment
             ))

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -117,7 +117,6 @@ package final class ACHDirectDebitComponent: PaymentComponent,
             
             submit(data: PaymentComponentData(
                 paymentMethodDetails: details,
-                amount: context.amount,
                 order: order,
                 storePaymentMethod: storePayment
             ))

--- a/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent+Extensions.swift
+++ b/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent+Extensions.swift
@@ -28,7 +28,6 @@ extension AbstractPersonalInformationComponent: LoadingComponent {
             let details = try createPaymentDetails()
             submit(data: PaymentComponentData(
                 paymentMethodDetails: details,
-                amount: context.amount,
                 order: order
             ))
         } catch {

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -107,8 +107,7 @@ extension ApplePayComponent {
             shippingMethod: payment.shippingMethod
         )
 
-        let amount = configuration.currentAmount
-        let data = PaymentComponentData(paymentMethodDetails: details, amount: amount, order: order)
+        let data = PaymentComponentData(paymentMethodDetails: details, order: order)
 
         // Store the continuation first, then submit. submit() is fire-and-forget — it triggers
         // the delegate's didSubmit which eventually leads to resolve(success:) being called.

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -107,15 +107,6 @@ public struct ApplePayConfiguration: CheckoutComponentConfiguration {
         }
     }
 
-    package var currentAmount: Amount? {
-        guard let lastItem = paymentRequest.paymentSummaryItems.last else { return nil }
-        let minorUnits = AmountFormatter.minorUnitAmount(
-            from: lastItem.amount.decimalValue,
-            currencyCode: paymentRequest.currencyCode
-        )
-        return Amount(value: minorUnits, currencyCode: paymentRequest.currencyCode)
-    }
-
     package func replacing(amount: Amount) -> Self {
         let newConfig = self
         guard let lastItem = newConfig.paymentRequest.paymentSummaryItems.last else { return newConfig }

--- a/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
+++ b/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
@@ -131,7 +131,7 @@ extension BACSDirectDebitComponent: BACSDirectDebitRouterProtocol {
             bankLocationId: data.bankLocationId
         )
         confirmationPresenter?.startLoading()
-        submit(data: PaymentComponentData(paymentMethodDetails: details, amount: context.amount, order: order))
+        submit(data: PaymentComponentData(paymentMethodDetails: details, order: order))
     }
 
     // MARK: - Private

--- a/AdyenComponents/BLIK/BLIKComponent.swift
+++ b/AdyenComponents/BLIK/BLIKComponent.swift
@@ -132,7 +132,7 @@ package final class BLIKComponent: PaymentComponent, PresentableComponent, Loadi
         button.showsActivityIndicator = true
         formViewController.view.isUserInteractionEnabled = false
 
-        let data = PaymentComponentData(paymentMethodDetails: details, amount: context.amount, order: order)
+        let data = PaymentComponentData(paymentMethodDetails: details, order: order)
         submit(data: data)
     }
 }

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -139,7 +139,6 @@ package final class IssuerListComponent: PaymentComponent, PresentableComponent,
                 )
                 self.submit(data: PaymentComponentData(
                     paymentMethodDetails: details,
-                    amount: self.context.amount,
                     order: self.order
                 ))
                 

--- a/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
+++ b/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
@@ -140,7 +140,7 @@ package final class OnlineBankingComponent: PaymentComponent,
         continueButton.showsActivityIndicator = true
         formViewController.view.isUserInteractionEnabled = false
 
-        submit(data: PaymentComponentData(paymentMethodDetails: details, amount: context.amount, order: order))
+        submit(data: PaymentComponentData(paymentMethodDetails: details, order: order))
     }
 
     private lazy var formViewController: FormViewController = {

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent.swift
@@ -29,7 +29,6 @@ package final class PayByBankUSComponent: PaymentComponent, PresentableComponent
 
         return PaymentComponentData(
             paymentMethodDetails: details,
-            amount: context.amount,
             order: order
         )
     }

--- a/AdyenComponents/PayTo/PayToComponent.swift
+++ b/AdyenComponents/PayTo/PayToComponent.swift
@@ -263,7 +263,6 @@ private extension PayToComponent {
         submit(
             data: PaymentComponentData(
                 paymentMethodDetails: details,
-                amount: context.amount,
                 order: order
             )
         )

--- a/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
+++ b/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
@@ -99,7 +99,7 @@ package final class SEPADirectDebitComponent: PaymentComponent, PresentableCompo
         button.showsActivityIndicator = true
         formViewController.view.isUserInteractionEnabled = false
         
-        submit(data: PaymentComponentData(paymentMethodDetails: details, amount: context.amount, order: order))
+        submit(data: PaymentComponentData(paymentMethodDetails: details, order: order))
     }
     
     // MARK: - Form Items

--- a/AdyenComponents/UPI/UPIComponent.swift
+++ b/AdyenComponents/UPI/UPIComponent.swift
@@ -392,14 +392,14 @@ private extension UPIComponent {
                 virtualPaymentAddress: nil,
                 appId: currentSelectedItemIdentifier
             )
-            submit(data: PaymentComponentData(paymentMethodDetails: details, amount: context.amount, order: order))
+            submit(data: PaymentComponentData(paymentMethodDetails: details, order: order))
         case .upiCollect:
             let details = UPIComponentDetails(
                 type: selectedUPIFlow.value,
                 virtualPaymentAddress: vpaInputItem.value,
                 appId: nil
             )
-            submit(data: PaymentComponentData(paymentMethodDetails: details, amount: context.amount, order: order))
+            submit(data: PaymentComponentData(paymentMethodDetails: details, order: order))
         }
     }
 }

--- a/AdyenTwint/TwintComponent.swift
+++ b/AdyenTwint/TwintComponent.swift
@@ -34,7 +34,6 @@ package final class TwintComponent: InitiablePaymentComponent {
 
         return PaymentComponentData(
             paymentMethodDetails: details,
-            amount: context.amount,
             order: nil,
             storePaymentMethod: nil
         )

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/DropIn/DropInAdvancedFlowExample.swift
@@ -219,7 +219,7 @@ extension DropInAdvancedFlowExample: PartialPaymentDelegate {
         component: Component,
         completion: @escaping (Result<Balance, Error>) -> Void
     ) {
-        let request = BalanceCheckRequest(data: data)
+        let request = BalanceCheckRequest(data: data, amount: ConfigurationConstants.current.amount)
         apiClient.perform(request) { [weak self] result in
             self?.handle(result: result, completion: completion)
         }

--- a/Demo/Common/Networking/BalanceCheckRequest.swift
+++ b/Demo/Common/Networking/BalanceCheckRequest.swift
@@ -14,6 +14,8 @@ internal struct BalanceCheckRequest: APIRequest {
 
     internal let data: PaymentComponentData
 
+    internal let amount: Amount
+
     internal let path = "paymentMethods/balance"
 
     internal var counter: UInt = 0
@@ -30,7 +32,7 @@ internal struct BalanceCheckRequest: APIRequest {
         let configurations = ConfigurationConstants.current
 
         try container.encode(data.paymentMethod.encodable, forKey: .details)
-        try container.encode(data.amount, forKey: .amount)
+        try container.encode(amount, forKey: .amount)
         try container.encode(configurations.merchantAccount, forKey: .merchantAccount)
     }
 

--- a/Demo/Common/Networking/PaymentsRequest.swift
+++ b/Demo/Common/Networking/PaymentsRequest.swift
@@ -30,9 +30,8 @@ internal struct PaymentsRequest: APIRequest {
 
         let currentConfiguration = ConfigurationConstants.current
 
-        // Important: for the demo purpose we are setting amount here.
-        // If you choose not to provide the amount to the payment component - it could be specified by your backend.
-        let amount = data.amount ?? currentConfiguration.amount
+        // Important: for demo purposes we set amount here. Merchants should update this value to match the final amount, for example after Apple Pay shipping/contact updates.
+        let amount = currentConfiguration.amount
         
         // If there is an order in the request, amount is optional
         if data.order == nil {

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -607,7 +607,6 @@ class ApplePayComponentTest: XCTestCase {
         let sut = config.replacing(amount: testAmount)
 
         // Then
-        XCTAssertEqual(sut.currentAmount, testAmount)
         XCTAssertEqual(sut.paymentRequest.paymentSummaryItems.count, 2)
         let summaryItem = sut.paymentRequest.paymentSummaryItems.last
         XCTAssertNotNil(summaryItem)
@@ -633,7 +632,6 @@ class ApplePayComponentTest: XCTestCase {
         let sut = config.replacing(amount: testAmount)
 
         // Then
-        XCTAssertEqual(sut.currentAmount, testAmount)
         XCTAssertEqual(sut.paymentRequest.paymentSummaryItems.count, 2)
         let summaryItem = sut.paymentRequest.paymentSummaryItems.last
         XCTAssertNotNil(summaryItem)

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -610,6 +610,12 @@ class ApplePayComponentTest: XCTestCase {
         XCTAssertEqual(sut.paymentRequest.paymentSummaryItems.count, 2)
         let summaryItem = sut.paymentRequest.paymentSummaryItems.last
         XCTAssertNotNil(summaryItem)
+        let expectedDecimalAmount = AmountFormatter.decimalAmount(
+            testAmount.value,
+            currencyCode: testAmount.currencyCode,
+            localeIdentifier: testAmount.localeIdentifier
+        )
+        XCTAssertEqual(summaryItem?.amount, expectedDecimalAmount)
         XCTAssertEqual(summaryItem?.amount, decimalAmount)
     }
 

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -641,6 +641,12 @@ class ApplePayComponentTest: XCTestCase {
         XCTAssertEqual(sut.paymentRequest.paymentSummaryItems.count, 2)
         let summaryItem = sut.paymentRequest.paymentSummaryItems.last
         XCTAssertNotNil(summaryItem)
+        let expectedDecimalAmount = AmountFormatter.decimalAmount(
+            testAmount.value,
+            currencyCode: testAmount.currencyCode,
+            localeIdentifier: testAmount.localeIdentifier
+        )
+        XCTAssertEqual(summaryItem?.amount, expectedDecimalAmount)
         XCTAssertEqual(summaryItem?.amount, decimalAmount)
     }
 

--- a/Tests/IntegrationTests/Components Tests/Instant Payment/InstantPaymentComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Instant Payment/InstantPaymentComponentTests.swift
@@ -62,6 +62,6 @@ class InstantPaymentComponentTests: XCTestCase {
 
     private var paymentComponentData: PaymentComponentData {
         let details = GiftCardDetails(paymentMethod: paymentMethod, encryptedCardNumber: "card", encryptedSecurityCode: "cvc")
-        return PaymentComponentData(paymentMethodDetails: details, amount: nil, order: nil)
+        return PaymentComponentData(paymentMethodDetails: details, order: nil)
     }
 }

--- a/Tests/IntegrationTests/Components Tests/IssuerList/IssuerListComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/IssuerList/IssuerListComponentTests.swift
@@ -53,8 +53,6 @@ class IssuerListComponentTests: XCTestCase {
         let expectation = expectation(description: "Call didSubmit")
         let mockDelegate = PaymentComponentDelegateMock()
         mockDelegate.onDidSubmit = { paymentData, paymentComponent in
-            XCTAssertEqual(paymentData.amount, Dummy.amount)
-            
             XCTAssertTrue(paymentData.paymentMethod is IssuerListDetails)
             let details = paymentData.paymentMethod as! IssuerListDetails
             XCTAssertEqual(details.issuer, expectedIssuer.identifier)

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -51,7 +51,7 @@ class PaymentComponentSubjectTests: XCTestCase {
         )
 
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
-        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, order: nil)
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
 
@@ -79,7 +79,7 @@ class PaymentComponentSubjectTests: XCTestCase {
     func test_submit_sets_browserInfo() {
         // Given
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
-        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, order: nil)
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
 
@@ -99,7 +99,7 @@ class PaymentComponentSubjectTests: XCTestCase {
 
     func test_submit_event() {
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
-        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, order: nil)
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
 
@@ -120,7 +120,7 @@ class PaymentComponentSubjectTests: XCTestCase {
         // Given
         let expectedCheckoutAttemptId = AnalyticsProviderMock.testCheckoutAttemptId
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
-        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, order: nil)
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
 
@@ -152,7 +152,7 @@ class PaymentComponentSubjectTests: XCTestCase {
         // Create a mock payment method that provides authentication
         let mockAuthProvider = MockSDKDataAuthenticationProvider()
         let paymentMethodDetails = MockAuthenticationPaymentDetails(authProvider: mockAuthProvider)
-        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, order: nil)
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
 
@@ -182,7 +182,7 @@ class PaymentComponentSubjectTests: XCTestCase {
 
         // Use a payment method that doesn't provide authentication
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
-        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, order: nil)
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
 
@@ -207,7 +207,7 @@ class PaymentComponentSubjectTests: XCTestCase {
     func test_submit_includes_sdkData_other_fields() {
         // Given
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
-        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, amount: nil, order: nil)
+        let paymentComponentData = PaymentComponentData(paymentMethodDetails: paymentMethodDetails, order: nil)
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
 
@@ -237,7 +237,6 @@ class PaymentComponentSubjectTests: XCTestCase {
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
         let paymentComponentData = PaymentComponentData(
             paymentMethodDetails: paymentMethodDetails,
-            amount: nil,
             order: nil
         )
 
@@ -271,7 +270,6 @@ class PaymentComponentSubjectTests: XCTestCase {
         let paymentMethodDetails = MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "0284294824")
         let paymentComponentData = PaymentComponentData(
             paymentMethodDetails: paymentMethodDetails,
-            amount: nil,
             order: nil
         )
 
@@ -307,7 +305,7 @@ class PaymentComponentSubjectTests: XCTestCase {
 
         let instantPaymentMethod = InstantPaymentMethod(type: .other("test"), name: "Test")
         let instantPaymentDetails = InstantPaymentDetails(type: .other("test"))
-        let paymentData = PaymentComponentData(paymentMethodDetails: instantPaymentDetails, amount: nil, order: nil)
+        let paymentData = PaymentComponentData(paymentMethodDetails: instantPaymentDetails, order: nil)
 
         let instantComponent = InstantPaymentComponent(
             paymentMethod: instantPaymentMethod,

--- a/Tests/IntegrationTests/Components Tests/Twint/TwintComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Twint/TwintComponentTests.swift
@@ -85,7 +85,6 @@ class TwintComponentTests: XCTestCase {
         )
         return PaymentComponentData(
             paymentMethodDetails: details,
-            amount: context.amount,
             order: nil
         )
     }

--- a/Tests/IntegrationTests/DropIn Tests/ComponentContainer/ComponentContainerViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/ComponentContainer/ComponentContainerViewModelTests.swift
@@ -246,7 +246,6 @@ struct ComponentContainerViewModelTests {
             holderName: "Katrina del Mar"
         )
 
-        let amount = Amount(value: amountValue, currencyCode: "EUR")
-        return PaymentComponentData(paymentMethodDetails: cardDetails, amount: amount, order: nil)
+        return PaymentComponentData(paymentMethodDetails: cardDetails, order: nil)
     }
 }

--- a/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewModelTests.swift
@@ -347,7 +347,6 @@ struct PaymentMethodListViewModelTests {
 
         return PaymentComponentData(
             paymentMethodDetails: cardDetails,
-            amount: Amount(value: 1000, currencyCode: "EUR"),
             order: nil
         )
     }

--- a/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentMethod/PreselectedPaymentMethodIntegrationTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PreselectedPaymentMethod/PreselectedPaymentMethodIntegrationTests.swift
@@ -355,7 +355,6 @@ internal class InitiablePaymentComponentMock: PaymentComponent, InitiablePayment
         let details = StoredPaymentDetails(paymentMethod: paymentMethod as! StoredPaymentMethod)
         let data = PaymentComponentData(
             paymentMethodDetails: details,
-            amount: context.amount,
             order: order
         )
         self.delegate?.didSubmit(data, from: self)

--- a/Tests/IntegrationTests/Session Tests/SessionTests.swift
+++ b/Tests/IntegrationTests/Session Tests/SessionTests.swift
@@ -219,7 +219,6 @@ class SessionTests: XCTestCase {
         let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular.last as? MBWayPaymentMethod)
         let data = PaymentComponentData(
             paymentMethodDetails: MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "telephone"),
-            amount: nil,
             order: nil
         )
 
@@ -250,7 +249,6 @@ class SessionTests: XCTestCase {
         let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular.last as? MBWayPaymentMethod)
         let data = PaymentComponentData(
             paymentMethodDetails: MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "telephone"),
-            amount: nil,
             order: nil
         )
 
@@ -300,7 +298,6 @@ class SessionTests: XCTestCase {
         let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular.last as? MBWayPaymentMethod)
         let data = PaymentComponentData(
             paymentMethodDetails: MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "telephone"),
-            amount: nil,
             order: nil
         )
 
@@ -327,7 +324,6 @@ class SessionTests: XCTestCase {
         let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular.last as? MBWayPaymentMethod)
         let data = PaymentComponentData(
             paymentMethodDetails: MBWayDetails(paymentMethod: paymentMethod, telephoneNumber: "telephone"),
-            amount: nil,
             order: nil
         )
 
@@ -378,7 +374,6 @@ class SessionTests: XCTestCase {
         let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular.first as? GiftCardPaymentMethod)
         let data = PaymentComponentData(
             paymentMethodDetails: GiftCardDetails(paymentMethod: paymentMethod, encryptedCardNumber: "card", encryptedSecurityCode: "cvc"),
-            amount: nil,
             order: nil
         )
 
@@ -400,7 +395,6 @@ class SessionTests: XCTestCase {
         let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular.first as? GiftCardPaymentMethod)
         let data = PaymentComponentData(
             paymentMethodDetails: GiftCardDetails(paymentMethod: paymentMethod, encryptedCardNumber: "card", encryptedSecurityCode: "cvc"),
-            amount: nil,
             order: nil
         )
 
@@ -420,7 +414,6 @@ class SessionTests: XCTestCase {
         let paymentMethod = try XCTUnwrap(expectedPaymentMethods.regular.first as? GiftCardPaymentMethod)
         let data = PaymentComponentData(
             paymentMethodDetails: GiftCardDetails(paymentMethod: paymentMethod, encryptedCardNumber: "card", encryptedSecurityCode: "cvc"),
-            amount: nil,
             order: nil
         )
 
@@ -569,7 +562,6 @@ class SessionTests: XCTestCase {
         let installments = Installments(totalMonths: 3, plan: .regular)
         let data = PaymentComponentData(
             paymentMethodDetails: cardDetails,
-            amount: nil,
             order: nil,
             installments: installments
         )
@@ -594,7 +586,6 @@ class SessionTests: XCTestCase {
         let cardDetails = makeTestCardDetails()
         let data = PaymentComponentData(
             paymentMethodDetails: cardDetails,
-            amount: nil,
             order: nil
         )
 

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -186,7 +186,6 @@ final class CheckoutTests: XCTestCase {
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
-            amount: nil,
             order: nil
         )
         let session = makeSessionMock()
@@ -210,7 +209,6 @@ final class CheckoutTests: XCTestCase {
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
-            amount: nil,
             order: nil
         )
         let session = makeSessionMock()
@@ -235,7 +233,6 @@ final class CheckoutTests: XCTestCase {
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
-            amount: nil,
             order: nil
         )
         let session = makeSessionMock()
@@ -258,7 +255,6 @@ final class CheckoutTests: XCTestCase {
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
-            amount: nil,
             order: nil
         )
         let session = makeSessionMock()
@@ -289,7 +285,6 @@ final class CheckoutTests: XCTestCase {
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
-            amount: nil,
             order: nil
         )
         let session = makeSessionMock()
@@ -318,7 +313,6 @@ final class CheckoutTests: XCTestCase {
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
-            amount: nil,
             order: nil
         )
         let session = makeSessionMock()
@@ -343,7 +337,6 @@ final class CheckoutTests: XCTestCase {
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let original = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
-            amount: nil,
             order: nil
         )
         
@@ -382,7 +375,6 @@ final class CheckoutTests: XCTestCase {
         )
         let paymentData = PaymentComponentData(
             paymentMethodDetails: blikDetails,
-            amount: nil,
             order: nil
         )
         
@@ -545,7 +537,6 @@ final class CheckoutTests: XCTestCase {
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
-            amount: nil,
             order: nil
         )
         
@@ -678,7 +669,6 @@ final class CheckoutTests: XCTestCase {
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
-            amount: nil,
             order: nil
         )
 

--- a/Tests/UnitTests/AdyenDropIn/ComponentManagerTests.swift
+++ b/Tests/UnitTests/AdyenDropIn/ComponentManagerTests.swift
@@ -388,8 +388,14 @@ class ComponentManagerTests: XCTestCase {
             sut.regularComponents.first { $0.paymentMethod.type == .applePay } as? ApplePayComponent
         )
         
-        let applePayAmount = applePayComponent.configuration.currentAmount
-        XCTAssertEqual(applePayAmount, remainingAmount, "Apple Pay should use order.remainingAmount for partial payments")
+        // Verify via the payment request's last summary item amount (converted from minor units to decimal)
+        let expectedDecimalAmount = AmountFormatter.decimalAmount(
+            remainingAmount.value,
+            currencyCode: remainingAmount.currencyCode,
+            localeIdentifier: remainingAmount.localeIdentifier
+        )
+        let actualAmount = applePayComponent.configuration.paymentRequest.paymentSummaryItems.last?.amount
+        XCTAssertEqual(actualAmount, expectedDecimalAmount, "Apple Pay should use order.remainingAmount for partial payments")
     }
 
     func testShopperInformationInjectionShouldSetShopperInformationOnAffirmComponent() throws {
@@ -650,7 +656,6 @@ class ComponentManagerTests: XCTestCase {
         XCTAssertEqual(achComponent.configuration.billingAddressCountryCodes, ["US", "UK"])
     }
     
-
     // MARK: - Private
 
     private var shopperInformation: PrefilledShopperInformation {

--- a/Tests/UnitTests/Core/BrowserInfoTests.swift
+++ b/Tests/UnitTests/Core/BrowserInfoTests.swift
@@ -16,7 +16,7 @@ struct BrowserInfoTests {
     }
     
     @Test func paymentComponentDataBrowserInfo() async {
-        let data = PaymentComponentData(paymentMethodDetails: InstantPaymentDetails(type: .payPal), amount: nil, order: nil)
+        let data = PaymentComponentData(paymentMethodDetails: InstantPaymentDetails(type: .payPal), order: nil)
         let updatedPaymentComponentData = await data.replacing(browserInfo: BrowserInfo())
         #expect(updatedPaymentComponentData.browserInfo?.userAgent != nil)
     }


### PR DESCRIPTION
# Summary

This PR removes the `amount` property from `PaymentComponentData` and its usage across the SDK.
The demo app has been updated to reflect the new changes.

## Ticket
<ticket>
COSDK-1127
</ticket>

## Checklist [Required]
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
