### PR TITLE
Fix: Cap card security code to its expected length in stored value

### DIFF
--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -82,6 +82,8 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
         replacementString string: String
     ) -> Bool {
         guard !string.isEmpty else { return true }
+
+        guard string.count == 1 else { return true }
         
         let currentText = textField.text ?? ""
         guard let textRange = Range(range, in: currentText) else { return true }

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -83,7 +83,11 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
     ) -> Bool {
         guard !string.isEmpty else { return true }
 
-        guard string.count == 1 else { return true }
+        // Multi-character replacements (e.g. paste) are allowed through here and truncated
+        // to the expected length by the formatter; a single typed keystroke is rejected
+        // once it would exceed the max length.
+        let isSingleCharacterReplacement = string.count == 1
+        guard isSingleCharacterReplacement else { return true }
         
         let currentText = textField.text ?? ""
         guard let textRange = Range(range, in: currentText) else { return true }

--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -75,6 +75,26 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
         super.textFieldDidEndEditing(text)
         cardHintView.isHighlighted = false
     }
+    
+    override internal func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        guard !string.isEmpty else { return true }
+        
+        let currentText = textField.text ?? ""
+        guard let textRange = Range(range, in: currentText) else { return true }
+        
+        let updatedText = currentText.replacingCharacters(in: textRange, with: string)
+        let digitCount = updatedText.filter(\.isNumber).count
+        
+        return digitCount <= expectedLength
+    }
+    
+    private var expectedLength: Int {
+        item.selectedCard == CardBrand.americanExpress ? 4 : 3
+    }
 }
 
 extension FormCardSecurityCodeItemView {

--- a/AdyenCard/Formatters/CardSecurityCodeFormatter.swift
+++ b/AdyenCard/Formatters/CardSecurityCodeFormatter.swift
@@ -36,7 +36,11 @@ public final class CardSecurityCodeFormatter: NumericFormatter {
     }
     
     override public func formattedValue(for value: String) -> String {
-        let value = super.formattedValue(for: value)
+        sanitizedValue(for: value)
+    }
+    
+    override public func sanitizedValue(for value: String) -> String {
+        let value = super.sanitizedValue(for: value)
         
         if value.count > expectedLength {
             return String(value.prefix(expectedLength))

--- a/Tests/IntegrationTests/Card Tests/Formatters/CardSecurityCodeFormatterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Formatters/CardSecurityCodeFormatterTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class CardSecurityCodeFormatterTests: XCTestCase {
     
-    func testFormatting() {
+    func test_formattedValue_givenInputExceedingExpectedLength_shouldTruncate() {
         let observer = AdyenObservable<CardBrand?>(.masterCard)
         let formatter = CardSecurityCodeFormatter(publisher: observer)
         XCTAssertEqual(formatter.formattedValue(for: "1"), "1")
@@ -26,7 +26,7 @@ class CardSecurityCodeFormatterTests: XCTestCase {
         XCTAssertEqual(formatter.formattedValue(for: "12345"), "1234")
     }
     
-    func testSanitizing() {
+    func test_sanitizedValue_givenNonDigitsAndExcessLength_shouldStripAndTruncate() {
         let observer = AdyenObservable<CardBrand?>(.masterCard)
         let formatter = CardSecurityCodeFormatter(publisher: observer)
         

--- a/Tests/IntegrationTests/Card Tests/Formatters/CardSecurityCodeFormatterTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Formatters/CardSecurityCodeFormatterTests.swift
@@ -27,11 +27,19 @@ class CardSecurityCodeFormatterTests: XCTestCase {
     }
     
     func testSanitizing() {
-        let formatter = CardSecurityCodeFormatter()
+        let observer = AdyenObservable<CardBrand?>(.masterCard)
+        let formatter = CardSecurityCodeFormatter(publisher: observer)
         
         XCTAssertEqual(formatter.sanitizedValue(for: "1"), "1")
         XCTAssertEqual(formatter.sanitizedValue(for: "1a2b"), "12")
         XCTAssertEqual(formatter.sanitizedValue(for: "12--"), "12")
-        XCTAssertEqual(formatter.sanitizedValue(for: "123456"), "123456")
+        XCTAssertEqual(formatter.sanitizedValue(for: "123456"), "123")
+        XCTAssertEqual(formatter.sanitizedValue(for: "12a3b456"), "123")
+        
+        observer.wrappedValue = nil
+        XCTAssertEqual(formatter.sanitizedValue(for: "123456"), "123")
+        
+        observer.wrappedValue = .americanExpress
+        XCTAssertEqual(formatter.sanitizedValue(for: "123456"), "1234")
     }
 }

--- a/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
@@ -35,7 +35,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testTextFieldSanitizationGivenNonAllowedCharactersShouldSanitizeAndFormatInput() {
+    func test_textFieldSanitization_givenNonAllowedCharacters_shouldSanitizeAndFormatInput() {
         // Given
         let expectedCVV = "458"
         let expectedFormattedCVV = formatter.formattedValue(for: expectedCVV)
@@ -51,7 +51,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertEqual(sut.textField.allowsEditingActions, false)
     }
 
-    func testTextFieldSanitizationGivenCorrectSecurityCodeShouldSanitizeAndFormatInput() {
+    func test_textFieldSanitization_givenCorrectSecurityCode_shouldSanitizeAndFormatInput() {
         // Given
         let expectedCVV = "917"
         let expectedFormattedCVV = formatter.formattedValue(for: expectedCVV)
@@ -66,7 +66,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertEqual(expectedFormattedCVV, sut.textField.text)
     }
 
-    func testShouldChangeCharactersGivenNonAmexAndInputExceedsThreeDigitsShouldReject() {
+    func test_shouldChangeCharacters_givenNonAmexAndInputExceedsThreeDigits_shouldReject() {
         // Given
         sut.textField.text = "123"
 
@@ -81,7 +81,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertFalse(shouldChange)
     }
 
-    func testShouldChangeCharactersGivenNonAmexAndInputWithinThreeDigitsShouldAllow() {
+    func test_shouldChangeCharacters_givenNonAmexAndInputWithinThreeDigits_shouldAllow() {
         // Given
         sut.textField.text = "12"
 
@@ -96,7 +96,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertTrue(shouldChange)
     }
 
-    func testShouldChangeCharactersGivenAmexAndInputWithinFourDigitsShouldAllow() {
+    func test_shouldChangeCharacters_givenAmexAndInputWithinFourDigits_shouldAllow() {
         // Given
         item.selectedCard = .americanExpress
         sut.textField.text = "123"
@@ -112,7 +112,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertTrue(shouldChange)
     }
 
-    func testShouldChangeCharactersGivenAmexAndInputExceedsFourDigitsShouldReject() {
+    func test_shouldChangeCharacters_givenAmexAndInputExceedsFourDigits_shouldReject() {
         // Given
         item.selectedCard = .americanExpress
         sut.textField.text = "1234"
@@ -128,7 +128,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertFalse(shouldChange)
     }
 
-    func testShouldChangeCharactersGivenDeletionShouldAlwaysAllow() {
+    func test_shouldChangeCharacters_givenDeletion_shouldAlwaysAllow() {
         // Given
         sut.textField.text = "123"
 
@@ -143,7 +143,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertTrue(shouldChange)
     }
 
-    func testPastingMoreThanMaxDigitsGivenNonAmexShouldAllowAndTruncateValue() {
+    func test_pasting_givenNonAmexAndMoreThanMaxDigits_shouldAllowAndTruncateValue() {
         // When
         let shouldChange = sut.textField(
             sut.textField,
@@ -159,7 +159,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertTrue(item.isValid())
     }
 
-    func testPastingValidLengthGivenNonAmexShouldAllowAndSetValue() {
+    func test_pasting_givenNonAmexAndValidLength_shouldAllowAndSetValue() {
         // When
         let shouldChange = sut.textField(
             sut.textField,
@@ -175,7 +175,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertTrue(item.isValid())
     }
 
-    func testPastingValidLengthGivenAmexShouldAllowAndSetValue() {
+    func test_pasting_givenAmexAndValidLength_shouldAllowAndSetValue() {
         // Given
         item.formatter = CardSecurityCodeFormatter(publisher: item.$selectedCard)
         item.validator = CardSecurityCodeValidator(publisher: item.$selectedCard)
@@ -196,7 +196,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertTrue(item.isValid())
     }
 
-    func testPastingMoreThanMaxDigitsGivenAmexShouldAllowAndTruncateValue() {
+    func test_pasting_givenAmexAndMoreThanMaxDigits_shouldAllowAndTruncateValue() {
         // Given
         item.formatter = CardSecurityCodeFormatter(publisher: item.$selectedCard)
         item.validator = CardSecurityCodeValidator(publisher: item.$selectedCard)
@@ -217,7 +217,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertTrue(item.isValid())
     }
 
-    func testEnteringMoreThanThreeDigitsGivenNonAmexShouldCapValueAndValidate() {
+    func test_entering_givenNonAmexAndMoreThanThreeDigits_shouldCapValueAndValidate() {
         // When
         sut.textField.text = "1234"
         sut.textField.sendActions(for: .editingChanged)
@@ -228,7 +228,7 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertTrue(item.isValid())
     }
 
-    func testEnteringMoreThanFourDigitsGivenAmexShouldCapValueAndValidate() {
+    func test_entering_givenAmexAndMoreThanFourDigits_shouldCapValueAndValidate() {
         // Given
         item.formatter = CardSecurityCodeFormatter(publisher: item.$selectedCard)
         item.validator = CardSecurityCodeValidator(publisher: item.$selectedCard)

--- a/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
@@ -142,4 +142,105 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         // Then
         XCTAssertTrue(shouldChange)
     }
+
+    func testPastingMoreThanMaxDigitsGivenNonAmexShouldAllowAndTruncateValue() {
+        // When
+        let shouldChange = sut.textField(
+            sut.textField,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "1234"
+        )
+        sut.textField.text = "1234"
+        sut.textField.sendActions(for: .editingChanged)
+
+        // Then
+        XCTAssertTrue(shouldChange)
+        XCTAssertEqual(item.value, "123")
+        XCTAssertTrue(item.isValid())
+    }
+
+    func testPastingValidLengthGivenNonAmexShouldAllowAndSetValue() {
+        // When
+        let shouldChange = sut.textField(
+            sut.textField,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "123"
+        )
+        sut.textField.text = "123"
+        sut.textField.sendActions(for: .editingChanged)
+
+        // Then
+        XCTAssertTrue(shouldChange)
+        XCTAssertEqual(item.value, "123")
+        XCTAssertTrue(item.isValid())
+    }
+
+    func testPastingValidLengthGivenAmexShouldAllowAndSetValue() {
+        // Given
+        item.formatter = CardSecurityCodeFormatter(publisher: item.$selectedCard)
+        item.validator = CardSecurityCodeValidator(publisher: item.$selectedCard)
+        item.selectedCard = .americanExpress
+
+        // When
+        let shouldChange = sut.textField(
+            sut.textField,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "1234"
+        )
+        sut.textField.text = "1234"
+        sut.textField.sendActions(for: .editingChanged)
+
+        // Then
+        XCTAssertTrue(shouldChange)
+        XCTAssertEqual(item.value, "1234")
+        XCTAssertTrue(item.isValid())
+    }
+
+    func testPastingMoreThanMaxDigitsGivenAmexShouldAllowAndTruncateValue() {
+        // Given
+        item.formatter = CardSecurityCodeFormatter(publisher: item.$selectedCard)
+        item.validator = CardSecurityCodeValidator(publisher: item.$selectedCard)
+        item.selectedCard = .americanExpress
+
+        // When
+        let shouldChange = sut.textField(
+            sut.textField,
+            shouldChangeCharactersIn: NSRange(location: 0, length: 0),
+            replacementString: "12345"
+        )
+        sut.textField.text = "12345"
+        sut.textField.sendActions(for: .editingChanged)
+
+        // Then
+        XCTAssertTrue(shouldChange)
+        XCTAssertEqual(item.value, "1234")
+        XCTAssertTrue(item.isValid())
+    }
+
+    func testEnteringMoreThanThreeDigitsGivenNonAmexShouldCapValueAndValidate() {
+        // When
+        sut.textField.text = "1234"
+        sut.textField.sendActions(for: .editingChanged)
+
+        // Then
+        XCTAssertEqual(item.value, "123")
+        XCTAssertEqual(item.formattedValue, "123")
+        XCTAssertTrue(item.isValid())
+    }
+
+    func testEnteringMoreThanFourDigitsGivenAmexShouldCapValueAndValidate() {
+        // Given
+        item.formatter = CardSecurityCodeFormatter(publisher: item.$selectedCard)
+        item.validator = CardSecurityCodeValidator(publisher: item.$selectedCard)
+        item.selectedCard = .americanExpress
+
+        // When
+        sut.textField.text = "12345"
+        sut.textField.sendActions(for: .editingChanged)
+
+        // Then
+        XCTAssertEqual(item.value, "1234")
+        XCTAssertEqual(item.formattedValue, "1234")
+        XCTAssertTrue(item.isValid())
+    }
 }

--- a/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
@@ -65,4 +65,81 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertEqual(expectedFormattedCVV, item.formattedValue)
         XCTAssertEqual(expectedFormattedCVV, sut.textField.text)
     }
+
+    func testShouldChangeCharactersGivenNonAmexAndInputExceedsThreeDigitsShouldReject() {
+        // Given
+        sut.textField.text = "123"
+
+        // When
+        let shouldChange = sut.textField(
+            sut.textField,
+            shouldChangeCharactersIn: NSRange(location: 3, length: 0),
+            replacementString: "4"
+        )
+
+        // Then
+        XCTAssertFalse(shouldChange)
+    }
+
+    func testShouldChangeCharactersGivenNonAmexAndInputWithinThreeDigitsShouldAllow() {
+        // Given
+        sut.textField.text = "12"
+
+        // When
+        let shouldChange = sut.textField(
+            sut.textField,
+            shouldChangeCharactersIn: NSRange(location: 2, length: 0),
+            replacementString: "3"
+        )
+
+        // Then
+        XCTAssertTrue(shouldChange)
+    }
+
+    func testShouldChangeCharactersGivenAmexAndInputWithinFourDigitsShouldAllow() {
+        // Given
+        item.selectedCard = .americanExpress
+        sut.textField.text = "123"
+
+        // When
+        let shouldChange = sut.textField(
+            sut.textField,
+            shouldChangeCharactersIn: NSRange(location: 3, length: 0),
+            replacementString: "4"
+        )
+
+        // Then
+        XCTAssertTrue(shouldChange)
+    }
+
+    func testShouldChangeCharactersGivenAmexAndInputExceedsFourDigitsShouldReject() {
+        // Given
+        item.selectedCard = .americanExpress
+        sut.textField.text = "1234"
+
+        // When
+        let shouldChange = sut.textField(
+            sut.textField,
+            shouldChangeCharactersIn: NSRange(location: 4, length: 0),
+            replacementString: "5"
+        )
+
+        // Then
+        XCTAssertFalse(shouldChange)
+    }
+
+    func testShouldChangeCharactersGivenDeletionShouldAlwaysAllow() {
+        // Given
+        sut.textField.text = "123"
+
+        // When
+        let shouldChange = sut.textField(
+            sut.textField,
+            shouldChangeCharactersIn: NSRange(location: 2, length: 1),
+            replacementString: ""
+        )
+
+        // Then
+        XCTAssertTrue(shouldChange)
+    }
 }

--- a/Tests/IntegrationTests/Card Tests/Validators/CardSecurityCodeValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardSecurityCodeValidatorTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class CardSecurityCodeValidatorTests: XCTestCase {
     
-    func testValidSecurityCodes() {
+    func test_isValid_givenCorrectLengthForBrand_shouldReturnTrue() {
         let observer = AdyenObservable<CardBrand?>(.masterCard)
         let validator = CardSecurityCodeValidator(publisher: observer)
         
@@ -22,7 +22,7 @@ class CardSecurityCodeValidatorTests: XCTestCase {
         XCTAssertTrue(validator.isValid("1234"))
     }
     
-    func testDefaultLengthGivenNilBrandShouldExpectThreeDigits() {
+    func test_defaultLength_givenNilBrand_shouldExpectThreeDigits() {
         let observer = AdyenObservable<CardBrand?>(nil)
         let validator = CardSecurityCodeValidator(publisher: observer)
 
@@ -31,7 +31,7 @@ class CardSecurityCodeValidatorTests: XCTestCase {
         XCTAssertFalse(validator.isValid("1234"))
     }
 
-    func testInvalidSecurityCodes() {
+    func test_isValid_givenIncorrectLength_shouldReturnFalse() {
         let validator = CardSecurityCodeValidator()
         
         XCTAssertFalse(validator.isValid(""))
@@ -40,7 +40,7 @@ class CardSecurityCodeValidatorTests: XCTestCase {
         XCTAssertFalse(validator.isValid("12345"))
     }
     
-    func testEmptyInvalidStatus() {
+    func test_validate_givenEmptyCode_shouldReturnEmptyError() {
         let validator = CardSecurityCodeValidator()
         let status = validator.validate("")
         
@@ -50,7 +50,7 @@ class CardSecurityCodeValidatorTests: XCTestCase {
         XCTAssertEqual(validationError?.analyticsErrorCode, AnalyticsConstants.ValidationErrorCodes.securityCodeEmpty)
     }
     
-    func testPartialInvalidStatus() {
+    func test_validate_givenPartialCode_shouldReturnPartialError() {
         let validator = CardSecurityCodeValidator()
         let status = validator.validate("12")
         
@@ -60,7 +60,7 @@ class CardSecurityCodeValidatorTests: XCTestCase {
         XCTAssertEqual(validationError?.analyticsErrorCode, AnalyticsConstants.ValidationErrorCodes.securityCodePartial)
     }
     
-    func testValidStatusRegular() {
+    func test_validate_givenValidRegularCode_shouldReturnValidStatus() {
         let validator = CardSecurityCodeValidator()
         let status = validator.validate("123")
         
@@ -68,7 +68,7 @@ class CardSecurityCodeValidatorTests: XCTestCase {
         XCTAssertTrue(status.isValid)
     }
     
-    func testValidStatusAmex() {
+    func test_validate_givenAmexBrand_shouldRequireFourDigits() {
         let validator = CardSecurityCodeValidator(cardBrand: .americanExpress)
         let invalidStatus = validator.validate("123")
         

--- a/Tests/IntegrationTests/Card Tests/Validators/CardSecurityCodeValidatorTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Validators/CardSecurityCodeValidatorTests.swift
@@ -22,6 +22,15 @@ class CardSecurityCodeValidatorTests: XCTestCase {
         XCTAssertTrue(validator.isValid("1234"))
     }
     
+    func testDefaultLengthGivenNilBrandShouldExpectThreeDigits() {
+        let observer = AdyenObservable<CardBrand?>(nil)
+        let validator = CardSecurityCodeValidator(publisher: observer)
+
+        XCTAssertFalse(validator.isValid("12"))
+        XCTAssertTrue(validator.isValid("123"))
+        XCTAssertFalse(validator.isValid("1234"))
+    }
+
     func testInvalidSecurityCodes() {
         let validator = CardSecurityCodeValidator()
         


### PR DESCRIPTION
# Summary [Required]

Fixes card security code (CVC/CVV) input accepting more than its expected length, being validated and submitted even though the extra digits are masked, because the cap was applied to the formatted value but not to the stored value.

# Demo [Optional]
These demo videos are provided for Non-Amex flow where the expected length is max 3. 

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/624bc1b7-97d5-4e38-9577-0dbf0d780b89" width="320"> | <img src="https://github.com/user-attachments/assets/00807f5a-79f3-4b1e-98ad-140a05417209" width="320"> |

<fixed>
- Fixed the card security code (CVC/CVV) field accepting more than the allowed number of digits, which could submit an over-length code while only showing the truncated value
</fixed>

## Testing Instructions [Optional]

1. Card component, non-Amex card (e.g. Visa): the CVC field stops accepting input after 3 digits; the submitted value is 3 digits.
2. Amex card: the CVC field accepts 4 digits.
3. Paste a long numeric string into the CVC field: it is truncated to the expected length in both the display and the submitted value.

## Ticket [Optional]
<ticket>
COSDK- 572
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
