### PR TITLE
Distribute the demo app to the internal Firebase tester group

### DIFF
--- a/Scripts/publish-demo-app-firebase.sh
+++ b/Scripts/publish-demo-app-firebase.sh
@@ -197,7 +197,7 @@ FIREBASE_RELEASE_NOTES="${RELEASE_NOTES:-Release: ${FIREBASE_RELEASE_NAME}, Vers
 # Upload
 firebase appdistribution:distribute "$IPA_PATH" \
   --app "$FIREBASE_APP_ID" \
-  --groups "ios-checkout-team" \
+  --groups "internal" \
   --release-notes "$FIREBASE_RELEASE_NOTES"
 
 echo "✅ Firebase upload complete! Release name: $FIREBASE_RELEASE_NAME"


### PR DESCRIPTION
## Summary

The iOS demo app distributed to `ios-checkout-team`, while the Android acceptance app distributes to `internal` in `release_acceptance_app.yml`, so the two platforms notified different sets of testers. This points `Scripts/publish-demo-app-firebase.sh` at `internal` so both stay in sync.

## Technical Information

`Scripts/publish-demo-app.sh` is deliberately left untouched as it will be refactored later and all Firebase related logic will be removed from there.

## Testing Instructions

1. Run the 📱🔥 Firebase Distribution workflow and verify the release appears with the expected testers notified.

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [ ] Tested changes locally
- [ ] Added/updated unit tests
- [ ] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)