### PR TITLE
🔥 Firebase: Add build version name input to Firebase distribution job

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       build_version_name:
-        description: 'Version name shown in Firebase App Distribution (e.g. 6.0.0-beta.1). Defaults to the version in Demo/UIKit/Info.plist'
-        required: false
+        description: 'Version name shown in Firebase App Distribution (e.g. 6.0.0-beta.1)'
+        required: true
         type: string
       build_number:
         description: 'Build number shown in Firebase App Distribution. Defaults to the build number in the project'

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -3,10 +3,6 @@ name: 📱🔥 Firebase Distribution
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Branch to build and distribute. Defaults to the branch this workflow runs on'
-        required: false
-        type: string
       build_version_name:
         description: 'Version name shown in Firebase App Distribution (e.g. 6.0.0-beta.1). Defaults to the version in Demo/UIKit/Info.plist'
         required: false
@@ -28,10 +24,8 @@ jobs:
     runs-on: macos-26-xlarge
 
     steps:
-      - name: 🪾 Checkout selected branch
+      - name: 🪾 Checkout
         uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.branch }}
 
       - uses: actions/setup-node@v7
         with:
@@ -43,10 +37,9 @@ jobs:
       - name: 📝 Create Firebase release name
         id: firebase_release_name
         env:
-          INPUT_BRANCH: ${{ inputs.branch }}
           BUILD_VERSION_NAME: ${{ inputs.build_version_name }}
         run: |
-          BRANCH_NAME="${INPUT_BRANCH:-${GITHUB_REF#refs/heads/}}"
+          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
           SHORT_SHA=$(git rev-parse --short HEAD)
           FIREBASE_RELEASE_NAME="firebase-${BUILD_VERSION_NAME:-$BRANCH_NAME}-${SHORT_SHA}"
           echo "FIREBASE_RELEASE_NAME=$FIREBASE_RELEASE_NAME" >> $GITHUB_ENV

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -1,8 +1,21 @@
 name: 📱🔥 Firebase Distribution
 
 on:
-  workflow_dispatch: {}
-        
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build and distribute. Defaults to the branch this workflow runs on'
+        required: false
+        type: string
+      build_version_name:
+        description: 'Version name shown in Firebase App Distribution (e.g. 6.0.0-beta.1). Defaults to the version in Demo/UIKit/Info.plist'
+        required: false
+        type: string
+      build_number:
+        description: 'Build number shown in Firebase App Distribution. Defaults to the build number in the project'
+        required: false
+        type: string
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -18,7 +31,7 @@ jobs:
       - name: 🪾 Checkout selected branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ inputs.branch }}
 
       - uses: actions/setup-node@v7
         with:
@@ -29,10 +42,13 @@ jobs:
 
       - name: 📝 Create Firebase release name
         id: firebase_release_name
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          BUILD_VERSION_NAME: ${{ inputs.build_version_name }}
         run: |
-          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
+          BRANCH_NAME="${INPUT_BRANCH:-${GITHUB_REF#refs/heads/}}"
           SHORT_SHA=$(git rev-parse --short HEAD)
-          FIREBASE_RELEASE_NAME="firebase-${BRANCH_NAME}-${SHORT_SHA}"
+          FIREBASE_RELEASE_NAME="firebase-${BUILD_VERSION_NAME:-$BRANCH_NAME}-${SHORT_SHA}"
           echo "FIREBASE_RELEASE_NAME=$FIREBASE_RELEASE_NAME" >> $GITHUB_ENV
           echo "Release name set to $FIREBASE_RELEASE_NAME"
 
@@ -66,6 +82,10 @@ jobs:
           ADYEN_SERVER_API_KEY: ${{ secrets.DEMO_SERVER_TEST_ENV_API_KEY }}
           APPLE_TEAM_IDENTIFIER: ${{ secrets.APPLE_DEVELOPMENT_TEAM_ID }}
           ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
+
+          # Version overrides (optional)
+          BUILD_VERSION_NAME: ${{ inputs.build_version_name }}
+          BUILD_NUMBER: ${{ inputs.build_number }}
         run: |
-          chmod +x ./Scripts/publish-demo-app.sh
-          ./Scripts/publish-demo-app.sh "firebase"
+          chmod +x ./Scripts/publish-demo-app-firebase.sh
+          ./Scripts/publish-demo-app-firebase.sh

