### PR TITLE
Align stored payment method display information

### DIFF
--- a/Adyen/Assets/Generated/LocalizationKey.swift
+++ b/Adyen/Assets/Generated/LocalizationKey.swift
@@ -566,6 +566,8 @@ public struct LocalizationKey {
     public static let preselectedPaymentMethodSubtitle = LocalizationKey(key: "adyen.preselectedPaymentMethod.subtitle")
     /// Other payment options
     public static let preselectedPaymentMethodOtherOptions = LocalizationKey(key: "adyen.preselectedPaymentMethod.otherOptions")
+    /// Expired
+    public static let storedPaymentMethodExpired = LocalizationKey(key: "adyen.storedPaymentMethod.expired")
     
     internal let key: String
     

--- a/Adyen/Assets/en-US.lproj/Localizable.strings
+++ b/Adyen/Assets/en-US.lproj/Localizable.strings
@@ -276,3 +276,4 @@
 "adyen.card.scanner.camera.access.denied.alert.settingsButton.title" = "Open Settings";
 "adyen.preselectedPaymentMethod.subtitle" = "Use %@";
 "adyen.preselectedPaymentMethod.otherOptions" = "Other payment options";
+"adyen.storedPaymentMethod.expired" = "Expired";

--- a/Adyen/Core/Core Protocols/PaymentMethod.swift
+++ b/Adyen/Core/Core Protocols/PaymentMethod.swift
@@ -37,6 +37,7 @@ package extension PaymentMethod {
     /// Returns the display information for this payment method.
     /// If the payment method conforms to `PaymentMethodDisplayOverridable`, its custom implementation is used.
     /// Otherwise, returns the default display information based on name and type.
+    /// Stored cards can provide a localized expired subtitle through their custom implementation.
     func displayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         if let displayable = self as? PaymentMethodDisplayOverridable {
             return displayable.overriddenDisplayInformation(using: parameters)

--- a/Adyen/Core/Payment Methods/ACHDirectDebitPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/ACHDirectDebitPaymentMethod.swift
@@ -42,13 +42,12 @@ public struct StoredACHDirectDebitPaymentMethod: StoredPaymentMethod, PaymentMet
         let lastFourSeparated = bankAccountLastFour.map { String($0) }.joined(separator: ", ")
         let accessibilityLabel = [
             name,
-            localizedString(.achBankAccountTitle, parameters),
             "\(localizedString(.accessibilityLastFourDigits, parameters)): \(lastFourSeparated)"
         ].joined(separator: ", ")
-        
+
         return DisplayInformation(
             title: String.Adyen.securedString + bankAccountLastFour,
-            subtitle: localizedString(.achBankAccountTitle, parameters),
+            subtitle: name,
             logoName: type.rawValue,
             accessibilityLabel: accessibilityLabel
         )

--- a/Adyen/Core/Payment Methods/CardPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/CardPaymentMethod.swift
@@ -63,16 +63,22 @@ public struct StoredCardPaymentMethod: StoredPaymentMethod, AnyCardPaymentMethod
 
     public var fundingSource: CardFundingSource?
 
+    package var descriptionProvider = StoredCardDescriptionProvider()
+
     package func overriddenDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
+        let description = descriptionProvider.description(for: self, using: parameters)
         let lastFourSeparated = lastFour.map { String($0) }.joined(separator: ", ")
         let accessibilityLabel = [
             name,
-            "\(localizedString(.accessibilityLastFourDigits, parameters)): \(lastFourSeparated)"
-        ].joined(separator: ", ")
+            "\(localizedString(.accessibilityLastFourDigits, parameters)): \(lastFourSeparated)",
+            description.isExpired ? description.subtitle : nil
+        ]
+        .compactMap { $0 }
+        .joined(separator: ", ")
 
         return DisplayInformation(
             title: String.Adyen.securedString + lastFour,
-            subtitle: name,
+            subtitle: description.subtitle,
             logoName: brand.rawValue,
             accessibilityLabel: accessibilityLabel
         )
@@ -110,6 +116,52 @@ public struct StoredCardPaymentMethod: StoredPaymentMethod, AnyCardPaymentMethod
         case fundingSource
     }
     
+}
+
+package struct StoredCardDescriptionProvider {
+
+    package struct Description {
+        package let subtitle: String
+        package let isExpired: Bool
+    }
+
+    private let currentDate: Date
+    private let calendar: Calendar
+
+    package init(currentDate: Date = .now, calendar: Calendar = .current) {
+        self.currentDate = currentDate
+        self.calendar = calendar
+    }
+
+    package func description(
+        for card: StoredCardPaymentMethod,
+        using parameters: LocalizationParameters?
+    ) -> Description {
+        guard isExpired(card) else {
+            return Description(subtitle: card.name, isExpired: false)
+        }
+
+        return Description(
+            subtitle: localizedString(.storedPaymentMethodExpired, parameters),
+            isExpired: true
+        )
+    }
+
+    private func isExpired(_ card: StoredCardPaymentMethod) -> Bool {
+        guard
+            let expiryMonth = Int(card.expiryMonth),
+            (1...12).contains(expiryMonth),
+            let expiryYear = Int(card.expiryYear),
+            let expiryMonthStart = calendar.date(
+                from: DateComponents(year: expiryYear, month: expiryMonth)
+            ),
+            let expiryThreshold = calendar.date(byAdding: .month, value: 1, to: expiryMonthStart)
+        else {
+            return false
+        }
+
+        return currentDate >= expiryThreshold
+    }
 }
 
 // MARK: - PaymentComponentBuildable

