### PR TITLE
Add stored payment method management models

### DIFF
--- a/Adyen/Assets/Generated/LocalizationKey.swift
+++ b/Adyen/Assets/Generated/LocalizationKey.swift
@@ -76,16 +76,14 @@ public struct LocalizationKey {
     public static let cardCvcItemInvalid = LocalizationKey(key: "adyen.card.cvcItem.invalid")
     /// Security code
     public static let cardCvcItemTitle = LocalizationKey(key: "adyen.card.cvcItem.title")
+    /// 123
+    public static let cardCvcItemPlaceholder = LocalizationKey(key: "adyen.card.cvcItem.placeholder")
     /// Enter security code
     public static let cardSecurityCodeTitle = LocalizationKey(key: "adyen.card.securityCode.title")
     /// Enter the security code for %@
     public static let cardSecurityCodeDescription = LocalizationKey(key: "adyen.card.securityCode.description")
-    /// 123
-    public static let cardCvcItemPlaceholder = LocalizationKey(key: "adyen.card.cvcItem.placeholder")
-    // TODO: Delete cardStoredTitle - no longer used after StoredCardAlertManager removal for v6
     /// Verify your card
     public static let cardStoredTitle = LocalizationKey(key: "adyen.card.stored.title")
-    // TODO: Delete cardStoredMessage - no longer used after StoredCardAlertManager removal for v6
     /// Please enter the CVC code for %@
     public static let cardStoredMessage = LocalizationKey(key: "adyen.card.stored.message")
     /// Expires %@
@@ -566,6 +564,24 @@ public struct LocalizationKey {
     public static let preselectedPaymentMethodSubtitle = LocalizationKey(key: "adyen.preselectedPaymentMethod.subtitle")
     /// Other payment options
     public static let preselectedPaymentMethodOtherOptions = LocalizationKey(key: "adyen.preselectedPaymentMethod.otherOptions")
+    /// Manage
+    public static let storedPaymentMethodManagementTitle = LocalizationKey(key: "adyen.storedPaymentMethodManagement.title")
+    /// Remove your favorite and saved payment methods
+    public static let storedPaymentMethodManagementDescription = LocalizationKey(key: "adyen.storedPaymentMethodManagement.description")
+    /// Cards
+    public static let storedPaymentMethodManagementCardsTitle = LocalizationKey(key: "adyen.storedPaymentMethodManagement.cardsTitle")
+    /// Other
+    public static let storedPaymentMethodManagementOtherTitle = LocalizationKey(key: "adyen.storedPaymentMethodManagement.otherTitle")
+    /// Expired
+    public static let storedPaymentMethodManagementExpired = LocalizationKey(key: "adyen.storedPaymentMethodManagement.expired")
+    /// Remove %@
+    public static let storedPaymentMethodManagementRemoveConfirmationAction = LocalizationKey(key: "adyen.storedPaymentMethodManagement.removeConfirmationAction")
+    /// Nothing here!
+    public static let storedPaymentMethodManagementEmptyTitle = LocalizationKey(key: "adyen.storedPaymentMethodManagement.emptyTitle")
+    /// You have no saved payment methods.
+    public static let storedPaymentMethodManagementEmptyMessage = LocalizationKey(key: "adyen.storedPaymentMethodManagement.emptyMessage")
+    /// Payment options
+    public static let storedPaymentMethodManagementPaymentOptions = LocalizationKey(key: "adyen.storedPaymentMethodManagement.paymentOptions")
     
     internal let key: String
     

--- a/Adyen/Assets/en-US.lproj/Localizable.strings
+++ b/Adyen/Assets/en-US.lproj/Localizable.strings
@@ -276,3 +276,12 @@
 "adyen.card.scanner.camera.access.denied.alert.settingsButton.title" = "Open Settings";
 "adyen.preselectedPaymentMethod.subtitle" = "Use %@";
 "adyen.preselectedPaymentMethod.otherOptions" = "Other payment options";
+"adyen.storedPaymentMethodManagement.title" = "Manage";
+"adyen.storedPaymentMethodManagement.description" = "Remove your favorite and saved payment methods";
+"adyen.storedPaymentMethodManagement.cardsTitle" = "Cards";
+"adyen.storedPaymentMethodManagement.otherTitle" = "Other";
+"adyen.storedPaymentMethodManagement.expired" = "Expired";
+"adyen.storedPaymentMethodManagement.removeConfirmationAction" = "Remove %@";
+"adyen.storedPaymentMethodManagement.emptyTitle" = "Nothing here!";
+"adyen.storedPaymentMethodManagement.emptyMessage" = "You have no saved payment methods.";
+"adyen.storedPaymentMethodManagement.paymentOptions" = "Payment options";

--- a/AdyenDropIn/Modules/StoredPaymentMethodManagement/Models/StoredPaymentMethodManagementItem.swift
+++ b/AdyenDropIn/Modules/StoredPaymentMethodManagement/Models/StoredPaymentMethodManagementItem.swift
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+import Foundation
+
+internal struct StoredPaymentMethodManagementItem {
+
+    internal let paymentMethod: any StoredPaymentMethod
+    internal let title: String
+    internal let subtitle: String?
+    internal let logoURL: URL
+    internal let accessibilityLabel: String?
+}

--- a/AdyenDropIn/Modules/StoredPaymentMethodManagement/Models/StoredPaymentMethodManagementPresentationMapper.swift
+++ b/AdyenDropIn/Modules/StoredPaymentMethodManagement/Models/StoredPaymentMethodManagementPresentationMapper.swift
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+@_spi(AdyenInternal) import struct Adyen.LocalizationKey
+import Foundation
+
+// swiftlint:disable:next type_name
+internal struct StoredPaymentMethodManagementPresentationMapper {
+
+    private let localizationParameters: LocalizationParameters?
+    private let logoURLProvider: LogoURLProvider
+
+    internal init(localizationParameters: LocalizationParameters?, logoURLProvider: LogoURLProvider) {
+        self.localizationParameters = localizationParameters
+        self.logoURLProvider = logoURLProvider
+    }
+
+    internal func sections(from paymentMethods: [any StoredPaymentMethod]) -> [StoredPaymentMethodManagementSection] {
+        let items = paymentMethods.map(item(from:))
+        let cards = items.filter { sectionKind(for: $0.paymentMethod) == .cards }
+        let other = items.filter { sectionKind(for: $0.paymentMethod) == .other }
+
+        return [
+            cards.isEmpty ? nil : StoredPaymentMethodManagementSection(kind: .cards, items: cards),
+            other.isEmpty ? nil : StoredPaymentMethodManagementSection(kind: .other, items: other)
+        ].compactMap { $0 }
+    }
+
+    internal func removalActionTitle(for paymentMethod: any StoredPaymentMethod) -> String {
+        localizedString(
+            .storedPaymentMethodManagementRemoveConfirmationAction,
+            localizationParameters,
+            removalTitle(for: paymentMethod)
+        )
+    }
+
+    private func item(from paymentMethod: any StoredPaymentMethod) -> StoredPaymentMethodManagementItem {
+        let displayInformation = paymentMethod.displayInformation(using: localizationParameters)
+
+        return StoredPaymentMethodManagementItem(
+            paymentMethod: paymentMethod,
+            title: displayInformation.title,
+            subtitle: displayInformation.subtitle,
+            logoURL: logoURLProvider.logoURL(withName: displayInformation.logoName),
+            accessibilityLabel: displayInformation.accessibilityLabel
+        )
+    }
+
+    private func sectionKind(for paymentMethod: any StoredPaymentMethod) -> StoredPaymentMethodManagementSection.Kind {
+        switch paymentMethod {
+        case is StoredCardPaymentMethod, is StoredBCMCPaymentMethod:
+            .cards
+        default:
+            .other
+        }
+    }
+
+    private func removalTitle(for paymentMethod: any StoredPaymentMethod) -> String {
+        switch paymentMethod {
+        case let card as StoredCardPaymentMethod:
+            return cardRemovalTitle(name: card.name, lastFour: card.lastFour)
+        case let card as StoredBCMCPaymentMethod:
+            return cardRemovalTitle(name: card.name, lastFour: card.lastFour)
+        case let ach as StoredACHDirectDebitPaymentMethod:
+            return cardRemovalTitle(name: ach.name, lastFour: String(ach.bankAccountNumber.suffix(4)))
+        default:
+            return paymentMethod.name
+        }
+    }
+
+    private func cardRemovalTitle(name: String, lastFour: String) -> String {
+        "\(name) \(String.Adyen.securedString)\(lastFour)"
+    }
+}

--- a/AdyenDropIn/Modules/StoredPaymentMethodManagement/Models/StoredPaymentMethodManagementSection.swift
+++ b/AdyenDropIn/Modules/StoredPaymentMethodManagement/Models/StoredPaymentMethodManagementSection.swift
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+internal struct StoredPaymentMethodManagementSection {
+
+    internal enum Kind: Hashable {
+        case cards
+        case other
+    }
+
+    internal let kind: Kind
+    internal let items: [StoredPaymentMethodManagementItem]
+}

--- a/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodManagementPresentationMapperTests.swift
+++ b/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodManagementPresentationMapperTests.swift
@@ -136,8 +136,8 @@ final class StoredPaymentMethodManagementPresentationMapperTests: XCTestCase {
 
         XCTAssertEqual(itemsByIdentifier[payByBank.identifier]?.title, "Primary checking")
         XCTAssertEqual(itemsByIdentifier[payByBank.identifier]?.subtitle, "Pay by Bank US")
-        XCTAssertEqual(itemsByIdentifier[payByBankWithoutLabel.identifier]?.title, "")
-        XCTAssertEqual(itemsByIdentifier[payByBankWithoutLabel.identifier]?.subtitle, "Pay by Bank US")
+        XCTAssertEqual(itemsByIdentifier[payByBankWithoutLabel.identifier]?.title, "Pay by Bank US")
+        XCTAssertNil(itemsByIdentifier[payByBankWithoutLabel.identifier]?.subtitle)
 
         XCTAssertEqual(itemsByIdentifier[payTo.identifier]?.title, "•••••••2311")
         XCTAssertEqual(itemsByIdentifier[payTo.identifier]?.subtitle, "payto")
@@ -147,7 +147,7 @@ final class StoredPaymentMethodManagementPresentationMapperTests: XCTestCase {
         XCTAssertEqual(itemsByIdentifier[ach.identifier]?.subtitle, "ACH Direct Debit")
 
         XCTAssertEqual(itemsByIdentifier[payPal.identifier]?.title, "PayPal")
-        XCTAssertNil(itemsByIdentifier[payPal.identifier]?.subtitle)
+        XCTAssertEqual(itemsByIdentifier[payPal.identifier]?.subtitle, "shopper@example.com")
         XCTAssertEqual(itemsByIdentifier[generic.identifier]?.title, "Generic payment method")
         XCTAssertNil(itemsByIdentifier[generic.identifier]?.subtitle)
         for paymentMethod in paymentMethods {

--- a/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodManagementPresentationMapperTests.swift
+++ b/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodManagementPresentationMapperTests.swift
@@ -1,0 +1,200 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@testable import Adyen
+@testable import AdyenDropIn
+import XCTest
+
+final class StoredPaymentMethodManagementPresentationMapperTests: XCTestCase {
+
+    func test_sections_groupsConcreteStoredCardModelsBeforeOtherMethods() throws {
+        let schemeCard = try decode(storedCreditCardDictionary, as: StoredCardPaymentMethod.self)
+        var cardTypeDictionary = storedCreditCardDictionary
+        cardTypeDictionary["type"] = "card"
+        cardTypeDictionary["id"] = "card-type-id"
+        let cardTypeCard = try decode(cardTypeDictionary, as: StoredCardPaymentMethod.self)
+        let bcmc = try decode(storedBcmcDictionary, as: StoredBCMCPaymentMethod.self)
+        let schemeGeneric = try decode(
+            [
+                "type": "scheme",
+                "id": "scheme-generic-id",
+                "name": "Scheme generic",
+                "supportedShopperInteractions": ["Ecommerce"]
+            ],
+            as: StoredGenericPaymentMethod.self
+        )
+        let payPal = try decode(
+            [
+                "type": "paypal",
+                "id": "paypal-id",
+                "name": "PayPal",
+                "shopperEmail": "shopper@example.com",
+                "supportedShopperInteractions": ["Ecommerce"]
+            ],
+            as: StoredPayPalPaymentMethod.self
+        )
+
+        let sections = makeSections(from: [payPal, schemeCard, cardTypeCard, bcmc, schemeGeneric])
+
+        XCTAssertEqual(sections.map(\.kind), [.cards, .other])
+        XCTAssertEqual(sections[0].items.map(\.paymentMethod.identifier), [schemeCard.identifier, cardTypeCard.identifier, bcmc.identifier])
+        XCTAssertEqual(sections[1].items.map(\.paymentMethod.identifier), [payPal.identifier, schemeGeneric.identifier])
+    }
+
+    func test_sections_omitsEmptyGroups() throws {
+        let payPal = try decode(
+            [
+                "type": "paypal",
+                "id": "paypal-id",
+                "name": "PayPal",
+                "shopperEmail": "shopper@example.com",
+                "supportedShopperInteractions": ["Ecommerce"]
+            ],
+            as: StoredPayPalPaymentMethod.self
+        )
+
+        let sections = makeSections(from: [payPal])
+
+        XCTAssertEqual(sections.map(\.kind), [.other])
+    }
+
+    func test_sections_mapsStoredPaymentMethodPresentations() throws {
+        let card = try decode(storedCreditCardDictionary, as: StoredCardPaymentMethod.self)
+        let cashAppPay = try decode(
+            [
+                "type": "cashapp",
+                "id": "cash-app-id",
+                "name": "Cash App Pay",
+                "cashtag": "$shopper",
+                "supportedShopperInteractions": ["Ecommerce"]
+            ],
+            as: StoredCashAppPayPaymentMethod.self
+        )
+        let payByBank = try decode(
+            [
+                "type": "paybybank",
+                "id": "pay-by-bank-id",
+                "name": "Pay by Bank US",
+                "label": "Primary checking",
+                "supportedShopperInteractions": ["Ecommerce"]
+            ],
+            as: StoredPayByBankUSPaymentMethod.self
+        )
+        let payByBankWithoutLabel = try decode(
+            [
+                "type": "paybybank",
+                "id": "pay-by-bank-no-label-id",
+                "name": "Pay by Bank US",
+                "supportedShopperInteractions": ["Ecommerce"]
+            ],
+            as: StoredPayByBankUSPaymentMethod.self
+        )
+        let payTo = try decode(storedPayToDictionary, as: StoredPayToPaymentMethod.self)
+        let ach = try decode(storedACHDictionary, as: StoredACHDirectDebitPaymentMethod.self)
+        let payPal = try decode(
+            [
+                "type": "paypal",
+                "id": "paypal-id",
+                "name": "PayPal",
+                "shopperEmail": "shopper@example.com",
+                "supportedShopperInteractions": ["Ecommerce"]
+            ],
+            as: StoredPayPalPaymentMethod.self
+        )
+        let generic = try decode(
+            [
+                "type": "custom",
+                "id": "generic-id",
+                "name": "Generic payment method",
+                "supportedShopperInteractions": ["Ecommerce"]
+            ],
+            as: StoredGenericPaymentMethod.self
+        )
+
+        let paymentMethods: [any StoredPaymentMethod] = [
+            card,
+            cashAppPay,
+            payByBank,
+            payByBankWithoutLabel,
+            payTo,
+            ach,
+            payPal,
+            generic
+        ]
+        let items = makeSections(from: paymentMethods).flatMap(\.items)
+        let itemsByIdentifier = Dictionary(uniqueKeysWithValues: items.map { ($0.paymentMethod.identifier, $0) })
+
+        let securedCardLastFour = String.Adyen.securedString + "1111"
+        XCTAssertEqual(itemsByIdentifier[card.identifier]?.title, securedCardLastFour)
+        XCTAssertEqual(itemsByIdentifier[card.identifier]?.subtitle, "VISA")
+
+        XCTAssertEqual(itemsByIdentifier[cashAppPay.identifier]?.title, "$shopper")
+        XCTAssertEqual(itemsByIdentifier[cashAppPay.identifier]?.subtitle, "Cash App Pay")
+
+        XCTAssertEqual(itemsByIdentifier[payByBank.identifier]?.title, "Primary checking")
+        XCTAssertEqual(itemsByIdentifier[payByBank.identifier]?.subtitle, "Pay by Bank US")
+        XCTAssertEqual(itemsByIdentifier[payByBankWithoutLabel.identifier]?.title, "")
+        XCTAssertEqual(itemsByIdentifier[payByBankWithoutLabel.identifier]?.subtitle, "Pay by Bank US")
+
+        XCTAssertEqual(itemsByIdentifier[payTo.identifier]?.title, "•••••••2311")
+        XCTAssertEqual(itemsByIdentifier[payTo.identifier]?.subtitle, "payto")
+
+        let securedACHLastFour = String.Adyen.securedString + "6789"
+        XCTAssertEqual(itemsByIdentifier[ach.identifier]?.title, securedACHLastFour)
+        XCTAssertEqual(itemsByIdentifier[ach.identifier]?.subtitle, "ACH Direct Debit")
+
+        XCTAssertEqual(itemsByIdentifier[payPal.identifier]?.title, "PayPal")
+        XCTAssertNil(itemsByIdentifier[payPal.identifier]?.subtitle)
+        XCTAssertEqual(itemsByIdentifier[generic.identifier]?.title, "Generic payment method")
+        XCTAssertNil(itemsByIdentifier[generic.identifier]?.subtitle)
+        for paymentMethod in paymentMethods {
+            try assertItemCopiesDisplayInformation(
+                XCTUnwrap(itemsByIdentifier[paymentMethod.identifier]),
+                from: paymentMethod
+            )
+        }
+    }
+
+    func test_removalActionTitle_usesOriginalPaymentMethodMetadata() throws {
+        let mapper = makeMapper()
+        let card = try decode(storedCreditCardDictionary, as: StoredCardPaymentMethod.self)
+        let bcmc = try decode(storedBcmcDictionary, as: StoredBCMCPaymentMethod.self)
+        let ach = try decode(storedACHDictionary, as: StoredACHDirectDebitPaymentMethod.self)
+        let payPal = try decode(storedPayPalDictionary, as: StoredPayPalPaymentMethod.self)
+
+        XCTAssertEqual(mapper.removalActionTitle(for: card), "Remove VISA \(String.Adyen.securedString)1111")
+        XCTAssertEqual(mapper.removalActionTitle(for: bcmc), "Remove Maestro \(String.Adyen.securedString)4449")
+        XCTAssertEqual(mapper.removalActionTitle(for: ach), "Remove ACH Direct Debit \(String.Adyen.securedString)6789")
+        XCTAssertEqual(mapper.removalActionTitle(for: payPal), "Remove PayPal")
+    }
+
+    private func assertItemCopiesDisplayInformation(
+        _ item: StoredPaymentMethodManagementItem,
+        from paymentMethod: any StoredPaymentMethod,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let displayInformation = paymentMethod.displayInformation(using: nil)
+        XCTAssertEqual(item.title, displayInformation.title, file: file, line: line)
+        XCTAssertEqual(item.subtitle, displayInformation.subtitle, file: file, line: line)
+        XCTAssertEqual(item.accessibilityLabel, displayInformation.accessibilityLabel, file: file, line: line)
+    }
+
+    private func makeSections(from paymentMethods: [any StoredPaymentMethod]) -> [StoredPaymentMethodManagementSection] {
+        makeMapper().sections(from: paymentMethods)
+    }
+
+    private func makeMapper() -> StoredPaymentMethodManagementPresentationMapper {
+        StoredPaymentMethodManagementPresentationMapper(
+            localizationParameters: nil,
+            logoURLProvider: LogoURLProvider(environment: Dummy.apiContext.environment)
+        )
+    }
+
+    private func decode<T: StoredPaymentMethod>(_ dictionary: [String: Any], as _: T.Type) throws -> T {
+        try AdyenCoder.decode(dictionary)
+    }
+}

--- a/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodManagementPresentationMapperTests.swift
+++ b/Tests/UnitTests/AdyenDropIn/StoredPaymentMethodManagementPresentationMapperTests.swift
@@ -129,7 +129,7 @@ final class StoredPaymentMethodManagementPresentationMapperTests: XCTestCase {
 
         let securedCardLastFour = String.Adyen.securedString + "1111"
         XCTAssertEqual(itemsByIdentifier[card.identifier]?.title, securedCardLastFour)
-        XCTAssertEqual(itemsByIdentifier[card.identifier]?.subtitle, "VISA")
+        XCTAssertEqual(itemsByIdentifier[card.identifier]?.subtitle, "Expired")
 
         XCTAssertEqual(itemsByIdentifier[cashAppPay.identifier]?.title, "$shopper")
         XCTAssertEqual(itemsByIdentifier[cashAppPay.identifier]?.subtitle, "Cash App Pay")


### PR DESCRIPTION
Adds a mapper to display specific presentation elements on the stored pm management screen. Also adds the localization keys with English only first.


## Ticket [Optional]
<ticket>
COSDK-1429
</ticket>

## Checklist [Required]
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)
