### PR TITLE
🔥 Firebase: Add a weekday nightly v6 distribution

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -2,7 +2,7 @@ name: 📱🔥 Firebase Distribution
 
 on:
   workflow_dispatch:
-    inputs:
+    inputs: &inputs # Anchored so the workflow_call trigger below reuses the same definitions
       build_version_name:
         description: 'Version name shown in Firebase App Distribution (e.g. 6.0.0-beta.1)'
         required: true
@@ -15,20 +15,8 @@ on:
         description: 'Release notes shown in Firebase App Distribution. Defaults to the branch name and build metadata'
         required: false
         type: string
-  workflow_call: # Inputs have to be repeated: GitHub does not share them between triggers
-    inputs:
-      build_version_name:
-        description: 'Version name shown in Firebase App Distribution (e.g. 6.0.0-beta.1)'
-        required: true
-        type: string
-      build_number:
-        description: 'Build number shown in Firebase App Distribution. Defaults to the build number in the project'
-        required: false
-        type: string
-      release_notes:
-        description: 'Release notes shown in Firebase App Distribution. Defaults to the branch name and build metadata'
-        required: false
-        type: string
+  workflow_call:
+    inputs: *inputs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -11,6 +11,24 @@ on:
         description: 'Build number shown in Firebase App Distribution. Defaults to the build number in the project'
         required: false
         type: string