--- a/Adyen/Core/Payment Methods/CardPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/CardPaymentMethod.swift
@@ -64,19 +64,15 @@ public struct StoredCardPaymentMethod: StoredPaymentMethod, AnyCardPaymentMethod
     public var fundingSource: CardFundingSource?
 
     package func overriddenDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
-        let expireDate = expiryMonth + "/" + String(expiryYear.suffix(2))
-        let localizedExpiryDate = localizedString(.cardStoredExpires, parameters, expireDate)
-        
         let lastFourSeparated = lastFour.map { String($0) }.joined(separator: ", ")
         let accessibilityLabel = [
-            brand.name,
-            "\(localizedString(.accessibilityLastFourDigits, parameters)): \(lastFourSeparated)",
-            localizedExpiryDate
+            name,
+            "\(localizedString(.accessibilityLastFourDigits, parameters)): \(lastFourSeparated)"
         ].joined(separator: ", ")
-        
+
         return DisplayInformation(
             title: String.Adyen.securedString + lastFour,
-            subtitle: localizedExpiryDate,
+            subtitle: name,
             logoName: brand.rawValue,
             accessibilityLabel: accessibilityLabel
         )

--- a/Adyen/Core/Payment Methods/StoredBCMCPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredBCMCPaymentMethod.swift
@@ -24,7 +24,12 @@ public struct StoredBCMCPaymentMethod: StoredPaymentMethod, PaymentMethodDisplay
     package func overriddenDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
         storedCardPaymentMethod.displayInformation(using: parameters)
     }
-    
+
+    package var descriptionProvider: StoredCardDescriptionProvider {
+        get { storedCardPaymentMethod.descriptionProvider }
+        set { storedCardPaymentMethod.descriptionProvider = newValue }
+    }
+
     public var supportedShopperInteractions: [ShopperInteraction] {
         storedCardPaymentMethod.supportedShopperInteractions
     }

--- a/Adyen/Core/Payment Methods/StoredPayByBankUSPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredPayByBankUSPaymentMethod.swift
@@ -20,7 +20,18 @@ public struct StoredPayByBankUSPaymentMethod: StoredPaymentMethod, PaymentMethod
     public let supportedShopperInteractions: [ShopperInteraction]
     
     package func overriddenDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
-        DisplayInformation(title: label ?? "", subtitle: name, logoName: type.rawValue)
+        let title: String
+        let subtitle: String?
+
+        if let label {
+            title = label
+            subtitle = name
+        } else {
+            title = name
+            subtitle = nil
+        }
+
+        return DisplayInformation(title: title, subtitle: subtitle, logoName: type.rawValue)
     }
 
     // MARK: - Decoding

--- a/Adyen/Core/Payment Methods/StoredPayByBankUSPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredPayByBankUSPaymentMethod.swift
@@ -20,18 +20,7 @@ public struct StoredPayByBankUSPaymentMethod: StoredPaymentMethod, PaymentMethod
     public let supportedShopperInteractions: [ShopperInteraction]
     
     package func overriddenDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