--- a/Scripts/publish-demo-app-firebase.sh
+++ b/Scripts/publish-demo-app-firebase.sh
@@ -12,16 +12,18 @@ EXPORT_OPTIONS_PLIST="$SCRIPT_DIR/exportOptions-Firebase.plist"
 EXPORT_CONFIGURATION="Firebase"
 PLIST_BUDDY=/usr/libexec/PlistBuddy
 
-# ---- Optional version overrides ----
+# ---- Version ----
 # Firebase App Distribution labels every release with the CFBundleShortVersionString (CFBundleVersion)
 # baked into the uploaded IPA, so both have to be set before archiving.
-# When either is empty the value committed in the project is used instead.
-BUILD_VERSION_NAME="${BUILD_VERSION_NAME:-}"
+# BUILD_VERSION_NAME is required; an empty BUILD_NUMBER keeps the one committed in the project.
 BUILD_NUMBER="${BUILD_NUMBER:-}"
 
 echo "📦 Using Firebase export options: $EXPORT_OPTIONS_PLIST"
 
 # ---- Required environment variables ----
+# Version
+: "${BUILD_VERSION_NAME:?Environment variable BUILD_VERSION_NAME not set}"
+
 # Apple credentials
 : "${APPLE_ID_USERNAME:?Environment variable APPLE_ID_USERNAME not set}"
 : "${APPLE_APP_SPECIFIC_PASSWORD:?Environment variable APPLE_APP_SPECIFIC_PASSWORD not set}"
@@ -53,14 +55,12 @@ echo "📦 Using Firebase export options: $EXPORT_OPTIONS_PLIST"
 
 echo "ℹ️ Firebase env vars validated."
 
-# ---- Apply the version name override ----
+# ---- Apply the version name ----
 # Restored on exit so a local run doesn't leave the working tree dirty.
-if [[ -n "$BUILD_VERSION_NAME" ]]; then
-  echo "🏷️ Setting version name to $BUILD_VERSION_NAME..."
-  cp "$INFO_PLIST_PATH" "$INFO_PLIST_BACKUP_PATH"
-  trap 'mv -f "$INFO_PLIST_BACKUP_PATH" "$INFO_PLIST_PATH"' EXIT
-  "$PLIST_BUDDY" -c "Set :CFBundleShortVersionString $BUILD_VERSION_NAME" "$INFO_PLIST_PATH"
-fi
+echo "🏷️ Setting version name to $BUILD_VERSION_NAME..."
+cp "$INFO_PLIST_PATH" "$INFO_PLIST_BACKUP_PATH"
+trap 'mv -f "$INFO_PLIST_BACKUP_PATH" "$INFO_PLIST_PATH"' EXIT
+"$PLIST_BUDDY" -c "Set :CFBundleShortVersionString $BUILD_VERSION_NAME" "$INFO_PLIST_PATH"
 
 # ---- Apply the build number override ----
 # CFBundleVersion already resolves to $(CURRENT_PROJECT_VERSION), so an archive setting is enough.

--- a/Scripts/publish-demo-app-firebase.sh
+++ b/Scripts/publish-demo-app-firebase.sh
@@ -12,6 +12,35 @@ EXPORT_OPTIONS_PLIST="$SCRIPT_DIR/exportOptions-Firebase.plist"
 EXPORT_CONFIGURATION="Firebase"
 PLIST_BUDDY=/usr/libexec/PlistBuddy
 
