### PR TITLE
[v6] (5/5) Non-UI components: DRY components to remove redundant `didSelectSubmitButton` method

### DIFF
--- a/Adyen/Core/Components/InstantPaymentComponent.swift
+++ b/Adyen/Core/Components/InstantPaymentComponent.swift
@@ -61,7 +61,7 @@ package final class InstantPaymentComponent: PaymentComponent {
     }
 
     /// Generate the payment details and invoke PaymentsComponentDelegate method.
-    package func submit() {
+    package func performSubmit() {
         submit(data: paymentData)
     }
 }

--- a/Adyen/Core/Components/StoredPaymentMethodComponent.swift
+++ b/Adyen/Core/Components/StoredPaymentMethodComponent.swift
@@ -39,7 +39,7 @@ package final class StoredPaymentMethodComponent: StoredPaymentComponent, Locali
     
     private let storedPaymentMethod: StoredPaymentMethod
 
-    package func submit() {
+    package func performSubmit() {
         let details = StoredPaymentDetails(paymentMethod: self.storedPaymentMethod)
         let data = PaymentComponentData(
             paymentMethodDetails: details,

--- a/Adyen/Core/Core Protocols/PaymentComponent.swift
+++ b/Adyen/Core/Core Protocols/PaymentComponent.swift
@@ -34,7 +34,7 @@ package protocol PaymentComponent: Component, PartialPaymentOrderAware, PaymentM
 
     var paymentMethodBehavior: SDKData.PaymentMethodBehavior { get }
 
-    func submit()
+    func performSubmit()
 }
 
 package extension PaymentComponent where Self: PresentableComponent {

--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -134,10 +134,6 @@ package class CardComponent: PaymentComponent,
         self.supportedCardTypes = configuration.supportedCardBrands ?? paymentMethod.brands
     }
 
-    package func submit() {
-        didSelectSubmitButton()
-    }
-
     // MARK: - Presentable Component Protocol
 
     package var viewController: UIViewController {
@@ -245,6 +241,10 @@ package class CardComponent: PaymentComponent,
 }
 
 extension CardComponent: CardViewControllerDelegate {
+
+    internal func didSelectSubmitButton() {
+        self.performSubmit()
+    }
 
     internal func didChange(pan: String) {
         panThrottler.throttle { [weak self] in

--- a/AdyenCard/Components/Card/CardComponentExtensions.swift
+++ b/AdyenCard/Components/Card/CardComponentExtensions.swift
@@ -19,7 +19,7 @@ import UIKit
 
 extension CardComponent {
     
-    internal func didSelectSubmitButton() {
+    package func performSubmit() {
         guard cardViewController.validate() else {
             return
         }

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -142,10 +142,6 @@ package final class GiftCardComponent: PaymentComponent,
         self.amount = amount
     }
 
-    package func submit() {
-        didSelectSubmitButton()
-    }
-
     // MARK: - Presentable Component Protocol
 
     package lazy var viewController: UIViewController = SecuredViewController(child: formViewController, style: style)
@@ -244,7 +240,7 @@ package final class GiftCardComponent: PaymentComponent,
         item.identifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "payButtonItem")
         item.title = localizedString(.cardApplyGiftcard, localizationParameters)
         item.buttonSelectionHandler = { [weak self] in
-            self?.didSelectSubmitButton()
+            self?.performSubmit()
         }
         return item
     }()
@@ -277,7 +273,7 @@ package final class GiftCardComponent: PaymentComponent,
 
 extension GiftCardComponent {
     
-    internal func didSelectSubmitButton() {
+    package func performSubmit() {
         hideError()
         guard formViewController.validate() else {
             return

--- a/AdyenCard/Components/Stored Card/StoredCardComponent.swift
+++ b/AdyenCard/Components/Stored Card/StoredCardComponent.swift
@@ -61,7 +61,7 @@ package final class StoredCardComponent: StoredPaymentComponent, Localizable {
         return StoredCardInputViewController(viewModel: viewModel)
     }()
 
-    package func submit() {
+    package func performSubmit() {
         Task { [weak self] in
             await self?.viewModel.submit()
         }

--- a/AdyenCashAppPay/CashAppPayComponent.swift
+++ b/AdyenCashAppPay/CashAppPayComponent.swift
@@ -89,7 +89,7 @@ package final class CashAppPayComponent: PaymentComponent,
 
     internal lazy var cashAppPayButton: CashAppPayButtonItem = {
         let item = CashAppPayButtonItem { [weak self] in
-            self?.didSelectSubmitButton()
+            self?.performSubmit()
         }
         item.identifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: ViewIdentifier.cashAppButtonItem)
         return item
@@ -133,11 +133,7 @@ package final class CashAppPayComponent: PaymentComponent,
         self.configuration = configuration
     }
 
-    package func submit() {
-        didSelectSubmitButton()
-    }
-
-    private func didSelectSubmitButton() {
+    package func performSubmit() {
         guard formViewController.validate() else { return }
     
         startLoading()

--- a/AdyenCheckout/Component/CheckoutPaymentComponent.swift
+++ b/AdyenCheckout/Component/CheckoutPaymentComponent.swift
@@ -94,6 +94,6 @@ public final class CheckoutPaymentComponent {
     /// ```
     ///
     public func submit() {
-        paymentComponent.submit()
+        paymentComponent.performSubmit()
     }
 }

--- a/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
+++ b/AdyenComponents/ACH Direct Debit/ACHDirectDebitComponent.swift
@@ -89,7 +89,7 @@ package final class ACHDirectDebitComponent: PaymentComponent,
         formViewController.view.isUserInteractionEnabled = false
     }
 
-    private func didSelectSubmitButton() {
+    package func performSubmit() {
         guard formViewController.validate() else { return }
         
         startLoading()
@@ -257,7 +257,7 @@ package final class ACHDirectDebitComponent: PaymentComponent,
             configuration.localizationParameters
         )
         item.buttonSelectionHandler = { [weak self] in
-            self?.didSelectSubmitButton()
+            self?.performSubmit()
         }
         return item
     }()
@@ -319,12 +319,5 @@ extension ACHDirectDebitComponent: ViewControllerPresenter {
     
     package func dismissViewController(animated: Bool) {
         self.viewController.dismissViewController(animated: animated)
-    }
-}
-
-extension ACHDirectDebitComponent {
-
-    package func submit() {
-        didSelectSubmitButton()
     }
 }

--- a/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent+Extensions.swift
+++ b/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent+Extensions.swift
@@ -19,7 +19,7 @@ extension AbstractPersonalInformationComponent: LoadingComponent {
         formViewController.view.isUserInteractionEnabled = true
     }
 
-    internal func didSelectSubmitButton() {
+    package func performSubmit() {
         guard formViewController.validate() else { return }
 
         button.showsActivityIndicator = true

--- a/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
+++ b/AdyenComponents/AbstractPersonalInformationComponent/AbstractPersonalInformationComponent.swift
@@ -72,10 +72,6 @@ package class AbstractPersonalInformationComponent: PaymentComponent, Presentabl
         self.configuration = configuration
     }
 
-    package func submit() {
-        didSelectSubmitButton()
-    }
-
     // MARK: - Private
 
     private func build(_ formViewController: FormViewController) {
@@ -226,7 +222,7 @@ package class AbstractPersonalInformationComponent: PaymentComponent, Presentabl
         item.identifier = ViewIdentifierBuilder.build(scopeInstance: self, postfix: "payButtonItem")
         item.title = submitButtonTitle()
         item.buttonSelectionHandler = { [weak self] in
-            self?.didSelectSubmitButton()
+            self?.performSubmit()
         }
         return item
     }()

--- a/AdyenComponents/Apple Pay/ApplePayComponent.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponent.swift
@@ -140,7 +140,7 @@ package class ApplePayComponent: NSObject, PresentableComponent, PaymentComponen
         completion?()
     }
 
-    package func submit() {
+    package func performSubmit() {
         delegate?.didFail(with: Error.submitNotSupported, from: self)
     }
 }

--- a/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
+++ b/AdyenComponents/BACS Direct Debit/BACSDirectDebitComponent.swift
@@ -103,7 +103,7 @@ package final class BACSDirectDebitComponent: PaymentComponent, PresentableCompo
         
     }
 
-    package func submit() {
+    package func performSubmit() {
         // TODO: - COSDK-1284: The confirmation screen will be removed.
     }
 }

--- a/AdyenComponents/BLIK/BLIKComponent.swift
+++ b/AdyenComponents/BLIK/BLIKComponent.swift
@@ -50,10 +50,6 @@ package final class BLIKComponent: PaymentComponent, PresentableComponent, Loadi
         self.context = context
         self.configuration = configuration
     }
-
-    package func submit() {
-        didSelectSubmitButton()
-    }
     
     package func stopLoading() {
         button.showsActivityIndicator = false
@@ -119,14 +115,14 @@ package final class BLIKComponent: PaymentComponent, PresentableComponent, Loadi
             configuration.localizationParameters
         )
         item.buttonSelectionHandler = { [weak self] in
-            self?.didSelectSubmitButton()
+            self?.performSubmit()
         }
         return item
     }()
 
     // MARK: - Private
 
-    private func didSelectSubmitButton() {
+    package func performSubmit() {
         guard formViewController.validate() else { return }
 
         let details = BLIKDetails(

--- a/AdyenComponents/Boleto/BoletoComponent.swift
+++ b/AdyenComponents/Boleto/BoletoComponent.swift
@@ -50,8 +50,8 @@ package final class BoletoComponent: PaymentComponent,
         socialSecurityNumberItem.isHidden.wrappedValue = false
     }
 
-    package func submit() {
-        formComponent.submit()
+    package func performSubmit() {
+        formComponent.performSubmit()
     }
 
     // MARK: - Private

--- a/AdyenComponents/Issuer List/IssuerListComponent.swift
+++ b/AdyenComponents/Issuer List/IssuerListComponent.swift
@@ -58,7 +58,7 @@ package final class IssuerListComponent: PaymentComponent, PresentableComponent,
         self.title = paymentMethod.displayInformation(using: configuration.localizationParameters).title
     }
 
-    package func submit() {
+    package func performSubmit() {
         // TODO: - COSDK-1262: Implementation will be done once the IssuerListComponent is redesigned to have a button.
     }
 

--- a/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
+++ b/AdyenComponents/OnlineBanking/OnlineBankingComponent.swift
@@ -82,7 +82,7 @@ package final class OnlineBankingComponent: PaymentComponent,
         )
         item.title = localizedString(.continueTitle, configuration.localizationParameters)
         item.buttonSelectionHandler = { [weak self] in
-            self?.didSelectContinueButton()
+            self?.performSubmit()
         }
         return item
     }()
@@ -123,18 +123,7 @@ package final class OnlineBankingComponent: PaymentComponent,
         self.configuration = configuration
     }
 
-    package func submit() {
-        didSelectContinueButton()
-    }
-
-    public func stopLoading() {
-        continueButton.showsActivityIndicator = false
-        formViewController.view.isUserInteractionEnabled = true
-    }
-
-    // MARK: - Private
-
-    private func didSelectContinueButton() {
+    package func performSubmit() {
         guard formViewController.validate() else { return }
 
         let details = OnlineBankingDetails(
@@ -146,6 +135,13 @@ package final class OnlineBankingComponent: PaymentComponent,
 
         submit(data: PaymentComponentData(paymentMethodDetails: details, amount: context.amount, order: order))
     }
+
+    public func stopLoading() {
+        continueButton.showsActivityIndicator = false
+        formViewController.view.isUserInteractionEnabled = true
+    }
+
+    // MARK: - Private
 
     private lazy var formViewController: FormViewController = {
         let formViewController = FormViewController(

--- a/AdyenComponents/PayByBank/US/PayByBankUSComponent.swift
+++ b/AdyenComponents/PayByBank/US/PayByBankUSComponent.swift
@@ -56,7 +56,7 @@ package final class PayByBankUSComponent: PaymentComponent, PresentableComponent
             localizationParameters: configuration.localizationParameters,
             logoUrlProvider: logoUrlProvider,
             continueHandler: { [weak self] in
-                self?.submit()
+                self?.performSubmit()
             }
         ))
     }()
@@ -81,7 +81,7 @@ package final class PayByBankUSComponent: PaymentComponent, PresentableComponent
     // MARK: - PaymentInitiable
 
     /// Generate the payment details and invoke PaymentsComponentDelegate method.
-    package func submit() {
+    package func performSubmit() {
         submit(data: paymentData)
     }
 }

--- a/AdyenComponents/PayTo/PayToComponent.swift
+++ b/AdyenComponents/PayTo/PayToComponent.swift
@@ -103,8 +103,27 @@ package final class PayToComponent: PaymentComponent, PresentableComponent, Adye
         self.configuration = configuration
     }
 
-    package func submit() {
-        didSelectContinueButton()
+    package func performSubmit() {
+        guard formViewController.validate() else { return }
+
+        startLoading()
+
+        let details = PayToDetails(
+            paymentMethod: payToPaymentMethod,
+            accountIdentifier: selectedPaymentIdentifier(),
+            shopperName: .init(
+                firstName: firstNameInputItem.value,
+                lastName: lastNameInputItem.value
+            )
+        )
+
+        submit(
+            data: PaymentComponentData(
+                paymentMethodDetails: details,
+                amount: context.amount,
+                order: order
+            )
+        )
     }
 
     /// The payment flow selection title label item.
@@ -179,7 +198,7 @@ package final class PayToComponent: PaymentComponent, PresentableComponent, Adye
     internal lazy var continueButtonItem: FormButtonItem = {
         let item = itemsProvider.createContinueButtonItem()
         item.buttonSelectionHandler = { [weak self] in
-            self?.didSelectContinueButton()
+            self?.performSubmit()
         }
         return item
     }()
@@ -239,29 +258,6 @@ extension PayToComponent: ViewControllerPresenter {
 // MARK: - Event Handling
 
 private extension PayToComponent {
-
-    func didSelectContinueButton() {
-        guard formViewController.validate() else { return }
-
-        startLoading()
-
-        let details = PayToDetails(
-            paymentMethod: payToPaymentMethod,
-            accountIdentifier: selectedPaymentIdentifier(),
-            shopperName: .init(
-                firstName: firstNameInputItem.value,
-                lastName: lastNameInputItem.value
-            )
-        )
-
-        submit(
-            data: PaymentComponentData(
-                paymentMethodDetails: details,
-                amount: context.amount,
-                order: order
-            )
-        )
-    }
 
     func startLoading() {
         continueButtonItem.showsActivityIndicator = true

--- a/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
+++ b/AdyenComponents/SEPA Direct Debit/SEPADirectDebitComponent.swift
@@ -49,10 +49,22 @@ package final class SEPADirectDebitComponent: PaymentComponent, PresentableCompo
         self.configuration = configuration
     }
 
-    package func submit() {
-        didSelectSubmitButton()
+    package func performSubmit() {
+        guard formViewController.validate() else {
+            return
+        }
+
+        let details = SEPADirectDebitDetails(
+            paymentMethod: sepaDirectDebitPaymentMethod,
+            iban: ibanItem.value,
+            ownerName: nameItem.value
+        )
+        button.showsActivityIndicator = true
+        formViewController.view.isUserInteractionEnabled = false
+
+        submit(data: PaymentComponentData(paymentMethodDetails: details, amount: context.amount, order: order))
     }
-    
+
     private let sepaDirectDebitPaymentMethod: SEPADirectDebitPaymentMethod
     
     // MARK: - Presentable Component Protocol
@@ -87,25 +99,7 @@ package final class SEPADirectDebitComponent: PaymentComponent, PresentableCompo
 
         return formViewController
     }()
-    
-    // MARK: - Private
-    
-    private func didSelectSubmitButton() {
-        guard formViewController.validate() else {
-            return
-        }
-        
-        let details = SEPADirectDebitDetails(
-            paymentMethod: sepaDirectDebitPaymentMethod,
-            iban: ibanItem.value,
-            ownerName: nameItem.value
-        )
-        button.showsActivityIndicator = true
-        formViewController.view.isUserInteractionEnabled = false
-        
-        submit(data: PaymentComponentData(paymentMethodDetails: details, amount: context.amount, order: order))
-    }
-    
+
     // MARK: - Form Items
     
     internal lazy var nameItem: FormTextInputItem = {
@@ -148,7 +142,7 @@ package final class SEPADirectDebitComponent: PaymentComponent, PresentableCompo
             configuration.localizationParameters
         )
         item.buttonSelectionHandler = { [weak self] in
-            self?.didSelectSubmitButton()
+            self?.performSubmit()
         }
         return item
     }()

--- a/AdyenComponents/UPI/UPIComponent.swift
+++ b/AdyenComponents/UPI/UPIComponent.swift
@@ -98,10 +98,20 @@ package final class UPIComponent: PaymentComponent,
         selectedUPIFlow = upiAppsList.isEmpty ? .upiCollect : .upiIntent
     }
 
-    package func submit() {
-        didSelectContinueButton()
+    package func performSubmit() {
+        guard formViewController.validate() else { return }
+
+        guard canSubmit() else {
+            showError()
+            return
+        }
+
+        continueButton.showsActivityIndicator = true
+        formViewController.view.isUserInteractionEnabled = false
+
+        submitPayment()
     }
-    
+
     // MARK: - LoadingComponent
     
     package func stopLoading() {
@@ -220,7 +230,7 @@ package final class UPIComponent: PaymentComponent,
         )
         item.title = localizedString(.continueTitle, configuration.localizationParameters)
         item.buttonSelectionHandler = { [weak self] in
-            self?.didSelectContinueButton()
+            self?.performSubmit()
         }
         return item
     }()
@@ -298,20 +308,6 @@ extension UPIComponent {
     private func handleSelection(item: SelectableFormItem?) {
         self.currentSelectedItemIdentifier = item?.identifier
         self.updateSelection()
-    }
-    
-    private func didSelectContinueButton() {
-        guard formViewController.validate() else { return }
-        
-        guard canSubmit() else {
-            showError()
-            return
-        }
-        
-        continueButton.showsActivityIndicator = true
-        formViewController.view.isUserInteractionEnabled = false
-        
-        submitPayment()
     }
     
     private func didChangeSegmentedControlIndex(_ index: Int) {

--- a/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListViewModel.swift
+++ b/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListViewModel.swift
@@ -141,7 +141,7 @@ internal class PaymentMethodListViewModel: PaymentMethodListViewModelProtocol {
             router?.present(component: component)
         case let .initiable(initiablePaymentComponent):
             state = .loading
-            initiablePaymentComponent.submit()
+            initiablePaymentComponent.performSubmit()
         }
     }
 

--- a/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodViewModel.swift
+++ b/AdyenDropIn/Modules/PreselectedPaymentMethod/PreselectedPaymentMethodViewModel.swift
@@ -154,7 +154,7 @@ internal final class PreselectedPaymentMethodViewModel: PreselectedPaymentMethod
         case .regular, .stored:
             router?.present(component: component)
         case let .initiable(initiablePaymentComponent):
-            initiablePaymentComponent.submit()
+            initiablePaymentComponent.performSubmit()
         }
     }
 

--- a/AdyenTwint/TwintComponent.swift
+++ b/AdyenTwint/TwintComponent.swift
@@ -64,7 +64,7 @@ package final class TwintComponent: PaymentComponent {
     }
 
     /// Generate the payment details and invoke PaymentsComponentDelegate method.
-    package func submit() {
+    package func performSubmit() {
         submit(data: paymentData)
     }
 }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
@@ -70,7 +70,7 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
         do {
             let component = try instantPaymentComponent(from: paymentMethods)
             instantPaymentComponent = component
-            component.submit()
+            component.performSubmit()
         } catch {
             self.presentAlert(with: error)
         }

--- a/Tests/Common/Mocks/PaymentComponentMock.swift
+++ b/Tests/Common/Mocks/PaymentComponentMock.swift
@@ -34,7 +34,7 @@ class PaymentComponentMock: PaymentComponent {
     /// When true, calling submit() will trigger didSubmit on the delegate with mock payment data
     var shouldCallDelegateOnSubmit = true
 
-    func submit() {
+    func performSubmit() {
         submitCallsCount += 1
         submitClosure?()
 

--- a/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/StoredCardComponentTests.swift
@@ -79,7 +79,7 @@ class StoredCardComponentTests: XCTestCase {
         proxy.enterText("737")
 
         // When
-        sut.submit()
+        sut.performSubmit()
 
         // Then
         waitForExpectations(timeout: 1)

--- a/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/ACH Direct Debit/ACHDirectDebitComponentTests.swift
@@ -286,7 +286,7 @@ class ACHDirectDebitComponentTests: XCTestCase {
         self.populate(textItemView: routingNumberItemView, with: "121000358")
 
         // When
-        sut.submit()
+        sut.performSubmit()
 
         // Then
         wait(for: [didSubmitExpectation], timeout: 10)

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -205,7 +205,7 @@ class ApplePayComponentTest: XCTestCase {
             onDidFailExpectation.fulfill()
         }
 
-        sut.submit()
+        sut.performSubmit()
 
         waitForExpectations(timeout: 10)
     }

--- a/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/BLIK Component/BLIKComponentTests.swift
@@ -113,7 +113,7 @@ class BLIKComponentTests: XCTestCase {
         self.populate(textItemView: codeItemView, with: "123456")
 
         // When
-        sut.submit()
+        sut.performSubmit()
 
         // Then
         wait(for: [didSubmitExpectation], timeout: 10)

--- a/Tests/IntegrationTests/Components Tests/Boleto/BoletoComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Boleto/BoletoComponentTests.swift
@@ -168,7 +168,7 @@ class BoletoComponentTests: XCTestCase {
         addressPickerItem.item.value = PostalAddressMocks.newYorkPostalAddress
 
         // When
-        sut.submit()
+        sut.performSubmit()
 
         // Then
         wait(for: [didSubmitExpectation], timeout: 10)

--- a/Tests/IntegrationTests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Cash App Pay/CashAppPayComponentTests.swift
@@ -278,7 +278,7 @@ import XCTest
             }
 
             // When
-            sut.submit()
+            sut.performSubmit()
             sut.submitApprovedRequest(with: [oneTimeGrant, onFileGrant], profile: .init(id: "testId", cashtag: "testtag"))
 
             // Then

--- a/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
@@ -149,7 +149,7 @@ class GiftCardComponentTests: XCTestCase {
             XCTAssertGreaterThan(paymentMethod.encryptedSecurityCode.count, 0)
             expectation.fulfill()
         }
-        sut.didSelectSubmitButton()
+        sut.performSubmit()
         waitForExpectations(timeout: 10, handler: nil)
     }
 

--- a/Tests/IntegrationTests/Components Tests/Instant Payment/InstantPaymentComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Instant Payment/InstantPaymentComponentTests.swift
@@ -53,7 +53,7 @@ class InstantPaymentComponentTests: XCTestCase {
             delegateExpectation.fulfill()
         }
 
-        sut.submit()
+        sut.performSubmit()
 
         waitForExpectations(timeout: 2, handler: nil)
     }

--- a/Tests/IntegrationTests/Components Tests/Online Banking/OnlineBankingComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Online Banking/OnlineBankingComponentTests.swift
@@ -88,7 +88,7 @@ class OnlineBankingComponentTests: XCTestCase {
         }
 
         // When
-        sut.submit()
+        sut.performSubmit()
 
         // Then
         wait(for: [didSubmitExpectation], timeout: 10)

--- a/Tests/IntegrationTests/Components Tests/PayByBankUSComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayByBankUSComponentTests.swift
@@ -34,7 +34,7 @@ class PayByBankUSComponentTests: XCTestCase {
         
         sut.delegate = delegate
         
-        sut.submit()
+        sut.performSubmit()
         
         wait(for: [delegateExpectation], timeout: 1)
     }

--- a/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PayTo/PayToComponentTests.swift
@@ -401,7 +401,7 @@ class PayToComponentTests: XCTestCase {
         try populateValidFields(sut: sut)
 
         // When
-        sut.submit()
+        sut.performSubmit()
 
         // Then
         wait(for: [didSubmitExpectation], timeout: 10)
@@ -499,7 +499,7 @@ class PayToComponentTests: XCTestCase {
         fill(sut)
         sut.firstNameInputItem.value = shopperName.firstName
         sut.lastNameInputItem.value = shopperName.lastName
-        sut.submit()
+        sut.performSubmit()
 
         waitForExpectations(timeout: 1.0)
     }

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubject.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubject.swift
@@ -37,5 +37,5 @@ class PaymentComponentSubject: PaymentComponent, PresentableComponent {
         self.paymentMethod = paymentMethod
     }
 
-    func submit() { /* Empty implementation */ }
+    func performSubmit() { /* Empty implementation */ }
 }

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -338,7 +338,7 @@ class PaymentComponentSubjectTests: XCTestCase {
             didSubmitExpectation.fulfill()
         }
 
-        instantComponent.submit()
+        instantComponent.performSubmit()
 
         wait(for: [didSubmitExpectation], timeout: 3)
     }

--- a/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/SEPA Tests/SEPADirectDebitComponentTests.swift
@@ -244,7 +244,7 @@ class SEPADirectDebitComponentTests: XCTestCase {
         self.populate(textItemView: nameItemView, with: "A. Klaassen")
 
         // When
-        sut.submit()
+        sut.performSubmit()
 
         // Then
         wait(for: [didSubmitExpectation], timeout: 10)

--- a/Tests/IntegrationTests/Components Tests/Twint/TwintComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Twint/TwintComponentTests.swift
@@ -53,7 +53,7 @@ class TwintComponentTests: XCTestCase {
         }
         sut.delegate = delegate
 
-        sut.submit()
+        sut.performSubmit()
 
         waitForExpectations(timeout: 2, handler: nil)
     }
@@ -72,7 +72,7 @@ class TwintComponentTests: XCTestCase {
         sut.delegate = paymentComponentDelegate
 
         // When
-        sut.submit()
+        sut.performSubmit()
 
         // Then
         wait(for: [didSubmitExpectation], timeout: 10)

--- a/Tests/IntegrationTests/Components Tests/UPIComponent/UPIComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/UPIComponent/UPIComponentTests.swift
@@ -73,7 +73,7 @@ class UPIComponentTests: XCTestCase {
         self.populate(textItemView: vpaInputItem, with: "testvpa@icici")
 
         // When
-        sut.submit()
+        sut.performSubmit()
 
         // Then
         wait(for: [didSubmitExpectation], timeout: 10)

--- a/Tests/SnapshotTests/Components/DokuComponentUITests.swift
+++ b/Tests/SnapshotTests/Components/DokuComponentUITests.swift
@@ -131,7 +131,7 @@ final class DokuComponentUITests: XCTestCase {
         }
 
         // When
-        sut.submit()
+        sut.performSubmit()
 
         // Then
         waitForExpectations(timeout: 10)

--- a/Tests/UnitTests/Core/PaymentComponentFactoryProtocolTests.swift
+++ b/Tests/UnitTests/Core/PaymentComponentFactoryProtocolTests.swift
@@ -76,7 +76,7 @@ final class PaymentComponentFactoryProtocolTests: XCTestCase {
 
         var submitClosure: (() -> Void)?
 
-        func submit() {
+        func performSubmit() {
             submitCallsCount += 1
             submitClosure?()
         }


### PR DESCRIPTION
## Summary

Most components already implement an internal or private `didSelectSubmitButton` method that triggers the submission flow.

To reduce duplication, this PR moves the submission logic from `didSelectSubmitButton` into the component's `submit` method, rather than introducing a separate `package`-scoped `submit` implementation that simply forwards the call.

Additionally, the component's `submit` method has been renamed `performSubmit` in order to avoid ambiguity with both `submit(data: PaymentComponentData)` and the `submit` method defined in `CheckoutPaymentComponent`.

## Ticket
<ticket>
COSDK-1103
</ticket>

## Checklist
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria