### PR TITLE
WIP: Split checkout result handling into two signatures: sessions and advanced flow

### DIFF
--- a/AdyenCheckout/Callbacks/CheckoutResultCallbackStore.swift
+++ b/AdyenCheckout/Callbacks/CheckoutResultCallbackStore.swift
@@ -7,9 +7,14 @@
 import Adyen
 import Foundation
 
+package enum CheckoutCompletion {
+    case session(resultCode: CheckoutResultCode, sessionId: String, sessionResult: String)
+    case advanced(resultCode: CheckoutResultCode)
+}
+
 package protocol CheckoutResultCallbackStore: AnyObject {
     @MainActor
-    func handleCompletion(resultCode: CheckoutResultCode, sessionId: String?, sessionResult: String?)
+    func handleCompletion(_ completion: CheckoutCompletion)
 
     var onFailure: CheckoutFailureHandler? { get set }
 }
@@ -21,8 +26,8 @@ package final class SessionCheckoutCallbackStore: CheckoutResultCallbackStore {
 
     package var onFailure: CheckoutFailureHandler?
 
-    package func handleCompletion(resultCode: CheckoutResultCode, sessionId: String?, sessionResult: String?) {
-        guard let sessionId, let sessionResult else {
+    package func handleCompletion(_ completion: CheckoutCompletion) {
+        guard case let .session(resultCode, sessionId, sessionResult) = completion else {
             AdyenAssertion.assertionFailure(message: "Session completion called without sessionId or sessionResult.")
             return
         }
@@ -39,8 +44,11 @@ package final class AdvancedCheckoutCallbackStore: CheckoutResultCallbackStore {
 
     package var onFailure: CheckoutFailureHandler?
 
-    package func handleCompletion(resultCode: CheckoutResultCode, sessionId: String?, sessionResult: String?) {
-        // sessionId and sessionResult are session-specific and not applicable to the advanced flow.
+    package func handleCompletion(_ completion: CheckoutCompletion) {
+        guard case let .advanced(resultCode) = completion else {
+            AdyenAssertion.assertionFailure(message: "Advanced completion called with session result.")
+            return
+        }
         onComplete?(AdvancedCheckoutResult(resultCode: resultCode))
     }
 }
@@ -52,8 +60,11 @@ package final class ActionOnlyCheckoutCallbackStore: CheckoutResultCallbackStore
 
     package var onFailure: CheckoutFailureHandler?
 
-    package func handleCompletion(resultCode: CheckoutResultCode, sessionId: String?, sessionResult: String?) {
-        // sessionId and sessionResult are session-specific and not applicable to the action-only flow.
+    package func handleCompletion(_ completion: CheckoutCompletion) {
+        guard case let .advanced(resultCode) = completion else {
+            AdyenAssertion.assertionFailure(message: "Action-only completion called with session result.")
+            return
+        }
         onComplete?(AdvancedCheckoutResult(resultCode: resultCode))
     }
 }

--- a/AdyenCheckout/Core/CheckoutCore+Orchestration.swift
+++ b/AdyenCheckout/Core/CheckoutCore+Orchestration.swift
@@ -149,11 +149,19 @@ internal extension CheckoutCore {
     func finish(with resultCode: CheckoutResultCode, from component: (any PaymentComponent)?) {
         (component as? any FinalizableComponent)?.didFinalize(with: resultCode.isSuccessful, completion: nil)
         pendingPaymentComponent = nil
-        resultCallbacks.handleCompletion(
-            resultCode: resultCode,
-            sessionId: session?.state.identifier,
-            sessionResult: session?.state.sessionResult
-        )
+        if let session {
+            guard let sessionResult = session.state.sessionResult else {
+                AdyenAssertion.assertionFailure(message: "Session completion called without sessionResult.")
+                return
+            }
+            resultCallbacks.handleCompletion(.session(
+                resultCode: resultCode,
+                sessionId: session.state.identifier,
+                sessionResult: sessionResult
+            ))
+        } else {
+            resultCallbacks.handleCompletion(.advanced(resultCode: resultCode))
+        }
     }
 
     func finish(with error: Error, from component: (any PaymentComponent)?) {


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

This is a follow-up to https://github.com/Adyen/adyen-ios/pull/2596/
While not perfect, it removes the `sessionId` and `sessionResult` optionality by splitting the interface for both flows using two separate callback signatures.

I am still not fully happy with the solution, let's use this as a discussion starter.

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [ ] Tested changes locally
- [ ] Added/updated unit tests
- [ ] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)
