### PR TITLE
[v6] (6/5) Non-UI components: Migrate standalone Instant component integration to v6

### DIFF
--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
@@ -53,12 +53,6 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
     }
 
     private func instantPaymentComponent(from paymentMethods: PaymentMethods) async throws -> CheckoutPaymentComponent {
-        // Get the correct payment method from the paymentMethods object
-        // In this example the first supported `InstantPaymentMethod` is chosen
-        guard let paymentMethod = paymentMethods.paymentMethod(ofType: InstantPaymentMethod.self) else {
-            throw IntegrationError.paymentMethodNotAvailable(paymentMethod: InstantPaymentMethod.self)
-        }
-
         let configuration = try CheckoutConfiguration(
             environment: ConfigurationConstants.componentsEnvironment,
             amount: ConfigurationConstants.current.amount,

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -723,42 +723,7 @@ class CardComponentTests: XCTestCase {
 
         waitForExpectations(timeout: 10, handler: nil)
     }
-
-    func testSubmit_withValidData_shouldCallDelegateDidSubmit() {
-        // Given
-        let sut = CardComponent(
-            paymentMethod: method,
-            context: Dummy.context(with: nil),
-            configuration: CardConfiguration(),
-            binProvider: BinInfoProviderMock()
-        )
-
-        let delegate = PaymentComponentDelegateMock()
-        sut.delegate = delegate
-        setupRootViewController(sut.viewController)
-
-        let delegateExpectation = expectation(description: "Expect delegate.didSubmit() to be called.")
-        let finalizationExpectation = expectation(description: "Component should finalize.")
-        delegate.onDidSubmit = { data, component in
-            XCTAssertTrue(component === sut)
-            XCTAssertTrue(data.paymentMethod is CardDetails)
-
-            sut.finalizeIfNeeded(with: true, completion: {
-                finalizationExpectation.fulfill()
-            })
-            delegateExpectation.fulfill()
-        }
-
-        fillCard(on: sut.viewController.view, with: Dummy.visaCard)
-
-        // When
-        sut.performSubmit()
-
-        // Then
-        wait(for: [delegateExpectation, finalizationExpectation], timeout: 10)
-        XCTAssertEqual(delegate.didSubmitCallsCount, 1)
-    }
-
+    
     func test_cardNumberField_whenComplete_shouldPassFocusToExpiryDate() throws {
         // Given
 

--- a/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Gift Card/GiftCardComponentTests.swift
@@ -533,36 +533,6 @@ class GiftCardComponentTests: XCTestCase {
         XCTAssertEqual(infoType, .rendered)
     }
 
-    func testSubmit_shouldCallPartialPaymentDelegateOnCheckBalance() {
-        // Given
-        sut.readyToSubmitComponentDelegate = nil
-
-        let onCheckBalanceExpectation = expectation(description: "Expect partialPaymentDelegate.onCheckBalance to be called.")
-        let balance = Balance(availableAmount: .init(value: 200, currencyCode: "EUR"), transactionLimit: nil)
-        partialPaymentDelegate.onCheckBalance = { _, completion in
-            completion(.success(balance))
-            onCheckBalanceExpectation.fulfill()
-        }
-
-        let onSubmitExpectation = expectation(description: "Expect delegateMock.onDidSubmit to be called.")
-        delegateMock.onDidSubmit = { data, component in
-            XCTAssertTrue(component === self.sut)
-            XCTAssertTrue(data.paymentMethod is GiftCardDetails)
-            onSubmitExpectation.fulfill()
-        }
-
-        sut.viewController.loadViewIfNeeded()
-
-        populate(cardNumber: "60643650100000000000", pin: "73737")
-
-        // When
-        sut.performSubmit()
-
-        // Then
-        wait(for: [onCheckBalanceExpectation, onSubmitExpectation], timeout: 10)
-        XCTAssertEqual(delegateMock.didSubmitCallsCount, 1)
-    }
-
     func testGiftCardHidingSecurityCodeItemView() {
 
         // Given

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -318,6 +318,28 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         XCTAssertNotNil(achComponent, "Component should be ACHDirectDebitComponent")
     }
 
+    // MARK: - Instant Payment Component Tests
+
+    func test_build_withInstantPaymentMethod_returnsInstantPaymentComponent() throws {
+        // Given
+        let dict: [String: Any] = [
+            "type": "ideal",
+            "name": "iDEAL"
+        ]
+        let paymentMethod = try XCTUnwrap(try? AdyenCoder.decode(dict) as InstantPaymentMethod)
+
+        // When
+        let component = try CheckoutComponentBuilder.build(
+            for: paymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+
+        // Then
+        XCTAssertEqual(component.paymentMethod.type, .ideal)
+        XCTAssertTrue(component is InstantPaymentComponent, "Component should be InstantPaymentComponent")
+    }
+
     // MARK: - Theme Propagation Tests
 
     func test_build_withCustomTheme_propagatesThemeToACHComponent() throws {


### PR DESCRIPTION
## Summary

This PR migrates the Demo app's standalone `InstantComponent` integration examples to v6.

The following integrations have been updated:
- Advanced flow
- Sessions flow

The changes align the examples with the latest v6 APIs and serve as updated references for merchants integrating the SDK.

# Demo

https://github.com/user-attachments/assets/b3af5784-6a52-48da-9248-9222d210ec76


## Ticket
<ticket>
COSDK-1103
</ticket>

## Checklist
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
