### PR TITLE
fix: Download simulator runtimes via xcodebuild instead of xcodes

### DIFF
--- a/.github/workflows/verify-os-compatibility.yml
+++ b/.github/workflows/verify-os-compatibility.yml
@@ -69,13 +69,11 @@ jobs:
     - name: Download and install simulator runtime
       if: matrix.needs_custom_sim == true
       run: |
-        echo "Downloading iOS ${{ matrix.version }} runtime using xcodes..."
-        sudo xcodes runtimes install "iOS ${{ matrix.version }}"
-        
+        echo "Downloading iOS ${{ matrix.version }} runtime via xcodebuild..."
+        sudo xcodebuild -downloadPlatform iOS -buildVersion ${{ matrix.version }}
+
         # Verify simulator is available
         xcrun simctl list runtimes
-
-    # This step is now handled by the xcodes tool above
 
     - name: Create simulator ${{ matrix.version }}
       run: |


### PR DESCRIPTION
## Summary
- CI job `Compatibility Test` fails at the "Download and install simulator runtime" step.
- Root cause: `xcodes runtimes install` crashes decoding Apple's downloadables manifest:
  `Error: dataCorrupted ... "Cannot initialize Authentication from invalid String value none"` (known xcodes bug).
- Replaces `xcodes runtimes install "iOS X"` with `xcodebuild -downloadPlatform iOS -buildVersion X`.
