### PR TITLE
(1/3) Redefine Component Abstractions: Synchronize generated mock names

### DIFF
--- a/Tests/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/GeneratedMocks/AutoMockable.generated.swift
@@ -26,9 +26,9 @@ class ActionPresenterMock: ActionPresenter {
 
     // MARK: - present
 
-    var presentActionComponentCallsCount = 0
-    var presentActionComponentCalled: Bool {
-        presentActionComponentCallsCount > 0
+    var presentActionViewControllerCallsCount = 0
+    var presentActionViewControllerCalled: Bool {
+        presentActionViewControllerCallsCount > 0
     }
 
     var presentActionViewControllerReceivedActionViewController: UIViewController?
@@ -36,7 +36,7 @@ class ActionPresenterMock: ActionPresenter {
     var presentActionViewControllerClosure: ((UIViewController) -> Void)?
 
     func present(actionViewController: UIViewController) {
-        presentActionComponentCallsCount += 1
+        presentActionViewControllerCallsCount += 1
         presentActionViewControllerReceivedActionViewController = actionViewController
         presentActionViewControllerReceivedInvocations.append(actionViewController)
         presentActionViewControllerClosure?(actionViewController)
@@ -191,16 +191,16 @@ class ComponentContainerRoutingMock: ComponentContainerRouting {
 
     // MARK: - present
 
-    var presentActionComponentOnCancelCallsCount = 0
-    var presentActionComponentOnCancelCalled: Bool {
-        presentActionComponentOnCancelCallsCount > 0
+    var presentActionViewControllerOnCancelCallsCount = 0
+    var presentActionViewControllerOnCancelCalled: Bool {
+        presentActionViewControllerOnCancelCallsCount > 0
     }
 
-    var presentActionComponentOnCancelClosure: ((UIViewController, (() -> Void)?) -> Void)?
+    var presentActionViewControllerOnCancelClosure: ((UIViewController, (() -> Void)?) -> Void)?
 
     func present(actionViewController: UIViewController, onCancel: (() -> Void)?) {
-        presentActionComponentOnCancelCallsCount += 1
-        presentActionComponentOnCancelClosure?(actionViewController, onCancel)
+        presentActionViewControllerOnCancelCallsCount += 1
+        presentActionViewControllerOnCancelClosure?(actionViewController, onCancel)
     }
 
     // MARK: - dismiss
@@ -405,16 +405,16 @@ class PaymentMethodListRoutingMock: PaymentMethodListRouting {
 
     // MARK: - present
 
-    var presentActionComponentOnCancelCallsCount = 0
-    var presentActionComponentOnCancelCalled: Bool {
-        presentActionComponentOnCancelCallsCount > 0
+    var presentActionViewControllerOnCancelCallsCount = 0
+    var presentActionViewControllerOnCancelCalled: Bool {
+        presentActionViewControllerOnCancelCallsCount > 0
     }
 
-    var presentActionComponentOnCancelClosure: ((UIViewController, (() -> Void)?) -> Void)?
+    var presentActionViewControllerOnCancelClosure: ((UIViewController, (() -> Void)?) -> Void)?
 
     func present(actionViewController: UIViewController, onCancel: (() -> Void)?) {
-        presentActionComponentOnCancelCallsCount += 1
-        presentActionComponentOnCancelClosure?(actionViewController, onCancel)
+        presentActionViewControllerOnCancelCallsCount += 1
+        presentActionViewControllerOnCancelClosure?(actionViewController, onCancel)
     }
 
     // MARK: - dismiss
@@ -572,16 +572,16 @@ class PreselectedPaymentMethodRoutingMock: PreselectedPaymentMethodRouting {
 
     // MARK: - present
 
-    var presentActionComponentOnCancelCallsCount = 0
-    var presentActionComponentOnCancelCalled: Bool {
-        presentActionComponentOnCancelCallsCount > 0
+    var presentActionViewControllerOnCancelCallsCount = 0
+    var presentActionViewControllerOnCancelCalled: Bool {
+        presentActionViewControllerOnCancelCallsCount > 0
     }
 
-    var presentActionComponentOnCancelClosure: ((UIViewController, (() -> Void)?) -> Void)?
+    var presentActionViewControllerOnCancelClosure: ((UIViewController, (() -> Void)?) -> Void)?
 
     func present(actionViewController: UIViewController, onCancel: (() -> Void)?) {
-        presentActionComponentOnCancelCallsCount += 1
-        presentActionComponentOnCancelClosure?(actionViewController, onCancel)
+        presentActionViewControllerOnCancelCallsCount += 1
+        presentActionViewControllerOnCancelClosure?(actionViewController, onCancel)
     }
 
     // MARK: - dismiss

--- a/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewModelTests.swift
@@ -245,7 +245,7 @@ struct PaymentMethodListViewModelTests {
         sut.present(actionViewController: actionComponentMock)
 
         // Then
-        #expect(routerMock.presentActionComponentOnCancelCallsCount == 1)
+        #expect(routerMock.presentActionViewControllerOnCancelCallsCount == 1)
     }
 
     @Test
@@ -258,7 +258,7 @@ struct PaymentMethodListViewModelTests {
 
         // Capture the onCancel callback when present is called
         var capturedOnCancel: (() -> Void)?
-        routerMock.presentActionComponentOnCancelClosure = { _, onCancel in
+        routerMock.presentActionViewControllerOnCancelClosure = { _, onCancel in
             capturedOnCancel = onCancel
         }
 


### PR DESCRIPTION
## Summary
 
Synchronize Sourcery-generated mock names with the current action view-controller APIs.
 
The generated mocks still used `ActionComponent` terminology for methods that receive an `actionViewController`. This updates the generated tracking properties and the affected Drop-in tests.
 
## Changes
 
- Rename generated `presentActionComponent...` properties to `presentActionViewController...`.
- Update `PaymentMethodListViewModelTests` to use the synchronized names.

## Checklist
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
