### PR TITLE
Rename CardBrand to DetectedCardBrand

### DIFF
--- a/AdyenCard/Components/Card/CardConfiguration.swift
+++ b/AdyenCard/Components/Card/CardConfiguration.swift
@@ -259,6 +259,7 @@ package protocol AnyCardComponentConfiguration {
     /// Indicates whether to show the security code field for stored cards. Defaults to true.
     var showSecurityCodeForStoredCard: Bool { get }
 
+    // TODO: Rename CardType to CardBrand once the internal CardBrand struct conflict is resolved.
     /// The list of supported card brands.  Defaults to nil.
     /// By default list of supported brands is extracted from component's `AnyCardPaymentMethod`.
     /// Use this property to enforce a custom collection of card brands.

--- a/AdyenCard/Components/Card/CardViewController.swift
+++ b/AdyenCard/Components/Card/CardViewController.swift
@@ -227,7 +227,7 @@ internal class CardViewController: FormViewController {
     }
     
     internal func update(binInfo: BinLookupResponse) {
-        var brands: [CardBrand] = []
+        var brands: [DetectedCardBrand] = []
 
         // no dual branding if response is from regex (fallback)
         if binInfo.isCreatedLocally, let firstBrand = binInfo.brands?.first {
@@ -244,14 +244,14 @@ internal class CardViewController: FormViewController {
         updateBillingAddressOptionalStatus(brands: brands)
     }
 
-    internal func handleSelection(_ selectedBrand: CardBrand) {
+    internal func handleSelection(_ selectedBrand: DetectedCardBrand) {
         items.coBadgedCardItem.updateSelection(selectedBrand)
         items.numberContainerItem.numberItem.selectBrand(cardBrand: selectedBrand)
 
         items.triggerInfoEvent(of: .selected, target: .dualBrandButton, brands: [selectedBrand])
     }
 
-    internal func showCoBadgedCardsUI(for brands: [CardBrand]) {
+    internal func showCoBadgedCardsUI(for brands: [DetectedCardBrand]) {
         let coBadgedBrands = brands.filter { brand in
             allowedCoBadgedCardTypes.contains(brand.type)
         }
@@ -265,7 +265,7 @@ internal class CardViewController: FormViewController {
 
 extension CardViewController {
     
-    private func updateBillingAddressOptionalStatus(brands: [CardBrand]) {
+    private func updateBillingAddressOptionalStatus(brands: [DetectedCardBrand]) {
         let isOptional = configuration.billingAddress.isOptional(for: brands.map(\.type))
         switch configuration.billingAddress.mode {
         case .lookup, .full:
@@ -306,7 +306,7 @@ extension CardViewController {
     }
 
     /// Updates relevant other fields after number field changes
-    private func updateFields(from brand: CardBrand?) {
+    private func updateFields(from brand: DetectedCardBrand?) {
         items.securityCodeItem.displayMode = brand?.securityCodeItemDisplayMode ?? .required
         items.expiryDateItem.isOptional = brand?.isExpiryDateOptional ?? false
         
@@ -420,7 +420,7 @@ extension CardViewController {
         }
     }
     
-    private func shouldHideSocialSecurityItem(with brand: CardBrand?) -> Bool {
+    private func shouldHideSocialSecurityItem(with brand: DetectedCardBrand?) -> Bool {
         guard let brand else { return true }
         switch configuration.socialSecurityNumberVisibility {
         case .show:
@@ -483,7 +483,7 @@ extension CardViewController {
     }
 }
 
-extension CardBrand {
+extension DetectedCardBrand {
     
     internal var securityCodeItemDisplayMode: FormCardSecurityCodeItem.DisplayMode {
         switch self.cvcPolicy {

--- a/AdyenCard/Components/Card/CardViewControllerItemsProvider.swift
+++ b/AdyenCard/Components/Card/CardViewControllerItemsProvider.swift
@@ -17,7 +17,7 @@ extension CardViewController {
     internal struct InfoEventData {
         internal let type: AnalyticsEventInfo.InfoType
         internal let target: AnalyticsEventTarget
-        internal let brands: [CardBrand]?
+        internal let brands: [DetectedCardBrand]?
         internal let error: AnalyticsValidationError?
     }
 
@@ -276,7 +276,7 @@ extension CardViewController {
         internal func triggerInfoEvent(
             of type: AnalyticsEventInfo.InfoType,
             target: AnalyticsEventTarget,
-            brands: [CardBrand]? = nil,
+            brands: [DetectedCardBrand]? = nil,
             error: AnalyticsValidationError? = nil
         ) {
             let infoEventData = InfoEventData(

--- a/AdyenCard/Form/FormCardNumberContainerItem.swift
+++ b/AdyenCard/Form/FormCardNumberContainerItem.swift
@@ -92,7 +92,7 @@ internal final class FormCardNumberContainerItem: FormItem, AdyenObserver {
         builder.build(with: self)
     }
     
-    internal func update(brands: [CardBrand]) {
+    internal func update(brands: [DetectedCardBrand]) {
         numberItem.update(brands: brands)
         
         updateLogosVisibility()

--- a/AdyenCard/Form/FormCardNumberItem.swift
+++ b/AdyenCard/Form/FormCardNumberItem.swift
@@ -34,10 +34,10 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
     @AdyenObservable("") internal var binValue: String
     
     /// Initial brand set after detection before any user interaction
-    @AdyenObservable(nil) internal private(set) var initialBrand: CardBrand?
+    @AdyenObservable(nil) internal private(set) var initialBrand: DetectedCardBrand?
     
     /// Brand selected in dual branded cards, set after user selection.
-    @AdyenObservable(nil) internal private(set) var selectedDualBrand: CardBrand?
+    @AdyenObservable(nil) internal private(set) var selectedDualBrand: DetectedCardBrand?
     
     /// Detected brand logo(s) for the entered bin.
     @AdyenObservable([]) internal private(set) var detectedBrandLogos: [FormCardLogosItem.CardTypeLogo]
@@ -46,7 +46,7 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
     @AdyenObservable(false) internal var isActive
     
     /// Current detected brands, mainly used for dual-branded cards.
-    internal private(set) var detectedBrands: [CardBrand] = []
+    internal private(set) var detectedBrands: [DetectedCardBrand] = []
     
     private let localizationParameters: LocalizationParameters?
     
@@ -59,7 +59,7 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
     
     /// Returns the initial brand for single brand cases
     /// or `selectedDualBrand` for dual brand cases
-    internal var currentBrand: CardBrand? {
+    internal var currentBrand: DetectedCardBrand? {
         isDualBranded ? selectedDualBrand : initialBrand
     }
     
@@ -172,7 +172,7 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
     
     /// Updates the item with the detected brands.
     /// and sets the first supported one as the `initialBrand`.
-    internal func update(brands: [CardBrand]) {
+    internal func update(brands: [DetectedCardBrand]) {
         detectedBrands = brands
         
         switch (brands.count, brands.first(where: \.isSupported)) {
@@ -198,19 +198,19 @@ internal final class FormCardNumberItem: FormTextItem, AdyenObserver {
 
     /// Changes the selected dual brand with the given cardBrand to trigger updates
     /// for the observing objects.
-    internal func selectBrand(cardBrand: CardBrand) {
+    internal func selectBrand(cardBrand: DetectedCardBrand) {
         updateValidation(for: cardBrand)
         self.selectedDualBrand = cardBrand
     }
 
     /// Updates the initial brand and the related validation checks.
-    private func update(initialBrand: CardBrand?, defaultSupportedValue: Bool = true) {
+    private func update(initialBrand: DetectedCardBrand?, defaultSupportedValue: Bool = true) {
         updateValidation(for: initialBrand, defaultSupportedValue: defaultSupportedValue)
         self.initialBrand = initialBrand
         updateBINIfNeeded()
     }
     
-    private func updateValidation(for brand: CardBrand?, defaultSupportedValue: Bool = true) {
+    private func updateValidation(for brand: DetectedCardBrand?, defaultSupportedValue: Bool = true) {
         // validation message will change based on if brand is supported or not
         // if brand is not supported, allow validation while editing to show the error instantly.
         let isBrandSupported = brand?.isSupported ?? defaultSupportedValue

--- a/AdyenCard/Form/FormCoBadgedCardItem.swift
+++ b/AdyenCard/Form/FormCoBadgedCardItem.swift
@@ -36,10 +36,10 @@ internal final class FormCoBadgedCardItem: FormItem {
     internal var style: FormCoBadgedCardItemStyle
 
     /// The callback to send the selected brand to the Card Viewcontroller
-    internal var onCardBrandSelection: ((CardBrand) -> Void)?
+    internal var onCardBrandSelection: ((DetectedCardBrand) -> Void)?
 
     /// Brands set after coBadgedCardItems are displayed on the view
-    @AdyenObservable(nil) internal var updatedCardBrands: [CardBrand]?
+    @AdyenObservable(nil) internal var updatedCardBrands: [DetectedCardBrand]?
 
     /// Initializes the FormCoBadged card item.
     ///
@@ -73,9 +73,9 @@ internal final class FormCoBadgedCardItem: FormItem {
     }
 
     internal func selectableFormItems(
-        from brands: [CardBrand],
+        from brands: [DetectedCardBrand],
         cardLogos: [FormCardLogosItem.CardTypeLogo],
-        defaultSelectedBrand: CardBrand
+        defaultSelectedBrand: DetectedCardBrand
     ) -> [SelectableFormItem] {
         brands.map { brand in
             let brandLogoURL = cardLogos.first(where: { $0.type == brand.type })?.url
@@ -97,7 +97,7 @@ internal final class FormCoBadgedCardItem: FormItem {
         }
     }
 
-    internal func updateItems(_ brands: [CardBrand], cardLogos: [FormCardLogosItem.CardTypeLogo]) {
+    internal func updateItems(_ brands: [DetectedCardBrand], cardLogos: [FormCardLogosItem.CardTypeLogo]) {
         selectableFormItems = []
         updatedCardBrands = []
         if brands.count == 2, brands.allSatisfy(\.isSupported) {
@@ -116,7 +116,7 @@ internal final class FormCoBadgedCardItem: FormItem {
         }
     }
 
-    internal func updateSelection(_ selectedBrand: CardBrand) {
+    internal func updateSelection(_ selectedBrand: DetectedCardBrand) {
         selectableFormItems.forEach { $0.isSelected = false }
         selectableFormItems.first(where: { $0.identifier == selectedBrand.type.rawValue })?.isSelected = true
     }

--- a/AdyenCard/Utilities/BinLookup/BinLookupResponse.swift
+++ b/AdyenCard/Utilities/BinLookup/BinLookupResponse.swift
@@ -10,7 +10,7 @@ import Foundation
 
 internal struct BinLookupResponse: Response {
 
-    internal var brands: [CardBrand]?
+    internal var brands: [DetectedCardBrand]?
 
     internal let requestId: String
 
@@ -19,7 +19,7 @@ internal struct BinLookupResponse: Response {
     internal var isCreatedLocally: Bool = false
     
     internal init(
-        brands: [CardBrand]? = nil,
+        brands: [DetectedCardBrand]? = nil,
         requestId: String = UUID().uuidString,
         issuingCountryCode: String? = "NL",
         isCreatedLocally: Bool = true

--- a/AdyenCard/Utilities/CardType/DetectedCardBrand.swift
+++ b/AdyenCard/Utilities/CardType/DetectedCardBrand.swift
@@ -8,7 +8,7 @@ import Adyen
 import Foundation
 
 /// Describes the Card brand.
-package struct CardBrand: Decodable {
+package struct DetectedCardBrand: Decodable {
     
     /// Indicates the requirement level of a field.
     internal enum RequirementPolicy: String, Decodable {
@@ -55,7 +55,7 @@ package struct CardBrand: Decodable {
         static let cbccText = "cbcc"
     }
 
-    /// Initializes a CardBrand.
+    /// Initializes a DetectedCardBrand.
     ///
     /// - Parameters:
     ///   - type: Indicates the card brand type.
@@ -122,4 +122,4 @@ package struct CardBrand: Decodable {
     }
 }
 
-extension CardBrand: Equatable {}
+extension DetectedCardBrand: Equatable {}

--- a/AdyenCard/Utilities/CardType/FallbackCardBrandProvider.swift
+++ b/AdyenCard/Utilities/CardType/FallbackCardBrandProvider.swift
@@ -12,9 +12,9 @@ internal final class FallbackBinInfoProvider: AnyBinInfoProvider {
 
     internal func provide(for bin: String, supportedTypes: [CardType], completion: @escaping (BinLookupResponse) -> Void) {
         // only return result out of the given supported types.
-        let result: [CardBrand] = supportedTypes.adyen.types(forCardNumber: bin).map { type in
+        let result: [DetectedCardBrand] = supportedTypes.adyen.types(forCardNumber: bin).map { type in
 
-            let cvcPolicy: CardBrand.RequirementPolicy
+            let cvcPolicy: DetectedCardBrand.RequirementPolicy
             switch type {
             case .laser,
                  .bcmc,
@@ -28,7 +28,7 @@ internal final class FallbackBinInfoProvider: AnyBinInfoProvider {
                 cvcPolicy = .required
             }
 
-            return CardBrand(type: type, cvcPolicy: cvcPolicy)
+            return DetectedCardBrand(type: type, cvcPolicy: cvcPolicy)
         }
         completion(BinLookupResponse(brands: result))
     }

--- a/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
@@ -102,7 +102,7 @@ class BCMCComponentTests: XCTestCase {
         
         fillCard(on: sut.viewController.view, with: Dummy.bancontactCard)
         
-        let binResponse = BinLookupResponse(brands: [CardBrand(type: .bcmc, isSupported: true)])
+        let binResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .bcmc, isSupported: true)])
         sut.cardViewController.update(binInfo: binResponse)
 
         wait(for: .milliseconds(30))
@@ -231,7 +231,7 @@ class BCMCComponentTests: XCTestCase {
             XCTFail("delegate.didFail() must not be called")
         }
         
-        let binResponse = BinLookupResponse(brands: [CardBrand(type: .bcmc, isSupported: true, cvcPolicy: .optional)])
+        let binResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .bcmc, isSupported: true, cvcPolicy: .optional)])
         sut.cardViewController.update(binInfo: binResponse)
         
         // Enter Card Number
@@ -309,7 +309,7 @@ class BCMCComponentTests: XCTestCase {
         let expectationBinLookup = XCTestExpectation(description: "Bin Lookup Expectation")
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
-            $0(BinLookupResponse(brands: [CardBrand(type: .bcmc, cvcPolicy: .optional, panLength: 19)]))
+            $0(BinLookupResponse(brands: [DetectedCardBrand(type: .bcmc, cvcPolicy: .optional, panLength: 19)]))
             expectationBinLookup.fulfill()
         }
         
@@ -346,7 +346,7 @@ class BCMCComponentTests: XCTestCase {
         let expectationBinLookup = XCTestExpectation(description: "Bin Lookup Expectation")
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
-            $0(BinLookupResponse(brands: [CardBrand(type: .bcmc, cvcPolicy: .optional, isLuhnCheckEnabled: false)]))
+            $0(BinLookupResponse(brands: [DetectedCardBrand(type: .bcmc, cvcPolicy: .optional, isLuhnCheckEnabled: false)]))
             expectationBinLookup.fulfill()
         }
         

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -384,7 +384,7 @@ class CardComponentTests: XCTestCase {
     func test_onBinChangeAndOnBinLookup_whenCardNumberEntered_shouldBeCalledWithCorrectValues() {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
-            $0(BinLookupResponse(brands: [CardBrand(type: .americanExpress)], isCreatedLocally: false))
+            $0(BinLookupResponse(brands: [DetectedCardBrand(type: .americanExpress)], isCreatedLocally: false))
         }
 
         let sut = CardComponent(
@@ -744,7 +744,7 @@ class CardComponentTests: XCTestCase {
 
         // no focus change without panglength till max (19)
         
-        var newResponse = BinLookupResponse(brands: [CardBrand(type: .americanExpress)])
+        var newResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .americanExpress)])
         sut.cardViewController.update(binInfo: newResponse)
         cardNumberItemView.becomeFirstResponder()
         
@@ -756,7 +756,7 @@ class CardComponentTests: XCTestCase {
         wait(until: cardNumberItemView, at: \.isFirstResponder, is: true)
         
         // focus should change with pan length set
-        newResponse = BinLookupResponse(brands: [CardBrand(type: .americanExpress, panLength: 15)])
+        newResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .americanExpress, panLength: 15)])
         sut.cardViewController.update(binInfo: newResponse)
         cardNumberItemView.becomeFirstResponder()
         
@@ -768,7 +768,7 @@ class CardComponentTests: XCTestCase {
         wait(until: expiryDateItemView, at: \.isFirstResponder, is: true)
 
         // focus should also change when reaching default max length 19
-        newResponse = BinLookupResponse(brands: [CardBrand(type: .maestro)])
+        newResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .maestro)])
         sut.cardViewController.update(binInfo: newResponse)
         cardNumberItemView.becomeFirstResponder()
         
@@ -864,7 +864,7 @@ class CardComponentTests: XCTestCase {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
             $0(BinLookupResponse(
-                brands: [CardBrand(type: .koreanLocalCard)],
+                brands: [DetectedCardBrand(type: .koreanLocalCard)],
                 issuingCountryCode: "KR"
             ))
         }
@@ -924,7 +924,7 @@ class CardComponentTests: XCTestCase {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
             $0(BinLookupResponse(
-                brands: [CardBrand(type: .elo, showSocialSecurityNumber: true)],
+                brands: [DetectedCardBrand(type: .elo, showSocialSecurityNumber: true)],
                 issuingCountryCode: "BR"
             ))
         }
@@ -964,7 +964,7 @@ class CardComponentTests: XCTestCase {
 
         tapSubmitButton(on: sut.viewController.view)
         
-        let newResponse = BinLookupResponse(brands: [CardBrand(type: .elo, showSocialSecurityNumber: false)])
+        let newResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .elo, showSocialSecurityNumber: false)])
         sut.cardViewController.update(binInfo: newResponse)
 
         wait(until: brazilSSNItemView, at: \.isHidden, is: true)
@@ -986,7 +986,7 @@ class CardComponentTests: XCTestCase {
         XCTAssertNil(brazilSSNItemView)
         
         // config is always hide, so item is not added to view
-        let newResponse = BinLookupResponse(brands: [CardBrand(type: .elo, showSocialSecurityNumber: true)])
+        let newResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .elo, showSocialSecurityNumber: true)])
         sut.cardViewController.update(binInfo: newResponse)
         
         XCTAssertNil(brazilSSNItemView)
@@ -1008,7 +1008,7 @@ class CardComponentTests: XCTestCase {
         XCTAssertFalse(try XCTUnwrap(brazilSSNItemView?.isHidden))
         
         // config is always show, so bin response is ignored
-        let newResponse = BinLookupResponse(brands: [CardBrand(type: .elo, showSocialSecurityNumber: false)])
+        let newResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .elo, showSocialSecurityNumber: false)])
         sut.cardViewController.update(binInfo: newResponse)
         
         XCTAssertFalse(try XCTUnwrap(brazilSSNItemView?.isHidden))
@@ -1022,8 +1022,8 @@ class CardComponentTests: XCTestCase {
         )
         
         let brands = [
-            CardBrand(type: .visa, isLuhnCheckEnabled: true),
-            CardBrand(type: .masterCard, isLuhnCheckEnabled: false)
+            DetectedCardBrand(type: .visa, isLuhnCheckEnabled: true),
+            DetectedCardBrand(type: .masterCard, isLuhnCheckEnabled: false)
         ]
         
         let cardNumberItem = sut.cardViewController.items.numberContainerItem.numberItem
@@ -1060,7 +1060,7 @@ class CardComponentTests: XCTestCase {
         
         fillCard(on: sut.viewController.view, with: Dummy.visaCard)
         
-        let binResponse = BinLookupResponse(brands: [CardBrand(type: .visa, isSupported: true)])
+        let binResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .visa, isSupported: true)])
         sut.cardViewController.update(binInfo: binResponse)
 
         wait(until: supportedCardLogosItem, at: \.isHidden, is: true)
@@ -1068,9 +1068,9 @@ class CardComponentTests: XCTestCase {
 
     func test_securityCodeField_withDifferentCVCPolicies_shouldUpdateDisplayMode() {
         let brands = [
-            CardBrand(type: .visa, cvcPolicy: .required),
-            CardBrand(type: .americanExpress, cvcPolicy: .optional),
-            CardBrand(type: .masterCard, cvcPolicy: .hidden)
+            DetectedCardBrand(type: .visa, cvcPolicy: .required),
+            DetectedCardBrand(type: .americanExpress, cvcPolicy: .optional),
+            DetectedCardBrand(type: .masterCard, cvcPolicy: .hidden)
         ]
 
         let method = CardPaymentMethod(
@@ -1123,9 +1123,9 @@ class CardComponentTests: XCTestCase {
         )
         
         let brands = [
-            CardBrand(type: .visa, expiryDatePolicy: .required),
-            CardBrand(type: .americanExpress, expiryDatePolicy: .optional),
-            CardBrand(type: .masterCard, expiryDatePolicy: .hidden)
+            DetectedCardBrand(type: .visa, expiryDatePolicy: .required),
+            DetectedCardBrand(type: .americanExpress, expiryDatePolicy: .optional),
+            DetectedCardBrand(type: .masterCard, expiryDatePolicy: .hidden)
         ]
         
         let expDateItem = sut.cardViewController.items.expiryDateItem
@@ -1404,7 +1404,7 @@ class CardComponentTests: XCTestCase {
 
         sut.viewController.loadViewIfNeeded()
 
-        let newResponse = BinLookupResponse(brands: [CardBrand(type: .visa), CardBrand(type: .carteBancaire)], issuingCountryCode: "FR", isCreatedLocally: false)
+        let newResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .visa), DetectedCardBrand(type: .carteBancaire)], issuingCountryCode: "FR", isCreatedLocally: false)
 
         try sut.cardViewController.showCoBadgedCardsUI(for: XCTUnwrap(newResponse.brands))
 
@@ -1425,7 +1425,7 @@ class CardComponentTests: XCTestCase {
 
         sut.viewController.loadViewIfNeeded()
 
-        let newResponse = BinLookupResponse(brands: [CardBrand(type: .masterCard), CardBrand(type: .other(named: "eftpos_australia"))], issuingCountryCode: "AU", isCreatedLocally: false)
+        let newResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .masterCard), DetectedCardBrand(type: .other(named: "eftpos_australia"))], issuingCountryCode: "AU", isCreatedLocally: false)
 
         try sut.cardViewController.showCoBadgedCardsUI(for: XCTUnwrap(newResponse.brands))
 
@@ -1448,12 +1448,12 @@ class CardComponentTests: XCTestCase {
 
         let newResponse = BinLookupResponse(
             brands: [
-                CardBrand(
-                    type: .bcmc,
+                DetectedCardBrand(
+                    brand: .bcmc,
                     localeBrand: "Bancontact card"
                 ),
-                CardBrand(
-                    type: .maestro,
+                DetectedCardBrand(
+                    brand: .maestro,
                     localeBrand: nil
                 )
             ],
@@ -1486,7 +1486,7 @@ class CardComponentTests: XCTestCase {
             configuration: CardConfiguration()
         )
 
-        let brands = [CardBrand(type: .visa), CardBrand(type: .carteBancaire)]
+        let brands = [DetectedCardBrand(type: .visa), DetectedCardBrand(type: .carteBancaire)]
         sut.viewController.loadViewIfNeeded()
 
         sut.cardViewController.items.coBadgedCardItem.updatedCardBrands = brands
@@ -1514,7 +1514,7 @@ class CardComponentTests: XCTestCase {
 
         setupRootViewController(sut.viewController)
 
-        let newResponse = BinLookupResponse(brands: [CardBrand(type: .visa), CardBrand(type: .carteBancaire)], issuingCountryCode: "FR", isCreatedLocally: false)
+        let newResponse = BinLookupResponse(brands: [DetectedCardBrand(type: .visa), DetectedCardBrand(type: .carteBancaire)], issuingCountryCode: "FR", isCreatedLocally: false)
 
         sut.cardViewController.update(binInfo: newResponse)
         sut.cardViewController.items.coBadgedCardItem.selectableFormItems.first?.selectionHandler?()
@@ -1846,7 +1846,7 @@ class CardComponentTests: XCTestCase {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
             $0(BinLookupResponse(
-                brands: [CardBrand(type: .visa)],
+                brands: [DetectedCardBrand(type: .visa)],
                 issuingCountryCode: "US"
             ))
         }
@@ -1913,7 +1913,7 @@ class CardComponentTests: XCTestCase {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
             $0(BinLookupResponse(
-                brands: [CardBrand(type: .visa)],
+                brands: [DetectedCardBrand(type: .visa)],
                 issuingCountryCode: "US"
             ))
         }
@@ -1968,7 +1968,7 @@ class CardComponentTests: XCTestCase {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
             $0(BinLookupResponse(
-                brands: [CardBrand(type: .visa)],
+                brands: [DetectedCardBrand(type: .visa)],
                 issuingCountryCode: "US"
             ))
         }
@@ -2024,7 +2024,7 @@ class CardComponentTests: XCTestCase {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
             $0(BinLookupResponse(
-                brands: [CardBrand(type: .visa)],
+                brands: [DetectedCardBrand(type: .visa)],
                 issuingCountryCode: "US"
             ))
         }
@@ -2156,7 +2156,7 @@ class CardComponentTests: XCTestCase {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
             $0(BinLookupResponse(
-                brands: [CardBrand(type: .visa)],
+                brands: [DetectedCardBrand(type: .visa)],
                 issuingCountryCode: "US"
             ))
         }
@@ -2211,7 +2211,7 @@ class CardComponentTests: XCTestCase {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
             $0(BinLookupResponse(
-                brands: [CardBrand(type: .visa)],
+                brands: [DetectedCardBrand(type: .visa)],
                 issuingCountryCode: "US"
             ))
         }
@@ -2272,7 +2272,7 @@ class CardComponentTests: XCTestCase {
         let cardTypeProviderMock = BinInfoProviderMock()
         cardTypeProviderMock.onFetch = {
             $0(BinLookupResponse(
-                brands: [CardBrand(type: .bijenkorfCard)],
+                brands: [DetectedCardBrand(type: .bijenkorfCard)],
                 issuingCountryCode: "GB"
             ))
         }

--- a/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/CardComponentTests.swift
@@ -1449,11 +1449,11 @@ class CardComponentTests: XCTestCase {
         let newResponse = BinLookupResponse(
             brands: [
                 DetectedCardBrand(
-                    brand: .bcmc,
+                    type: .bcmc,
                     localeBrand: "Bancontact card"
                 ),
                 DetectedCardBrand(
-                    brand: .maestro,
+                    type: .maestro,
                     localeBrand: nil
                 )
             ],

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberItemTests.swift
@@ -112,7 +112,7 @@ class FormCardNumberItemTests: XCTestCase {
     }
 
     func testExternalBinLookupHappyFlow() {
-        let mockedBrands = [CardBrand(type: .masterCard)]
+        let mockedBrands = [DetectedCardBrand(type: .masterCard)]
         apiClient.mockedResults = [
             .success(BinLookupResponse(brands: mockedBrands)),
             .success(BinLookupResponse(brands: []))

--- a/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberValidationTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardNumberItem/FormCardNumberValidationTests.swift
@@ -81,7 +81,7 @@ class FormCardNumberValidationTests: XCTestCase {
         )
 
         // When - brand is detected (simulating typing "4")
-        containerItem.update(brands: [CardBrand(type: .visa)])
+        containerItem.update(brands: [DetectedCardBrand(type: .visa)])
 
         // Then - logos should be hidden (brand is known, placeholder not needed)
         XCTAssertTrue(
@@ -303,7 +303,7 @@ class FormCardNumberValidationTests: XCTestCase {
         )
 
         // When brands are detected (valid brand)
-        containerItem.update(brands: [CardBrand(type: .visa)])
+        containerItem.update(brands: [DetectedCardBrand(type: .visa)])
 
         // Then logos should be hidden (brand detected)
         XCTAssertTrue(

--- a/Tests/IntegrationTests/Card Tests/Utilities/CardBrandProviderTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/CardBrandProviderTests.swift
@@ -38,7 +38,7 @@ class CardBrandProviderTests: XCTestCase {
     }
 
     func testRemoteCardTypeFetch() {
-        let mockedBrands = [CardBrand(type: .solo)]
+        let mockedBrands = [DetectedCardBrand(type: .solo)]
         apiClientMock.mockedResults = [.success(BinLookupResponse(brands: mockedBrands))]
 
         sut.provide(for: "5656565656565656", supportedTypes: [.masterCard, .visa, .maestro]) { result in


### PR DESCRIPTION
Renames CardBrand to DetectedCardBrand as the CardBrand name will be used as the public enum (follow-up PR).

Note: Initial plan was to rename it to DetectedCardType to match Android's internal name but all the properties are named brand and brand is used extensively, so we went DetectedCardBrand


## Ticket [Optional]
<ticket>
COSDK-1243
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)