+      release_notes:
+        description: 'Text prepended to the Firebase release notes. The build metadata is always appended'
+        required: false
+        type: string
+  workflow_call: # Inputs have to be repeated: GitHub does not share them between triggers
+    inputs:
+      build_version_name:
+        description: 'Version name shown in Firebase App Distribution (e.g. 6.0.0-beta.1)'
+        required: true
+        type: string
+      build_number:
+        description: 'Build number shown in Firebase App Distribution. Defaults to the build number in the project'
+        required: false
+        type: string
+      release_notes:
+        description: 'Text prepended to the Firebase release notes. The build metadata is always appended'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -67,6 +85,7 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           FIREBASE_RELEASE_NAME: ${{ env.FIREBASE_RELEASE_NAME }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
 
           # App configuration
           MERCHANT_CLIENT_KEY: ${{ secrets.DEMO_APP_TEST_ENV_CLIENT_KEY }}

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       release_notes:
-        description: 'Text prepended to the Firebase release notes. Defaults to the branch name. The build metadata is always appended'
+        description: 'Release notes shown in Firebase App Distribution. Defaults to the branch name and build metadata'
         required: false
         type: string
   workflow_call: # Inputs have to be repeated: GitHub does not share them between triggers
@@ -26,7 +26,7 @@ on:
         required: false
         type: string
       release_notes:
-        description: 'Text prepended to the Firebase release notes. Defaults to the branch name. The build metadata is always appended'
+        description: 'Release notes shown in Firebase App Distribution. Defaults to the branch name and build metadata'
         required: false
         type: string
 
@@ -85,9 +85,7 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           FIREBASE_RELEASE_NAME: ${{ env.FIREBASE_RELEASE_NAME }}
-          # Defaulted here rather than on the inputs themselves: workflow_dispatch input defaults
-          # cannot contain expressions, so this is the only place both triggers behave the same.
-          RELEASE_NOTES: ${{ inputs.release_notes || format('Build from the {0} branch', github.ref_name) }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
 
           # App configuration
           MERCHANT_CLIENT_KEY: ${{ secrets.DEMO_APP_TEST_ENV_CLIENT_KEY }}

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: string
       release_notes:
-        description: 'Text prepended to the Firebase release notes. The build metadata is always appended'
+        description: 'Text prepended to the Firebase release notes. Defaults to the branch name. The build metadata is always appended'
         required: false
         type: string
   workflow_call: # Inputs have to be repeated: GitHub does not share them between triggers
@@ -26,7 +26,7 @@ on:
         required: false
         type: string
       release_notes:
-        description: 'Text prepended to the Firebase release notes. The build metadata is always appended'
+        description: 'Text prepended to the Firebase release notes. Defaults to the branch name. The build metadata is always appended'
         required: false
         type: string
 
@@ -85,7 +85,9 @@ jobs:
           FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           FIREBASE_RELEASE_NAME: ${{ env.FIREBASE_RELEASE_NAME }}
-          RELEASE_NOTES: ${{ inputs.release_notes }}
+          # Defaulted here rather than on the inputs themselves: workflow_dispatch input defaults
+          # cannot contain expressions, so this is the only place both triggers behave the same.
+          RELEASE_NOTES: ${{ inputs.release_notes || format('Build from the {0} branch', github.ref_name) }}
 
           # App configuration
           MERCHANT_CLIENT_KEY: ${{ secrets.DEMO_APP_TEST_ENV_CLIENT_KEY }}

--- a/.github/workflows/v6-firebase-nightly.yml
+++ b/.github/workflows/v6-firebase-nightly.yml
@@ -1,0 +1,29 @@
+name: v6_firebase_nightly
+
+on:
+  # 22:00 UTC Sun-Thu is 00:00 Amsterdam Mon-Fri during CEST (UTC+2). Midnight local falls on the
+  # previous UTC day, which is why the day-of-week range is shifted back by one.
+  # GitHub cron is UTC only, so this drifts to 01:00 Amsterdam once CET (UTC+1) starts.
+  # The offset minute avoids the top of the hour, when scheduled runs are most likely to be delayed.
+  schedule:
+    - cron: '7 22 * * 0-4'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false # A nightly is not worth cancelling halfway through an archive
+
+permissions:
+  contents: read
+
+jobs:
+  distribute:
+    name: 📱🔥 Nightly Firebase Distribution
+    # The version name and build number are intentionally fixed so every nightly reports the same
+    # build to Firebase App Distribution.
+    uses: ./.github/workflows/firebase-app-distribution.yml
+    with:
+      build_version_name: 6.0.0-nightly
+      build_number: '1'
+      release_notes: Latest development state of v6
+    secrets: inherit

--- a/Scripts/publish-demo-app-firebase.sh
+++ b/Scripts/publish-demo-app-firebase.sh
@@ -192,11 +192,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="$FIREBASE_JSON_PATH"
 # A caller-provided note is used verbatim, with no build metadata appended: recurring builds such as
 # the nightly have to report byte-identical release notes on every run. Without one, fall back to the
 # metadata so ad-hoc builds stay traceable back to a commit.
-if [[ -n "$RELEASE_NOTES" ]]; then
-  FIREBASE_RELEASE_NOTES="$RELEASE_NOTES"
-else
-  FIREBASE_RELEASE_NOTES="Release: ${FIREBASE_RELEASE_NAME}, Version: ${RESOLVED_VERSION_NAME} (${BUILD_NUMBER:-project default}), Branch: ${GITHUB_REF_NAME:-manual}, Build: ${GITHUB_SHA:-manual}"
-fi
+FIREBASE_RELEASE_NOTES="${RELEASE_NOTES:-Release: ${FIREBASE_RELEASE_NAME}, Version: ${RESOLVED_VERSION_NAME} (${BUILD_NUMBER:-project default}), Branch: ${GITHUB_REF_NAME:-manual}, Build: ${GITHUB_SHA:-manual}}"
 
 # Upload
 firebase appdistribution:distribute "$IPA_PATH" \

--- a/Scripts/publish-demo-app-firebase.sh
+++ b/Scripts/publish-demo-app-firebase.sh
@@ -189,12 +189,13 @@ FIREBASE_JSON_PATH="$(mktemp)"
 echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$FIREBASE_JSON_PATH"
 export GOOGLE_APPLICATION_CREDENTIALS="$FIREBASE_JSON_PATH"
 
-# The build metadata is always appended so a release stays traceable even with a custom note.
-BUILD_METADATA="Release: ${FIREBASE_RELEASE_NAME}, Version: ${RESOLVED_VERSION_NAME} (${BUILD_NUMBER:-project default}), Branch: ${GITHUB_REF_NAME:-manual}, Build: ${GITHUB_SHA:-manual}"
+# A caller-provided note is used verbatim, with no build metadata appended: recurring builds such as
+# the nightly have to report byte-identical release notes on every run. Without one, fall back to the
+# metadata so ad-hoc builds stay traceable back to a commit.
 if [[ -n "$RELEASE_NOTES" ]]; then
-  FIREBASE_RELEASE_NOTES="${RELEASE_NOTES}"$'\n'"${BUILD_METADATA}"
+  FIREBASE_RELEASE_NOTES="$RELEASE_NOTES"
 else
-  FIREBASE_RELEASE_NOTES="$BUILD_METADATA"
+  FIREBASE_RELEASE_NOTES="Release: ${FIREBASE_RELEASE_NAME}, Version: ${RESOLVED_VERSION_NAME} (${BUILD_NUMBER:-project default}), Branch: ${GITHUB_REF_NAME:-manual}, Build: ${GITHUB_SHA:-manual}"
 fi
 
 # Upload

--- a/Scripts/publish-demo-app-firebase.sh
+++ b/Scripts/publish-demo-app-firebase.sh
@@ -47,6 +47,10 @@ trap cleanup EXIT
 # BUILD_VERSION_NAME is required; an empty BUILD_NUMBER keeps the one committed in the project.
 BUILD_NUMBER="${BUILD_NUMBER:-}"
 
+# Optional free-text note shown above the build metadata in Firebase. Defaulted here because `set -u`
+# would otherwise abort when the caller omits it.
+RELEASE_NOTES="${RELEASE_NOTES:-}"
+
 echo "📦 Using Firebase export options: $EXPORT_OPTIONS_PLIST"
 
 # ---- Required environment variables ----
@@ -185,11 +189,19 @@ FIREBASE_JSON_PATH="$(mktemp)"
 echo "$FIREBASE_SERVICE_ACCOUNT_JSON" > "$FIREBASE_JSON_PATH"
 export GOOGLE_APPLICATION_CREDENTIALS="$FIREBASE_JSON_PATH"
 
+# The build metadata is always appended so a release stays traceable even with a custom note.
+BUILD_METADATA="Release: ${FIREBASE_RELEASE_NAME}, Version: ${RESOLVED_VERSION_NAME} (${BUILD_NUMBER:-project default}), Branch: ${GITHUB_REF_NAME:-manual}, Build: ${GITHUB_SHA:-manual}"
+if [[ -n "$RELEASE_NOTES" ]]; then
+  FIREBASE_RELEASE_NOTES="${RELEASE_NOTES}"$'\n'"${BUILD_METADATA}"
+else
+  FIREBASE_RELEASE_NOTES="$BUILD_METADATA"
+fi
+
 # Upload
 firebase appdistribution:distribute "$IPA_PATH" \
   --app "$FIREBASE_APP_ID" \
   --groups "ios-checkout-team" \
-  --release-notes "Release: ${FIREBASE_RELEASE_NAME}, Version: ${RESOLVED_VERSION_NAME} (${BUILD_NUMBER:-project default}), Branch: ${GITHUB_REF_NAME:-manual}, Build: ${GITHUB_SHA:-manual}"
+  --release-notes "$FIREBASE_RELEASE_NOTES"
 
 echo "✅ Firebase upload complete! Release name: $FIREBASE_RELEASE_NAME"
 


### PR DESCRIPTION
# Summary

Adds a `v6_firebase_nightly` workflow that ships the demo app to Firebase App
Distribution every weekday at midnight Amsterdam time, so there's always a recent v6
build to test. Version name and build number are pinned to `6.0.0-nightly` / `1` so
every nightly reports as the same build.

To support this, `firebase-app-distribution` gains a `workflow_call` trigger and a
`release_notes` input.

## Technical Information [Optional]

- Cron is `'7 22 * * 0-4'`, Mon–Fri: midnight Amsterdam falls on the *previous* UTC
  day during CEST. Drifts to 01:07 local once CET starts, as GitHub cron is UTC-only.
- Both triggers share one anchored `inputs` map so they can't drift.
- A caller-provided `release_notes` is used verbatim, with no build metadata appended,
  so recurring builds report identical notes every run. Without one, the existing
  metadata line is used and stays traceable to a commit.

## Testing Instructions [Optional]

1. Merge to `develop` — the cron only registers from the default branch.
2. Run `v6_firebase_nightly` manually to validate the `workflow_call` wiring before
   relying on the schedule.
3. Confirm the Firebase release shows `6.0.0-nightly (1)` with notes reading exactly
   `Latest development state of v6`.