### PR TITLE
Rename onError and ApplePay callbacks

### DIFF
--- a/AdyenCheckout/Callbacks/CheckoutResultCallbackStore.swift
+++ b/AdyenCheckout/Callbacks/CheckoutResultCallbackStore.swift
@@ -10,7 +10,7 @@ import Foundation
 package protocol CheckoutResultCallbackStore: AnyObject {
     var onComplete: CheckoutSuccessHandler? { get set }
 
-    var onError: CheckoutErrorHandler? { get set }
+    var onFailure: CheckoutErrorHandler? { get set }
 }
 
 package final class SessionCheckoutCallbackStore: CheckoutResultCallbackStore {
@@ -18,7 +18,7 @@ package final class SessionCheckoutCallbackStore: CheckoutResultCallbackStore {
 
     package var onComplete: CheckoutSuccessHandler?
 
-    package var onError: CheckoutErrorHandler?
+    package var onFailure: CheckoutErrorHandler?
 }
 
 package final class AdvancedCheckoutCallbackStore: CheckoutResultCallbackStore {
@@ -28,7 +28,7 @@ package final class AdvancedCheckoutCallbackStore: CheckoutResultCallbackStore {
 
     package var onComplete: CheckoutSuccessHandler?
 
-    package var onError: CheckoutErrorHandler?
+    package var onFailure: CheckoutErrorHandler?
 }
 
 package final class ActionOnlyCheckoutCallbackStore: CheckoutResultCallbackStore {
@@ -36,5 +36,5 @@ package final class ActionOnlyCheckoutCallbackStore: CheckoutResultCallbackStore
 
     package var onComplete: CheckoutSuccessHandler?
 
-    package var onError: CheckoutErrorHandler?
+    package var onFailure: CheckoutErrorHandler?
 }

--- a/AdyenCheckout/Core/CheckoutCore+Orchestration.swift
+++ b/AdyenCheckout/Core/CheckoutCore+Orchestration.swift
@@ -135,7 +135,7 @@ internal extension CheckoutCore {
         finish(with: error, from: component)
     }
 
-    // TODO: `onComplete` / `onError` currently fire synchronously right after finalization,
+    // TODO: `onComplete` / `onFailure` currently fire synchronously right after finalization,
     // which for Apple Pay means they fire while PK is still animating its success/failure
     // result and has not yet dismissed the sheet. If a merchant's callback presents any
     // UI (alert, navigation, etc.), that presentation wedges UIKit's transition machinery
@@ -155,7 +155,7 @@ internal extension CheckoutCore {
     func finish(with error: Error, from component: (any PaymentComponent)?) {
         (component as? any FinalizableComponent)?.didFinalize(with: false, completion: nil)
         pendingPaymentComponent = nil
-        resultCallbacks.onError?(CheckoutError(error: error))
+        resultCallbacks.onFailure?(CheckoutError(error: error))
     }
 }
 

--- a/AdyenCheckout/Flows/BaseCheckout.swift
+++ b/AdyenCheckout/Flows/BaseCheckout.swift
@@ -40,8 +40,8 @@ public class BaseCheckout {
     /// Sets the callback invoked when checkout fails.
     /// - Parameter handler: Callback invoked with the checkout failure.
     ///   - error: The `Error` describing why the checkout flow failed.
-    public func onError(_ handler: @escaping CheckoutErrorHandler) -> Self {
-        resultCallbacks.onError = handler
+    public func onFailure(_ handler: @escaping CheckoutErrorHandler) -> Self {
+        resultCallbacks.onFailure = handler
         return self
     }
 

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -49,7 +49,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         _ controller: PKPaymentAuthorizationViewController,
         didSelectShippingContact contact: PKContact
     ) async -> PKPaymentRequestShippingContactUpdate {
-        await handleShippingContactChange(contact)
+        await handleDidSelectShippingContact(contact)
     }
 
     // MARK: - Shipping Method (async)
@@ -58,7 +58,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         _ controller: PKPaymentAuthorizationViewController,
         didSelect shippingMethod: PKShippingMethod
     ) async -> PKPaymentRequestShippingMethodUpdate {
-        await handleShippingMethodChange(shippingMethod)
+        await handleDidSelectShippingMethod(shippingMethod)
     }
 
     // MARK: - Coupon Code (async)
@@ -67,7 +67,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         _ controller: PKPaymentAuthorizationViewController,
         didChangeCouponCode couponCode: String
     ) async -> PKPaymentRequestCouponCodeUpdate {
-        await handleCouponCodeChange(couponCode)
+        await handleDidChangeCouponCode(couponCode)
     }
 }
 
