### PR TITLE
Binlook alignment pt1: Logic

### DIFF
--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -263,7 +263,11 @@ extension CardComponent: CardViewControllerDelegate {
         binInfoProvider.provide(for: pan, supportedTypes: supportedCardTypes) { [weak self] binInfo in
             guard let self else { return }
             self.cardViewController.update(binInfo: binInfo)
-            self.configuration.onBinLookup?(binInfo.brands ?? [])
+            guard !binInfo.isCreatedLocally else { return }
+            let brands = (binInfo.brands ?? []).map {
+                BinLookupBrand(brand: $0.type.rawValue, supported: $0.isSupported, paymentMethodVariant: $0.paymentMethodVariant)
+            }
+            self.configuration.onBinLookup?(BinLookupData(issuingCountryCode: binInfo.issuingCountryCode, brands: brands))
         }
     }
 }

--- a/AdyenCard/Components/Card/CardConfiguration.swift
+++ b/AdyenCard/Components/Card/CardConfiguration.swift
@@ -71,7 +71,7 @@ public struct CardConfiguration: CheckoutComponentConfiguration, AnyPersonalInfo
     internal var onBinChange: ((String) -> Void)?
     
     /// Called when card brand(s) are detected from the entered card number.
-    internal var onBinLookup: (([CardBrand]) -> Void)?
+    internal var onBinLookup: ((BinLookupData) -> Void)?
     
     // TODO: Add onFieldValidationChange closure that provides field validation
     // updates including last 4 digits, or add it here after deciding on alignment.
@@ -224,9 +224,9 @@ extension CardConfiguration {
     }
     
     /// Sets the handler to be called when card brand(s) are detected.
-    /// - Parameter onBinLookup: The closure to call with the detected card brands.
+    /// - Parameter onBinLookup: The closure to call with the BIN lookup result.
     /// - Returns: A modified copy of the configuration.
