### PR TITLE
chore: Move Renovate scanning from v5 to develop

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,9 @@
   ],
   "labels": [
     "chore"
+  ],
+  "baseBranchPatterns": [
+    "$default",
+    "develop"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
     "chore"
   ],
   "baseBranchPatterns": [
-    "$default",
     "develop"
   ]
 }


### PR DESCRIPTION
# Summary
Renovate currently scans the repository default branch (v5), which is the merchant-facing maintenance branch. Active v6 development happens on develop, and v5 should not receive dependency updates since some updated versions are not compatible with the older v5 codebase. This switches baseBranchPatterns to develop only, so Renovate exclusively targets develop going forward.

## Technical Information
- Uses baseBranchPatterns (current Renovate option, supersedes baseBranches) set to ["develop"], removing $default so v5 is no longer scanned at all.
- This must be merged into v5 (the default branch): Renovate always reads its config from the repository default branch, even when baseBranchPatterns lists other branches, so the config change only takes effect if merged into v5.