+# Secrets written to disk further down, wiped by the cleanup below.
+AUTH_KEY_PATH=""
+FIREBASE_JSON_PATH=""
+
+# Set on the last line; anything earlier means the script was cut short.
+SCRIPT_SUCCEEDED=false
+
+# Single EXIT handler: a second `trap ... EXIT` would silently replace this one.
+# The status has to be re-raised explicitly, and a premature exit forced to non-zero: with an EXIT
+# trap installed, bash reports 0 for `${VAR:?}` and `set -u` aborts, which would turn a missing
+# secret into a green build.
+cleanup() {
+  local exit_status=$?
+  if [[ -f "$INFO_PLIST_BACKUP_PATH" ]]; then
+    mv -f "$INFO_PLIST_BACKUP_PATH" "$INFO_PLIST_PATH"
+  fi
+  if [[ -n "$AUTH_KEY_PATH" ]]; then
+    rm -f "$AUTH_KEY_PATH"
+  fi
+  if [[ -n "$FIREBASE_JSON_PATH" ]]; then
+    rm -f "$FIREBASE_JSON_PATH"
+  fi
+  if [[ "$SCRIPT_SUCCEEDED" != true ]] && [[ "$exit_status" -eq 0 ]]; then
+    exit_status=1
+  fi
+  exit "$exit_status"
+}
+trap cleanup EXIT
+
 # ---- Version ----
 # Firebase App Distribution labels every release with the CFBundleShortVersionString (CFBundleVersion)
 # baked into the uploaded IPA, so both have to be set before archiving.
@@ -56,10 +85,9 @@ echo "📦 Using Firebase export options: $EXPORT_OPTIONS_PLIST"
 echo "ℹ️ Firebase env vars validated."
 
 # ---- Apply the version name ----
-# Restored on exit so a local run doesn't leave the working tree dirty.
+# The backup is restored by cleanup() so a local run doesn't leave the working tree dirty.
 echo "🏷️ Setting version name to $BUILD_VERSION_NAME..."
 cp "$INFO_PLIST_PATH" "$INFO_PLIST_BACKUP_PATH"
-trap 'mv -f "$INFO_PLIST_BACKUP_PATH" "$INFO_PLIST_PATH"' EXIT
 "$PLIST_BUDDY" -c "Set :CFBundleShortVersionString $BUILD_VERSION_NAME" "$INFO_PLIST_PATH"
 
 # ---- Apply the build number override ----
@@ -133,7 +161,7 @@ xcodebuild archive \
 # ---- Export IPA with signing ----
 AUTH_KEY_PATH="$RUNNER_TEMP/auth_key.p8"
 echo -n "$XCODE_AUTHENTICATION_KEY_BASE64" | base64 --decode > "$AUTH_KEY_PATH"
-chmod 600 "$AUTH_KEY_PATH"  # restrict permissions
+chmod 600 "$AUTH_KEY_PATH"  # redirection uses the umask, so restrict explicitly. Removed by cleanup()
 
 echo "📤 Exporting .ipa with manual signing..."
 xcodebuild -exportArchive \
@@ -149,10 +177,12 @@ xcodebuild -exportArchive \
 # ---- Distribution ----
 echo "🔥 Uploading to Firebase App Distribution..."
 
-# Write service account JSON to temp file
+# Write service account JSON to temp file.
+# mktemp creates it 0600 regardless of umask, so no chmod is needed here — unlike AUTH_KEY_PATH above,
+# which shell redirection creates using the umask. Removed by cleanup().
 FIREBASE_JSON_PATH="$(mktemp)"
 echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$FIREBASE_JSON_PATH"
-export GOOGLE_APPLICATION_CREDENTIALS=$FIREBASE_JSON_PATH
+export GOOGLE_APPLICATION_CREDENTIALS="$FIREBASE_JSON_PATH"
 
 # Upload
 firebase appdistribution:distribute "$IPA_PATH" \
@@ -161,3 +191,5 @@ firebase appdistribution:distribute "$IPA_PATH" \
   --release-notes "Release: ${FIREBASE_RELEASE_NAME}, Version: ${RESOLVED_VERSION_NAME} (${BUILD_NUMBER:-project default}), Branch: ${GITHUB_REF_NAME:-manual}, Build: ${GITHUB_SHA:-manual}"
 
 echo "✅ Firebase upload complete! Release name: $FIREBASE_RELEASE_NAME"
+
+SCRIPT_SUCCEEDED=true