-        let title: String
-        let subtitle: String?
-        
-        if let label {
-            title = label
-            subtitle = name
-        } else {
-            title = name
-            subtitle = nil
-        }
-        
-        return DisplayInformation(title: title, subtitle: subtitle, logoName: type.rawValue)
+        DisplayInformation(title: label ?? "", subtitle: name, logoName: type.rawValue)
     }
 
     // MARK: - Decoding

--- a/Adyen/Core/Payment Methods/StoredPayPalPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredPayPalPaymentMethod.swift
@@ -18,7 +18,7 @@ public struct StoredPayPalPaymentMethod: StoredPaymentMethod, PaymentMethodDispl
     public let supportedShopperInteractions: [ShopperInteraction]
 
     package func overriddenDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
-        DisplayInformation(title: name, subtitle: nil, logoName: type.rawValue)
+        DisplayInformation(title: name, subtitle: emailAddress, logoName: type.rawValue)
     }
     
     /// The email address of the PayPal account.

--- a/Adyen/Core/Payment Methods/StoredPayPalPaymentMethod.swift
+++ b/Adyen/Core/Payment Methods/StoredPayPalPaymentMethod.swift
@@ -18,7 +18,7 @@ public struct StoredPayPalPaymentMethod: StoredPaymentMethod, PaymentMethodDispl
     public let supportedShopperInteractions: [ShopperInteraction]
 
     package func overriddenDisplayInformation(using parameters: LocalizationParameters?) -> DisplayInformation {
-        DisplayInformation(title: name, subtitle: emailAddress, logoName: type.rawValue)
+        DisplayInformation(title: name, subtitle: nil, logoName: type.rawValue)
     }
     
     /// The email address of the PayPal account.

--- a/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewModelTests.swift
@@ -249,9 +249,9 @@ struct PaymentMethodListViewModelTests {
         let ach = items.first { $0.title == String.Adyen.securedString + "6789" }
         let bancontact = items.first { $0.title == String.Adyen.securedString + "4449" }
 
-        #expect(card?.subtitle == "VISA")
+        #expect(card?.subtitle == "Expired")
         #expect(ach?.subtitle == "ACH Direct Debit")
-        #expect(bancontact?.subtitle == "Maestro")
+        #expect(bancontact?.subtitle == "Expired")
     }
 
     // MARK: - ActionPresenter Tests

--- a/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewModelTests.swift
@@ -233,6 +233,27 @@ struct PaymentMethodListViewModelTests {
         }
     }
 
