### PR TITLE
[v6] (4/5) Non-UI components: Implement `submit` in `ApplePayComponent`

### DIFF
--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -141,8 +141,7 @@ package class ApplePayComponent: NSObject, PresentableComponent, PaymentComponen
     }
 
     package func submit() {
-        // TODO: - Naufal: Check where to perform submit in ApplePay.
-        // Web triggers the ApplePay system view.
+        delegate?.didFail(with: Error.submitNotSupported, from: self)
     }
 }
 

--- a/AdyenComponents/Apple Pay/ApplePayComponentError.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentError.swift
@@ -41,6 +41,8 @@ extension ApplePayComponent {
         /// Indicates that the token was generated incorrectly.
         case invalidToken
 
+        case submitNotSupported
+
         public var errorDescription: String? {
             switch self {
             case .userCannotMakePayment:
@@ -61,6 +63,8 @@ extension ApplePayComponent {
                 return "The currency code is invalid."
             case .invalidToken:
                 return "The Apple Pay token is invalid. Make sure you are using physical device, not a Simulator."
+            case .submitNotSupported:
+                return "Submit call is not supported"
             }
         }
     }

--- a/AdyenComponents/Apple Pay/ApplePayComponentError.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentError.swift
@@ -41,6 +41,7 @@ extension ApplePayComponent {
         /// Indicates that the token was generated incorrectly.
         case invalidToken
 
+        /// Indicates that calling submit is not supported for Apple Pay.
         case submitNotSupported
 
         public var errorDescription: String? {

--- a/AdyenComponents/Apple Pay/ApplePayComponentError.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentError.swift
@@ -65,7 +65,7 @@ extension ApplePayComponent {
             case .invalidToken:
                 return "The Apple Pay token is invalid. Make sure you are using physical device, not a Simulator."
             case .submitNotSupported:
-                return "Submit call is not supported"
+                return "Submit call is not supported."
             }
         }
     }

--- a/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
+++ b/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
@@ -104,9 +104,7 @@ package final class BACSDirectDebitComponent: PaymentComponent, PresentableCompo
     }
 
     package func submit() {
-        // TODO: - Naufal: How to handle submit in BACS?
-        // - submit() flow does not fit into a two step component.
-        // - Zero traffic on BACS. We either drop support or BACS has to be redesigned into a single step component.
+        // TODO: - COSDK-1284: The confirmation screen will be removed.
     }
 }
 

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -59,8 +59,7 @@ package final class IssuerListComponent: PaymentComponent, PresentableComponent,
     }
 
     package func submit() {
-        // TODO: - Naufal: What should we do in the IssuerListComponent?
-        // IssuerListComponent needs to be changed so it validates shopper issuer selection.
+        // TODO: - COSDK-1262: Implemenation will be done once the IssuerListComponent is redesigned to have a button.
     }
 
     private let issuerListPaymentMethod: IssuerListPaymentMethod

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -59,7 +59,7 @@ package final class IssuerListComponent: PaymentComponent, PresentableComponent,
     }
 
     package func submit() {
-        // TODO: - COSDK-1262: Implemenation will be done once the IssuerListComponent is redesigned to have a button.
+        // TODO: - COSDK-1262: Implementation will be done once the IssuerListComponent is redesigned to have a button.
     }
 
     private let issuerListPaymentMethod: IssuerListPaymentMethod

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -196,6 +196,20 @@ class ApplePayComponentTest: XCTestCase {
         waitForExpectations(timeout: 10)
     }
 
+    func testSubmitShouldCallDelegateDidFailWithSubmitNotSupported() {
+        sut.delegate = mockDelegate
+        let onDidFailExpectation = expectation(description: "Wait for delegate call")
+        mockDelegate.onDidFail = { error, component in
+            XCTAssertEqual(error as? ApplePayComponent.Error, .submitNotSupported)
+            XCTAssertTrue(component === self.sut)
+            onDidFailExpectation.fulfill()
+        }
+
+        sut.submit()
+
+        waitForExpectations(timeout: 10)
+    }
+
     func testApplePayShipping() async throws {
         var receivedMethod: PKShippingMethod?
         var configuration = try ApplePayConfiguration(


### PR DESCRIPTION
## Summary

This PR adds a `submit` implementation to `ApplePayComponent`.

### Changes

* Added support for the `submit` API in `ApplePayComponent`.
* Introduced a new `submitNotSupported` case in `ApplePayComponentError`.
* Added unit tests covering the submit behavior.

### Rationale

Due to the nature of Apple Pay, the payment flow cannot be initiated programmatically. User interaction is always required to authorize a payment (for example, via Face ID, Touch ID, passcode, or another shopper action).

As a result, calling `submit()` on `ApplePayComponent` is not supported and will return a merchant-facing `submitNotSupported` error.

## Ticket
<ticket>
COSDK-1103
</ticket>

## Checklist
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
