### PR TITLE
Update comparison link to show the commit not the release branch

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -55,8 +55,9 @@ jobs:
         mkdir -p "$TMP_DIR"
 
         LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+        SOURCE_COMMIT_SHA="${{ github.sha }}"
         if [ -n "$LAST_TAG" ]; then
-          echo "**Changes since \`$LAST_TAG\`:** https://github.com/${{ github.repository }}/compare/${LAST_TAG}...release/${{ github.event.inputs.sdk-version }}" >> $RELEASE_NOTES_FILE_PATH
+          echo "**Changes since \`$LAST_TAG\`:** https://github.com/${{ github.repository }}/compare/${LAST_TAG}...${SOURCE_COMMIT_SHA}" >> $RELEASE_NOTES_FILE_PATH
           echo "" >> $RELEASE_NOTES_FILE_PATH
           echo "---" >> $RELEASE_NOTES_FILE_PATH
           echo "" >> $RELEASE_NOTES_FILE_PATH


### PR DESCRIPTION
# Summary [Required]
The release branches are deleted, making the new comparison link void. So we use the commit instead.

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [ ] Tested changes locally
- [ ] Added/updated unit tests
- [ ] Verified against acceptance criteria
