### PR TITLE
Dropin stored payment removal capability / temp resolver

### DIFF
--- a/AdyenCheckout/Flows/AdvancedCheckout.swift
+++ b/AdyenCheckout/Flows/AdvancedCheckout.swift
@@ -29,8 +29,10 @@ public final class AdvancedCheckout: PaymentCheckout {
 
     /// Sets the callback invoked when payment data is submitted.
     /// - Parameter handler: Callback invoked when a payment component submits payment data.
-    ///   - data: The `PaymentComponentData` containing the selected payment method details and any shopper or browser information collected by the component.
-    /// - Returns: A `SubmitResult` describing how checkout should continue, such as completion, presenting an action, retry, or partial payment handling.
+    ///   - data: The `PaymentComponentData` containing the selected payment method details and
+    ///   any shopper or browser information collected by the component.
+    /// - Returns: A `SubmitResult` describing how checkout should continue, such as completion,
+    /// presenting an action, retry, or partial payment handling.
     public func onSubmit(_ handler: @escaping SubmitHandler) -> Self {
         callbackStore.onSubmit = handler
         return self
@@ -38,7 +40,8 @@ public final class AdvancedCheckout: PaymentCheckout {
 
     /// Sets the callback invoked when additional action details are submitted.
     /// - Parameter handler: Callback invoked when an action component provides data for `/payments/details`.
-    ///   - data: The `ActionComponentData` containing the action `details` and optional `paymentData` returned by the previous `/payments` response.
+    ///   - data: The `ActionComponentData` containing the action `details` and
+    ///   optional `paymentData` returned by the previous `/payments` response.
     /// - Returns: An `AdditionalDetailsResult` describing how checkout should continue after the details are submitted.
     public func onAdditionalDetails(_ handler: @escaping AdditionalDetailsHandler) -> Self {
         callbackStore.onAdditionalDetails = handler

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -51,7 +51,8 @@ package final class DropInComponent: NSObject,
             context: context,
             configuration: configuration,
             dropInFlowManager: dropInFlowManager,
-            partialPaymentDelegate: partialPaymentDelegate
+            partialPaymentDelegate: partialPaymentDelegate,
+            storedPaymentMethodManagementCapability: storedPaymentMethodManagementCapability
         )
         return dropInAssembler.resolveDropInRouter()
     }()
@@ -59,6 +60,10 @@ package final class DropInComponent: NSObject,
     private lazy var componentManager: ComponentManager = {
         createComponentManager(order: nil)
     }()
+
+    private lazy var storedPaymentMethodManagementResolver = StoredPaymentMethodManagementResolver(
+        dropInComponent: self
+    )
 
     internal var configuration: Configuration
 
@@ -126,13 +131,10 @@ package final class DropInComponent: NSObject,
     package weak var partialPaymentDelegate: PartialPaymentDelegate?
 
     /// The stored payment methods delegate.
-    package weak var storedPaymentMethodsDelegate: StoredPaymentMethodsDelegate? {
-        didSet {
-            guard let sessionAsStoredPaymentMethodsDelegate else { return }
+    package weak var storedPaymentMethodsDelegate: StoredPaymentMethodsDelegate?
 
-            let showRemoveStoredPaymentButton = sessionAsStoredPaymentMethodsDelegate.showRemovePaymentMethodButton
-            configuration.paymentMethodsList.allowDisablingStoredPaymentMethods = showRemoveStoredPaymentButton
-        }
+    internal var storedPaymentMethodManagementCapability: StoredPaymentMethodManagementCapability? {
+        storedPaymentMethodManagementResolver.capability
     }
 
     // MARK: - Presentable Component Protocol
@@ -156,11 +158,6 @@ package final class DropInComponent: NSObject,
 
     internal func reloadComponentManager() {
         componentManager = createComponentManager(order: componentManager.order)
-    }
-
-    /// Convenience accessor to the session if it's the delegate for removing stored payment methods
-    internal var sessionAsStoredPaymentMethodsDelegate: SessionStoredPaymentMethodsDelegate? {
-        storedPaymentMethodsDelegate as? SessionStoredPaymentMethodsDelegate
     }
 
     /// Reloads the DropIn with a partial payment order and a new `PaymentMethods` object.

--- a/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListAssembler.swift
+++ b/AdyenDropIn/Modules/PaymentMethodList/PaymentMethodListAssembler.swift
@@ -29,6 +29,7 @@ internal struct PaymentMethodListAssembler: PaymentMethodListAssemblerProtocol {
     private let dropInFlowManager: DropInFlowManaging
     private let theme: CheckoutTheme
     private let partialPaymentDelegate: PartialPaymentDelegate?
+    private let storedPaymentMethodManagementCapability: StoredPaymentMethodManagementCapability?
 
     // MARK: - Initializers
 
@@ -40,7 +41,8 @@ internal struct PaymentMethodListAssembler: PaymentMethodListAssemblerProtocol {
         configuration: DropInComponent.Configuration,
         dropInFlowManager: DropInFlowManaging,
         theme: CheckoutTheme,
-        partialPaymentDelegate: PartialPaymentDelegate?
+        partialPaymentDelegate: PartialPaymentDelegate?,
+        storedPaymentMethodManagementCapability: StoredPaymentMethodManagementCapability?
     ) {
         self.componentContainerAssembler = componentContainerAssembler
         self.componentManager = componentManager
@@ -50,6 +52,7 @@ internal struct PaymentMethodListAssembler: PaymentMethodListAssemblerProtocol {
         self.dropInFlowManager = dropInFlowManager
         self.theme = theme
         self.partialPaymentDelegate = partialPaymentDelegate
+        self.storedPaymentMethodManagementCapability = storedPaymentMethodManagementCapability
     }
 
     // MARK: - PaymentMethodListAssemblerProtocol

--- a/AdyenDropIn/Modules/Root/DropInAssembler.swift
+++ b/AdyenDropIn/Modules/Root/DropInAssembler.swift
@@ -24,6 +24,7 @@ internal struct DropInAssembler {
     private let componentManager: ComponentManager
     private let dropInFlowManager: DropInFlowManaging
     private let partialPaymentDelegate: PartialPaymentDelegate?
+    private let storedPaymentMethodManagementCapability: StoredPaymentMethodManagementCapability?
 
     // MARK: - Initializers
 
@@ -33,7 +34,8 @@ internal struct DropInAssembler {
         context: AdyenContext,
         configuration: DropInComponent.Configuration,
         dropInFlowManager: DropInFlowManaging,
-        partialPaymentDelegate: PartialPaymentDelegate?
+        partialPaymentDelegate: PartialPaymentDelegate?,
+        storedPaymentMethodManagementCapability: StoredPaymentMethodManagementCapability?
     ) {
         self.title = title
         self.paymentMethods = paymentMethods
@@ -41,6 +43,7 @@ internal struct DropInAssembler {
         self.configuration = configuration
         self.partialPaymentDelegate = partialPaymentDelegate
         self.dropInFlowManager = dropInFlowManager
+        self.storedPaymentMethodManagementCapability = storedPaymentMethodManagementCapability
         self.componentManager = ComponentManager(
             paymentMethods: paymentMethods,
             context: context,
@@ -107,7 +110,8 @@ internal struct DropInAssembler {
             configuration: configuration,
             dropInFlowManager: dropInFlowManager,
             theme: resolveCheckoutTheme(),
-            partialPaymentDelegate: partialPaymentDelegate
+            partialPaymentDelegate: partialPaymentDelegate,
+            storedPaymentMethodManagementCapability: storedPaymentMethodManagementCapability
         )
     }
     

--- a/AdyenDropIn/StoredPaymentMethodRemovalHandler.swift
+++ b/AdyenDropIn/StoredPaymentMethodRemovalHandler.swift
@@ -1,0 +1,14 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+
+package typealias StoredPaymentMethodRemovalHandler = @MainActor @Sendable (StoredPaymentMethod) async throws -> Void
+
+package enum StoredPaymentMethodRemovalError: Error, Equatable {
+    case unavailable
+    case unsuccessful
+}

--- a/AdyenDropIn/Utilities/StoredPaymentMethodManagementResolver.swift
+++ b/AdyenDropIn/Utilities/StoredPaymentMethodManagementResolver.swift
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+
+// TODO: This resolver will be deleted by the Drop-in callback/configuration task,
+// when CheckoutCore provides `StoredPaymentMethodManagementCapability` directly.
+
+/// Resolves the current Drop-in management capability from the legacy removal delegates.
+@MainActor
+package final class StoredPaymentMethodManagementResolver {
+
+    private weak var dropInComponent: DropInComponent?
+
+    package init(dropInComponent: DropInComponent) {
+        self.dropInComponent = dropInComponent
+    }
+
+    package var capability: StoredPaymentMethodManagementCapability? {
+        guard let dropInComponent,
+              let delegate = dropInComponent.storedPaymentMethodsDelegate
+        else {
+            return nil
+        }
+
+        if let sessionDelegate = delegate as? SessionStoredPaymentMethodsDelegate {
+            guard sessionDelegate.showRemovePaymentMethodButton else {
+                return nil
+            }
+        } else if !dropInComponent.configuration.paymentMethodsList.allowDisablingStoredPaymentMethods {
+            return nil
+        }
+
+        return StoredPaymentMethodManagementCapability { [weak self] storedPaymentMethod in
+            guard let self else {
+                throw StoredPaymentMethodRemovalError.unavailable
+            }
+
+            try await self.remove(storedPaymentMethod)
+        }
+    }
+
+    private func remove(_ storedPaymentMethod: StoredPaymentMethod) async throws {
+        guard let dropInComponent,
+              let delegate = dropInComponent.storedPaymentMethodsDelegate
+        else {
+            throw StoredPaymentMethodRemovalError.unavailable
+        }
+
+        try await withCheckedThrowingContinuation { continuation in
+            let completion = StoredPaymentMethodRemovalCompletion(continuation: continuation)
+            let resolve: Completion<Bool> = { success in
+                Task {
+                    await completion.resolve(success)
+                }
+            }
+
+            if let sessionDelegate = delegate as? SessionStoredPaymentMethodsDelegate {
+                sessionDelegate.disable(
+                    storedPaymentMethod: storedPaymentMethod,
+                    dropInComponent: dropInComponent,
+                    completion: resolve
+                )
+            } else {
+                delegate.disable(storedPaymentMethod: storedPaymentMethod, completion: resolve)
+            }
+        }
+    }
+}
+
+private actor StoredPaymentMethodRemovalCompletion {
+
+    private var continuation: CheckedContinuation<Void, Error>?
+
+    init(continuation: CheckedContinuation<Void, Error>) {
+        self.continuation = continuation
+    }
+
+    func resolve(_ success: Bool) {
+        guard let continuation else {
+            return
+        }
+
+        self.continuation = nil
+        continuation.resume(with: success ? .success(()) : .failure(StoredPaymentMethodRemovalError.unsuccessful))
+    }
+}

--- a/AdyenDropIn/Utilities/StoredPaymentMethodRemovalHandler.swift
+++ b/AdyenDropIn/Utilities/StoredPaymentMethodRemovalHandler.swift
@@ -8,6 +8,15 @@ import Adyen
 
 package typealias StoredPaymentMethodRemovalHandler = @MainActor @Sendable (StoredPaymentMethod) async throws -> Void
 
+package struct StoredPaymentMethodManagementCapability {
+
+    package let remove: StoredPaymentMethodRemovalHandler
+
+    package init(remove: @escaping StoredPaymentMethodRemovalHandler) {
+        self.remove = remove
+    }
+}
+
 package enum StoredPaymentMethodRemovalError: Error, Equatable {
     case unavailable
     case unsuccessful

--- a/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodManagementResolverTests.swift
+++ b/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodManagementResolverTests.swift
@@ -28,6 +28,17 @@ struct StoredPaymentMethodManagementResolverTests {
     }
 
     @Test
+    func managementCapability_whenResolverIsAvailable_shouldBeExposedByDropInComponent() {
+        // Given
+        let dropInComponent = dropInComponent(allowsDisablingStoredPaymentMethods: true)
+        let delegate = StoredPaymentMethodsDelegateMock(completionResults: [true])
+        dropInComponent.storedPaymentMethodsDelegate = delegate
+
+        // Then
+        #expect(dropInComponent.storedPaymentMethodManagementCapability != nil)
+    }
+
+    @Test
     func capability_whenAdvancedManagementIsEnabled_shouldPassStoredPaymentMethod() async throws {
         // Given
         let paymentMethod = try storedPaymentMethod()

--- a/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodManagementResolverTests.swift
+++ b/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodManagementResolverTests.swift
@@ -1,0 +1,245 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenDropIn
+import Testing
+
+@MainActor
+struct StoredPaymentMethodManagementResolverTests {
+
+    @Test
+    func capability_whenRemovalOperationIsInjected_shouldUseOperation() async throws {
+        // Given
+        let paymentMethod = try storedPaymentMethod()
+        let spy = StoredPaymentMethodRemovalHandlerSpy()
+        let capability = StoredPaymentMethodManagementCapability { storedPaymentMethod in
+            spy.remove(storedPaymentMethod)
+        }
+
+        // When
+        try await capability.remove(paymentMethod)
+
+        // Then
+        #expect(spy.receivedStoredPaymentMethodIdentifier == paymentMethod.identifier)
+    }
+
+    @Test
+    func capability_whenAdvancedManagementIsEnabled_shouldPassStoredPaymentMethod() async throws {
+        // Given
+        let paymentMethod = try storedPaymentMethod()
+        let dropInComponent = dropInComponent(allowsDisablingStoredPaymentMethods: true)
+        let delegate = StoredPaymentMethodsDelegateMock(completionResults: [true])
+        dropInComponent.storedPaymentMethodsDelegate = delegate
+        let sut = StoredPaymentMethodManagementResolver(dropInComponent: dropInComponent)
+        let capability = try #require(sut.capability)
+
+        // When
+        try await capability.remove(paymentMethod)
+
+        // Then
+        #expect(delegate.receivedStoredPaymentMethodIdentifier == paymentMethod.identifier)
+    }
+
+    @Test
+    func capability_whenAdvancedManagementIsDisabled_shouldBeNil() {
+        // Given
+        let dropInComponent = dropInComponent(allowsDisablingStoredPaymentMethods: false)
+        dropInComponent.storedPaymentMethodsDelegate = StoredPaymentMethodsDelegateMock(completionResults: [true])
+        let sut = StoredPaymentMethodManagementResolver(dropInComponent: dropInComponent)
+
+        // Then
+        #expect(sut.capability == nil)
+    }
+
+    @Test
+    func capability_whenSessionManagementIsEnabled_shouldUseSessionRemovalPath() async throws {
+        // Given
+        let paymentMethod = try storedPaymentMethod()
+        let dropInComponent = dropInComponent(allowsDisablingStoredPaymentMethods: false)
+        let delegate = SessionStoredPaymentMethodsDelegateMock(
+            showRemovePaymentMethodButton: true,
+            completionResults: [true]
+        )
+        dropInComponent.storedPaymentMethodsDelegate = delegate
+        let sut = StoredPaymentMethodManagementResolver(dropInComponent: dropInComponent)
+        let capability = try #require(sut.capability)
+
+        // When
+        try await capability.remove(paymentMethod)
+
+        // Then
+        #expect(delegate.receivedStoredPaymentMethodIdentifier == paymentMethod.identifier)
+        #expect(delegate.receivedDropInComponent === dropInComponent)
+    }
+
+    @Test
+    func capability_whenSessionManagementIsDisabled_shouldBeNil() {
+        // Given
+        let dropInComponent = dropInComponent(allowsDisablingStoredPaymentMethods: true)
+        let delegate = SessionStoredPaymentMethodsDelegateMock(
+            showRemovePaymentMethodButton: false,
+            completionResults: [true]
+        )
+        dropInComponent.storedPaymentMethodsDelegate = delegate
+        let sut = StoredPaymentMethodManagementResolver(dropInComponent: dropInComponent)
+
+        // Then
+        #expect(sut.capability == nil)
+    }
+
+    @Test
+    func capability_whenDelegateIsUnavailable_shouldBeNil() {
+        // Given
+        let sut = StoredPaymentMethodManagementResolver(
+            dropInComponent: dropInComponent(allowsDisablingStoredPaymentMethods: true)
+        )
+
+        // Then
+        #expect(sut.capability == nil)
+    }
+
+    @Test
+    func remove_whenDelegateFails_shouldThrowUnsuccessfulError() async throws {
+        // Given
+        let dropInComponent = dropInComponent(allowsDisablingStoredPaymentMethods: true)
+        let delegate = StoredPaymentMethodsDelegateMock(completionResults: [false])
+        dropInComponent.storedPaymentMethodsDelegate = delegate
+        let sut = StoredPaymentMethodManagementResolver(dropInComponent: dropInComponent)
+        let capability = try #require(sut.capability)
+
+        // When
+        await #expect(throws: StoredPaymentMethodRemovalError.unsuccessful) {
+            try await capability.remove(storedPaymentMethod())
+        }
+    }
+
+    @Test
+    func remove_whenDelegateCallsCompletionTwice_shouldResolveOnlyOnce() async throws {
+        // Given
+        let dropInComponent = dropInComponent(allowsDisablingStoredPaymentMethods: true)
+        let delegate = StoredPaymentMethodsDelegateMock(completionResults: [true, false])
+        dropInComponent.storedPaymentMethodsDelegate = delegate
+        let sut = StoredPaymentMethodManagementResolver(dropInComponent: dropInComponent)
+        let capability = try #require(sut.capability)
+
+        // When
+        try await capability.remove(storedPaymentMethod())
+
+        // Then
+        #expect(delegate.completionCallCount == 2)
+    }
+
+    @Test
+    func remove_whenResolverIsDeallocated_shouldThrowUnavailableError() async throws {
+        // Given
+        let dropInComponent = dropInComponent(allowsDisablingStoredPaymentMethods: true)
+        let delegate = StoredPaymentMethodsDelegateMock(completionResults: [true])
+        dropInComponent.storedPaymentMethodsDelegate = delegate
+        var resolver: StoredPaymentMethodManagementResolver? = .init(dropInComponent: dropInComponent)
+        let capability = try #require(resolver?.capability)
+        resolver = nil
+
+        // Then
+        await #expect(throws: StoredPaymentMethodRemovalError.unavailable) {
+            try await capability.remove(storedPaymentMethod())
+        }
+    }
+
+    @Test
+    func remove_whenDropInIsDeallocated_shouldThrowUnavailableError() async throws {
+        // Given
+        let delegate = StoredPaymentMethodsDelegateMock(completionResults: [true])
+        var dropInComponent: DropInComponent? = dropInComponent(allowsDisablingStoredPaymentMethods: true)
+        dropInComponent?.storedPaymentMethodsDelegate = delegate
+        let resolver = try #require(dropInComponent.map(StoredPaymentMethodManagementResolver.init))
+        let capability = try #require(resolver.capability)
+        dropInComponent = nil
+
+        // Then
+        await #expect(throws: StoredPaymentMethodRemovalError.unavailable) {
+            try await capability.remove(storedPaymentMethod())
+        }
+    }
+
+    private func dropInComponent(allowsDisablingStoredPaymentMethods: Bool) -> DropInComponent {
+        let configuration = DropInComponent.Configuration()
+        configuration.paymentMethodsList.allowDisablingStoredPaymentMethods = allowsDisablingStoredPaymentMethods
+
+        return DropInComponent(
+            paymentMethods: PaymentMethods(regular: [], stored: []),
+            context: Dummy.context,
+            configuration: configuration
+        )
+    }
+
+    private func storedPaymentMethod() throws -> StoredCardPaymentMethod {
+        try AdyenCoder.decode(storedCreditCardDictionary) as StoredCardPaymentMethod
+    }
+}
+
+@MainActor
+private final class StoredPaymentMethodsDelegateMock: StoredPaymentMethodsDelegate {
+
+    private let completionResults: [Bool]
+    private(set) var completionCallCount = 0
+    private(set) var receivedStoredPaymentMethodIdentifier: String?
+
+    init(completionResults: [Bool]) {
+        self.completionResults = completionResults
+    }
+
+    func disable(storedPaymentMethod: StoredPaymentMethod, completion: @escaping Completion<Bool>) {
+        receivedStoredPaymentMethodIdentifier = storedPaymentMethod.identifier
+
+        for result in completionResults {
+            completionCallCount += 1
+            completion(result)
+        }
+    }
+}
+
+@MainActor
+private final class SessionStoredPaymentMethodsDelegateMock: SessionStoredPaymentMethodsDelegate {
+
+    let showRemovePaymentMethodButton: Bool
+
+    private let completionResults: [Bool]
+    private(set) var receivedStoredPaymentMethodIdentifier: String?
+    private(set) weak var receivedDropInComponent: AnyObject?
+
+    init(showRemovePaymentMethodButton: Bool, completionResults: [Bool]) {
+        self.showRemovePaymentMethodButton = showRemovePaymentMethodButton
+        self.completionResults = completionResults
+    }
+
+    func disable(
+        storedPaymentMethod: StoredPaymentMethod,
+        dropInComponent: AnyDropInComponent,
+        completion: @escaping Completion<Bool>
+    ) {
+        receivedStoredPaymentMethodIdentifier = storedPaymentMethod.identifier
+        receivedDropInComponent = dropInComponent as AnyObject
+
+        for result in completionResults {
+            completion(result)
+        }
+    }
+
+    func disable(storedPaymentMethod: StoredPaymentMethod, completion: @escaping Completion<Bool>) {
+        Issue.record("The Session removal path should be used.")
+    }
+}
+
+@MainActor
+private final class StoredPaymentMethodRemovalHandlerSpy {
+
+    private(set) var receivedStoredPaymentMethodIdentifier: String?
+
+    func remove(_ storedPaymentMethod: StoredPaymentMethod) {
+        receivedStoredPaymentMethodIdentifier = storedPaymentMethod.identifier
+    }
+}

--- a/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodRemovalHandlerTests.swift
+++ b/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodRemovalHandlerTests.swift
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenDropIn
+import Testing
+
+@MainActor
+struct StoredPaymentMethodRemovalHandlerTests {
+
+    @Test
+    func handler_whenProviderSucceeds_shouldComplete() async throws {
+        // Given
+        let paymentMethod = try storedPaymentMethod()
+        let handler: StoredPaymentMethodRemovalHandler = { _ in }
+
+        // When
+        try await handler(paymentMethod)
+    }
+
+    @Test
+    func handler_whenProviderFails_shouldPropagateError() async throws {
+        // Given
+        let paymentMethod = try storedPaymentMethod()
+        let handler: StoredPaymentMethodRemovalHandler = { _ in
+            throw StoredPaymentMethodRemovalError.unsuccessful
+        }
+
+        // When
+        do {
+            try await handler(paymentMethod)
+            Issue.record("Expected the removal handler to throw.")
+        } catch let error as StoredPaymentMethodRemovalError {
+            // Then
+            #expect(error == .unsuccessful)
+        }
+    }
+
+    @Test
+    func removalError_whenProviderIsUnavailable_shouldBeExplicit() {
+        // Given
+        let error = StoredPaymentMethodRemovalError.unavailable
+
+        // Then
+        #expect(error == .unavailable)
+    }
+
+    private func storedPaymentMethod() throws -> StoredCardPaymentMethod {
+        try AdyenCoder.decode(storedCreditCardDictionary) as StoredCardPaymentMethod
+    }
+}


### PR DESCRIPTION
# Summary [Required]
Adds the internal stored payment method management capability for Drop-in.

- Introduces an async removal contract and capability wrapper.
- Adds a temporary resolver that maps existing Advanced and Session gates/delegates to that capability.
- Keeps Session and Advanced behavior separate, without exposing flow-specific checks to future UI code.
- Safely handles unavailable providers, failed removals, duplicate callbacks, and resolver/Drop-in deallocation.
- Wires the capability through Drop-in assembly, without changing shopper-facing behavior yet.

**Note**: The resolver is transitional and will be removed by the Drop-in migration once CheckoutCore provides the capability directly.

## Ticket [Optional]
<ticket>
COSDK-1362
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)
