### PR TITLE
Simplify BeforeSubmitData API

### DIFF
--- a/Adyen/Core/Configuration/BeforeSubmitResult.swift
+++ b/Adyen/Core/Configuration/BeforeSubmitResult.swift
@@ -8,32 +8,32 @@ import Foundation
 
 /// Result returned by `onBeforeSubmit` callback in the session flow.
 public enum BeforeSubmitResult: Sendable {
-    
+
     /// Continue the submission flow with the provided data.
     /// - Parameters:
     ///   - data: The submit data (pass back unchanged if unmodified).
     ///   - sessionData: Optional. Pass the sessionData you received from your server's `PATCH` request
     ///     so the SDK can update the current session state data before continuing.
     case proceed(data: BeforeSubmitData, sessionData: String?)
-    
+
     /// Stop the submission and reset the state.
     case abort
 }
 
 public struct BeforeSubmitData: Sendable {
-    
+
     /// Billing address of the shopper.
-    public private(set) var billingAddress: PostalAddress?
-    
+    public var billingAddress: PostalAddress?
+
     /// Delivery address of the shopper.
-    public private(set) var deliveryAddress: PostalAddress?
-    
+    public var deliveryAddress: PostalAddress?
+
     /// Name of the shopper.
-    public private(set) var shopperName: ShopperName?
-    
+    public var shopperName: ShopperName?
+
     /// Email address of the shopper.
-    public private(set) var shopperEmail: String?
-    
+    public var shopperEmail: String?
+
     package init(
         billingAddress: PostalAddress? = nil,
         deliveryAddress: PostalAddress? = nil,
@@ -44,29 +44,5 @@ public struct BeforeSubmitData: Sendable {
         self.deliveryAddress = deliveryAddress
         self.shopperName = shopperName
         self.shopperEmail = shopperEmail
-    }
-
-    public func replacing(billingAddress: PostalAddress) -> BeforeSubmitData {
-        var copy = self
-        copy.billingAddress = billingAddress
-        return copy
-    }
-
-    public func replacing(deliveryAddress: PostalAddress) -> BeforeSubmitData {
-        var copy = self
-        copy.deliveryAddress = deliveryAddress
-        return copy
-    }
-
-    public func replacing(shopperName: ShopperName) -> BeforeSubmitData {
-        var copy = self
-        copy.shopperName = shopperName
-        return copy
-    }
-
-    public func replacing(shopperEmail: String) -> BeforeSubmitData {
-        var copy = self
-        copy.shopperEmail = shopperEmail
-        return copy
     }
 }

--- a/AdyenCheckout/Flows/SessionCheckout.swift
+++ b/AdyenCheckout/Flows/SessionCheckout.swift
@@ -25,8 +25,9 @@ public final class SessionCheckout: PaymentCheckout {
     /// in `.proceed(data:sessionData:)` so the SDK can update the session state data before continuing.
     /// - Parameter handler: Callback invoked before the session performs the `/payments` call.
     ///   - data: The `BeforeSubmitData` containing shopper fields that can be validated, modified, or passed back unchanged.
+    ///     Setting a field to `nil` has no effect; the original value collected by the component will be used instead.
     /// - Returns: A `BeforeSubmitResult`. Return `.proceed(data:sessionData:)` to continue or `.abort`
-    /// to stop the flow and reset the component state.
+    ///   to stop the flow and reset the component state.
     public func onBeforeSubmit(_ handler: @escaping BeforeSubmitHandler) -> Self {
         callbackStore.onBeforeSubmit = handler
         return self

--- a/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
@@ -133,9 +133,9 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
 
             switch ConfigurationConstants.current.applePaySettings.onBeforeSubmitMode {
             case .updateData:
-                let updatedData = data
-                    .replacing(shopperName: ShopperName(firstName: "Demo", lastName: "Shopper"))
-                    .replacing(shopperEmail: "updatedForDemo-\(ConfigurationConstants.shopperEmail)")
+                var updatedData = data
+                updatedData.shopperName = ShopperName(firstName: "Demo", lastName: "Shopper")
+                updatedData.shopperEmail = "updatedForDemo-\(ConfigurationConstants.shopperEmail)"
                 return .proceed(data: updatedData, sessionData: nil)
             case .abort:
                 return .abort

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -262,9 +262,9 @@ final class CheckoutTests: XCTestCase {
         
         let modifiedName = ShopperName(firstName: "Modified", lastName: "Name")
         callbackStore.onBeforeSubmit = { data in
-            let modified = data
-                .replacing(shopperName: modifiedName)
-                .replacing(shopperEmail: "modified@test.com")
+            var modified = data
+            modified.shopperName = modifiedName
+            modified.shopperEmail = "modified@test.com"
             return .proceed(data: modified, sessionData: nil)
         }
         callbackStore.onComplete = { _ in
@@ -345,16 +345,11 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(original.billingAddress)
         XCTAssertNil(original.deliveryAddress)
         
-        let overrides = BeforeSubmitData(
-            billingAddress: nil,
-            deliveryAddress: nil,
-            shopperName: nil,
-            shopperEmail: nil
-        )
-        .replacing(billingAddress: PostalAddress(city: "Amsterdam", country: "NL"))
-        .replacing(deliveryAddress: PostalAddress(city: "Berlin", country: "DE"))
-        .replacing(shopperName: ShopperName(firstName: "John", lastName: "Doe"))
-        .replacing(shopperEmail: "john@example.com")
+        var overrides = BeforeSubmitData()
+        overrides.billingAddress = PostalAddress(city: "Amsterdam", country: "NL")
+        overrides.deliveryAddress = PostalAddress(city: "Berlin", country: "DE")
+        overrides.shopperName = ShopperName(firstName: "John", lastName: "Doe")
+        overrides.shopperEmail = "john@example.com"
         
         let updated = original.replacing(beforeSubmitData: overrides)
         

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -345,11 +345,12 @@ final class CheckoutTests: XCTestCase {
         XCTAssertNil(original.billingAddress)
         XCTAssertNil(original.deliveryAddress)
         
-        var overrides = BeforeSubmitData()
-        overrides.billingAddress = PostalAddress(city: "Amsterdam", country: "NL")
-        overrides.deliveryAddress = PostalAddress(city: "Berlin", country: "DE")
-        overrides.shopperName = ShopperName(firstName: "John", lastName: "Doe")
-        overrides.shopperEmail = "john@example.com"
+        let overrides = BeforeSubmitData(
+            billingAddress: PostalAddress(city: "Amsterdam", country: "NL"),
+            deliveryAddress: PostalAddress(city: "Berlin", country: "DE"),
+            shopperName: ShopperName(firstName: "John", lastName: "Doe"),
+            shopperEmail: "john@example.com"
+        )
         
         let updated = original.replacing(beforeSubmitData: overrides)
         


### PR DESCRIPTION
# Summary

Simplifies the `BeforeSubmitData` API introduced with `onBeforeSubmit`. The previous design exposed `public private(set) var` properties alongside dedicated `replacing()` modifier functions. This replaces that with plain `public var` properties so merchants can mutate fields directly via standard Swift value semantics.

The `package init` is unchanged — merchants cannot construct a fresh `BeforeSubmitData` instance, so the `??\ fallback in `PaymentComponentData` remains correct: setting a field to `nil` has no effect and the original value collected by the component is preserved.

## Ticket

<ticket>
COSDK-907
</ticket>

## Checklist
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)