+    @Test
+    func didLoad_shouldUseSharedStoredPaymentMethodPresentation() {
+        // Given
+        let (sut, _, _) = makeSUT()
+
+        // When
+        sut.didLoad()
+
+        // Then
+        #expect(sut.state.isLoaded)
+        guard case let .loaded(sections) = sut.state else { return }
+        let items = sections.flatMap(\.items)
+        let card = items.first { $0.title == String.Adyen.securedString + "1111" }
+        let ach = items.first { $0.title == String.Adyen.securedString + "6789" }
+        let bancontact = items.first { $0.title == String.Adyen.securedString + "4449" }
+
+        #expect(card?.subtitle == "VISA")
+        #expect(ach?.subtitle == "ACH Direct Debit")
+        #expect(bancontact?.subtitle == "Maestro")
+    }
+
     // MARK: - ActionPresenter Tests
 
     @Test

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -119,6 +119,7 @@ class PaymentMethodTests: XCTestCase {
         
         // Test StoredCardPaymentMethod localization
         var storedCardPaymentMethod = try XCTUnwrap(paymentMethods.stored[1] as? StoredCardPaymentMethod)
+        storedCardPaymentMethod.descriptionProvider = try descriptionProvider(year: 2018, month: 8)
         let expectedLocalizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
         XCTAssertEqual(
             storedCardPaymentMethod.displayInformation(using: expectedLocalizationParameters),
@@ -144,6 +145,7 @@ class PaymentMethodTests: XCTestCase {
         
         // Test StoredBCMCPaymentMethod localization
         var storedBCMCPaymentMethod = try XCTUnwrap(paymentMethods.stored[4] as? StoredBCMCPaymentMethod)
+        storedBCMCPaymentMethod.descriptionProvider = try descriptionProvider(year: 2020, month: 10)
         XCTAssertEqual(
             storedBCMCPaymentMethod.displayInformation(using: nil),
             expectedBancontactCardDisplayInfo(method: storedBCMCPaymentMethod, localizationParameters: nil)
@@ -514,7 +516,8 @@ class PaymentMethodTests: XCTestCase {
     }
     
     func test_decodingStoredCreditCardPaymentMethod() throws {
-        let paymentMethod = try AdyenCoder.decode(storedCreditCardDictionary) as StoredCardPaymentMethod
+        var paymentMethod = try AdyenCoder.decode(storedCreditCardDictionary) as StoredCardPaymentMethod
+        paymentMethod.descriptionProvider = try descriptionProvider(year: 2018, month: 8)
         let expectedLocalizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
         XCTAssertEqual(paymentMethod.type.rawValue, "scheme")
         XCTAssertEqual(paymentMethod.name, "VISA")
@@ -531,7 +534,8 @@ class PaymentMethodTests: XCTestCase {
     }
     
     func test_decodingStoredDebitCardPaymentMethod() throws {
-        let paymentMethod = try AdyenCoder.decode(storedDebitCardDictionary) as StoredCardPaymentMethod
+        var paymentMethod = try AdyenCoder.decode(storedDebitCardDictionary) as StoredCardPaymentMethod
+        paymentMethod.descriptionProvider = try descriptionProvider(year: 2018, month: 8)
         let expectedLocalizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
         XCTAssertEqual(paymentMethod.type.rawValue, "scheme")
         XCTAssertEqual(paymentMethod.name, "VISA")
@@ -558,6 +562,50 @@ class PaymentMethodTests: XCTestCase {
         )
     }
     
+    func test_storedCardDisplayInformation_showsExpiredStartingTheFollowingMonth() throws {
+        var paymentMethod = try AdyenCoder.decode(storedCreditCardDictionary) as StoredCardPaymentMethod
+        let calendar = Calendar(identifier: .gregorian)
+        paymentMethod.descriptionProvider = try StoredCardDescriptionProvider(
+            currentDate: date(year: 2018, month: 9, day: 1, calendar: calendar),
+            calendar: calendar
+        )
+
+        let displayInformation = paymentMethod.displayInformation(using: nil)
+
+        XCTAssertEqual(displayInformation.title, String.Adyen.securedString + "1111")
+        XCTAssertEqual(displayInformation.subtitle, "Expired")
+        XCTAssertEqual(displayInformation.accessibilityLabel, "VISA, Last 4 digits: 1, 1, 1, 1, Expired")
+    }
+
+    func test_storedCardDisplayInformation_keepsExpiryMonthValid() throws {
+        var paymentMethod = try AdyenCoder.decode(storedCreditCardDictionary) as StoredCardPaymentMethod
+        let calendar = Calendar(identifier: .gregorian)
+        paymentMethod.descriptionProvider = try StoredCardDescriptionProvider(
+            currentDate: date(year: 2018, month: 8, day: 31, calendar: calendar),
+            calendar: calendar
+        )
+
+        let displayInformation = paymentMethod.displayInformation(using: nil)
+
+        XCTAssertEqual(displayInformation.subtitle, "VISA")
+        XCTAssertEqual(displayInformation.accessibilityLabel, "VISA, Last 4 digits: 1, 1, 1, 1")
+    }
+
+    func test_storedBCMCDisplayInformation_showsExpiredStartingTheFollowingMonth() throws {
+        var paymentMethod = try AdyenCoder.decode(storedBcmcDictionary) as StoredBCMCPaymentMethod
+        let calendar = Calendar(identifier: .gregorian)
+        paymentMethod.descriptionProvider = try StoredCardDescriptionProvider(
+            currentDate: date(year: 2020, month: 11, day: 1, calendar: calendar),
+            calendar: calendar
+        )
+
+        let displayInformation = paymentMethod.displayInformation(using: nil)
+
+        XCTAssertEqual(displayInformation.title, String.Adyen.securedString + "4449")
+        XCTAssertEqual(displayInformation.subtitle, "Expired")
+        XCTAssertEqual(displayInformation.accessibilityLabel, "Maestro, Last 4 digits: 4, 4, 4, 9, Expired")
+    }
+
     // MARK: - Issuer List
     
     func test_decodingIssuerListPaymentMethod() throws {
@@ -693,7 +741,8 @@ class PaymentMethodTests: XCTestCase {
     // MARK: - Stored Bancontact
     
     func test_decodingStoredBancontactPaymentMethod() throws {
-        let paymentMethod = try AdyenCoder.decode(storedBcmcDictionary) as StoredBCMCPaymentMethod
+        var paymentMethod = try AdyenCoder.decode(storedBcmcDictionary) as StoredBCMCPaymentMethod
+        paymentMethod.descriptionProvider = try descriptionProvider(year: 2020, month: 10)
         let expectedLocalizationParameters = LocalizationParameters(tableName: "AdyenUIHost", keySeparator: nil)
         XCTAssertEqual(paymentMethod.type.rawValue, "bcmc")
         XCTAssertEqual(paymentMethod.brand, "bcmc")
@@ -976,6 +1025,18 @@ class PaymentMethodTests: XCTestCase {
 }
 
 private extension PaymentMethodTests {
+
+    func descriptionProvider(year: Int, month: Int) throws -> StoredCardDescriptionProvider {
+        let calendar = Calendar(identifier: .gregorian)
+        return try StoredCardDescriptionProvider(
+            currentDate: date(year: year, month: month, day: 1, calendar: calendar),
+            calendar: calendar
+        )
+    }
+
+    func date(year: Int, month: Int, day: Int, calendar: Calendar) throws -> Date {
+        try XCTUnwrap(calendar.date(from: DateComponents(year: year, month: month, day: day)))
+    }
     
     func assertDisplayInformation(
         _ paymentMethod: any StoredPaymentMethod,

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -952,10 +952,10 @@ class PaymentMethodTests: XCTestCase {
 
         assertDisplayInformation(cashAppPay, title: "$shopper", subtitle: "Cash App Pay", logoName: "cashapp")
         assertDisplayInformation(payByBank, title: "Primary checking", subtitle: "Pay by Bank US", logoName: "paybybank")
-        assertDisplayInformation(payByBankWithoutLabel, title: "", subtitle: "Pay by Bank US", logoName: "paybybank")
+        assertDisplayInformation(payByBankWithoutLabel, title: "Pay by Bank US", subtitle: nil, logoName: "paybybank")
         assertDisplayInformation(payTo, title: "•••••••2311", subtitle: "payto", logoName: "payto")
         assertDisplayInformation(ach, title: String.Adyen.securedString + "6789", subtitle: "ACH Direct Debit", logoName: "ach")
-        assertDisplayInformation(payPal, title: "PayPal", subtitle: nil, logoName: "paypal")
+        assertDisplayInformation(payPal, title: "PayPal", subtitle: "example@shopper.com", logoName: "paypal")
         assertDisplayInformation(generic, title: "Generic payment method", subtitle: nil, logoName: "custom")
     }
 

--- a/Tests/UnitTests/Core/PaymentMethodTests.swift
+++ b/Tests/UnitTests/Core/PaymentMethodTests.swift
@@ -548,12 +548,11 @@ class PaymentMethodTests: XCTestCase {
     }
     
     func expectedStoredCardPaymentMethodDisplayInfo(method: StoredCardPaymentMethod, localizationParameters: LocalizationParameters?) -> DisplayInformation {
-        let expireDate = method.expiryMonth + "/" + method.expiryYear.suffix(2)
-        let accessibilityLabel = "\(method.brand.name), Last 4 digits: \(method.lastFour.map { String($0) }.joined(separator: ", ")), \(localizedString(.cardStoredExpires, localizationParameters, expireDate))"
-        
+        let accessibilityLabel = "\(method.name), Last 4 digits: \(method.lastFour.map { String($0) }.joined(separator: ", "))"
+
         return DisplayInformation(
             title: String.Adyen.securedString + method.lastFour,
-            subtitle: localizedString(.cardStoredExpires, localizationParameters, expireDate),
+            subtitle: method.name,
             logoName: method.brand.rawValue,
             accessibilityLabel: accessibilityLabel
         )
@@ -736,12 +735,11 @@ class PaymentMethodTests: XCTestCase {
         method: StoredBCMCPaymentMethod,
         localizationParameters: LocalizationParameters?
     ) -> DisplayInformation {
-        let expireDate = method.expiryMonth + "/" + method.expiryYear.suffix(2)
-        let accessibilityLabel = "BCMC, Last 4 digits: \(method.lastFour.map { String($0) }.joined(separator: ", ")), \(localizedString(.cardStoredExpires, localizationParameters, expireDate))"
-        
+        let accessibilityLabel = "\(method.name), Last 4 digits: \(method.lastFour.map { String($0) }.joined(separator: ", "))"
+
         return DisplayInformation(
             title: String.Adyen.securedString + method.lastFour,
-            subtitle: localizedString(.cardStoredExpires, localizationParameters, expireDate),
+            subtitle: method.name,
             logoName: method.brand,
             accessibilityLabel: accessibilityLabel
         )
@@ -919,6 +917,48 @@ class PaymentMethodTests: XCTestCase {
         XCTAssertEqual(paymentMethod.issuers[0].name, "Tink Demo Bank")
     }
     
+    // MARK: - Stored Payment Method Presentation
+
+    func test_storedPaymentMethodDisplayInformation_matchesSharedPresentation() throws {
+        let cashAppPay = try AdyenCoder.decode([
+            "type": "cashapp",
+            "id": "cash-app-id",
+            "name": "Cash App Pay",
+            "cashtag": "$shopper",
+            "supportedShopperInteractions": ["Ecommerce"]
+        ]) as StoredCashAppPayPaymentMethod
+        let payByBank = try AdyenCoder.decode([
+            "type": "paybybank",
+            "id": "pay-by-bank-id",
+            "name": "Pay by Bank US",
+            "label": "Primary checking",
+            "supportedShopperInteractions": ["Ecommerce"]
+        ]) as StoredPayByBankUSPaymentMethod
+        let payByBankWithoutLabel = try AdyenCoder.decode([
+            "type": "paybybank",
+            "id": "pay-by-bank-no-label-id",
+            "name": "Pay by Bank US",
+            "supportedShopperInteractions": ["Ecommerce"]
+        ]) as StoredPayByBankUSPaymentMethod
+        let payTo = try AdyenCoder.decode(storedPayToDictionary) as StoredPayToPaymentMethod
+        let ach = try AdyenCoder.decode(storedACHDictionary) as StoredACHDirectDebitPaymentMethod
+        let payPal = try AdyenCoder.decode(storedPayPalDictionary) as StoredPayPalPaymentMethod
+        let generic = try AdyenCoder.decode([
+            "type": "custom",
+            "id": "generic-id",
+            "name": "Generic payment method",
+            "supportedShopperInteractions": ["Ecommerce"]
+        ]) as StoredGenericPaymentMethod
+
+        assertDisplayInformation(cashAppPay, title: "$shopper", subtitle: "Cash App Pay", logoName: "cashapp")
+        assertDisplayInformation(payByBank, title: "Primary checking", subtitle: "Pay by Bank US", logoName: "paybybank")
+        assertDisplayInformation(payByBankWithoutLabel, title: "", subtitle: "Pay by Bank US", logoName: "paybybank")
+        assertDisplayInformation(payTo, title: "•••••••2311", subtitle: "payto", logoName: "payto")
+        assertDisplayInformation(ach, title: String.Adyen.securedString + "6789", subtitle: "ACH Direct Debit", logoName: "ach")
+        assertDisplayInformation(payPal, title: "PayPal", subtitle: nil, logoName: "paypal")
+        assertDisplayInformation(generic, title: "Generic payment method", subtitle: nil, logoName: "custom")
+    }
+
     // MARK: - Accessibility
     
     func test_paymentMethodTypeName() {
@@ -937,6 +977,20 @@ class PaymentMethodTests: XCTestCase {
 
 private extension PaymentMethodTests {
     
+    func assertDisplayInformation(
+        _ paymentMethod: any StoredPaymentMethod,
+        title: String,
+        subtitle: String?,
+        logoName: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let displayInformation = paymentMethod.displayInformation(using: nil)
+        XCTAssertEqual(displayInformation.title, title, file: file, line: line)
+        XCTAssertEqual(displayInformation.subtitle, subtitle, file: file, line: line)
+        XCTAssertEqual(displayInformation.logoName, logoName, file: file, line: line)
+    }
+
     func testCoding<T: PaymentMethod>(_ paymentMethod: T) {
         do {
             let encoded: Data = try AdyenCoder.encode(paymentMethod)


### PR DESCRIPTION
Aligns stored payment method display information per the PRD to be used in both payment list and management screen.

## Ticket [Optional]
<ticket>
COSDK-1429
</ticket>

## Checklist [Required]
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)
