### PR TITLE
(2/3) Redefine Component Abstractions: Rename `InstantPaymentComponent` to `GenericPaymentComponent`

### DIFF
--- a/Adyen/Core/Components/GenericPaymentComponent.swift
+++ b/Adyen/Core/Components/GenericPaymentComponent.swift
@@ -8,7 +8,7 @@ import Foundation
 
 /// A component that handles payment methods that don't need any payment detail to be filled.
 @MainActor
-package final class InstantPaymentComponent: PaymentComponent {
+package final class GenericPaymentComponent: PaymentComponent {
 
     /// The context object for this component.
     package let context: AdyenContext
@@ -22,7 +22,7 @@ package final class InstantPaymentComponent: PaymentComponent {
     /// The delegate of the component.
     package weak var delegate: PaymentComponentDelegate?
 
-    /// Initializes a new instance of `InstantPaymentComponent`.
+    /// Initializes a new instance of `GenericPaymentComponent`.
     ///
     /// - Parameters:
     ///   - paymentMethod: The payment method.
@@ -38,7 +38,7 @@ package final class InstantPaymentComponent: PaymentComponent {
         self.context = context
     }
 
-    /// Initializes a new instance of `InstantPaymentComponent`.
+    /// Initializes a new instance of `GenericPaymentComponent`.
     ///
     /// - Parameters:
     ///   - paymentMethod: The payment method.

--- a/Adyen/Core/Core Protocols/ReadyToSubmitPaymentComponentDelegate.swift
+++ b/Adyen/Core/Core Protocols/ReadyToSubmitPaymentComponentDelegate.swift
@@ -13,7 +13,7 @@ package protocol ReadyToSubmitPaymentComponentDelegate: AnyObject {
     /// Called when the payment component is ready to submit shopper details,
     /// and the delegate needs to show a confirmation screen to the shopper.
     /// - Parameters:
-    ///   - component: The `InstantPaymentComponent`
+    ///   - component: The `GenericPaymentComponent`
     ///   - order: The partial payment order if any.
-    func showConfirmation(for component: InstantPaymentComponent, with order: PartialPaymentOrder?)
+    func showConfirmation(for component: GenericPaymentComponent, with order: PartialPaymentOrder?)
 }

--- a/Adyen/Model/SDKData.swift
+++ b/Adyen/Model/SDKData.swift
@@ -82,7 +82,7 @@ package extension PaymentComponent {
     }
 }
 
-package extension InstantPaymentComponent {
+package extension GenericPaymentComponent {
 
     var paymentMethodBehavior: SDKData.PaymentMethodBehavior {
         .genericComponent

--- a/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
+++ b/AdyenCard/Components/GiftCardComponent/GiftCardComponent.swift
@@ -381,7 +381,7 @@ extension GiftCardComponent {
             remainingAmount: remainingAmount
         )
         
-        let component = InstantPaymentComponent(
+        let component = GenericPaymentComponent(
             paymentMethod: paymentMethod,
             context: context,
             paymentData: paymentData

--- a/AdyenCheckout/Component/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/Component/CheckoutComponentBuilder.swift
@@ -66,7 +66,7 @@ internal enum CheckoutComponentBuilder {
             
         #endif
         case let instantPaymentMethod as InstantPaymentMethod:
-            return InstantPaymentComponent(
+            return GenericPaymentComponent(
                 paymentMethod: instantPaymentMethod,
                 context: context,
                 order: nil

--- a/AdyenComponents/Instant/InstantComponents.swift
+++ b/AdyenComponents/Instant/InstantComponents.swift
@@ -10,10 +10,10 @@ import Adyen
 package typealias OXXOPaymentMethod = InstantPaymentMethod
 
 /// A component for handling OXXO payment.
-package typealias OXXOComponent = InstantPaymentComponent
+package typealias OXXOComponent = GenericPaymentComponent
 
 /// A  payment method for Multibanco.
 package typealias MultibancoPaymentMethod = InstantPaymentMethod
 
 /// A component for handling Multibanco payment.
-package typealias MultibancoComponent = InstantPaymentComponent
+package typealias MultibancoComponent = GenericPaymentComponent

--- a/AdyenDropIn/DropInComponentExtensions.swift
+++ b/AdyenDropIn/DropInComponentExtensions.swift
@@ -44,7 +44,7 @@ extension DropInComponent: FinalizableComponent {
 
 extension DropInComponent: ReadyToSubmitPaymentComponentDelegate {
 
-    package func showConfirmation(for component: InstantPaymentComponent, with order: PartialPaymentOrder?) {
+    package func showConfirmation(for component: GenericPaymentComponent, with order: PartialPaymentOrder?) {
 //        let newRootViewController = resolvePreselectedPaymentMethodView(
 //            for: component,
 //            onCancel: { [weak self] in

--- a/AdyenDropIn/Modules/ComponentContainer/ComponentContainerViewModel.swift
+++ b/AdyenDropIn/Modules/ComponentContainer/ComponentContainerViewModel.swift
@@ -112,7 +112,7 @@ extension ComponentContainerViewModel: ActionPresenter {
 extension ComponentContainerViewModel: ReadyToSubmitPaymentComponentDelegate {
 
     internal func showConfirmation(
-        for component: InstantPaymentComponent,
+        for component: GenericPaymentComponent,
         with order: PartialPaymentOrder?
     ) {
         // TODO: - Handle gift card balance confirmation

--- a/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
+++ b/AdyenDropIn/Utilities/ComponentManager+PaymentComponentBuilder.swift
@@ -112,7 +112,7 @@ extension ComponentManager: PaymentComponentBuilder {
     internal func build(paymentMethod: WeChatPayPaymentMethod) -> PaymentComponent? {
         guard let classObject = loadTheConcreteWeChatPaySDKActionComponentClass() else { return nil }
         guard classObject.isDeviceSupported() else { return nil }
-        return InstantPaymentComponent(
+        return GenericPaymentComponent(
             paymentMethod: paymentMethod,
             context: context,
             order: order
@@ -197,7 +197,7 @@ extension ComponentManager: PaymentComponentBuilder {
     }
 
     internal func build(paymentMethod: PaymentMethod) -> PaymentComponent? {
-        InstantPaymentComponent(
+        GenericPaymentComponent(
             paymentMethod: paymentMethod,
             context: context,
             order: order

--- a/Demo/Common/IntegrationExamples/AdvancedFlow/Components/GenericPaymentComponentAdvancedFlowExample.swift
+++ b/Demo/Common/IntegrationExamples/AdvancedFlow/Components/GenericPaymentComponentAdvancedFlowExample.swift
@@ -5,17 +5,18 @@
 //
 
 import Adyen
+import AdyenActions
 import AdyenCheckout
 import AdyenComponents
 import Foundation
 import UIKit
 
 @MainActor
-internal final class InstantPaymentComponentExample: InitialDataFlowProtocol {
+internal final class GenericPaymentComponentAdvancedFlow: InitialDataAdvancedFlowProtocol {
 
     internal weak var presenter: PresenterExampleProtocol?
 
-    private var checkout: SessionCheckout?
+    private var checkout: AdvancedCheckout?
     private var adyenComponent: CheckoutPaymentComponent?
 
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
@@ -31,8 +32,8 @@ internal final class InstantPaymentComponentExample: InitialDataFlowProtocol {
 
         Task {
             do {
-                let sessionResponse = try await requestSessionInitialInfo()
-                let component = try await instantPaymentComponent(from: sessionResponse)
+                let paymentMethods = try await requestPaymentMethods(order: nil)
+                let component = try await instantPaymentComponent(from: paymentMethods)
                 self.adyenComponent = component
                 hideLoading()
 
@@ -49,7 +50,7 @@ internal final class InstantPaymentComponentExample: InitialDataFlowProtocol {
         }
     }
 
-    private func instantPaymentComponent(from sessionResponse: SessionResponse) async throws -> CheckoutPaymentComponent {
+    private func instantPaymentComponent(from paymentMethods: PaymentMethods) async throws -> CheckoutPaymentComponent {
         let configuration = try CheckoutConfiguration(
             environment: ConfigurationConstants.componentsEnvironment,
             amount: ConfigurationConstants.current.amount,
@@ -62,10 +63,18 @@ internal final class InstantPaymentComponentExample: InitialDataFlowProtocol {
         }
 
         let checkout = try await Checkout.setup(
-            with: sessionResponse,
+            with: paymentMethods,
             configuration: configuration,
             presentationDelegate: self
         )
+        .onSubmit { [weak self] data in
+            guard let self else { return .completion(resultCode: "Error") }
+            return await self.callPayments(with: data)
+        }
+        .onAdditionalDetails { [weak self] data in
+            guard let self else { return .completion(resultCode: "Error") }
+            return await self.callDetails(with: data)
+        }
         .onComplete { [weak self] result in
             self?.dismissAndShowAlert(
                 result.resultCode.isSuccess,
@@ -81,6 +90,35 @@ internal final class InstantPaymentComponentExample: InitialDataFlowProtocol {
         return try checkout.createPaymentComponent(for: PaymentMethodType.ideal)
     }
 
+    // MARK: - Backend calls
+
+    private func callPayments(with data: PaymentComponentData) async -> SubmitResult {
+        do {
+            let request = PaymentsRequest(data: data)
+            let response = try await asyncApiClient.performAsync(request)
+            if let action = response.action {
+                return .action(action)
+            }
+            return .completion(resultCode: response.resultCode.rawValue)
+        } catch {
+            return .completion(resultCode: "Error")
+        }
+    }
+
+    private func callDetails(with data: ActionComponentData) async -> AdditionalDetailsResult {
+        do {
+            let request = PaymentDetailsRequest(
+                details: data.details,
+                paymentData: data.paymentData,
+                merchantAccount: ConfigurationConstants.current.merchantAccount
+            )
+            let response = try await asyncApiClient.performAsync(request)
+            return .completion(resultCode: response.resultCode.rawValue)
+        } catch {
+            return .completion(resultCode: "Error")
+        }
+    }
+
     // MARK: - Private
 
     private func startLoading() {
@@ -94,7 +132,7 @@ internal final class InstantPaymentComponentExample: InitialDataFlowProtocol {
     private func hideLoading() {
         presenter?.hideLoadingIndicator()
     }
-
+    
     private func dismissAndShowAlert(_ success: Bool, _ message: String) {
         presenter?.dismiss {
             // Payment is processed. Add your code here.
@@ -104,9 +142,8 @@ internal final class InstantPaymentComponentExample: InitialDataFlowProtocol {
     }
 }
 
-extension InstantPaymentComponentExample: PresentationDelegate {
+extension GenericPaymentComponentAdvancedFlow: PresentationDelegate {
     internal func present(viewController: UIViewController) {
-        presenter?.hideLoadingIndicator()
         presenter?.present(viewController: viewController, completion: nil)
     }
 }

--- a/Demo/Common/IntegrationExamples/Session/Components/GenericPaymentComponentExample.swift
+++ b/Demo/Common/IntegrationExamples/Session/Components/GenericPaymentComponentExample.swift
@@ -5,18 +5,17 @@
 //
 
 import Adyen
-import AdyenActions
 import AdyenCheckout
 import AdyenComponents
 import Foundation
 import UIKit
 
 @MainActor
-internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlowProtocol {
+internal final class GenericPaymentComponentExample: InitialDataFlowProtocol {
 
     internal weak var presenter: PresenterExampleProtocol?
 
-    private var checkout: AdvancedCheckout?
+    private var checkout: SessionCheckout?
     private var adyenComponent: CheckoutPaymentComponent?
 
     internal lazy var apiClient = ApiClientHelper.generateApiClient()
@@ -32,8 +31,8 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
 
         Task {
             do {
-                let paymentMethods = try await requestPaymentMethods(order: nil)
-                let component = try await instantPaymentComponent(from: paymentMethods)
+                let sessionResponse = try await requestSessionInitialInfo()
+                let component = try await instantPaymentComponent(from: sessionResponse)
                 self.adyenComponent = component
                 hideLoading()
 
@@ -50,7 +49,7 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
         }
     }
 
-    private func instantPaymentComponent(from paymentMethods: PaymentMethods) async throws -> CheckoutPaymentComponent {
+    private func instantPaymentComponent(from sessionResponse: SessionResponse) async throws -> CheckoutPaymentComponent {
         let configuration = try CheckoutConfiguration(
             environment: ConfigurationConstants.componentsEnvironment,
             amount: ConfigurationConstants.current.amount,
@@ -63,18 +62,10 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
         }
 
         let checkout = try await Checkout.setup(
-            with: paymentMethods,
+            with: sessionResponse,
             configuration: configuration,
             presentationDelegate: self
         )
-        .onSubmit { [weak self] data in
-            guard let self else { return .completion(resultCode: "Error") }
-            return await self.callPayments(with: data)
-        }
-        .onAdditionalDetails { [weak self] data in
-            guard let self else { return .completion(resultCode: "Error") }
-            return await self.callDetails(with: data)
-        }
         .onComplete { [weak self] result in
             self?.dismissAndShowAlert(
                 result.resultCode.isSuccess,
@@ -90,35 +81,6 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
         return try checkout.createPaymentComponent(for: PaymentMethodType.ideal)
     }
 
-    // MARK: - Backend calls
-
-    private func callPayments(with data: PaymentComponentData) async -> SubmitResult {
-        do {
-            let request = PaymentsRequest(data: data)
-            let response = try await asyncApiClient.performAsync(request)
-            if let action = response.action {
-                return .action(action)
-            }
-            return .completion(resultCode: response.resultCode.rawValue)
-        } catch {
-            return .completion(resultCode: "Error")
-        }
-    }
-
-    private func callDetails(with data: ActionComponentData) async -> AdditionalDetailsResult {
-        do {
-            let request = PaymentDetailsRequest(
-                details: data.details,
-                paymentData: data.paymentData,
-                merchantAccount: ConfigurationConstants.current.merchantAccount
-            )
-            let response = try await asyncApiClient.performAsync(request)
-            return .completion(resultCode: response.resultCode.rawValue)
-        } catch {
-            return .completion(resultCode: "Error")
-        }
-    }
-
     // MARK: - Private
 
     private func startLoading() {
@@ -132,7 +94,7 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
     private func hideLoading() {
         presenter?.hideLoadingIndicator()
     }
-    
+
     private func dismissAndShowAlert(_ success: Bool, _ message: String) {
         presenter?.dismiss {
             // Payment is processed. Add your code here.
@@ -142,8 +104,9 @@ internal final class InstantPaymentComponentAdvancedFlow: InitialDataAdvancedFlo
     }
 }
 
-extension InstantPaymentComponentAdvancedFlow: PresentationDelegate {
+extension GenericPaymentComponentExample: PresentationDelegate {
     internal func present(viewController: UIViewController) {
+        presenter?.hideLoadingIndicator()
         presenter?.present(viewController: viewController, completion: nil)
     }
 }

--- a/Demo/README.md
+++ b/Demo/README.md
@@ -95,7 +95,7 @@ Located in [`Common/IntegrationExamples/Session/Components/`](Common/Integration
 
 - **[`CardComponentExample.swift`](Common/IntegrationExamples/Session/Components/CardComponentExample.swift)** – Card payments
 - **[`ApplePayComponentExample.swift`](Common/IntegrationExamples/Session/Components/ApplePayComponentExample.swift)** – Apple Pay integration
-- **[`InstantPaymentComponentExample.swift`](Common/IntegrationExamples/Session/Components/InstantPaymentComponentExample.swift)** – Instant payment methods
+- **[`GenericPaymentComponentExample.swift`](Common/IntegrationExamples/Session/Components/GenericPaymentComponentExample.swift)** – Instant payment methods
 - **[`IssuerListComponentExample.swift`](Common/IntegrationExamples/Session/Components/IssuerListComponentExample.swift)** – Issuer list payments
 
 ---
@@ -116,7 +116,7 @@ Located in [`Common/IntegrationExamples/AdvancedFlow/Components/`](Common/Integr
 
 - **[`CardComponentAdvancedFlowExample.swift`](Common/IntegrationExamples/AdvancedFlow/Components/CardComponentAdvancedFlowExample.swift)**
 - **[`ApplePayComponentAdvancedFlowExample.swift`](Common/IntegrationExamples/AdvancedFlow/Components/ApplePayComponentAdvancedFlowExample.swift)**
-- **[`InstantPaymentComponentAdvancedFlowExample.swift`](Common/IntegrationExamples/AdvancedFlow/Components/InstantPaymentComponentAdvancedFlowExample.swift)**
+- **[`GenericPaymentComponentAdvancedFlowExample.swift`](Common/IntegrationExamples/AdvancedFlow/Components/GenericPaymentComponentAdvancedFlowExample.swift)**
 - **[`IssuerListComponentAdvancedFlowExample.swift`](Common/IntegrationExamples/AdvancedFlow/Components/IssuerListComponentAdvancedFlowExample.swift)**
 
 ---

--- a/Demo/SwiftUI/ComponentsViewModel.swift
+++ b/Demo/SwiftUI/ComponentsViewModel.swift
@@ -47,16 +47,16 @@ internal final class ComponentsViewModel: ObservableObject, Identifiable {
         return cardComponentExample
     }
     
-    private var instantPaymentComponentExample: GenericPaymentComponentExample {
-        let instantPaymentComponentExample = GenericPaymentComponentExample()
-        instantPaymentComponentExample.presenter = self
-        return instantPaymentComponentExample
+    private var genericPaymentComponentExample: GenericPaymentComponentExample {
+        let genericPaymentComponentExample = GenericPaymentComponentExample()
+        genericPaymentComponentExample.presenter = self
+        return genericPaymentComponentExample
     }
     
-    private var instantPaymentComponentAdvancedFlow: GenericPaymentComponentAdvancedFlow {
-        let instantPaymentComponentExample = GenericPaymentComponentAdvancedFlow()
-        instantPaymentComponentExample.presenter = self
-        return instantPaymentComponentExample
+    private var genericPaymentComponentAdvancedFlow: GenericPaymentComponentAdvancedFlow {
+        let genericPaymentComponentExample = GenericPaymentComponentAdvancedFlow()
+        genericPaymentComponentExample.presenter = self
+        return genericPaymentComponentExample
     }
 
     @Published internal var viewControllerToPresent: UIViewController?
@@ -107,9 +107,9 @@ internal final class ComponentsViewModel: ObservableObject, Identifiable {
     
     internal func presentGenericPaymentComponent() {
         if isUsingSession {
-            start(instantPaymentComponentExample)
+            start(genericPaymentComponentExample)
         } else {
-            start(instantPaymentComponentAdvancedFlow)
+            start(genericPaymentComponentAdvancedFlow)
         }
     }
 

--- a/Demo/SwiftUI/ComponentsViewModel.swift
+++ b/Demo/SwiftUI/ComponentsViewModel.swift
@@ -47,14 +47,14 @@ internal final class ComponentsViewModel: ObservableObject, Identifiable {
         return cardComponentExample
     }
     
-    private var instantPaymentComponentExample: InstantPaymentComponentExample {
-        let instantPaymentComponentExample = InstantPaymentComponentExample()
+    private var instantPaymentComponentExample: GenericPaymentComponentExample {
+        let instantPaymentComponentExample = GenericPaymentComponentExample()
         instantPaymentComponentExample.presenter = self
         return instantPaymentComponentExample
     }
     
-    private var instantPaymentComponentAdvancedFlow: InstantPaymentComponentAdvancedFlow {
-        let instantPaymentComponentExample = InstantPaymentComponentAdvancedFlow()
+    private var instantPaymentComponentAdvancedFlow: GenericPaymentComponentAdvancedFlow {
+        let instantPaymentComponentExample = GenericPaymentComponentAdvancedFlow()
         instantPaymentComponentExample.presenter = self
         return instantPaymentComponentExample
     }
@@ -105,7 +105,7 @@ internal final class ComponentsViewModel: ObservableObject, Identifiable {
         }
     }
     
-    internal func presentInstantPaymentComponent() {
+    internal func presentGenericPaymentComponent() {
         if isUsingSession {
             start(instantPaymentComponentExample)
         } else {
@@ -126,7 +126,7 @@ internal final class ComponentsViewModel: ObservableObject, Identifiable {
                 ComponentsItem(
                     title: "Instant/Redirect Payment",
                     subtitle: "e.g. iDEAL, PayPal, Alipay, ...",
-                    selectionHandler: presentInstantPaymentComponent
+                    selectionHandler: presentGenericPaymentComponent
                 )
             ]
         ]

--- a/Demo/UIKit/ComponentsViewController.swift
+++ b/Demo/UIKit/ComponentsViewController.swift
@@ -49,16 +49,16 @@ internal final class ComponentsViewController: UIViewController {
         return issuerListComponent
     }
     
-    private var instantPaymentComponentExample: GenericPaymentComponentExample {
-        let instantPaymentComponentExample = GenericPaymentComponentExample()
-        instantPaymentComponentExample.presenter = self
-        return instantPaymentComponentExample
+    private var genericPaymentComponentExample: GenericPaymentComponentExample {
+        let genericPaymentComponentExample = GenericPaymentComponentExample()
+        genericPaymentComponentExample.presenter = self
+        return genericPaymentComponentExample
     }
     
-    private var instantPaymentComponentAdvancedFlow: GenericPaymentComponentAdvancedFlow {
-        let instantPaymentComponentExample = GenericPaymentComponentAdvancedFlow()
-        instantPaymentComponentExample.presenter = self
-        return instantPaymentComponentExample
+    private var genericPaymentComponentAdvancedFlow: GenericPaymentComponentAdvancedFlow {
+        let genericPaymentComponentExample = GenericPaymentComponentAdvancedFlow()
+        genericPaymentComponentExample.presenter = self
+        return genericPaymentComponentExample
     }
 
     private var applePayComponentAdvancedFlowExample: ApplePayComponentAdvancedFlowExample {
@@ -166,9 +166,9 @@ internal final class ComponentsViewController: UIViewController {
     
     internal func presentGenericPaymentComponent() {
         if componentsView.isUsingSession {
-            start(instantPaymentComponentExample)
+            start(genericPaymentComponentExample)
         } else {
-            start(instantPaymentComponentAdvancedFlow)
+            start(genericPaymentComponentAdvancedFlow)
         }
     }
 

--- a/Demo/UIKit/ComponentsViewController.swift
+++ b/Demo/UIKit/ComponentsViewController.swift
@@ -49,14 +49,14 @@ internal final class ComponentsViewController: UIViewController {
         return issuerListComponent
     }
     
-    private var instantPaymentComponentExample: InstantPaymentComponentExample {
-        let instantPaymentComponentExample = InstantPaymentComponentExample()
+    private var instantPaymentComponentExample: GenericPaymentComponentExample {
+        let instantPaymentComponentExample = GenericPaymentComponentExample()
         instantPaymentComponentExample.presenter = self
         return instantPaymentComponentExample
     }
     
-    private var instantPaymentComponentAdvancedFlow: InstantPaymentComponentAdvancedFlow {
-        let instantPaymentComponentExample = InstantPaymentComponentAdvancedFlow()
+    private var instantPaymentComponentAdvancedFlow: GenericPaymentComponentAdvancedFlow {
+        let instantPaymentComponentExample = GenericPaymentComponentAdvancedFlow()
         instantPaymentComponentExample.presenter = self
         return instantPaymentComponentExample
     }
@@ -108,7 +108,7 @@ internal final class ComponentsViewController: UIViewController {
                 ComponentsItem(
                     title: "Instant/Redirect Payment",
                     subtitle: "e.g. iDEAL, PayPal, Alipay, ...",
-                    selectionHandler: presentInstantPaymentComponent
+                    selectionHandler: presentGenericPaymentComponent
                 )
             ],
             [ComponentsItem(title: "Apple Pay", selectionHandler: presentApplePayComponent)],
@@ -164,7 +164,7 @@ internal final class ComponentsViewController: UIViewController {
         }
     }
     
-    internal func presentInstantPaymentComponent() {
+    internal func presentGenericPaymentComponent() {
         if componentsView.isUsingSession {
             start(instantPaymentComponentExample)
         } else {

--- a/Tests/IntegrationTests/Components Tests/Gift Card/ReadyToSubmitPaymentComponentDelegateMock.swift
+++ b/Tests/IntegrationTests/Components Tests/Gift Card/ReadyToSubmitPaymentComponentDelegateMock.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 final class ReadyToSubmitPaymentComponentDelegateMock: ReadyToSubmitPaymentComponentDelegate {
-    var onShowConfirmation: ((InstantPaymentComponent, PartialPaymentOrder?) -> Void)?
+    var onShowConfirmation: ((GenericPaymentComponent, PartialPaymentOrder?) -> Void)?
 
-    func showConfirmation(for component: InstantPaymentComponent, with order: PartialPaymentOrder?) {
+    func showConfirmation(for component: GenericPaymentComponent, with order: PartialPaymentOrder?) {
         onShowConfirmation?(component, order)
     }
 }

--- a/Tests/IntegrationTests/Components Tests/Instant Payment/GenericPaymentComponentTests.swift
+++ b/Tests/IntegrationTests/Components Tests/Instant Payment/GenericPaymentComponentTests.swift
@@ -9,11 +9,11 @@
 import XCTest
 
 @MainActor
-class InstantPaymentComponentTests: XCTestCase {
+class GenericPaymentComponentTests: XCTestCase {
 
     private var paymentMethod: GiftCardPaymentMethod!
     private var delegate: PaymentComponentDelegateMock!
-    private var sut: InstantPaymentComponent!
+    private var sut: GenericPaymentComponent!
     private var context: AdyenContext!
 
     override func setUp() {
@@ -26,7 +26,7 @@ class InstantPaymentComponentTests: XCTestCase {
 
         delegate = PaymentComponentDelegateMock()
         paymentMethod = GiftCardPaymentMethod(type: .giftcard, name: "name", brand: "brand")
-        sut = InstantPaymentComponent(
+        sut = GenericPaymentComponent(
             paymentMethod: paymentMethod,
             context: context,
             paymentData: paymentComponentData

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -307,7 +307,7 @@ class PaymentComponentSubjectTests: XCTestCase {
         let instantPaymentDetails = InstantPaymentDetails(type: .other("test"))
         let paymentData = PaymentComponentData(paymentMethodDetails: instantPaymentDetails, order: nil)
 
-        let instantComponent = InstantPaymentComponent(
+        let instantComponent = GenericPaymentComponent(
             paymentMethod: instantPaymentMethod,
             context: context,
             paymentData: paymentData
@@ -331,7 +331,7 @@ class PaymentComponentSubjectTests: XCTestCase {
                 jsonString.contains(
                     "\"paymentMethodBehavior\":\"genericComponent\""
                 ),
-                "InstantPaymentComponent should use genericComponent behavior"
+                "GenericPaymentComponent should use genericComponent behavior"
             )
             didSubmitExpectation.fulfill()
         }

--- a/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
+++ b/Tests/IntegrationTests/Components Tests/PaymentComponent/PaymentComponentSubjectTests.swift
@@ -307,12 +307,12 @@ class PaymentComponentSubjectTests: XCTestCase {
         let instantPaymentDetails = InstantPaymentDetails(type: .other("test"))
         let paymentData = PaymentComponentData(paymentMethodDetails: instantPaymentDetails, order: nil)
 
-        let instantComponent = GenericPaymentComponent(
+        let genericComponent = GenericPaymentComponent(
             paymentMethod: instantPaymentMethod,
             context: context,
             paymentData: paymentData
         )
-        instantComponent.delegate = paymentComponentDelegate
+        genericComponent.delegate = paymentComponentDelegate
 
         let didSubmitExpectation = expectation(description: "didSubmit should get called")
 
@@ -336,7 +336,7 @@ class PaymentComponentSubjectTests: XCTestCase {
             didSubmitExpectation.fulfill()
         }
 
-        instantComponent.performSubmit()
+        genericComponent.performSubmit()
 
         wait(for: [didSubmitExpectation], timeout: 3)
     }

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -320,7 +320,7 @@ final class CheckoutComponentBuilderTests: XCTestCase {
 
     // MARK: - Instant Payment Component Tests
 
-    func test_build_withInstantPaymentMethod_returnsInstantPaymentComponent() throws {
+    func test_build_withInstantPaymentMethod_returnsGenericPaymentComponent() throws {
         // Given
         let dict: [String: Any] = [
             "type": "ideal",
@@ -337,7 +337,7 @@ final class CheckoutComponentBuilderTests: XCTestCase {
 
         // Then
         XCTAssertEqual(component.paymentMethod.type, .ideal)
-        XCTAssertTrue(component is InstantPaymentComponent, "Component should be InstantPaymentComponent")
+        XCTAssertTrue(component is GenericPaymentComponent, "Component should be GenericPaymentComponent")
     }
 
     // MARK: - Theme Propagation Tests

--- a/Tests/UnitTests/AdyenDropIn/ComponentManagerTests.swift
+++ b/Tests/UnitTests/AdyenDropIn/ComponentManagerTests.swift
@@ -223,7 +223,7 @@ class ComponentManagerTests: XCTestCase {
             let twintComponent = paymentComponent as? TwintComponent
             XCTAssertNotNil(twintComponent)
         #else
-            let twintComponent = paymentComponent as? InstantPaymentComponent
+            let twintComponent = paymentComponent as? GenericPaymentComponent
             XCTAssertNil(twintComponent)
         #endif
     }


### PR DESCRIPTION
## Summary

Rename `InstantPaymentComponent` to `GenericPaymentComponent`.

The component handles payment methods that do not require shopper details, so the new name better reflects its generic purpose and existing `.genericComponent` behavior.


## Changes

- Rename the component and source file.
- Update builders, aliases, and delegate signatures.
- Update Checkout and Drop-in references.
- Rename associated tests and demo examples.
- Preserve the `.genericComponent` SDK-data behavior.
