### PR TITLE
[v6] (6/5) Non-UI components: Migrate standalone Instant component integration to v6

### DIFF
--- a/AdyenCheckout/Component/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/Component/CheckoutComponentBuilder.swift
@@ -65,6 +65,12 @@ internal enum CheckoutComponentBuilder {
                 // TODO: add other card methods like stored or write a generic one.
             
         #endif
+        case let instantPaymentMethod as InstantPaymentMethod:
+            return InstantPaymentComponent(
+                paymentMethod: instantPaymentMethod,
+                context: context,
+                order: nil
+            )
         default:
             break
         }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
@@ -6,132 +6,135 @@
 
 import Adyen
 import AdyenActions
+import AdyenCheckout
 import AdyenComponents
 import Foundation
 
+@MainActor
 internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlowProtocol {
 
-    // MARK: - Properties
-
-    internal var instantPaymentComponent: InstantPaymentComponent?
-
     internal weak var presenter: PresenterExampleProtocol?
-    
+
+    private var checkout: AdvancedCheckout?
+    private var adyenComponent: CheckoutPaymentComponent?
+
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
-    
+    private lazy var asyncApiClient = ApiClientHelper.generateAsyncApiClient()
+
     /// comes from demo app protocol, unused on new structure
     internal var context: AdyenContext?
-
-    // MARK: - Action Handling
-
-    private lazy var actionComponent: CheckoutActionComponent = {
-        guard let context else {
-            fatalError("Context not initialized")
-        }
-        let handler = CheckoutActionComponent(context: context)
-        handler.delegate = self
-        handler.presentationDelegate = self
-        return handler
-    }()
-
-    // MARK: - Initializers
 
     internal init() {}
 
     internal func start() {
-        presenter?.showLoadingIndicator()
+        startLoading()
+
         Task {
             do {
-                try await initializeExampleAppAdyenContext()
-                requestPaymentMethods(order: nil) { [weak self] result in
-                    guard let self else { return }
+                let paymentMethods = try await requestPaymentMethods(order: nil)
+                let component = try await instantPaymentComponent(from: paymentMethods)
+                self.adyenComponent = component
+                hideLoading()
 
-                    self.presenter?.hideLoadingIndicator()
-
-                    switch result {
-                    case let .success(paymentMethods):
-                        self.presentComponent(with: paymentMethods)
-
-                    case let .failure(error):
-                        self.presentAlert(with: error)
+                if component.requiresUserInteraction {
+                    // Present the component UI if user interaction is needed
+                    if let viewController = component.viewController {
+                        presenter?.present(viewController: viewController, completion: nil)
                     }
+                } else {
+                    // Submit directly for instant payment methods
+                    component.submit()
                 }
             } catch {
-                self.presenter?.hideLoadingIndicator()
-                self.presentAlert(with: error)
+                hideLoading()
+                handleError(error)
             }
-
         }
     }
-    
-    // MARK: - Presentation
-    
-    private func presentComponent(with paymentMethods: PaymentMethods) {
+
+    private func instantPaymentComponent(from paymentMethods: PaymentMethods) async throws -> CheckoutPaymentComponent {
+        let configuration = try CheckoutConfiguration(
+            environment: ConfigurationConstants.componentsEnvironment,
+            amount: ConfigurationConstants.current.amount,
+            clientKey: ConfigurationConstants.clientKey,
+            analyticsConfiguration: .init(
+                isEnabled: ConfigurationConstants.current.analyticsSettings.isEnabled
+            )
+        ) {
+            // No component-specific configuration needed for instant payments
+        }
+
+        let checkout = try await Checkout.setup(
+            with: paymentMethods,
+            configuration: configuration,
+            presentationDelegate: self
+        )
+        .onSubmit { [weak self] data in
+            guard let self else { return .completion(resultCode: "Error") }
+            return await self.callPayments(with: data)
+        }
+        .onAdditionalDetails { [weak self] data in
+            guard let self else { return .completion(resultCode: "Error") }
+            return await self.callDetails(with: data)
+        }
+        .onComplete { [weak self] result in
+            self?.dismissAndShowAlert(
+                result.resultCode.isSuccess,
+                result.resultCode.rawValue
+            )
+        }
+        .onError { [weak self] error in
+            self?.dismissAndShowAlert(false, error.localizedDescription)
+        }
+
+        self.checkout = checkout
+
+        return try checkout.createPaymentComponent(for: PaymentMethodType.ideal)
+    }
+
+    // MARK: - Backend calls
+
+    private func callPayments(with data: PaymentComponentData) async -> SubmitResult {
         do {
-            let component = try instantPaymentComponent(from: paymentMethods)
-            instantPaymentComponent = component
-            component.performSubmit()
-        } catch {
-            self.presentAlert(with: error)
-        }
-    }
-    
-    private func instantPaymentComponent(from paymentMethods: PaymentMethods) throws -> InstantPaymentComponent {
-        
-        // Get the correct payment method from the paymentMethods object
-        // In this example the first supported `InstantPaymentMethod` is chosen
-        guard let paymentMethod = paymentMethods.paymentMethod(ofType: InstantPaymentMethod.self) else {
-            throw IntegrationError.paymentMethodNotAvailable(paymentMethod: InstantPaymentMethod.self)
-        }
-        guard let context else {
-            fatalError("AdyenContext not initialized")
-        }
-        
-        return InstantPaymentComponent(paymentMethod: paymentMethod, context: context, order: nil)
-    }
-
-    // MARK: - Payment response handling
-
-    private func paymentResponseHandler(result: Result<PaymentsResponse, Error>) {
-        switch result {
-        case let .success(response):
+            let request = PaymentsRequest(data: data)
+            let response = try await asyncApiClient.performAsync(request)
             if let action = response.action {
-                actionComponent.handle(action)
-            } else {
-                finish(with: response)
+                return .action(action)
             }
-        case let .failure(error):
-            finish(with: error)
+            return .completion(resultCode: response.resultCode.rawValue)
+        } catch {
+            return .completion(resultCode: "Error")
         }
     }
 
-    private func finish(with result: PaymentsResponse) {
-        let success = result.isAccepted
-        let message = "\(result.resultCode.rawValue) \(result.amount?.formatted ?? "")"
-        finalize(success, message)
+    private func callDetails(with data: ActionComponentData) async -> AdditionalDetailsResult {
+        do {
+            let request = PaymentDetailsRequest(
+                details: data.details,
+                paymentData: data.paymentData,
+                merchantAccount: ConfigurationConstants.current.merchantAccount
+            )
+            let response = try await asyncApiClient.performAsync(request)
+            return .completion(resultCode: response.resultCode.rawValue)
+        } catch {
+            return .completion(resultCode: "Error")
+        }
     }
 
-    private func finish(with error: Error) {
-        let message: String
-        if let componentError = (error as? ComponentError), componentError == ComponentError.cancelled {
-            message = "Cancelled"
-        } else {
-            message = error.localizedDescription
-        }
-        finalize(false, message)
+    // MARK: - Private
+
+    private func startLoading() {
+        presenter?.showLoadingIndicator()
     }
 
-    private func finalize(_ success: Bool, _ message: String) {
-        instantPaymentComponent?.finalizeIfNeeded(with: success) { [weak self] in
-            guard let self else { return }
-            self.dismissAndShowAlert(success, message)
-        }
+    private func handleError(_ error: Error) {
+        presenter?.presentAlert(withTitle: "Error", message: error.localizedDescription)
+    }
+
+    private func hideLoading() {
+        presenter?.hideLoadingIndicator()
     }
     
-    private func presentAlert(with error: Error, retryHandler: (() -> Void)? = nil) {
-        presenter?.presentAlert(with: error, retryHandler: retryHandler)
-    }
-
     private func dismissAndShowAlert(_ success: Bool, _ message: String) {
         presenter?.dismiss {
             // Payment is processed. Add your code here.
@@ -139,65 +142,11 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
             self.presenter?.presentAlert(withTitle: title, message: message)
         }
     }
-
-}
-
-extension InstantPaymentComponentAdvancedFlow: PaymentComponentDelegate {
-
-    internal func didSubmit(_ data: PaymentComponentData, from component: PaymentComponent) {
-        presenter?.showLoadingIndicator()
-        let request = PaymentsRequest(data: data)
-        apiClient.perform(request) { [weak self] result in
-            self?.presenter?.hideLoadingIndicator()
-            self?.paymentResponseHandler(result: result)
-        }
-    }
-
-    internal func didFail(with error: Error, from component: PaymentComponent) {
-        finish(with: error)
-    }
-
-}
-
-extension InstantPaymentComponentAdvancedFlow: ActionComponentDelegate {
-
-    internal func didFail(with error: Error, from component: ActionComponent) {
-        finish(with: error)
-    }
-
-    internal func didComplete(from component: ActionComponent) {
-        finish(with: .received)
-    }
-
-    internal func didProvide(_ data: ActionComponentData, from component: ActionComponent) {
-        (component as? PresentableComponent)?.viewController.view.isUserInteractionEnabled = false
-        let request = PaymentDetailsRequest(
-            details: data.details,
-            paymentData: data.paymentData,
-            merchantAccount: ConfigurationConstants.current.merchantAccount
-        )
-        apiClient.perform(request) { [weak self] result in
-            self?.paymentResponseHandler(result: result)
-        }
-    }
 }
 
 extension InstantPaymentComponentAdvancedFlow: PresentationDelegate {
-    internal func present(component: PresentableComponent) {
-        let componentViewController = component.viewController
-        componentViewController.navigationItem.leftBarButtonItem = .init(
-            barButtonSystemItem: .cancel,
-            target: self,
-            action: #selector(cancelPressed)
-        )
-        presenter?.present(viewController: componentViewController, completion: nil)
-    }
-}
 
-private extension InstantPaymentComponentAdvancedFlow {
-
-    @objc private func cancelPressed() {
-        instantPaymentComponent?.cancel()
-        presenter?.dismiss(completion: nil)
+    func present(component: any PresentableComponent) {
+        presenter?.present(viewController: component.viewController, completion: nil)
     }
 }

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
@@ -36,15 +36,12 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
                 self.adyenComponent = component
                 hideLoading()
 
-                if component.requiresUserInteraction {
-                    // Present the component UI if user interaction is needed
-                    if let viewController = component.viewController {
-                        presenter?.present(viewController: viewController, completion: nil)
-                    }
-                } else {
-                    // Submit directly for instant payment methods
-                    component.submit()
+                guard !component.requiresUserInteraction else {
+                    // Instant payment methods don't require user interaction
+                    // For payment methods that require UI, see the card component example
+                    return
                 }
+                component.submit()
             } catch {
                 hideLoading()
                 handleError(error)

--- a/Demo/Common/IntegrationExamples/Session/Components/InstantPaymentComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/InstantPaymentComponentExample.swift
@@ -35,15 +35,12 @@ internal final class InstantPaymentComponentExample: InitialDataFlowProtocol {
                 self.adyenComponent = component
                 hideLoading()
 
-                if component.requiresUserInteraction {
-                    // Present the component UI if user interaction is needed
-                    if let viewController = component.viewController {
-                        presenter?.present(viewController: viewController, completion: nil)
-                    }
-                } else {
-                    // Submit directly for instant payment methods
-                    component.submit()
+                guard !component.requiresUserInteraction else {
+                    // Instant payment methods don't require user interaction
+                    // For payment methods that require UI, see the card component example
+                    return
                 }
+                component.submit()
             } catch {
                 hideLoading()
                 handleError(error)

--- a/Demo/Common/IntegrationExamples/Session/Components/InstantPaymentComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/InstantPaymentComponentExample.swift
@@ -5,144 +5,110 @@
 //
 
 import Adyen
+import AdyenCheckout
 import AdyenComponents
-import AdyenSession
 import Foundation
 
+@MainActor
 internal final class InstantPaymentComponentExample: InitialDataFlowProtocol {
 
-    // MARK: - Properties
-
-    internal var session: Session?
     internal weak var presenter: PresenterExampleProtocol?
-    internal var instantPaymentComponent: InstantPaymentComponent?
+
+    private var checkout: SessionCheckout?
+    private var adyenComponent: CheckoutPaymentComponent?
 
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
-    
-    internal var context: AdyenContext?
+    private lazy var asyncApiClient = ApiClientHelper.generateAsyncApiClient()
 
-    // MARK: - Initializers
+    /// comes from demo app protocol, unused on new structure
+    internal var context: AdyenContext?
 
     internal init() {}
 
     internal func start() {
-        presenter?.showLoadingIndicator()
+        startLoading()
+
         Task {
             do {
-                try await initializeExampleAppAdyenContext()
-                loadSession { [weak self] response in
-                    guard let self else { return }
+                let sessionResponse = try await requestSessionInitialInfo()
+                let component = try await instantPaymentComponent(from: sessionResponse)
+                self.adyenComponent = component
+                hideLoading()
 
-                    self.presenter?.hideLoadingIndicator()
-
-                    switch response {
-                    case let .success(session):
-                        self.session = session
-                        self.presentComponent(with: session)
-
-                    case let .failure(error):
-                        self.presentAlert(with: error)
+                if component.requiresUserInteraction {
+                    // Present the component UI if user interaction is needed
+                    if let viewController = component.viewController {
+                        presenter?.present(viewController: viewController, completion: nil)
                     }
+                } else {
+                    // Submit directly for instant payment methods
+                    component.submit()
                 }
             } catch {
-                self.presenter?.hideLoadingIndicator()
-                self.presentAlert(with: error)
+                hideLoading()
+                handleError(error)
             }
         }
     }
 
-    // MARK: - Networking
-
-    internal func loadSession(completion: @escaping (Result<Session, Error>) -> Void) {
-        requestSessionInitialInfo { [weak self] response in
-            guard let self else { return }
-            switch response {
-            case let .success(model):
-//                AdyenSession.initialize(
-//                    with: configuration,
-//                    delegate: self,
-//                    presentationDelegate: self,
-//                    completion: completion
-//                )
-                break
-            case let .failure(error):
-                completion(.failure(error))
-            }
+    private func instantPaymentComponent(from sessionResponse: SessionResponse) async throws -> CheckoutPaymentComponent {
+        let configuration = try CheckoutConfiguration(
+            environment: ConfigurationConstants.componentsEnvironment,
+            amount: ConfigurationConstants.current.amount,
+            clientKey: ConfigurationConstants.clientKey,
+            analyticsConfiguration: .init(
+                isEnabled: ConfigurationConstants.current.analyticsSettings.isEnabled
+            )
+        ) {
+            // No component-specific configuration needed for instant payments
         }
+
+        let checkout = try await Checkout.setup(
+            with: sessionResponse,
+            configuration: configuration,
+            presentationDelegate: self
+        )
+        .onComplete { [weak self] result in
+            self?.dismissAndShowAlert(
+                result.resultCode.isSuccess,
+                result.resultCode.rawValue
+            )
+        }
+        .onError { [weak self] error in
+            self?.dismissAndShowAlert(false, error.localizedDescription)
+        }
+
+        self.checkout = checkout
+
+        return try checkout.createPaymentComponent(for: PaymentMethodType.ideal)
     }
 
-    // MARK: Presentation
+    // MARK: - Private
 
-    internal func presentComponent(with session: Session) {
-        do {
-            let component = try instantPaymentComponent(from: session)
-            instantPaymentComponent = component
-            presenter?.showLoadingIndicator()
-            // TODO: Migrate to Checkout — Session no longer conforms to PaymentComponentDelegate in v6.
-            // component.initiatePayment(delegate: session)
-        } catch {
-            self.presentAlert(with: error)
-        }
+    private func startLoading() {
+        presenter?.showLoadingIndicator()
     }
 
-    private func instantPaymentComponent(from session: Session) throws -> InstantPaymentComponent {
-        let paymentMethods = session.state.paymentMethods
-        
-        // Get the correct payment method from the paymentMethods object
-        // In this example the first supported `InstantPaymentMethod` is chosen
-        guard let paymentMethod = paymentMethods.paymentMethod(ofType: InstantPaymentMethod.self) else {
-            throw IntegrationError.paymentMethodNotAvailable(paymentMethod: InstantPaymentMethod.self)
-        }
-
-        guard let context else {
-            fatalError("AdyenContext not initialized")
-        }
-
-        return InstantPaymentComponent(paymentMethod: paymentMethod, context: context, order: nil)
+    private func handleError(_ error: Error) {
+        presenter?.presentAlert(withTitle: "Error", message: error.localizedDescription)
     }
 
-    private func present(_ component: PresentableComponent) {
+    private func hideLoading() {
         presenter?.hideLoadingIndicator()
-        presenter?.present(viewController: component.viewController, completion: nil)
     }
 
-    // MARK: - Alert handling
-
-    internal func presentAlert(with error: Error, retryHandler: (() -> Void)? = nil) {
-        presenter?.hideLoadingIndicator()
-        presenter?.presentAlert(with: error, retryHandler: retryHandler)
-    }
-
-    internal func dismissAndShowAlert(_ success: Bool, _ message: String) {
-        presenter?.hideLoadingIndicator()
+    private func dismissAndShowAlert(_ success: Bool, _ message: String) {
         presenter?.dismiss {
             // Payment is processed. Add your code here.
             let title = success ? "Success" : "Error"
             self.presenter?.presentAlert(withTitle: title, message: message)
         }
     }
-
 }
-
-// TODO: Migrate to Checkout API — SessionDelegate has been removed in v6.
 
 extension InstantPaymentComponentExample: PresentationDelegate {
-    internal func present(component: PresentableComponent) {
-        presenter?.hideLoadingIndicator()
-        let componentViewController = component.viewController
-        componentViewController.navigationItem.leftBarButtonItem = .init(
-            barButtonSystemItem: .cancel,
-            target: self,
-            action: #selector(cancelPressed)
-        )
-        presenter?.present(viewController: componentViewController, completion: nil)
-    }
-}
 
-private extension InstantPaymentComponentExample {
-
-    @objc private func cancelPressed() {
-        instantPaymentComponent?.cancel()
-        presenter?.dismiss(completion: nil)
+    func present(component: any PresentableComponent) {
+        presenter?.present(viewController: component.viewController, completion: nil)
     }
 }

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -318,6 +318,28 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         XCTAssertNotNil(achComponent, "Component should be ACHDirectDebitComponent")
     }
 
+    // MARK: - Instant Payment Component Tests
+
+    func test_build_withInstantPaymentMethod_returnsInstantPaymentComponent() throws {
+        // Given
+        let dict: [String: Any] = [
+            "type": "ideal",
+            "name": "iDEAL"
+        ]
+        let paymentMethod = try XCTUnwrap(try? AdyenCoder.decode(dict) as InstantPaymentMethod)
+
+        // When
+        let component = try CheckoutComponentBuilder.build(
+            for: paymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+
+        // Then
+        XCTAssertEqual(component.paymentMethod.type, .ideal)
+        XCTAssertTrue(component is InstantPaymentComponent, "Component should be InstantPaymentComponent")
+    }
+
     // MARK: - Theme Propagation Tests
 
     func test_build_withCustomTheme_propagatesThemeToACHComponent() throws {


### PR DESCRIPTION
## Summary

This PR migrates the Demo app's standalone `InstantComponent` integration examples to v6.

The following integrations have been updated:
- Advanced flow
- Sessions flow

The changes align the examples with the latest v6 APIs and serve as updated references for merchants integrating the SDK.

# Demo

https://github.com/user-attachments/assets/b3af5784-6a52-48da-9248-9222d210ec76


## Ticket
<ticket>
COSDK-1103
</ticket>

## Checklist
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
