### PR TITLE
Extract CVC/CVV length rule into a single source of truth

### DIFF
--- a/AdyenCard/Form/FormCardSecurityCodeItemView.swift
+++ b/AdyenCard/Form/FormCardSecurityCodeItemView.swift
@@ -26,7 +26,7 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
         
         observe(item.$selectedCard) { [weak self] cardsType in
             guard let self else { return }
-            let number = cardsType == CardBrand.americanExpress ? "4" : "3"
+            let number = String(cardsType.expectedSecurityCodeLength)
             let localizedPlaceholder = localizedString(.cardCvcItemPlaceholderDigits, item.localizationParameters, number)
             
             // Set placeholder on item - it will be shown in footer label reactively
@@ -95,7 +95,7 @@ internal final class FormCardSecurityCodeItemView: FormTextItemView<FormCardSecu
     }
     
     private var expectedLength: Int {
-        item.selectedCard == CardBrand.americanExpress ? 4 : 3
+        item.selectedCard.expectedSecurityCodeLength
     }
 }
 

--- a/AdyenCard/Formatters/CardSecurityCodeFormatter.swift
+++ b/AdyenCard/Formatters/CardSecurityCodeFormatter.swift
@@ -9,26 +9,25 @@ import Foundation
 
 /// Formats a card's security code (CVC/CVV).
 public final class CardSecurityCodeFormatter: NumericFormatter {
-    
-    /// Indicate is validating CVV belong to a Amex card
+
     private var cardBrand: CardBrand?
     private var expectedLength: Int {
-        cardBrand == CardBrand.americanExpress ? 4 : 3
+        cardBrand.expectedSecurityCodeLength
     }
     
-    /// Initiate new instance of CardSecurityCodeValidator
+    /// Initiate new instance of CardSecurityCodeFormatter
     override public init() {
         super.init()
     }
     
-    /// Initiate new instance of CardSecurityCodeValidator
+    /// Initiate new instance of CardSecurityCodeFormatter
     /// - Parameter publisher: observer of a card type.
     public init(publisher: AdyenObservable<CardBrand?>) {
         super.init()
         bind(publisher, to: self, at: \.cardBrand)
     }
     
-    /// Initiate new instance of CardSecurityCodeValidator with a fixed ``CardBrand``
+    /// Initiate new instance of CardSecurityCodeFormatter with a fixed ``CardBrand``
     /// - Parameter cardBrand: The card brand to format the security code for
     public init(cardBrand: CardBrand) {
         super.init()

--- a/AdyenCard/Utilities/CardBrand/CardBrand+SecurityCode.swift
+++ b/AdyenCard/Utilities/CardBrand/CardBrand+SecurityCode.swift
@@ -6,10 +6,17 @@
 
 import Adyen
 
+extension CardBrand {
+    /// Expected security code (CVC/CVV) length: 4 for Amex, 3 for any other brand.
+    internal var expectedSecurityCodeLength: Int {
+        self == .americanExpress ? Constants.amexLength : Constants.generalLength
+    }
+}
+
 extension CardBrand? {
     /// Expected security code (CVC/CVV) length: 4 for Amex, 3 for any other or undetected brand.
     internal var expectedSecurityCodeLength: Int {
-        self == .americanExpress ? Constants.amexLength : Constants.generalLength
+        self?.expectedSecurityCodeLength ?? Constants.generalLength
     }
 }
 

--- a/AdyenCard/Utilities/CardBrand/CardBrand+SecurityCode.swift
+++ b/AdyenCard/Utilities/CardBrand/CardBrand+SecurityCode.swift
@@ -11,16 +11,16 @@ extension CardBrand {
     internal var expectedSecurityCodeLength: Int {
         self == .americanExpress ? Constants.amexLength : Constants.generalLength
     }
+
+    fileprivate enum Constants {
+        static let amexLength = 4
+        static let generalLength = 3
+    }
 }
 
 extension CardBrand? {
     /// Expected security code (CVC/CVV) length: 4 for Amex, 3 for any other or undetected brand.
     internal var expectedSecurityCodeLength: Int {
-        self?.expectedSecurityCodeLength ?? Constants.generalLength
+        self?.expectedSecurityCodeLength ?? CardBrand.Constants.generalLength
     }
-}
-
-private enum Constants {
-    static let amexLength = 4
-    static let generalLength = 3
 }

--- a/AdyenCard/Utilities/CardBrand/CardBrand+SecurityCode.swift
+++ b/AdyenCard/Utilities/CardBrand/CardBrand+SecurityCode.swift
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+
+extension CardBrand? {
+    /// Expected security code (CVC/CVV) length: 4 for Amex, 3 for any other or undetected brand.
+    internal var expectedSecurityCodeLength: Int {
+        self == .americanExpress ? Constants.amexLength : Constants.generalLength
+    }
+}
+
+private enum Constants {
+    static let amexLength = 4
+    static let generalLength = 3
+}

--- a/AdyenCard/Validators/CardSecurityCodeValidator.swift
+++ b/AdyenCard/Validators/CardSecurityCodeValidator.swift
@@ -37,7 +37,7 @@ public final class CardSecurityCodeValidator: NumericStringValidator, AdyenObser
     }
     
     private func updateExpectedLength(from cardBrand: CardBrand?) {
-        let length = cardBrand == .americanExpress ? 4 : 3
+        let length = cardBrand.expectedSecurityCodeLength
         maximumLength = length
         minimumLength = length
     }

--- a/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
@@ -244,11 +244,11 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertTrue(item.isValid())
     }
 
