### PR TITLE
Change onError to onFailure in standalone `InstantComponent` integration

### DIFF
--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift
@@ -80,7 +80,7 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
                 result.resultCode.rawValue
             )
         }
-        .onError { [weak self] error in
+        .onFailure { [weak self] error in
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
 

--- a/Demo/Common/IntegrationExamples/Session/Components/InstantPaymentComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/InstantPaymentComponentExample.swift
@@ -71,7 +71,7 @@ internal final class InstantPaymentComponentExample: InitialDataFlowProtocol {
                 result.resultCode.rawValue
             )
         }
-        .onError { [weak self] error in
+        .onFailure { [weak self] error in
             self?.dismissAndShowAlert(false, error.localizedDescription)
         }
 


### PR DESCRIPTION
# Summary

Replace `onError` to `onFailure`
Stale change that was not flagged as a conflict when merging #2592 

## Checklist
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
