### PR TITLE
Support merge queue runs in the required CI workflows

### DIFF
--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -3,6 +3,8 @@ name: 👀 Detect public API changes
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
     inputs:
       new:
@@ -23,6 +25,9 @@ permissions:
 jobs:
 
   build:
+    # This job diffs the pull request head against its base and reports back on the pull request,
+    # neither of which exists in the merge queue. Skipping reports success to the required check.
+    if: github.event_name != 'merge_group'
     runs-on: macos-26
 
     steps:

--- a/.github/workflows/detect_api_changes.yml
+++ b/.github/workflows/detect_api_changes.yml
@@ -25,9 +25,10 @@ permissions:
 jobs:
 
   build:
-    # This job diffs the pull request head against its base and reports back on the pull request,
-    # neither of which exists in the merge queue. Skipping reports success to the required check.
-    if: github.event_name != 'merge_group'
+    # This job needs two versions to diff: either a pull request and its base, or the inputs of a
+    # manual run. The merge queue provides neither, so it skips and reports success to the required
+    # check. Listed as an allowlist so any trigger added later has to opt in deliberately.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: macos-26
 
     steps:

--- a/.github/workflows/pr_scan.yml
+++ b/.github/workflows/pr_scan.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - develop
@@ -126,8 +128,10 @@ jobs:
         brew install swiftlint
         fastlane run swiftlint output_file:"reports/swiftlint.json" reporter:"json" ignore_exit_status:"true"
 
+    # Skipped in the merge queue: analysing the temporary gh-readonly-queue/** ref
+    # would register a throwaway branch in Sonar for every queued pull request.
     - name: 📡 Run Sonar
-      if: ${{ env.sonarToken != 0 }}
+      if: ${{ env.sonarToken != 0 && github.event_name != 'merge_group' }}
       run: |
         git fetch --unshallow --no-tags
         sonar-scanner -Dsonar.token=${{ secrets.SONAR_TOKEN }} -Dsonar.coverageReportPaths=sonarqube_updated_CI.xml

--- a/.github/workflows/test-SPM-integration.yml
+++ b/.github/workflows/test-SPM-integration.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+  merge_group:
+    types: [checks_requested]
+
   push:
     branches:
     - develop

--- a/.github/workflows/test_cocoapods_integration.yml
+++ b/.github/workflows/test_cocoapods_integration.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+  merge_group:
+    types: [checks_requested]
+
   push:
     branches:
     - develop

--- a/.github/workflows/test_library_evolution.yml
+++ b/.github/workflows/test_library_evolution.yml
@@ -3,7 +3,10 @@ name: 📚 Library Evolution Compatibility
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    
+
+  merge_group:
+    types: [checks_requested]
+
   push:
     branches:
       - develop


### PR DESCRIPTION
## Summary

We want to enable a merge queue on `develop`, like `adyen-android` has. A queue only
works if every gating workflow reacts to `merge_group` events — otherwise the queue
waits forever on required checks that never report. This adds a
`merge_group: [checks_requested]` trigger to the five workflows we want gating merges,
plus two guards for jobs that can't run without a pull request.

## Technical Information

| Workflow | Behaviour in the queue |
|---|---|
| `pr_scan.yml` | Builds and tests the queued ref |
| `test_library_evolution.yml` | Builds the queued ref |
| `test-SPM-integration.yml` | Builds the queued ref |
| `test_cocoapods_integration.yml` | Builds the queued ref |
| `detect_api_changes.yml` | **Skips** (reports success) |

Two guards were needed:

- **Sonar** (`pr_scan.yml`) is skipped in the queue. Analysing the temporary
  `gh-readonly-queue/**` ref would register a throwaway branch in Sonar for every
  queued PR.
- **Detect public API changes** diffs a PR head against its base and comments back on
  the PR. Neither exists in a merge queue, so the job skips — a skipped required check
  counts as passing, so the queue won't stall. Worth knowing: this means the check
  contributes no merge-time protection once the queue is on. That's inherent to what it
  does, and keeping it required preserves its PR behaviour.

Other PR workflows (spell check, PR size, SDK size, label validation, CodeQL) are
untouched — they aren't required checks and are either PR-metadata-only or advisory, so
they'd only ever skip.

## Testing Instructions

The `merge_group` paths can't run until this lands on `develop`, so on this PR just
confirm the five checks still behave normally on `pull_request`.

After merging, on the `develop` ruleset:

1. Add required checks: `Scan PR / build`, `👀 Detect public API changes / build`,
   `📚 Library Evolution Compatibility / Verify`,
   `Test Swift Package Manager Integration / SPM`, `Test Cocoapods Integration / pods`
2. Turn **off** "Require branches to be up to date before merging" (redundant with a queue)
3. Turn **on** "Require merge queue" — squash, build concurrency 5, and raise the status
   check timeout from 60 to ~120 min so a slow `Scan PR` doesn't eject PRs from the queue

Then push one trivial PR through the queue and check that `Scan PR` runs with Sonar
skipped, and that `Detect public API changes` shows skipped without blocking.