--- a/Scripts/publish-demo-app-firebase.sh
+++ b/Scripts/publish-demo-app-firebase.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+set -euo pipefail
+
+# Constants
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_PATH="$SCRIPT_DIR/../Build-Temp"
+ARCHIVE_PATH="$BUILD_PATH/AdyenUIHost.xcarchive"
+IPA_PATH="$BUILD_PATH/AdyenUIHost.ipa"
+INFO_PLIST_PATH="$SCRIPT_DIR/../Demo/UIKit/Info.plist"
+INFO_PLIST_BACKUP_PATH="$INFO_PLIST_PATH.original"
+EXPORT_OPTIONS_PLIST="$SCRIPT_DIR/exportOptions-Firebase.plist"
+EXPORT_CONFIGURATION="Firebase"
+PLIST_BUDDY=/usr/libexec/PlistBuddy
+
+# ---- Optional version overrides ----
+# Firebase App Distribution labels every release with the CFBundleShortVersionString (CFBundleVersion)
+# baked into the uploaded IPA, so both have to be set before archiving.
+# When either is empty the value committed in the project is used instead.
+BUILD_VERSION_NAME="${BUILD_VERSION_NAME:-}"
+BUILD_NUMBER="${BUILD_NUMBER:-}"
+
+echo "📦 Using Firebase export options: $EXPORT_OPTIONS_PLIST"
+
+# ---- Required environment variables ----
+# Apple credentials
+: "${APPLE_ID_USERNAME:?Environment variable APPLE_ID_USERNAME not set}"
+: "${APPLE_APP_SPECIFIC_PASSWORD:?Environment variable APPLE_APP_SPECIFIC_PASSWORD not set}"
+
+# Xcode signing key
+: "${XCODE_AUTHENTICATION_KEY_ID:?Environment variable XCODE_AUTHENTICATION_KEY_ID not set}"
+: "${XCODE_AUTHENTICATION_KEY_ISSUER_ID:?Environment variable XCODE_AUTHENTICATION_KEY_ISSUER_ID not set}"
+: "${XCODE_AUTHENTICATION_KEY_BASE64:?Environment variable XCODE_AUTHENTICATION_KEY_BASE64 not set}"
+
+# Build certificates & profiles
+: "${BUILD_CERTIFICATE_BASE64:?Environment variable BUILD_CERTIFICATE_BASE64 not set}"
+: "${DEVELOPMENT_CERTIFICATE_BASE64:?Environment variable DEVELOPMENT_CERTIFICATE_BASE64 not set}"
+: "${P12_PASSWORD:?Environment variable P12_PASSWORD not set}"
+: "${BUILD_PROVISION_PROFILE_BASE64:?Environment variable BUILD_PROVISION_PROFILE_BASE64 not set}"
+: "${KEYCHAIN_PASSWORD:?Environment variable KEYCHAIN_PASSWORD not set}"
+
+# App configuration
+: "${MERCHANT_CLIENT_KEY:?Environment variable MERCHANT_CLIENT_KEY not set}"
+: "${MERCHANT_SERVER_HOST:?Environment variable MERCHANT_SERVER_HOST not set}"
+: "${MERCHANT_ACCOUNT:?Environment variable MERCHANT_ACCOUNT not set}"
+: "${ADYEN_SERVER_API_KEY:?Environment variable ADYEN_SERVER_API_KEY not set}"
+: "${APPLE_TEAM_IDENTIFIER:?Environment variable APPLE_TEAM_IDENTIFIER not set}"
+: "${ENVIRONMENT:?Environment variable ENVIRONMENT not set}"
+
+# Firebase configuration
+: "${FIREBASE_SERVICE_ACCOUNT_JSON:?Environment variable FIREBASE_SERVICE_ACCOUNT_JSON not set}"
+: "${FIREBASE_APP_ID:?Environment variable FIREBASE_APP_ID not set}"
+: "${FIREBASE_RELEASE_NAME:?Environment variable FIREBASE_RELEASE_NAME not set}"
+
+echo "ℹ️ Firebase env vars validated."
+
+# ---- Apply the version name override ----
+# Restored on exit so a local run doesn't leave the working tree dirty.
+if [[ -n "$BUILD_VERSION_NAME" ]]; then
+  echo "🏷️ Setting version name to $BUILD_VERSION_NAME..."
+  cp "$INFO_PLIST_PATH" "$INFO_PLIST_BACKUP_PATH"
+  trap 'mv -f "$INFO_PLIST_BACKUP_PATH" "$INFO_PLIST_PATH"' EXIT
+  "$PLIST_BUDDY" -c "Set :CFBundleShortVersionString $BUILD_VERSION_NAME" "$INFO_PLIST_PATH"
+fi
+
+# ---- Apply the build number override ----
+# CFBundleVersion already resolves to $(CURRENT_PROJECT_VERSION), so an archive setting is enough.
+ARCHIVE_OVERRIDES=()
+if [[ -n "$BUILD_NUMBER" ]]; then
+  echo "🏷️ Setting build number to $BUILD_NUMBER..."
+  ARCHIVE_OVERRIDES+=("CURRENT_PROJECT_VERSION=$BUILD_NUMBER")
+fi
+
+RESOLVED_VERSION_NAME="$("$PLIST_BUDDY" -c "Print :CFBundleShortVersionString" "$INFO_PLIST_PATH")"
+echo "🔖 Distributing $RESOLVED_VERSION_NAME (${BUILD_NUMBER:-project default})"
+
+# ---- Install certificates & provisioning profiles ----
+echo "🛡️ Installing certificates and provisioning profile..."
+
+CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+DEV_CERTIFICATE_PATH=$RUNNER_TEMP/dev_certificate.p12
+PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+echo -n "$DEVELOPMENT_CERTIFICATE_BASE64" | base64 --decode -o $DEV_CERTIFICATE_PATH
+echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+security import $DEV_CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+security list-keychain -d user -s $KEYCHAIN_PATH
+
+mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
+echo "✅ Certificates and provisioning profile installed."
+
+# ---- Clean project ----
+echo "🧹 Cleaning project..."
+xcodebuild clean -project Adyen.xcodeproj \
+  -scheme AdyenUIHost \
+  -sdk iphoneos \
+  -configuration "$EXPORT_CONFIGURATION" \
+  -skipPackagePluginValidation
+
+# ---- Prepare build folder ----
+echo "📁 Creating build directory..."
+rm -rf "$BUILD_PATH"
+mkdir -p "$BUILD_PATH"
+
+# ---- Archive app ----
+echo "📦 Archiving app (signing disabled)..."
+xcodebuild archive \
+  -project Adyen.xcodeproj \
+  -scheme AdyenUIHost \
+  -configuration "$EXPORT_CONFIGURATION" \
+  -archivePath "$ARCHIVE_PATH" \
+  -destination "generic/platform=iOS" \
+  -sdk iphoneos \
+  -skipPackagePluginValidation \
+  CODE_SIGNING_ALLOWED=NO \
+  MERCHANT_CLIENT_KEY="$MERCHANT_CLIENT_KEY" \
+  MERCHANT_SERVER_HOST="$MERCHANT_SERVER_HOST" \
+  MERCHANT_ACCOUNT="$MERCHANT_ACCOUNT" \
+  ADYEN_SERVER_API_KEY="$ADYEN_SERVER_API_KEY" \
+  APPLE_TEAM_IDENTIFIER="$APPLE_TEAM_IDENTIFIER" \
+  APPLE_PAY_MERCHANT_IDENTIFIER="${APPLE_PAY_MERCHANT_IDENTIFIER:-"merchant.com.adyen.test"}" \
+  ${ARCHIVE_OVERRIDES[@]+"${ARCHIVE_OVERRIDES[@]}"}
+
+# ---- Export IPA with signing ----
+AUTH_KEY_PATH="$RUNNER_TEMP/auth_key.p8"
+echo -n "$XCODE_AUTHENTICATION_KEY_BASE64" | base64 --decode > "$AUTH_KEY_PATH"
+chmod 600 "$AUTH_KEY_PATH"  # restrict permissions
+
+echo "📤 Exporting .ipa with manual signing..."
+xcodebuild -exportArchive \
+  -archivePath "$ARCHIVE_PATH" \
+  -exportOptionsPlist "$EXPORT_OPTIONS_PLIST" \
+  -exportPath "$BUILD_PATH" \
+  -allowProvisioningUpdates \
+  -authenticationKeyID "$XCODE_AUTHENTICATION_KEY_ID" \
+  -authenticationKeyIssuerID "$XCODE_AUTHENTICATION_KEY_ISSUER_ID" \
+  -authenticationKeyPath "$AUTH_KEY_PATH" \
+  -skipPackagePluginValidation
+
+# ---- Distribution ----
+echo "🔥 Uploading to Firebase App Distribution..."
+
+# Write service account JSON to temp file
+FIREBASE_JSON_PATH="$(mktemp)"
+echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$FIREBASE_JSON_PATH"
+export GOOGLE_APPLICATION_CREDENTIALS=$FIREBASE_JSON_PATH
+
+# Upload
+firebase appdistribution:distribute "$IPA_PATH" \
+  --app "$FIREBASE_APP_ID" \
+  --groups "ios-checkout-team" \
+  --release-notes "Release: ${FIREBASE_RELEASE_NAME}, Version: ${RESOLVED_VERSION_NAME} (${BUILD_NUMBER:-project default}), Branch: ${GITHUB_REF_NAME:-manual}, Build: ${GITHUB_SHA:-manual}"
+
+echo "✅ Firebase upload complete! Release name: $FIREBASE_RELEASE_NAME"