-    func testPlaceholderGivenNonAmexShouldShowThreeDigitPlaceholder() {
+    func test_placeholder_givenNonAmex_shouldShowThreeDigits() {
         assert(for: .masterCard, showsDigits: 3)
     }
 
-    func testPlaceholderGivenAmexShouldShowFourDigitPlaceholder() {
+    func test_placeholder_givenAmex_shouldShowFourDigits() {
         assert(for: .americanExpress, showsDigits: 4)
     }
 

--- a/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Items/CardSecurityCodeItem/FormCardSecurityCodeItemViewTests.swift
@@ -243,4 +243,23 @@ class FormCardSecurityCodeItemViewTests: XCTestCase {
         XCTAssertEqual(item.formattedValue, "1234")
         XCTAssertTrue(item.isValid())
     }
+
+    func testPlaceholderGivenNonAmexShouldShowThreeDigitPlaceholder() {
+        assert(for: .masterCard, showsDigits: 3)
+    }
+
+    func testPlaceholderGivenAmexShouldShowFourDigitPlaceholder() {
+        assert(for: .americanExpress, showsDigits: 4)
+    }
+
+    private func assert(
+        for brand: CardBrand,
+        showsDigits digits: Int,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let expectedPlaceholder = localizedString(.cardCvcItemPlaceholderDigits, item.localizationParameters, String(digits))
+        item.selectedCard = brand
+        XCTAssertEqual(item.placeholder, expectedPlaceholder, file: file, line: line)
+    }
 }

--- a/Tests/IntegrationTests/Card Tests/Utilities/CardBrandSecurityCodeTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/CardBrandSecurityCodeTests.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenCard
+import XCTest
+
+class CardBrandSecurityCodeTests: XCTestCase {
+
+    func testExpectedSecurityCodeLengthGivenAmexShouldReturnFour() {
+        assert(brand: .americanExpress, expectedLength: 4)
+    }
+
+    func testExpectedSecurityCodeLengthGivenNonAmexShouldReturnThree() {
+        assert(brand: .masterCard, expectedLength: 3)
+    }
+
+    func testExpectedSecurityCodeLengthGivenNilShouldReturnThree() {
+        assert(brand: nil, expectedLength: 3)
+    }
+
+    private func assert(
+        brand: CardBrand?,
+        expectedLength: Int,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(brand.expectedSecurityCodeLength, expectedLength, file: file, line: line)
+    }
+}

--- a/Tests/IntegrationTests/Card Tests/Utilities/CardBrandSecurityCodeTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/CardBrandSecurityCodeTests.swift
@@ -10,23 +10,23 @@ import XCTest
 
 class CardBrandSecurityCodeTests: XCTestCase {
 
-    func testExpectedSecurityCodeLengthGivenAmexShouldReturnFour() {
+    func test_expectedSecurityCodeLength_givenAmex_shouldReturnFour() {
         assert(brand: .americanExpress, expectedLength: 4)
     }
 
-    func testExpectedSecurityCodeLengthGivenNonAmexShouldReturnThree() {
+    func test_expectedSecurityCodeLength_givenNonAmex_shouldReturnThree() {
         assert(brand: .masterCard, expectedLength: 3)
     }
 
-    func testExpectedSecurityCodeLengthGivenNilShouldReturnThree() {
+    func test_expectedSecurityCodeLength_givenNil_shouldReturnThree() {
         assert(brand: nil, expectedLength: 3)
     }
 
-    func testExpectedSecurityCodeLengthOnConcreteBrandGivenAmexShouldReturnFour() {
+    func test_expectedSecurityCodeLength_givenConcreteAmexBrand_shouldReturnFour() {
         assert(concreteBrand: .americanExpress, expectedLength: 4)
     }
 
-    func testExpectedSecurityCodeLengthOnConcreteBrandGivenNonAmexShouldReturnThree() {
+    func test_expectedSecurityCodeLength_givenConcreteNonAmexBrand_shouldReturnThree() {
         assert(concreteBrand: .masterCard, expectedLength: 3)
     }
 

--- a/Tests/IntegrationTests/Card Tests/Utilities/CardBrandSecurityCodeTests.swift
+++ b/Tests/IntegrationTests/Card Tests/Utilities/CardBrandSecurityCodeTests.swift
@@ -22,6 +22,14 @@ class CardBrandSecurityCodeTests: XCTestCase {
         assert(brand: nil, expectedLength: 3)
     }
 
+    func testExpectedSecurityCodeLengthOnConcreteBrandGivenAmexShouldReturnFour() {
+        assert(concreteBrand: .americanExpress, expectedLength: 4)
+    }
+
+    func testExpectedSecurityCodeLengthOnConcreteBrandGivenNonAmexShouldReturnThree() {
+        assert(concreteBrand: .masterCard, expectedLength: 3)
+    }
+
     private func assert(
         brand: CardBrand?,
         expectedLength: Int,
@@ -29,5 +37,14 @@ class CardBrandSecurityCodeTests: XCTestCase {
         line: UInt = #line
     ) {
         XCTAssertEqual(brand.expectedSecurityCodeLength, expectedLength, file: file, line: line)
+    }
+
+    private func assert(
+        concreteBrand: CardBrand,
+        expectedLength: Int,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(concreteBrand.expectedSecurityCodeLength, expectedLength, file: file, line: line)
     }
 }


### PR DESCRIPTION
# Summary [Required]
<!-- Provide a concise description (2-4 sentences) of what changes this PR implements and why -->

## Key changes

- Introduces a single source of truth for the card security code length: `CardBrand?.expectedSecurityCodeLength`, which returns **4 for American Express** and **3 for every other or undetected brand**.
- The `CardSecurityCodeFormatter`, `CardSecurityCodeValidator`, and `FormCardSecurityCodeItemView` now derive the length from this one property instead of each re-implementing the `4 : 3` rule.
- Cleans up misleading documentation in `CardSecurityCodeFormatter `. 


## Ticket [Optional]
<ticket>
COSDK-572
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [ ] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)
