### PR TITLE
Bin callbacks alignment - onBinChange

### DIFF
--- a/AdyenCard/Components/Card/CardComponent.swift
+++ b/AdyenCard/Components/Card/CardComponent.swift
@@ -218,7 +218,6 @@ package class CardComponent: PaymentComponent,
     }()
 
     private let panThrottler = Throttler(minimumDelay: CardComponent.Constant.secondsThrottlingDelay)
-    private let binThrottler = Throttler(minimumDelay: CardComponent.Constant.secondsThrottlingDelay)
 
     private func sendInfoEvent(with data: CardViewController.InfoEventData) {
         var infoEvent = AnalyticsEventInfo(
@@ -253,10 +252,7 @@ extension CardComponent: CardViewControllerDelegate {
     }
 
     internal func didChange(bin: String) {
-        binThrottler.throttle { [weak self] in
-            guard let self else { return }
-            self.configuration.onBinChange?(bin)
-        }
+        configuration.onBinChange?(bin)
     }
 
     private func updateBrand(with pan: String) {

--- a/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
@@ -293,7 +293,9 @@ class BCMCComponentTests: XCTestCase {
             .onBinChange { value in
                 XCTAssertTrue("67034444".hasPrefix(value))
                 XCTAssertTrue(value.count <= 8)
-                expectationBin.fulfill()
+                if value == "67034444" {
+                    expectationBin.fulfill()
+                }
             }
         
         let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")

--- a/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
+++ b/Tests/IntegrationTests/Card Tests/BCMCComponentTests.swift
@@ -289,8 +289,6 @@ class BCMCComponentTests: XCTestCase {
         sut.viewController.loadViewIfNeeded()
 
         let expectationBin = XCTestExpectation(description: "Bin Expectation")
-        expectationBin.expectedFulfillmentCount = 1
-        expectationBin.assertForOverFulfill = true
         sut.configuration = sut.configuration
             .onBinChange { value in
                 XCTAssertTrue("67034444".hasPrefix(value))
@@ -302,6 +300,31 @@ class BCMCComponentTests: XCTestCase {
         try populate(textItemView: XCTUnwrap(cardNumberItemView), with: XCTUnwrap(Dummy.bancontactCard.number))
 
         wait(for: [expectationBin], timeout: 10)
+    }
+
+    func test_onBinChange_whenTypingDigits_shouldFirePerDigitUpToSixThenStopWithoutThrottling() throws {
+        let method = CardPaymentMethod(type: .bcmc, name: "Test name", fundingSource: .debit, brands: [.masterCard])
+        let paymentMethod = BCMCPaymentMethod(cardPaymentMethod: method)
+        let sut = BCMCComponent(
+            paymentMethod: paymentMethod,
+            context: context
+        )
+
+        sut.viewController.loadViewIfNeeded()
+
+        var receivedBins: [String] = []
+        sut.configuration = sut.configuration
+            .onBinChange { value in
+                receivedBins.append(value)
+            }
+
+        let cardNumberItemView: FormCardNumberItemView? = sut.viewController.view.findView(with: "AdyenCard.BCMCComponent.numberContainerItem.numberItem")
+        // Typing 7 digits one by one. Without throttling each distinct BIN must be
+        // reported (no coalescing of rapid keystrokes), but the BIN is capped at 6
+        // digits, so the 7th digit produces no new value and must not fire again.
+        try populateSimulatingKeystrokes(textItemView: XCTUnwrap(cardNumberItemView), with: "6703444")
+
+        XCTAssertEqual(receivedBins, ["6", "67", "670", "6703", "67034", "670344"])
     }
     
     func test_onBinChange_with6DigitsBIN_shouldReturn6Digits() {


### PR DESCRIPTION
# Summary [Required]
Removes the 0.5s throttle previously applied to the card `onBinChange` callback so that every distinct BIN value is reported as the shopper types, aligning iOS with the cross-platform BIN change callback spec (and Android's behavior). BIN values are already deduplicated via `AdyenObservable`, so consecutive identical values are not reported. The bin-lookup / brand-detection path (`panThrottler`) is intentionally left unchanged.

## Technical Information [Optional]
- Removed `binThrottler` from `CardComponent`; `didChange(bin:)` now invokes `configuration.onBinChange` directly.
- `panThrottler` (brand detection / `onBinLookup`) is intentionally left in place.
- Deduplication is handled by `AdyenObservable`, which only publishes when the value changes — so the callback never fires twice in a row with the same value.

## Testing Instructions [Optional]
- Run the `onBinChange` tests in `IntegrationUIKitTests/BCMCComponentTests` and `IntegrationUIKitTests/CardComponentTests`.
- Manually: type a card number digit-by-digit and confirm `onBinChange` fires for each of the first 6 digits, does not fire for digits 7–15, and fires once with the 8-digit BIN at a valid 16-digit PAN.

## Ticket [Optional]
<ticket>
COSDK-1297
</ticket>

## Checklist [Required]
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