@@ -119,32 +119,32 @@ extension ApplePayComponent {
         return PKPaymentAuthorizationResult(status: success ? .success : .failure, errors: nil)
     }
 
-    private func handleShippingContactChange(_ contact: PKContact) async -> PKPaymentRequestShippingContactUpdate {
-        guard let onShippingContactChange = configuration.onShippingContactChange else {
+    private func handleDidSelectShippingContact(_ contact: PKContact) async -> PKPaymentRequestShippingContactUpdate {
+        guard let onSelectShippingContact = configuration.onSelectShippingContact else {
             return PKPaymentRequestShippingContactUpdate(paymentSummaryItems: paymentRequest.paymentSummaryItems)
         }
 
-        let result = await onShippingContactChange(contact, paymentRequest.paymentSummaryItems)
+        let result = await onSelectShippingContact(contact, paymentRequest.paymentSummaryItems)
         result.paymentSummaryItems = validSummaryItems(from: result)
         return result
     }
 
-    private func handleShippingMethodChange(_ shippingMethod: PKShippingMethod) async -> PKPaymentRequestShippingMethodUpdate {
-        guard let onShippingMethodChange = configuration.onShippingMethodChange else {
+    private func handleDidSelectShippingMethod(_ shippingMethod: PKShippingMethod) async -> PKPaymentRequestShippingMethodUpdate {
+        guard let onSelectShippingMethod = configuration.onSelectShippingMethod else {
             return PKPaymentRequestShippingMethodUpdate(paymentSummaryItems: paymentRequest.paymentSummaryItems)
         }
 
-        let result = await onShippingMethodChange(shippingMethod, paymentRequest.paymentSummaryItems)
+        let result = await onSelectShippingMethod(shippingMethod, paymentRequest.paymentSummaryItems)
         result.paymentSummaryItems = validSummaryItems(from: result)
         return result
     }
 
-    private func handleCouponCodeChange(_ couponCode: String) async -> PKPaymentRequestCouponCodeUpdate {
-        guard let onCouponCodeChange = configuration.onCouponCodeChange else {
+    private func handleDidChangeCouponCode(_ couponCode: String) async -> PKPaymentRequestCouponCodeUpdate {
+        guard let onChangeCouponCode = configuration.onChangeCouponCode else {
             return PKPaymentRequestCouponCodeUpdate(paymentSummaryItems: paymentRequest.paymentSummaryItems)
         }
 
-        let result = await onCouponCodeChange(couponCode, paymentRequest.paymentSummaryItems)
+        let result = await onChangeCouponCode(couponCode, paymentRequest.paymentSummaryItems)
         result.paymentSummaryItems = validSummaryItems(from: result)
         return result
     }

--- a/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
+++ b/AdyenComponents/Apple Pay/ApplePayComponentExtensions.swift
@@ -40,7 +40,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         _ controller: PKPaymentAuthorizationViewController,
         didSelect paymentMethod: PKPaymentMethod
     ) async -> PKPaymentRequestPaymentMethodUpdate {
-        await handlePaymentMethodChange(paymentMethod)
+        await handleSelectPaymentMethod(paymentMethod)
     }
 
     // MARK: - Shipping Contact (async)
@@ -49,7 +49,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         _ controller: PKPaymentAuthorizationViewController,
         didSelectShippingContact contact: PKContact
     ) async -> PKPaymentRequestShippingContactUpdate {
-        await handleDidSelectShippingContact(contact)
+        await handleSelectShippingContact(contact)
     }
 
     // MARK: - Shipping Method (async)
@@ -58,7 +58,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         _ controller: PKPaymentAuthorizationViewController,
         didSelect shippingMethod: PKShippingMethod
     ) async -> PKPaymentRequestShippingMethodUpdate {
-        await handleDidSelectShippingMethod(shippingMethod)
+        await handleSelectShippingMethod(shippingMethod)
     }
 
     // MARK: - Coupon Code (async)
@@ -67,7 +67,7 @@ extension ApplePayComponent: PKPaymentAuthorizationViewControllerDelegate {
         _ controller: PKPaymentAuthorizationViewController,
         didChangeCouponCode couponCode: String
     ) async -> PKPaymentRequestCouponCodeUpdate {
-        await handleDidChangeCouponCode(couponCode)
+        await handleChangeCouponCode(couponCode)
     }
 }
 
@@ -119,7 +119,7 @@ extension ApplePayComponent {
         return PKPaymentAuthorizationResult(status: success ? .success : .failure, errors: nil)
     }
 
-    private func handleDidSelectShippingContact(_ contact: PKContact) async -> PKPaymentRequestShippingContactUpdate {
+    private func handleSelectShippingContact(_ contact: PKContact) async -> PKPaymentRequestShippingContactUpdate {
         guard let onSelectShippingContact = configuration.onSelectShippingContact else {
             return PKPaymentRequestShippingContactUpdate(paymentSummaryItems: paymentRequest.paymentSummaryItems)
         }
@@ -129,7 +129,7 @@ extension ApplePayComponent {
         return result
     }
 
-    private func handleDidSelectShippingMethod(_ shippingMethod: PKShippingMethod) async -> PKPaymentRequestShippingMethodUpdate {
+    private func handleSelectShippingMethod(_ shippingMethod: PKShippingMethod) async -> PKPaymentRequestShippingMethodUpdate {
         guard let onSelectShippingMethod = configuration.onSelectShippingMethod else {
             return PKPaymentRequestShippingMethodUpdate(paymentSummaryItems: paymentRequest.paymentSummaryItems)
         }
@@ -139,7 +139,7 @@ extension ApplePayComponent {
         return result
     }
 
-    private func handleDidChangeCouponCode(_ couponCode: String) async -> PKPaymentRequestCouponCodeUpdate {
+    private func handleChangeCouponCode(_ couponCode: String) async -> PKPaymentRequestCouponCodeUpdate {
         guard let onChangeCouponCode = configuration.onChangeCouponCode else {
             return PKPaymentRequestCouponCodeUpdate(paymentSummaryItems: paymentRequest.paymentSummaryItems)
         }
@@ -149,7 +149,7 @@ extension ApplePayComponent {
         return result
     }
 
-    private func handlePaymentMethodChange(_ paymentMethod: PKPaymentMethod) async -> PKPaymentRequestPaymentMethodUpdate {
+    private func handleSelectPaymentMethod(_ paymentMethod: PKPaymentMethod) async -> PKPaymentRequestPaymentMethodUpdate {
         guard let onPaymentMethodChange = configuration.onPaymentMethodChange else {
             return PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: paymentRequest.paymentSummaryItems)
         }

--- a/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
+++ b/AdyenComponents/Apple Pay/ApplePayConfiguration.swift
@@ -33,21 +33,21 @@ public struct ApplePayConfiguration: CheckoutComponentConfiguration {
 
     internal var onAuthorize: (@MainActor (PKPayment) async -> PKPaymentAuthorizationResult)?
 
-    internal var onShippingContactChange: (
+    internal var onSelectShippingContact: (
         @MainActor (
             PKContact,
             [PKPaymentSummaryItem]
         ) async -> PKPaymentRequestShippingContactUpdate
     )?
 
-    internal var onShippingMethodChange: (
+    internal var onSelectShippingMethod: (
         @MainActor (
             PKShippingMethod,
             [PKPaymentSummaryItem]
         ) async -> PKPaymentRequestShippingMethodUpdate
     )?
 
-    internal var onCouponCodeChange: (
+    internal var onChangeCouponCode: (
         @MainActor (
             String,
             [PKPaymentSummaryItem]
@@ -154,61 +154,61 @@ extension ApplePayConfiguration {
     ///
     /// Return an updated `PKPaymentRequestShippingContactUpdate` with revised summary items
     /// and optionally updated shipping methods or errors.
-    /// - Parameter onShippingContactChange: The closure to call when the shipping contact changes.
+    /// - Parameter onSelectShippingContact: The closure to call when the shopper selects a shipping contact.
     ///   - Parameters:
     ///     - contact: The selected `PKContact` containing the shipping address and contact information.
     ///     - summaryItems: The current array of `PKPaymentSummaryItem` objects representing line items and total.
     ///   - Returns: A `PKPaymentRequestShippingContactUpdate` with updated summary items, shipping methods, and/or errors.
     /// - Returns: A modified copy of the configuration.
-    public func onShippingContactChange(
-        _ onShippingContactChange: @escaping @MainActor (
+    public func onSelectShippingContact(
+        _ onSelectShippingContact: @escaping @MainActor (
             PKContact,
             [PKPaymentSummaryItem]
         ) async -> PKPaymentRequestShippingContactUpdate
     ) -> Self {
         var copy = self
-        copy.onShippingContactChange = onShippingContactChange
+        copy.onSelectShippingContact = onSelectShippingContact
         return copy
     }
 
     /// Sets the handler called when the shopper selects a shipping method.
     ///
     /// Return an updated `PKPaymentRequestShippingMethodUpdate` with revised summary items.
-    /// - Parameter onShippingMethodChange: The closure to call when the shipping method changes.
+    /// - Parameter onSelectShippingMethod: The closure to call when the shopper selects a shipping method.
     ///   - Parameters:
     ///     - shippingMethod: The selected `PKShippingMethod` containing the shipping option details.
     ///     - summaryItems: The current array of `PKPaymentSummaryItem` objects representing line items and total.
     ///   - Returns: A `PKPaymentRequestShippingMethodUpdate` with updated summary items reflecting the new shipping cost.
     /// - Returns: A modified copy of the configuration.
-    public func onShippingMethodChange(
-        _ onShippingMethodChange: @escaping @MainActor (
+    public func onSelectShippingMethod(
+        _ onSelectShippingMethod: @escaping @MainActor (
             PKShippingMethod,
             [PKPaymentSummaryItem]
         ) async -> PKPaymentRequestShippingMethodUpdate
     ) -> Self {
         var copy = self
-        copy.onShippingMethodChange = onShippingMethodChange
+        copy.onSelectShippingMethod = onSelectShippingMethod
         return copy
     }
 
     /// Sets the handler called when the shopper enters or updates a coupon code.
     ///
     /// Return an updated `PKPaymentRequestCouponCodeUpdate` with revised summary items.
-    /// - Parameter onCouponCodeChange: The closure to call when the coupon code changes.
+    /// - Parameter onChangeCouponCode: The closure to call when the shopper enters or updates a coupon code.
     ///   - Parameters:
     ///     - couponCode: The entered or updated coupon code string.
     ///     - summaryItems: The current array of `PKPaymentSummaryItem` objects representing line items and total.
     ///   - Returns: A `PKPaymentRequestCouponCodeUpdate` with updated summary items reflecting the applied discount
     ///    or errors if the code is invalid.
     /// - Returns: A modified copy of the configuration.
-    public func onCouponCodeChange(
-        _ onCouponCodeChange: @escaping @MainActor (
+    public func onChangeCouponCode(
+        _ onChangeCouponCode: @escaping @MainActor (
             String,
             [PKPaymentSummaryItem]
         ) async -> PKPaymentRequestCouponCodeUpdate
     ) -> Self {
         var copy = self
-        copy.onCouponCodeChange = onCouponCodeChange
+        copy.onChangeCouponCode = onChangeCouponCode
         return copy
     }
 

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift
@@ -66,7 +66,7 @@ internal final class ApplePayComponentAdvancedFlowExample: InitialDataAdvancedFl
                         return PKPaymentAuthorizationResult(status: .failure, errors: [postalCodeError])
                     }
                 }
-                .onShippingContactChange { contact, summaryItems in
+                .onSelectShippingContact { contact, summaryItems in
                     var items = summaryItems
                     if let last = items.last {
                         items = items.dropLast()
@@ -79,7 +79,7 @@ internal final class ApplePayComponentAdvancedFlowExample: InitialDataAdvancedFl
                     }
                     return PKPaymentRequestShippingContactUpdate(paymentSummaryItems: items)
                 }
-                .onShippingMethodChange { shippingMethod, summaryItems in
+                .onSelectShippingMethod { shippingMethod, summaryItems in
                     var items = summaryItems
                     if let last = items.last {
                         items = items.dropLast()
@@ -91,7 +91,7 @@ internal final class ApplePayComponentAdvancedFlowExample: InitialDataAdvancedFl
                     }
                     return PKPaymentRequestShippingMethodUpdate(paymentSummaryItems: items)
                 }
-                .onCouponCodeChange { _, summaryItems in
+                .onChangeCouponCode { _, summaryItems in
                     var items = summaryItems
                     if let last = items.last {
                         items = items.dropLast()
@@ -136,7 +136,7 @@ internal final class ApplePayComponentAdvancedFlowExample: InitialDataAdvancedFl
                 result.resultCode.rawValue
             )
         }
-        .onError { [weak self] error in
+        .onFailure { [weak self] error in
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
 

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/BLIKComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/BLIKComponentAdvancedFlowExample.swift
@@ -88,7 +88,7 @@ internal final class BLIKComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
                 result.resultCode.rawValue
             )
         }
-        .onError { [weak self] error in
+        .onFailure { [weak self] error in
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
 

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -97,7 +97,7 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
                 result.resultCode.rawValue
             )
         }
-        .onError { [weak self] error in
+        .onFailure { [weak self] error in
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
 

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/DummyActionComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/DummyActionComponentExample.swift
@@ -58,7 +58,7 @@ internal final class DummyActionComponentExample: InitialDataAdvancedFlowProtoco
             guard let self else { return .completion(resultCode: "Error") }
             return await self.callDetails(with: data)
         }
-        .onError { [weak self] error in
+        .onFailure { [weak self] error in
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
     }

--- a/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift
@@ -67,7 +67,7 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
                         )
                         return PKPaymentAuthorizationResult(status: .failure, errors: [postalCodeError])
                     }
-                }.onShippingContactChange { contact, summaryItems in
+                }.onSelectShippingContact { contact, summaryItems in
                     let cityLabel = contact.postalAddress?.city ?? "Somewhere"
                     let items = self.updatedSummaryItems(
                         from: summaryItems,
@@ -82,7 +82,7 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
                     self.updateLatestApplePayAmount(using: items)
                     return PKPaymentRequestShippingContactUpdate(paymentSummaryItems: items)
                 }
-                .onShippingMethodChange { shippingMethod, summaryItems in
+                .onSelectShippingMethod { shippingMethod, summaryItems in
                     let items = self.updatedSummaryItems(
                         from: summaryItems,
                         appendedItems: [shippingMethod],
@@ -91,7 +91,7 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
                     self.updateLatestApplePayAmount(using: items)
                     return PKPaymentRequestShippingMethodUpdate(paymentSummaryItems: items)
                 }
-                .onCouponCodeChange { _, summaryItems in
+                .onChangeCouponCode { _, summaryItems in
                     // make sure your backend's amount and apple pay sheet amount are the same
                     let items = self.updatedSummaryItems(
                         from: summaryItems,
@@ -154,7 +154,7 @@ internal final class ApplePayComponentExample: InitialDataFlowProtocol {
                 result.resultCode.rawValue
             )
         }
-        .onError { [weak self] error in
+        .onFailure { [weak self] error in
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
 

--- a/Demo/Common/IntegrationExamples/Session/Components/BLIKComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/BLIKComponentExample.swift
@@ -62,7 +62,7 @@ internal final class BLIKComponentExample: InitialDataFlowProtocol {
                 result.resultCode.rawValue
             )
         }
-        .onError { [weak self] error in
+        .onFailure { [weak self] error in
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
         

--- a/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
@@ -78,7 +78,7 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
                 result.resultCode.rawValue
             )
         }
-        .onError { [weak self] error in
+        .onFailure { [weak self] error in
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
         

--- a/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Apple Pay/ApplePayComponentTests.swift
@@ -201,7 +201,7 @@ class ApplePayComponentTest: XCTestCase {
         var configuration = try ApplePayConfiguration(
             paymentRequest: Dummy.createTestApplePayPaymentRequest()
         )
-        configuration.onShippingMethodChange = { method, _ in
+        configuration.onSelectShippingMethod = { method, _ in
             receivedMethod = method
             return PKPaymentRequestShippingMethodUpdate(paymentSummaryItems: [
                 PKPaymentSummaryItem(label: "New Item 1", amount: 1111),
@@ -239,7 +239,7 @@ class ApplePayComponentTest: XCTestCase {
         var configuration = try ApplePayConfiguration(
             paymentRequest: Dummy.createTestApplePayPaymentRequest()
         )
-        configuration.onShippingContactChange = { contact, _ in
+        configuration.onSelectShippingContact = { contact, _ in
             receivedContact = contact
             return PKPaymentRequestShippingContactUpdate(paymentSummaryItems: [
                 PKPaymentSummaryItem(label: "New Item 1", amount: 1111),
@@ -276,7 +276,7 @@ class ApplePayComponentTest: XCTestCase {
         var configuration = try ApplePayConfiguration(
             paymentRequest: Dummy.createTestApplePayPaymentRequest()
         )
-        configuration.onCouponCodeChange = { coupon, _ in
+        configuration.onChangeCouponCode = { coupon, _ in
             receivedCoupon = coupon
             return PKPaymentRequestCouponCodeUpdate(paymentSummaryItems: [
                 PKPaymentSummaryItem(label: "New Item 1", amount: 1111),
@@ -345,7 +345,7 @@ class ApplePayComponentTest: XCTestCase {
         var configuration = try ApplePayConfiguration(
             paymentRequest: Dummy.createTestApplePayPaymentRequest()
         )
-        configuration.onShippingMethodChange = { _, _ in
+        configuration.onSelectShippingMethod = { _, _ in
             PKPaymentRequestShippingMethodUpdate(paymentSummaryItems: [
                 PKPaymentSummaryItem(label: "Item", amount: 10.0),
                 PKPaymentSummaryItem(label: "Total", amount: NSDecimalNumber(value: -1.0))
@@ -380,7 +380,7 @@ class ApplePayComponentTest: XCTestCase {
         var configuration = try ApplePayConfiguration(
             paymentRequest: Dummy.createTestApplePayPaymentRequest()
         )
-        configuration.onShippingContactChange = { _, _ in
+        configuration.onSelectShippingContact = { _, _ in
             PKPaymentRequestShippingContactUpdate(paymentSummaryItems: [
                 PKPaymentSummaryItem(label: "Item", amount: NSDecimalNumber.notANumber),
                 PKPaymentSummaryItem(label: "Total", amount: 10.0)
@@ -415,7 +415,7 @@ class ApplePayComponentTest: XCTestCase {
         var configuration = try ApplePayConfiguration(
             paymentRequest: Dummy.createTestApplePayPaymentRequest()
         )
-        configuration.onCouponCodeChange = { _, _ in
+        configuration.onChangeCouponCode = { _, _ in
             PKPaymentRequestCouponCodeUpdate(paymentSummaryItems: [])
         }
 

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -306,7 +306,7 @@ final class CheckoutTests: XCTestCase {
         XCTAssertTrue(session.performSubmitCalled)
     }
     
-    func test_didSubmit_withOnBeforeSubmitAbort_shouldStopLoadingAndNotCallOnError() async throws {
+    func test_didSubmit_withOnBeforeSubmitAbort_shouldStopLoadingAndNotCallOnFailure() async throws {
         let callbackStore = SessionCheckoutCallbackStore()
         let onFailureExpectation = expectation(description: "onFailure should NOT be called")
         onFailureExpectation.isInverted = true

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -203,9 +203,9 @@ final class CheckoutTests: XCTestCase {
         XCTAssertFalse(session.didSubmitCalled)
     }
     
-    func test_didSubmit_withSessionPerformSubmitError_shouldCallOnError() async throws {
+    func test_didSubmit_withSessionPerformSubmitError_shouldCallOnFailure() async throws {
         let callbackStore = SessionCheckoutCallbackStore()
-        let onErrorExpectation = expectation(description: "onError called")
+        let onFailureExpectation = expectation(description: "onFailure called")
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
@@ -213,13 +213,13 @@ final class CheckoutTests: XCTestCase {
         )
         let session = makeSessionMock()
         session.performSubmitResult = .failure(TestError())
-        callbackStore.onError = { _ in
-            onErrorExpectation.fulfill()
+        callbackStore.onFailure = { _ in
+            onFailureExpectation.fulfill()
         }
         let sut = makeSessionCheckoutCore(session: session, callbackStore: callbackStore)
         
         sut.didSubmit(paymentData, from: PaymentComponentMock(paymentMethod: blik))
-        await fulfillment(of: [onErrorExpectation], timeout: 1)
+        await fulfillment(of: [onFailureExpectation], timeout: 1)
         
         XCTAssertTrue(session.performSubmitCalled)
         XCTAssertFalse(session.didSubmitCalled)
@@ -308,8 +308,8 @@ final class CheckoutTests: XCTestCase {
     
     func test_didSubmit_withOnBeforeSubmitAbort_shouldStopLoadingAndNotCallOnError() async throws {
         let callbackStore = SessionCheckoutCallbackStore()
-        let onErrorExpectation = expectation(description: "onError should NOT be called")
-        onErrorExpectation.isInverted = true
+        let onFailureExpectation = expectation(description: "onFailure should NOT be called")
+        onFailureExpectation.isInverted = true
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
@@ -320,14 +320,14 @@ final class CheckoutTests: XCTestCase {
         callbackStore.onBeforeSubmit = { _ in
             .abort
         }
-        callbackStore.onError = { _ in
-            onErrorExpectation.fulfill()
+        callbackStore.onFailure = { _ in
+            onFailureExpectation.fulfill()
         }
         let component = PresentableComponentMock(paymentMethod: blik, viewController: UIViewController())
         let sut = makeSessionCheckoutCore(session: session, callbackStore: callbackStore)
         
         sut.didSubmit(paymentData, from: component)
-        await fulfillment(of: [onErrorExpectation], timeout: 0.5)
+        await fulfillment(of: [onFailureExpectation], timeout: 0.5)
         
         XCTAssertTrue(component.stopLoadingCalled)
         XCTAssertFalse(session.performSubmitCalled)
@@ -661,7 +661,7 @@ final class CheckoutTests: XCTestCase {
         let callbackStore = AdvancedCheckoutCallbackStore()
         let onSubmitExpectation = expectation(description: "onSubmit called")
         let onCompleteExpectation = expectation(description: "onComplete called")
-        var onErrorCalled = false
+        var onFailureCalled = false
         let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
         let paymentData = PaymentComponentData(
             paymentMethodDetails: BLIKDetails(paymentMethod: blik, blikCode: "code"),
@@ -676,19 +676,19 @@ final class CheckoutTests: XCTestCase {
             XCTAssertEqual(result.resultCode, .refused)
             onCompleteExpectation.fulfill()
         }
-        callbackStore.onError = { _ in onErrorCalled = true }
+        callbackStore.onFailure = { _ in onFailureCalled = true }
 
         let sut = makeAdvancedCheckoutCore(callbackStore: callbackStore)
         sut.didSubmit(paymentData, from: PaymentComponentMock(paymentMethod: blik))
         await fulfillment(of: [onSubmitExpectation, onCompleteExpectation], timeout: 1)
-        XCTAssertFalse(onErrorCalled)
+        XCTAssertFalse(onFailureCalled)
     }
 
     func test_didProvide_withErrorResultCode_callsOnComplete() async {
         let callbackStore = AdvancedCheckoutCallbackStore()
         let onAdditionalDetailsExpectation = expectation(description: "onAdditionalDetails called")
         let onCompleteExpectation = expectation(description: "onComplete called")
-        var onErrorCalled = false
+        var onFailureCalled = false
         let actionData = ActionComponentData(
             details: AwaitActionDetails(payload: "payload"),
             paymentData: "data"
@@ -702,12 +702,12 @@ final class CheckoutTests: XCTestCase {
             XCTAssertEqual(result.resultCode, .refused)
             onCompleteExpectation.fulfill()
         }
-        callbackStore.onError = { _ in onErrorCalled = true }
+        callbackStore.onFailure = { _ in onFailureCalled = true }
 
         let sut = makeAdvancedCheckoutCore(callbackStore: callbackStore)
         sut.didProvide(actionData, from: ActionComponentMock())
         await fulfillment(of: [onAdditionalDetailsExpectation, onCompleteExpectation], timeout: 1)
-        XCTAssertFalse(onErrorCalled)
+        XCTAssertFalse(onFailureCalled)
     }
 
     private func makeSessionCheckoutCore(


### PR DESCRIPTION
## Changes

### Rename `onError` to `onFailure`
As per the ADR decision to align public callbacks, the `onError` callback on `BaseCheckout` is renamed to `onFailure`.

- `CheckoutResultCallbackStore` protocol and all concrete stores (`SessionCheckoutCallbackStore`, `AdvancedCheckoutCallbackStore`, `ActionOnlyCheckoutCallbackStore`)
- `BaseCheckout.onFailure(_:)` public method
- Internal call site in `CheckoutCore+Orchestration`

### Rename ApplePay callbacks
Follow Apple Pay delegate methods as closely as possible, replacing the `did` keyword with `on`:

| Old name | New name |
|---|---|
| `onShippingMethodChange` | `onSelectShippingMethod` |
| `onShippingContactChange` | `onSelectShippingContact` |
| `onCouponCodeChange` | `onChangeCouponCode` |

Applies to `ApplePayConfiguration` (internal properties + public builder methods) and the private helpers in `ApplePayComponentExtensions` (renamed to `handleDidSelectShippingContact`, `handleDidSelectShippingMethod`, `handleDidChangeCouponCode`).

### Updated files
- Demo examples (session and advanced flow)
- Unit and integration tests