--- a/Scripts/publish-demo-app-firebase.sh
+++ b/Scripts/publish-demo-app-firebase.sh
@@ -104,25 +104,26 @@ echo "🔖 Distributing $RESOLVED_VERSION_NAME (${BUILD_NUMBER:-project default}
 # ---- Install certificates & provisioning profiles ----
 echo "🛡️ Installing certificates and provisioning profile..."
 
-CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-DEV_CERTIFICATE_PATH=$RUNNER_TEMP/dev_certificate.p12
-PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
+DEV_CERTIFICATE_PATH="$RUNNER_TEMP/dev_certificate.p12"
+PP_PATH="$RUNNER_TEMP/build_pp.mobileprovision"
+KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+PROFILES_PATH="$HOME/Library/MobileDevice/Provisioning Profiles"
 
-echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
-echo -n "$DEVELOPMENT_CERTIFICATE_BASE64" | base64 --decode -o $DEV_CERTIFICATE_PATH
-echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERTIFICATE_PATH"
+echo -n "$DEVELOPMENT_CERTIFICATE_BASE64" | base64 --decode -o "$DEV_CERTIFICATE_PATH"
+echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
 
-security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-security import $DEV_CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-security list-keychain -d user -s $KEYCHAIN_PATH
+security import "$CERTIFICATE_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+security import "$DEV_CERTIFICATE_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+security list-keychain -d user -s "$KEYCHAIN_PATH"
 
-mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+mkdir -p "$PROFILES_PATH"
+cp "$PP_PATH" "$PROFILES_PATH"
 
 echo "✅ Certificates and provisioning profile installed."
 


### PR DESCRIPTION
# Summary

Firebase App Distribution labelled every release with whatever semantic version happened to be committed in the demo app, so builds from different branches were indistinguishable in the panel. The version name is now a required input on the workflow, with an optional build number alongside it. Publishing moves to a new Firebase-specific script that writes those values into the demo app before archiving, since Firebase reads the label from the uploaded IPA.

## Technical Information

- The demo app version lives in `Demo/UIKit/Info.plist` (`CFBundleShortVersionString`), **not** in `MARKETING_VERSION`, which is empty for `AdyenUIHost`. Overriding `MARKETING_VERSION` via `xcodebuild` would have had no effect, so the script rewrites the plist before archiving and restores it on exit (nothing is committed).
- The build number is passed as a `CURRENT_PROJECT_VERSION` override instead, since `CFBundleVersion` already resolves to it.
- New standalone `Scripts/publish-demo-app-firebase.sh`. `publish-demo-app.sh` is untouched; its now-unused `firebase` path can be removed separately.
- The version name is enforced both by `required: true` and by a `:?` check in the script, because GitHub does not reject an empty string for a required `workflow_dispatch` input.

## Testing Instructions

1. Run the **📱🔥 Firebase Distribution** workflow, selecting this branch under *"Use workflow from"*.
2. Enter a version name (e.g. `6.0.0-beta.1`) and optionally a build number.
3. Confirm the release in the Firebase App Distribution panel is labelled with exactly those values.

## Checklist

- [x] Tested changes locally (dry run with `xcodebuild`/`firebase` stubbed on `PATH`, covering unset/empty/version-only/version+build; a real archive still needs a workflow run)
- [x] Verified against acceptance criteria