### PR TITLE
Expand release regex to allow more SemVer branch names

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -26,7 +26,7 @@ jobs:
         # Extracting the version number from the source branch name
         # If the version number does not match we fail to indicate an issue
         VERSION_NUMBER=${SOURCE_BRANCH#release/}
-        if [[ ! "$VERSION_NUMBER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        if [[ ! "$VERSION_NUMBER" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
           echo "'$VERSION_NUMBER' does not match semantic versioning format. Exiting."
           exit 1
         fi


### PR DESCRIPTION
# Summary [Required]
Current job only supported decimals for release names. Add support for more semantic versioning release names for the job like 6.0.0-alpha.1

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [ ] Tested changes locally
- [ ] Added/updated unit tests
- [ ] Verified against acceptance criteria
