### PR TITLE
Add opt-in header to picker search screen via FormPickerConfiguration

### DIFF
--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerConfiguration.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerConfiguration.swift
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Foundation
+
+/// Configuration for the picker search screen.
+package struct FormPickerConfiguration {
+
+    /// Header shown at the top of the picker screen. `nil` → no header.
+    package let header: Header?
+
+    package init(header: Header? = nil) {
+        self.header = header
+    }
+}
+
+extension FormPickerConfiguration {
+
+    /// The title/subtitle content of the picker screen header.
+    package struct Header: Equatable {
+
+        package let title: String
+
+        package let subtitle: String?
+
+        package init(title: String, subtitle: String? = nil) {
+            self.title = title
+            self.subtitle = subtitle
+        }
+    }
+}

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerHeaderView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerHeaderView.swift
@@ -52,7 +52,7 @@ internal final class FormPickerHeaderView: UIView {
     // MARK: - Initializers
 
     internal init?(header: FormPickerConfiguration.Header, theme: CheckoutTheme) {
-        guard !header.title.isEmpty || header.subtitle?.isEmpty == false else {
+        guard !header.title.isEmpty else {
             return nil
         }
 

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerHeaderView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerHeaderView.swift
@@ -54,7 +54,11 @@ internal final class FormPickerHeaderView: UIView {
 
     // MARK: - Initializers
 
-    internal init(header: FormPickerConfiguration.Header, theme: CheckoutTheme) {
+    internal init?(header: FormPickerConfiguration.Header, theme: CheckoutTheme) {
+        guard !header.title.isEmpty || header.subtitle?.isEmpty == false else {
+            return nil
+        }
+
         self.header = header
         self.theme = theme
         super.init(frame: .zero)

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerHeaderView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerHeaderView.swift
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+import Adyen
+import UIKit
+
+/// A header shown at the top of a picker search screen, displaying a title and an optional subtitle.
+///
+/// Mirrors the title/subtitle styling of the payment method list header
+/// (`title` uses `labels.title`, `subtitle` uses `labels.body` + `colors.textSecondary`).
+internal final class FormPickerHeaderView: UIView {
+
+    private enum Layout {
+        static let stackSpacing: CGFloat = 4
+    }
+
+    // MARK: - Subviews
+
+    internal lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = header.title
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    internal lazy var subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = header.subtitle
+        label.isHidden = header.subtitle?.isEmpty ?? true
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        stackView.axis = .vertical
+        stackView.alignment = .leading
+        stackView.spacing = Layout.stackSpacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    // MARK: - Properties
+
+    private let header: FormPickerConfiguration.Header
+    private let theme: CheckoutTheme
+
+    // MARK: - Initializers
+
+    internal init(header: FormPickerConfiguration.Header, theme: CheckoutTheme) {
+        self.header = header
+        self.theme = theme
+        super.init(frame: .zero)
+        setupView()
+    }
+
+    @available(*, unavailable)
+    internal required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Private
+
+    private func setupView() {
+        layoutMargins = .zero
+
+        addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
+        ])
+
+        applyTheme()
+    }
+
+    private func applyTheme() {
+        titleLabel.apply(theme.elements.labels.title)
+
+        subtitleLabel.apply(theme.elements.labels.body)
+        subtitleLabel.textColor = theme.colors.textSecondary
+    }
+}

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerHeaderView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerHeaderView.swift
@@ -8,9 +8,6 @@ import Adyen
 import UIKit
 
 /// A header shown at the top of a picker search screen, displaying a title and an optional subtitle.
-///
-/// Mirrors the title/subtitle styling of the payment method list header
-/// (`title` uses `labels.title`, `subtitle` uses `labels.body` + `colors.textSecondary`).
 internal final class FormPickerHeaderView: UIView {
 
     private enum Layout {

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerItem.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerItem.swift
@@ -48,6 +48,8 @@ public struct FormPickerElement: FormPickable {
 open class FormPickerItem<Value: FormPickable>: FormSelectableValueItem<Value?> {
     
     package let localizationParameters: LocalizationParameters?
+    /// The picker item's configuration.
+    package let configuration: FormPickerConfiguration
     public private(set) var isOptional: Bool = false
     internal private(set) weak var presenter: ViewControllerPresenter?
     
@@ -69,6 +71,7 @@ open class FormPickerItem<Value: FormPickable>: FormSelectableValueItem<Value?> 
     ///   - placeholder: The placeholder of the item when the value is `nil`
     ///   - style: The `FormTextItemStyle` UI style.
     ///   - localizationParameters: The localization parameters.
+    ///   - configuration: The picker screen configuration (e.g. header).
     ///   - identifier: The item identifier
     package convenience init(
         preselectedValue: Value?,
@@ -77,6 +80,7 @@ open class FormPickerItem<Value: FormPickable>: FormSelectableValueItem<Value?> 
         placeholder: String,
         style: FormTextItemStyle,
         presenter: ViewControllerPresenter?,
+        configuration: FormPickerConfiguration = .init(),
         identifier: String? = nil
     ) {
         self.init(
@@ -87,6 +91,7 @@ open class FormPickerItem<Value: FormPickable>: FormSelectableValueItem<Value?> 
             style: style,
             presenter: presenter,
             localizationParameters: nil,
+            configuration: configuration,
             identifier: identifier
         )
     }
@@ -99,9 +104,11 @@ open class FormPickerItem<Value: FormPickable>: FormSelectableValueItem<Value?> 
         style: FormTextItemStyle,
         presenter: ViewControllerPresenter?,
         localizationParameters: LocalizationParameters? = nil,
+        configuration: FormPickerConfiguration = .init(),
         identifier: String? = nil
     ) {
         self.localizationParameters = localizationParameters
+        self.configuration = configuration
         self.presenter = presenter
 
         super.init(

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerItemView.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerItemView.swift
@@ -18,6 +18,8 @@ package class FormPickerItemView<Value: FormPickable>: FormSelectableValueItemVi
             let pickerViewController = FormPickerSearchViewController(
                 localizationParameters: item.localizationParameters,
                 title: item.title,
+                configuration: item.configuration,
+                theme: theme,
                 options: item.selectableValues
             ) { [weak topPresenter] selectedItem in
                 item.value = selectedItem

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController.swift
@@ -51,7 +51,9 @@ package final class FormPickerSearchViewController<Option: FormPickable>: UINavi
             handler(results)
         }
         
-        let headerView = configuration.header.map { FormPickerHeaderView(header: $0, theme: theme) }
+        let headerView = configuration.header.flatMap {
+            FormPickerHeaderView(header: $0, theme: theme)
+        }
 
         let searchViewController = SearchViewController(
             viewModel: viewModel,

--- a/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController.swift
+++ b/AdyenUI/UI/Form/Items/Value/Picker/FormPickerSearchViewController.swift
@@ -12,6 +12,8 @@ package final class FormPickerSearchViewController<Option: FormPickable>: UINavi
     package convenience init(
         style: Style = .init(),
         title: String?,
+        configuration: FormPickerConfiguration = .init(),
+        theme: CheckoutTheme = .default,
         options: [Option],
         selectionHandler: @escaping (Option) -> Void
     ) {
@@ -19,6 +21,8 @@ package final class FormPickerSearchViewController<Option: FormPickable>: UINavi
             localizationParameters: nil,
             style: style,
             title: title,
+            configuration: configuration,
+            theme: theme,
             options: options,
             selectionHandler: selectionHandler
         )
@@ -28,6 +32,8 @@ package final class FormPickerSearchViewController<Option: FormPickable>: UINavi
         localizationParameters: LocalizationParameters? = nil,
         style: Style = .init(),
         title: String?,
+        configuration: FormPickerConfiguration = .init(),
+        theme: CheckoutTheme = .default,
         options: [Option],
         selectionHandler: @escaping (Option) -> Void
     ) {
@@ -45,12 +51,18 @@ package final class FormPickerSearchViewController<Option: FormPickable>: UINavi
             handler(results)
         }
         
+        let headerView = configuration.header.map { FormPickerHeaderView(header: $0, theme: theme) }
+
         let searchViewController = SearchViewController(
             viewModel: viewModel,
-            emptyView: EmptyView()
+            emptyView: EmptyView(),
+            headerView: headerView
         )
         
-        searchViewController.title = title
+        // When a header is shown the title lives in the header; otherwise fall back to the navigation bar title.
+        if headerView == nil {
+            searchViewController.title = title
+        }
         
         super.init(rootViewController: searchViewController)
         

--- a/AdyenUI/UI/View Controllers/SearchViewController/SearchViewController.swift
+++ b/AdyenUI/UI/View Controllers/SearchViewController/SearchViewController.swift
@@ -24,6 +24,9 @@ package class SearchViewController: UIViewController, AdyenObserver {
 
     internal let viewModel: ViewModel
     internal let emptyView: SearchResultsEmptyView
+
+    /// Optional view shown above the search bar (e.g. a title/description header).
+    internal let headerView: UIView?
     
     /// Delegate to handle different viewController events.
     package weak var delegate: ViewControllerDelegate?
@@ -37,10 +40,12 @@ package class SearchViewController: UIViewController, AdyenObserver {
     ///   - emptyView: The view (conforming to ``SearchResultsEmptyView``) to show when the search results are empty.
     package init(
         viewModel: ViewModel,
-        emptyView: SearchResultsEmptyView
+        emptyView: SearchResultsEmptyView,
+        headerView: UIView? = nil
     ) {
         self.emptyView = emptyView
         self.viewModel = viewModel
+        self.headerView = headerView
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -87,6 +92,11 @@ package class SearchViewController: UIViewController, AdyenObserver {
         searchBar.setContentCompressionResistancePriority(.required, for: .vertical)
         searchBar.setContentHuggingPriority(.required, for: .vertical)
         view.addSubview(searchBar)
+
+        if let headerView {
+            headerView.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview(headerView)
+        }
         
         setupConstraints()
         
@@ -120,11 +130,30 @@ package class SearchViewController: UIViewController, AdyenObserver {
     }
     
     private func setupConstraints() {
+
+        let searchBarTopAnchor: NSLayoutYAxisAnchor
+        let searchBarTopSpacing: CGFloat
+        if let headerView {
+            // Keep the header at its content height so the results list, not the header, absorbs extra vertical space.
+            let headerHeightHug = headerView.heightAnchor.constraint(equalToConstant: 0)
+            headerHeightHug.priority = .defaultHigh
+            NSLayoutConstraint.activate([
+                headerView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
+                headerView.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+                headerView.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+                headerHeightHug
+            ])
+            searchBarTopAnchor = headerView.bottomAnchor
+            searchBarTopSpacing = 8
+        } else {
+            searchBarTopAnchor = view.layoutMarginsGuide.topAnchor
+            searchBarTopSpacing = 0
+        }
         
         NSLayoutConstraint.activate([
             searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8),
             searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8),
-            searchBar.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor, constant: 0),
+            searchBar.topAnchor.constraint(equalTo: searchBarTopAnchor, constant: searchBarTopSpacing),
             
             resultsListViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
             resultsListViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),

--- a/AdyenUI/UI/View Controllers/SearchViewController/SearchViewController.swift
+++ b/AdyenUI/UI/View Controllers/SearchViewController/SearchViewController.swift
@@ -136,7 +136,7 @@ package class SearchViewController: UIViewController, AdyenObserver {
         if let headerView {
             // Keep the header at its content height so the results list, not the header, absorbs extra vertical space.
             let headerHeightHug = headerView.heightAnchor.constraint(equalToConstant: 0)
-            headerHeightHug.priority = .defaultHigh
+            headerHeightHug.priority = .defaultLow
             NSLayoutConstraint.activate([
                 headerView.topAnchor.constraint(equalTo: view.layoutMarginsGuide.topAnchor),
                 headerView.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),

--- a/Tests/IntegrationTests/UIKit/Form/FormItems/Picker/FormPickerItemTests.swift
+++ b/Tests/IntegrationTests/UIKit/Form/FormItems/Picker/FormPickerItemTests.swift
@@ -6,6 +6,7 @@
 
 @_spi(AdyenInternal) @testable import Adyen
 @_spi(AdyenInternal) @testable import AdyenUI
+import UIKit
 import XCTest
 
 class FormPickerItemTests: XCTestCase {
@@ -108,5 +109,95 @@ class FormPickerItemTests: XCTestCase {
         wait(for: [updateFormattedValueException], timeout: 10)
         
         AdyenAssertion.listener = nil
+    }
+
+    func test_pickerItem_whenConfigurationOmitted_shouldDefaultToNoHeader() {
+        let formPickerItem = FormPickerItem<FormPickerElement>(
+            preselectedValue: nil,
+            selectableValues: [],
+            title: "",
+            placeholder: "",
+            style: .init(),
+            presenter: nil
+        )
+
+        XCTAssertNil(formPickerItem.configuration.header)
+    }
+
+    func test_pickerItem_whenConfigurationHasHeader_shouldPresentPickerWithHeader() throws {
+        let secondaryColor: UIColor = .purple
+        let theme = CheckoutTheme(colors: CheckoutColors(textSecondary: secondaryColor))
+        let presentationExpectation = expectation(description: "presenter.presentViewController was called")
+
+        var presentedViewController: UIViewController?
+        let presenter = PresenterMock(
+            present: { viewController, _ in
+                presentedViewController = viewController
+                presentationExpectation.fulfill()
+            },
+            dismiss: { _ in }
+        )
+
+        let formPickerItem = FormPickerItem<FormPickerElement>(
+            preselectedValue: nil,
+            selectableValues: [.init(identifier: "Identifier", title: "Title", subtitle: "Subtitle")],
+            title: "Installments",
+            placeholder: "",
+            style: .init(),
+            presenter: presenter,
+            configuration: .init(header: .init(title: "Installments", subtitle: "Split the total cost into monthly payments."))
+        )
+
+        // FormPickerItemView installs the selection handler that presents the picker.
+        _ = FormPickerItemView(item: formPickerItem, theme: theme)
+
+        formPickerItem.selectionHandler()
+
+        wait(for: [presentationExpectation], timeout: 10)
+
+        let pickerViewController = try XCTUnwrap(presentedViewController as? FormPickerSearchViewController<FormPickerElement>)
+        setupRootViewController(pickerViewController)
+
+        let searchViewController = try XCTUnwrap(pickerViewController.viewControllers.first as? SearchViewController)
+        let headerView = try XCTUnwrap(searchViewController.headerView as? FormPickerHeaderView)
+        XCTAssertEqual(headerView.titleLabel.text, "Installments")
+        XCTAssertEqual(headerView.subtitleLabel.text, "Split the total cost into monthly payments.")
+        XCTAssertEqual(headerView.subtitleLabel.textColor, secondaryColor)
+        XCTAssertNil(searchViewController.title)
+    }
+
+    func test_pickerItem_whenConfigurationOmitted_shouldPresentPickerWithoutHeader() throws {
+        let presentationExpectation = expectation(description: "presenter.presentViewController was called")
+
+        var presentedViewController: UIViewController?
+        let presenter = PresenterMock(
+            present: { viewController, _ in
+                presentedViewController = viewController
+                presentationExpectation.fulfill()
+            },
+            dismiss: { _ in }
+        )
+
+        let formPickerItem = FormPickerItem<FormPickerElement>(
+            preselectedValue: nil,
+            selectableValues: [.init(identifier: "Identifier", title: "Title", subtitle: "Subtitle")],
+            title: "Country/Region",
+            placeholder: "",
+            style: .init(),
+            presenter: presenter
+        )
+
+        _ = FormPickerItemView(item: formPickerItem, theme: .default)
+
+        formPickerItem.selectionHandler()
+
+        wait(for: [presentationExpectation], timeout: 10)
+
+        let pickerViewController = try XCTUnwrap(presentedViewController as? FormPickerSearchViewController<FormPickerElement>)
+        setupRootViewController(pickerViewController)
+
+        let searchViewController = try XCTUnwrap(pickerViewController.viewControllers.first as? SearchViewController)
+        XCTAssertNil(searchViewController.headerView)
+        XCTAssertEqual(searchViewController.title, "Country/Region")
     }
 }

--- a/Tests/IntegrationTests/UIKit/View Controllers/FormPickerSearchViewControllerTests.swift
+++ b/Tests/IntegrationTests/UIKit/View Controllers/FormPickerSearchViewControllerTests.swift
@@ -175,6 +175,21 @@ class FormPickerSearchViewControllerTests: XCTestCase {
         XCTAssertEqual(searchViewController.title, "Installments")
     }
 
+    func test_pickerHeader_whenTitleEmptyAndSubtitleProvided_shouldUseNavigationTitle() throws {
+        let searchViewController = try makeSearchViewController(
+            title: "Installments",
+            configuration: .init(
+                header: .init(
+                    title: "",
+                    subtitle: "Split the total cost into monthly payments."
+                )
+            )
+        )
+
+        XCTAssertNil(searchViewController.headerView)
+        XCTAssertEqual(searchViewController.title, "Installments")
+    }
+
     func test_pickerHeader_whenSubtitleEmpty_shouldHideSubtitleLabel() throws {
         let searchViewController = try makeSearchViewController(
             configuration: .init(header: .init(title: "Installments", subtitle: ""))

--- a/Tests/IntegrationTests/UIKit/View Controllers/FormPickerSearchViewControllerTests.swift
+++ b/Tests/IntegrationTests/UIKit/View Controllers/FormPickerSearchViewControllerTests.swift
@@ -165,6 +165,16 @@ class FormPickerSearchViewControllerTests: XCTestCase {
         XCTAssertEqual(searchViewController.title, "Country/Region")
     }
 
+    func test_pickerHeader_whenTitleAndSubtitleEmpty_shouldUseNavigationTitle() throws {
+        let searchViewController = try makeSearchViewController(
+            title: "Installments",
+            configuration: .init(header: .init(title: "", subtitle: ""))
+        )
+
+        XCTAssertNil(searchViewController.headerView)
+        XCTAssertEqual(searchViewController.title, "Installments")
+    }
+
     func test_pickerHeader_whenSubtitleEmpty_shouldHideSubtitleLabel() throws {
         let searchViewController = try makeSearchViewController(
             configuration: .init(header: .init(title: "Installments", subtitle: ""))

--- a/Tests/IntegrationTests/UIKit/View Controllers/FormPickerSearchViewControllerTests.swift
+++ b/Tests/IntegrationTests/UIKit/View Controllers/FormPickerSearchViewControllerTests.swift
@@ -37,7 +37,7 @@ class FormPickerSearchViewControllerTests: XCTestCase {
         }
     }
     
-    func testSetup() throws {
+    func test_picker_whenOptionSelected_shouldInvokeSelectionHandlerWithSelectedOption() throws {
         
         let option: FormPickerElement = .init(identifier: "Identifier", title: "Title", subtitle: "Subtitle")
         
@@ -69,7 +69,7 @@ class FormPickerSearchViewControllerTests: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
     
-    func testSearchSuccess() throws {
+    func test_search_withMatchingTerm_shouldReturnMatchingResults() throws {
         
         // Given
         
@@ -107,7 +107,7 @@ class FormPickerSearchViewControllerTests: XCTestCase {
         }
     }
     
-    func testSearchNoResults() throws {
+    func test_search_withNonMatchingTerm_shouldShowEmptyState() throws {
         
         // Given
         
@@ -142,5 +142,87 @@ class FormPickerSearchViewControllerTests: XCTestCase {
             
             XCTAssertEqual(searchViewController.viewModel.interfaceState.emptyStateSearchTerm, $0)
         }
+    }
+
+    func test_pickerHeader_whenSubtitleProvided_shouldRenderTitleAndSubtitle() throws {
+        let searchViewController = try makeSearchViewController(
+            configuration: .init(header: .init(title: "Installments", subtitle: "Split the total cost into monthly payments."))
+        )
+
+        let headerView = try XCTUnwrap(searchViewController.headerView as? FormPickerHeaderView)
+        XCTAssertEqual(headerView.titleLabel.text, "Installments")
+        XCTAssertEqual(headerView.subtitleLabel.text, "Split the total cost into monthly payments.")
+        XCTAssertFalse(headerView.subtitleLabel.isHidden)
+        XCTAssertTrue(headerView.isDescendant(of: searchViewController.view))
+        // Title lives in the header, so it is not duplicated in the navigation bar.
+        XCTAssertNil(searchViewController.title)
+    }
+
+    func test_pickerHeader_whenHeaderAbsent_shouldUseNavigationTitle() throws {
+        let searchViewController = try makeSearchViewController(title: "Country/Region")
+
+        XCTAssertNil(searchViewController.headerView)
+        XCTAssertEqual(searchViewController.title, "Country/Region")
+    }
+
+    func test_pickerHeader_whenSubtitleEmpty_shouldHideSubtitleLabel() throws {
+        let searchViewController = try makeSearchViewController(
+            configuration: .init(header: .init(title: "Installments", subtitle: ""))
+        )
+
+        let headerView = try XCTUnwrap(searchViewController.headerView as? FormPickerHeaderView)
+        XCTAssertEqual(headerView.titleLabel.text, "Installments")
+        XCTAssertTrue(headerView.subtitleLabel.isHidden)
+    }
+
+    func test_pickerHeader_shouldApplySecondaryColorToSubtitle() throws {
+        let secondaryColor: UIColor = .purple
+
+        let searchViewController = try makeSearchViewController(
+            configuration: .init(header: .init(title: "Installments", subtitle: "Split the total cost into monthly payments.")),
+            theme: CheckoutTheme(colors: CheckoutColors(textSecondary: secondaryColor))
+        )
+
+        let headerView = try XCTUnwrap(searchViewController.headerView as? FormPickerHeaderView)
+        XCTAssertEqual(headerView.subtitleLabel.textColor, secondaryColor)
+    }
+
+    func test_pickerHeader_whenSubtitleNil_shouldHideSubtitleLabel() throws {
+        let searchViewController = try makeSearchViewController(
+            configuration: .init(header: .init(title: "Installments"))
+        )
+
+        let headerView = try XCTUnwrap(searchViewController.headerView as? FormPickerHeaderView)
+        XCTAssertEqual(headerView.titleLabel.text, "Installments")
+        XCTAssertNil(headerView.subtitleLabel.text)
+        XCTAssertTrue(headerView.subtitleLabel.isHidden)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSearchViewController(
+        title: String? = nil,
+        configuration: FormPickerConfiguration = .init(),
+        theme: CheckoutTheme = .default,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> SearchViewController {
+        let option = FormPickerElement(identifier: "Identifier", title: "Title", subtitle: "Subtitle")
+
+        let pickerSearchViewController = FormPickerSearchViewController(
+            title: title,
+            configuration: configuration,
+            theme: theme,
+            options: [option]
+        ) { _ in }
+
+        // Allow setup in viewDidLoad
+        setupRootViewController(pickerSearchViewController)
+
+        return try XCTUnwrap(
+            pickerSearchViewController.viewControllers.first as? SearchViewController,
+            file: file,
+            line: line
+        )
     }
 }


### PR DESCRIPTION
# Summary [Required]

**What:** Adds an opt-in title and optional subtitle header to the generic picker search screen through `FormPickerConfiguration`. The configuration is threaded through `FormPickerItem` and `FormPickerItemView`, while existing picker flows retain their navigation-title behavior by default.

**Why:** Establishes reusable generic-picker header infrastructure for upcoming picker migrations, including installments, Address Lookup, Issuer List, and Phone Extension, without changing current callers that do not opt in.


## Technical Information [Optional]

- Adds `FormPickerConfiguration.Header` with required title and optional subtitle content.
- Adds `FormPickerHeaderView` using checkout title/body styles and secondary subtitle color.
- Preserves the active checkout theme through the item-to-picker presentation flow.
- Omits headers with an empty title, including subtitle-only configurations, preserving the navigation-title fallback.
- Keeps the header content-sized while allowing the results list to absorb remaining vertical space.
- Leaves Address Lookup, Issuer List, and Phone Extension behavior unchanged until they explicitly migrate.

## Ticket [Optional]
<ticket>
COSDK-1431
</ticket>

## Checklist [Required]
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (not applicable; no public API change)