-    public func onBinLookup(_ onBinLookup: @escaping ([CardBrand]) -> Void) -> Self {
+    public func onBinLookup(_ onBinLookup: @escaping (BinLookupData) -> Void) -> Self {
         var copy = self
         copy.onBinLookup = onBinLookup
         return copy

--- a/AdyenCard/Utilities/BinLookup/BinLookupData.swift
+++ b/AdyenCard/Utilities/BinLookup/BinLookupData.swift
@@ -14,16 +14,6 @@ public struct BinLookupData: Decodable, Equatable {
 
     /// The card brands detected from the BIN. Empty when no brands are detected.
     public let brands: [BinLookupBrand]
-
-    public init(issuingCountryCode: String?, brands: [BinLookupBrand]) {
-        self.issuingCountryCode = issuingCountryCode
-        self.brands = brands
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case issuingCountryCode
-        case brands
-    }
 }
 
 /// Describes a single card brand entry in a BIN lookup result.
@@ -37,16 +27,4 @@ public struct BinLookupBrand: Decodable, Equatable {
 
     /// The payment method variant, if provided by the backend.
     public let paymentMethodVariant: String?
-
-    public init(brand: String, supported: Bool, paymentMethodVariant: String?) {
-        self.brand = brand
-        self.supported = supported
-        self.paymentMethodVariant = paymentMethodVariant
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case brand
-        case supported
-        case paymentMethodVariant
-    }
 }

--- a/AdyenCard/Utilities/BinLookup/BinLookupData.swift
+++ b/AdyenCard/Utilities/BinLookup/BinLookupData.swift
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+/// Contains the result of a BIN lookup, provided to merchants via the `onBinLookup` callback.
+public struct BinLookupData: Decodable, Equatable {
+
+    /// The issuing country code detected from the BIN, or `nil` if not available.
+    public let issuingCountryCode: String?
+
+    /// The card brands detected from the BIN. Empty when no brands are detected.
+    public let brands: [BinLookupBrand]
+
+    public init(issuingCountryCode: String?, brands: [BinLookupBrand]) {
+        self.issuingCountryCode = issuingCountryCode
+        self.brands = brands
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case issuingCountryCode
+        case brands
+    }
+}
+
+/// Describes a single card brand entry in a BIN lookup result.
+public struct BinLookupBrand: Decodable, Equatable {
+
+    /// The brand identifier, e.g. `"visa"`, `"mc"`.
+    public let brand: String
+
+    /// Indicates whether the brand is supported by the merchant.
+    public let supported: Bool
+
+    /// The payment method variant, if provided by the backend.
+    public let paymentMethodVariant: String?
+
+    public init(brand: String, supported: Bool, paymentMethodVariant: String?) {
+        self.brand = brand
+        self.supported = supported
+        self.paymentMethodVariant = paymentMethodVariant
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case brand
+        case supported
+        case paymentMethodVariant
+    }
+}

--- a/AdyenCard/Utilities/CardType/CardBrand.swift
+++ b/AdyenCard/Utilities/CardType/CardBrand.swift
@@ -8,7 +8,7 @@ import Adyen
 import Foundation
 
 /// Describes the Card brand.
-public struct CardBrand: Decodable {
+package struct CardBrand: Decodable {
     
     /// Indicates the requirement level of a field.
     internal enum RequirementPolicy: String, Decodable {
@@ -24,10 +24,10 @@ public struct CardBrand: Decodable {
     }
 
     /// Indicates the card brand type.
-    public let type: CardType
+    package let type: CardType
 
     /// Indicates whether its supported by the merchant or not.
-    public let isSupported: Bool
+    package let isSupported: Bool
 
     /// Indicates the cvc policy of the brand.
     internal let cvcPolicy: RequirementPolicy
@@ -46,6 +46,9 @@ public struct CardBrand: Decodable {
     
     /// The length of the PAN of the card brand.
     internal let panLength: Int?
+
+    /// The payment method variant, if provided by the backend.
+    internal let paymentMethodVariant: String?
     
     private enum Constants {
         static let plccText = "plcc"
@@ -69,7 +72,8 @@ public struct CardBrand: Decodable {
         isLuhnCheckEnabled: Bool = true,
         showSocialSecurityNumber: Bool = false,
         panLength: Int? = nil,
-        localeBrand: String? = nil
+        localeBrand: String? = nil,
+        paymentMethodVariant: String? = nil
     ) {
         self.type = type
         self.isSupported = isSupported
@@ -79,6 +83,7 @@ public struct CardBrand: Decodable {
         self.showsSocialSecurityNumber = showSocialSecurityNumber
         self.panLength = panLength
         self.localeBrand = localeBrand
+        self.paymentMethodVariant = paymentMethodVariant
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -90,6 +95,7 @@ public struct CardBrand: Decodable {
         case expiryDatePolicy
         case panLength
         case localeBrand
+        case paymentMethodVariant
     }
     
     internal var isCVCOptional: Bool {

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift
@@ -71,8 +71,8 @@ internal final class CardComponentAdvancedFlowExample: InitialDataAdvancedFlowPr
                 .onBinChange { bin in
                     print("Here is the bin \(bin)")
                 }
-                .onBinLookup { brands in
-                    print("Bin lookup response \(brands)")
+                .onBinLookup { data in
+                    print("Bin lookup response \(data)")
                 }
         }
         .localizationProvider(DemoLocalizationProvider())

--- a/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/CardComponentExample.swift
@@ -60,8 +60,8 @@ internal final class CardComponentExample: InitialDataFlowProtocol {
                 .onBinChange { bin in
                     print("Here is the bin \(bin)")
                 }
-                .onBinLookup { brands in
-                    print("Bin lookup response \(brands)")
+                .onBinLookup { data in
+                    print("Bin lookup response \(data)")
                 }
             AuthenticationConfiguration()
                 .requestorAppURL(ConfigurationConstants.returnUrl)

--- a/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
@@ -254,7 +254,7 @@ class BCMCComponentTests: XCTestCase {
         wait(for: [didSubmitExpectation], timeout: 10)
     }
     
-    func test_onBinLookup_withCorrectCard_shouldReturnMatchingBrands() throws {
+    func test_onBinLookup_withLessThan11Digits_shouldNotBeCalled() throws {
         let brands: [CardType] = [.bcmc]
         let method = CardPaymentMethod(type: .bcmc, name: "Test name", fundingSource: .debit, brands: brands)
         let paymentMethod = BCMCPaymentMethod(cardPaymentMethod: method)
@@ -262,21 +262,20 @@ class BCMCComponentTests: XCTestCase {
             paymentMethod: paymentMethod,
             context: context
         )
-        
+
         sut.viewController.loadViewIfNeeded()
-        
-        let expectationCardType = XCTestExpectation(description: "CardType Expectation")
-        let mockedBrands = [CardBrand(type: .bcmc, cvcPolicy: .optional)]
+
+        let expectation = XCTestExpectation(description: "onBinLookup should not fire for < 11 digits")
+        expectation.isInverted = true
         sut.configuration = sut.configuration
-            .onBinLookup { value in
-                XCTAssertEqual(value, mockedBrands)
-                expectationCardType.fulfill()
+            .onBinLookup { _ in
+                expectation.fulfill()
             }
-        
+
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
         try self.populate(textItemView: XCTUnwrap(cardNumberItemView), with: "67034")
-        
-        wait(for: [expectationCardType], timeout: 10)
+
+        wait(for: [expectation], timeout: 2)
     }
 
     func test_onBinChange_withCorrectBIN_shouldReturnBINValue() throws {
@@ -379,7 +378,7 @@ class BCMCComponentTests: XCTestCase {
         wait(for: [expectationBin], timeout: 10)
     }
     
-    func test_onBinLookup_withIncorrectCard_shouldReturnEmptyBrands() throws {
+    func test_onBinLookup_withIncorrectCardAndLessThan11Digits_shouldNotBeCalled() throws {
         let method = CardPaymentMethod(type: .bcmc, name: "Test name", fundingSource: .debit, brands: [.argencard])
         let paymentMethod = BCMCPaymentMethod(cardPaymentMethod: method)
         let sut = BCMCComponent(
@@ -388,20 +387,20 @@ class BCMCComponentTests: XCTestCase {
         )
 
         sut.viewController.loadViewIfNeeded()
-        
-        let expectationCardType = XCTestExpectation(description: "CardType Expectation")
+
+        let expectation = XCTestExpectation(description: "onBinLookup should not fire for < 11 digits")
+        expectation.isInverted = true
         sut.configuration = sut.configuration
-            .onBinLookup { value in
-                XCTAssertEqual(value, [])
-                expectationCardType.fulfill()
+            .onBinLookup { _ in
+                expectation.fulfill()
             }
-        
+
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
         try self.populate(textItemView: XCTUnwrap(cardNumberItemView), with: "32145")
-        
-        wait(for: [expectationCardType], timeout: 10)
+
+        wait(for: [expectation], timeout: 2)
     }
-    
+
     func test_submit_withInvalidCardNumber_shouldShowValidationError() throws {
         let cardPaymentMethod = CardPaymentMethod(type: .bcmc, name: "Test name", fundingSource: .debit, brands: [.maestro])
         let paymentMethod = BCMCPaymentMethod(cardPaymentMethod: cardPaymentMethod)

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -384,7 +384,7 @@ class CardComponentTests: XCTestCase {
     func test_onBinChangeAndOnBinLookup_whenCardNumberEntered_shouldBeCalledWithCorrectValues() {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
-            $0(BinLookupResponse(brands: [CardBrand(type: .americanExpress)]))
+            $0(BinLookupResponse(brands: [CardBrand(type: .americanExpress)], isCreatedLocally: false))
         }
 
         let sut = CardComponent(
@@ -405,7 +405,11 @@ class CardComponentTests: XCTestCase {
                 expectationBin.fulfill()
             }
             .onBinLookup { value in
-                XCTAssertEqual(value, [CardBrand(type: .americanExpress)])
+                let expected = BinLookupData(
+                    issuingCountryCode: "NL",
+                    brands: [BinLookupBrand(brand: "amex", supported: true, paymentMethodVariant: nil)]
+                )
+                XCTAssertEqual(value, expected)
                 expectationCardType.fulfill()
             }
         


### PR DESCRIPTION
# Summary [Required]
Aligns binlookup public API and trigger logic to the spec.

## New types

- BinLookupData and BinLookupBrand - new public, Decodable, Equatable structs in AdyenCard/Utilities/BinLookup/BinLookupData.swift, aligned with Android's merchant-facing API
Callback changes

- CardConfiguration.onBinLookup signature changed from ([CardBrand]) -> Void to (BinLookupData) -> Void
updateBrand in CardComponent now guards on !binInfo.isCreatedLocally - the callback only fires for actual /binLookup API responses (live or cached), never for client-side regex/fallback detection

## CardBrand internals

- Added paymentMethodVariant: String? property (decoded from API, forwarded into BinLookupBrand)

## Ticket [Optional]
<ticket>
COSDK-1243
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [ ] Tested changes locally
- [ ] Added/updated unit tests
- [ ] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)
