### PR TITLE
Showcase: Apply State-Action-Reducer architecture to stored payment methods screen

### DIFF
--- a/AdyenDropIn/Modules/StoredPaymentMethodManagement/StoredPaymentMethodManagementHostingController.swift
+++ b/AdyenDropIn/Modules/StoredPaymentMethodManagement/StoredPaymentMethodManagementHostingController.swift
@@ -75,11 +75,9 @@ internal final class StoredPaymentMethodManagementHostingController: UIHostingCo
     }
 
     private func observeRemovalState() {
-        viewModel.$identifiersBeingRemoved
-            .map { !$0.isEmpty }
-            .removeDuplicates()
-            .sink { [weak self] isActive in
-                self?.setNavigationLock(active: isActive)
+        viewModel.isRemovingPublisher
+            .sink { [weak self] isRemoving in
+                self?.setNavigationLock(active: isRemoving)
             }
             .store(in: &cancellables)
     }

--- a/AdyenDropIn/Modules/StoredPaymentMethodManagement/StoredPaymentMethodManagementHostingController.swift
+++ b/AdyenDropIn/Modules/StoredPaymentMethodManagement/StoredPaymentMethodManagementHostingController.swift
@@ -53,17 +53,20 @@ internal final class StoredPaymentMethodManagementHostingController: UIHostingCo
             return
         }
 
-        originalNavigationState = NavigationState(
-            isUserInteractionEnabled: navigationController.navigationBar.isUserInteractionEnabled,
-            tintColor: navigationController.navigationBar.tintColor,
-            isInteractivePopGestureEnabled: navigationController.interactivePopGestureRecognizer?.isEnabled ?? false
-        )
+        if originalNavigationState == nil {
+            originalNavigationState = NavigationState(
+                isUserInteractionEnabled: navigationController.navigationBar.isUserInteractionEnabled,
+                tintColor: navigationController.navigationBar.tintColor,
+                isInteractivePopGestureEnabled: navigationController.interactivePopGestureRecognizer?.isEnabled ?? false
+            )
+        }
         setNavigationLock(active: viewModel.isRemoving)
     }
 
     override internal func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         setNavigationLock(active: false)
+        originalNavigationState = nil
     }
 
     override internal func viewDidDisappear(_ animated: Bool) {

--- a/AdyenDropIn/Modules/StoredPaymentMethodManagement/StoredPaymentMethodManagementViewModel.swift
+++ b/AdyenDropIn/Modules/StoredPaymentMethodManagement/StoredPaymentMethodManagementViewModel.swift
@@ -15,16 +15,13 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
     internal typealias StoredPaymentMethodId = String
 
     fileprivate struct State {
+        var sections: [StoredPaymentMethodManagementSection]
         var itemPendingConfirmation: StoredPaymentMethodManagementItem?
-        private var removalStatesByIdentifier = [StoredPaymentMethodId: ItemRemovalState]()
+        var identifiersBeingRemoved = Set<StoredPaymentMethodId>()
+        var removalError: StoredPaymentMethodRemovalError?
     }
 
-    fileprivate enum ItemRemovalState {
-        case removing
-        case failed
-    }
-
-    private enum RemovalAction {
+    private enum Action {
         case removeButtonTapped(StoredPaymentMethodManagementItem)
         case removeConfirmButtonTapped(StoredPaymentMethodManagementItem)
         case removeCancelButtonTapped
@@ -35,12 +32,14 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
     // MARK: - Properties
 
     private let capability: StoredPaymentMethodManagementCapability
-    private let mapper: StoredPaymentMethodManagementPresentationMapper
     private let localizationParameters: LocalizationParameters?
     internal weak var router: StoredPaymentMethodManagementRouting?
 
-    @Published internal private(set) var sections: [StoredPaymentMethodManagementSection]
-    @Published private var state = State()
+    @Published private var state: State
+
+    internal var sections: [StoredPaymentMethodManagementSection] {
+        state.sections
+    }
 
     internal var itemPendingConfirmation: StoredPaymentMethodManagementItem? {
         state.itemPendingConfirmation
@@ -110,9 +109,8 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
         localizationParameters: LocalizationParameters?
     ) {
         self.capability = capability
-        self.mapper = mapper
         self.localizationParameters = localizationParameters
-        self.sections = mapper.sections(from: paymentMethods)
+        self.state = State(sections: mapper.sections(from: paymentMethods))
     }
 
     // MARK: - Internal
@@ -160,8 +158,6 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
         guard send(.removalSucceeded(identifier: identifier)) else {
             return
         }
-
-        remove(item)
         router?.didRemove(paymentMethod: item.paymentMethod)
     }
 
@@ -173,7 +169,7 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
 
     private static func reduce(
         state: State,
-        action: RemovalAction
+        action: Action
     ) -> State? {
         var state = state
 
@@ -185,15 +181,14 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
             }
 
             state.itemPendingConfirmation = item
-            state.clearRemovalState(for: item)
         case let .removeConfirmButtonTapped(item):
-            guard state.isPendingConfirmation(for: item),
-                  state.isIdle(item) else {
+            guard state.isPendingConfirmation(for: item) else {
                 return nil
             }
 
             state.itemPendingConfirmation = nil
-            state.setRemovalState(.removing, for: item)
+            state.identifiersBeingRemoved.insert(item.paymentMethod.identifier)
+            state.removalError = nil
         case .removeCancelButtonTapped:
             guard state.itemPendingConfirmation != nil else {
                 return nil
@@ -205,26 +200,23 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
                 return nil
             }
 
-            state.clearRemovalState(for: identifier)
+            state.identifiersBeingRemoved.remove(identifier)
+            state.removeItem(withIdentifier: identifier)
         case let .removalFailed(identifier):
             guard state.isRemoving(identifier) else {
                 return nil
             }
 
-            state.setRemovalState(.failed, for: identifier)
+            state.identifiersBeingRemoved.remove(identifier)
+            state.removalError = .unsuccessful
         }
 
         return state
     }
 
     @discardableResult
-    private func send(_ action: RemovalAction) -> Bool {
+    private func send(_ action: Action) -> Bool {
         guard let newState = Self.reduce(state: state, action: action) else {
-            return false
-        }
-
-        guard newState.isValid else {
-            assertionFailure("Reducer produced an invalid removal state")
             return false
         }
 
@@ -232,60 +224,17 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
         return true
     }
 
-    private func remove(_ item: StoredPaymentMethodManagementItem) {
-        sections = sections.compactMap { section in
-            let remainingItems = section.items.filter { $0.paymentMethod.identifier != item.paymentMethod.identifier }
-
-            guard !remainingItems.isEmpty else {
-                return nil
-            }
-
-            return StoredPaymentMethodManagementSection(kind: section.kind, items: remainingItems)
-        }
-    }
 }
 
 private extension StoredPaymentMethodManagementViewModel.State {
 
     typealias StoredPaymentMethodId = StoredPaymentMethodManagementViewModel.StoredPaymentMethodId
-    typealias ItemRemovalState = StoredPaymentMethodManagementViewModel.ItemRemovalState
-
-    var identifiersBeingRemoved: Set<StoredPaymentMethodId> {
-        Set(removalStatesByIdentifier.compactMap { identifier, removalState in
-            removalState.isRemoving ? identifier : nil
-        })
-    }
-
-    var removalError: StoredPaymentMethodRemovalError? {
-        removalStatesByIdentifier.values.contains(where: \.isFailed) ? .unsuccessful : nil
-    }
-
     var isRemoving: Bool {
-        removalStatesByIdentifier.values.contains(where: \.isRemoving)
-    }
-
-    var isValid: Bool {
-        guard let itemPendingConfirmation else {
-            return true
-        }
-
-        return isIdle(itemPendingConfirmation)
-    }
-
-    func removalState(for identifier: StoredPaymentMethodId) -> ItemRemovalState? {
-        removalStatesByIdentifier[identifier]
-    }
-
-    func removalState(for item: StoredPaymentMethodManagementItem) -> ItemRemovalState? {
-        removalState(for: item.paymentMethod.identifier)
-    }
-
-    func isIdle(_ item: StoredPaymentMethodManagementItem) -> Bool {
-        removalState(for: item) == nil
+        !identifiersBeingRemoved.isEmpty
     }
 
     func isRemoving(_ identifier: StoredPaymentMethodId) -> Bool {
-        removalState(for: identifier)?.isRemoving == true
+        identifiersBeingRemoved.contains(identifier)
     }
 
     func isRemoving(_ item: StoredPaymentMethodManagementItem) -> Bool {
@@ -296,38 +245,15 @@ private extension StoredPaymentMethodManagementViewModel.State {
         itemPendingConfirmation?.paymentMethod.identifier == item.paymentMethod.identifier
     }
 
-    mutating func setRemovalState(_ removalState: ItemRemovalState, for identifier: StoredPaymentMethodId) {
-        removalStatesByIdentifier[identifier] = removalState
-    }
+    mutating func removeItem(withIdentifier identifier: StoredPaymentMethodId) {
+        sections = sections.compactMap { section in
+            let remainingItems = section.items.filter { $0.paymentMethod.identifier != identifier }
 
-    mutating func setRemovalState(_ removalState: ItemRemovalState, for item: StoredPaymentMethodManagementItem) {
-        setRemovalState(removalState, for: item.paymentMethod.identifier)
-    }
+            guard !remainingItems.isEmpty else {
+                return nil
+            }
 
-    mutating func clearRemovalState(for identifier: StoredPaymentMethodId) {
-        removalStatesByIdentifier[identifier] = nil
-    }
-
-    mutating func clearRemovalState(for item: StoredPaymentMethodManagementItem) {
-        clearRemovalState(for: item.paymentMethod.identifier)
-    }
-}
-
-private extension StoredPaymentMethodManagementViewModel.ItemRemovalState {
-
-    var isRemoving: Bool {
-        if case .removing = self {
-            return true
+            return StoredPaymentMethodManagementSection(kind: section.kind, items: remainingItems)
         }
-
-        return false
-    }
-
-    var isFailed: Bool {
-        if case .failed = self {
-            return true
-        }
-
-        return false
     }
 }

--- a/AdyenDropIn/Modules/StoredPaymentMethodManagement/StoredPaymentMethodManagementViewModel.swift
+++ b/AdyenDropIn/Modules/StoredPaymentMethodManagement/StoredPaymentMethodManagementViewModel.swift
@@ -12,9 +12,31 @@ import Foundation
 @MainActor
 internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
 
-    // MARK: - Properties
-
     internal typealias StoredPaymentMethodId = String
+
+    private struct RemovalState {
+        var itemPendingConfirmation: StoredPaymentMethodManagementItem?
+        var identifiersBeingRemoved = Set<StoredPaymentMethodId>()
+        var removalError: StoredPaymentMethodRemovalError?
+
+        var isRemoving: Bool {
+            !identifiersBeingRemoved.isEmpty
+        }
+
+        func isRemoving(_ item: StoredPaymentMethodManagementItem) -> Bool {
+            identifiersBeingRemoved.contains(item.paymentMethod.identifier)
+        }
+    }
+
+    private enum RemovalAction {
+        case removeButtonTapped(StoredPaymentMethodManagementItem)
+        case removeConfirmButtonTapped(StoredPaymentMethodManagementItem)
+        case removeCancelButtonTapped
+        case removalSucceeded(identifier: StoredPaymentMethodId)
+        case removalFailed(identifier: StoredPaymentMethodId)
+    }
+
+    // MARK: - Properties
 
     private let capability: StoredPaymentMethodManagementCapability
     private let mapper: StoredPaymentMethodManagementPresentationMapper
@@ -22,12 +44,29 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
     internal weak var router: StoredPaymentMethodManagementRouting?
 
     @Published internal private(set) var sections: [StoredPaymentMethodManagementSection]
-    @Published internal private(set) var removalError: StoredPaymentMethodRemovalError?
-    @Published internal private(set) var itemToRemove: StoredPaymentMethodManagementItem?
-    @Published internal private(set) var identifiersBeingRemoved = Set<StoredPaymentMethodId>()
+    @Published private var removalState = RemovalState()
+
+    internal var itemPendingConfirmation: StoredPaymentMethodManagementItem? {
+        removalState.itemPendingConfirmation
+    }
+
+    internal var identifiersBeingRemoved: Set<StoredPaymentMethodId> {
+        removalState.identifiersBeingRemoved
+    }
+
+    internal var removalError: StoredPaymentMethodRemovalError? {
+        removalState.removalError
+    }
 
     internal var isRemoving: Bool {
-        !identifiersBeingRemoved.isEmpty
+        removalState.isRemoving
+    }
+
+    internal var isRemovingPublisher: AnyPublisher<Bool, Never> {
+        $removalState
+            .map(\.isRemoving)
+            .removeDuplicates()
+            .eraseToAnyPublisher()
     }
 
     internal var isEmpty: Bool {
@@ -97,40 +136,32 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
     }
 
     internal func isRemoving(_ item: StoredPaymentMethodManagementItem) -> Bool {
-        identifiersBeingRemoved.contains(item.paymentMethod.identifier)
+        removalState.isRemoving(item)
     }
 
-    internal func requestRemoval(of item: StoredPaymentMethodManagementItem) {
-        guard itemToRemove == nil, !isRemoving(item) else {
+    internal func onRemoveButtonTap(_ item: StoredPaymentMethodManagementItem) {
+        send(.removeButtonTapped(item))
+    }
+
+    internal func onRemoveCancelButtonTap() {
+        send(.removeCancelButtonTapped)
+    }
+
+    internal func onRemoveConfirmButtonTap(_ item: StoredPaymentMethodManagementItem) async {
+        guard send(.removeConfirmButtonTapped(item)) else {
             return
         }
-
-        itemToRemove = item
-    }
-
-    internal func dismissRemovalConfirmation() {
-        itemToRemove = nil
-    }
-
-    internal func confirmRemoval() async {
-        guard let item = itemToRemove else {
-            return
-        }
-
-        itemToRemove = nil
 
         let identifier = item.paymentMethod.identifier
-        guard identifiersBeingRemoved.insert(identifier).inserted else {
-            return
-        }
-
-        removalError = nil
-        defer { identifiersBeingRemoved.remove(identifier) }
 
         do {
             try await capability.remove(item.paymentMethod)
         } catch {
-            removalError = .unsuccessful
+            send(.removalFailed(identifier: identifier))
+            return
+        }
+
+        guard send(.removalSucceeded(identifier: identifier)) else {
             return
         }
 
@@ -143,6 +174,61 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
     }
 
     // MARK: - Private
+
+    private static func reduce(
+        state: RemovalState,
+        action: RemovalAction
+    ) -> RemovalState? {
+        var state = state
+
+        switch action {
+        case let .removeButtonTapped(item):
+            let identifier = item.paymentMethod.identifier
+            guard state.itemPendingConfirmation == nil,
+                  !state.identifiersBeingRemoved.contains(identifier) else {
+                return nil
+            }
+
+            state.itemPendingConfirmation = item
+            state.removalError = nil
+        case let .removeConfirmButtonTapped(item):
+            let identifier = item.paymentMethod.identifier
+            guard state.itemPendingConfirmation?.paymentMethod.identifier == identifier,
+                  state.identifiersBeingRemoved.insert(identifier).inserted else {
+                return nil
+            }
+
+            state.itemPendingConfirmation = nil
+        case .removeCancelButtonTapped:
+            guard state.itemPendingConfirmation != nil else {
+                return nil
+            }
+
+            state.itemPendingConfirmation = nil
+        case let .removalSucceeded(identifier):
+            guard state.identifiersBeingRemoved.remove(identifier) != nil else {
+                return nil
+            }
+        case let .removalFailed(identifier):
+            guard state.identifiersBeingRemoved.remove(identifier) != nil else {
+                return nil
+            }
+
+            state.removalError = .unsuccessful
+        }
+
+        return state
+    }
+
+    @discardableResult
+    private func send(_ action: RemovalAction) -> Bool {
+        guard let state = Self.reduce(state: removalState, action: action) else {
+            return false
+        }
+
+        removalState = state
+        return true
+    }
 
     private func remove(_ item: StoredPaymentMethodManagementItem) {
         sections = sections.compactMap { section in

--- a/AdyenDropIn/Modules/StoredPaymentMethodManagement/StoredPaymentMethodManagementViewModel.swift
+++ b/AdyenDropIn/Modules/StoredPaymentMethodManagement/StoredPaymentMethodManagementViewModel.swift
@@ -14,18 +14,14 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
 
     internal typealias StoredPaymentMethodId = String
 
-    private struct RemovalState {
+    fileprivate struct State {
         var itemPendingConfirmation: StoredPaymentMethodManagementItem?
-        var identifiersBeingRemoved = Set<StoredPaymentMethodId>()
-        var removalError: StoredPaymentMethodRemovalError?
+        private var removalStatesByIdentifier = [StoredPaymentMethodId: ItemRemovalState]()
+    }
 
-        var isRemoving: Bool {
-            !identifiersBeingRemoved.isEmpty
-        }
-
-        func isRemoving(_ item: StoredPaymentMethodManagementItem) -> Bool {
-            identifiersBeingRemoved.contains(item.paymentMethod.identifier)
-        }
+    fileprivate enum ItemRemovalState {
+        case removing
+        case failed
     }
 
     private enum RemovalAction {
@@ -44,26 +40,26 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
     internal weak var router: StoredPaymentMethodManagementRouting?
 
     @Published internal private(set) var sections: [StoredPaymentMethodManagementSection]
-    @Published private var removalState = RemovalState()
+    @Published private var state = State()
 
     internal var itemPendingConfirmation: StoredPaymentMethodManagementItem? {
-        removalState.itemPendingConfirmation
+        state.itemPendingConfirmation
     }
 
     internal var identifiersBeingRemoved: Set<StoredPaymentMethodId> {
-        removalState.identifiersBeingRemoved
+        state.identifiersBeingRemoved
     }
 
     internal var removalError: StoredPaymentMethodRemovalError? {
-        removalState.removalError
+        state.removalError
     }
 
     internal var isRemoving: Bool {
-        removalState.isRemoving
+        state.isRemoving
     }
 
     internal var isRemovingPublisher: AnyPublisher<Bool, Never> {
-        $removalState
+        $state
             .map(\.isRemoving)
             .removeDuplicates()
             .eraseToAnyPublisher()
@@ -136,7 +132,7 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
     }
 
     internal func isRemoving(_ item: StoredPaymentMethodManagementItem) -> Bool {
-        removalState.isRemoving(item)
+        state.isRemoving(item)
     }
 
     internal func onRemoveButtonTap(_ item: StoredPaymentMethodManagementItem) {
@@ -176,29 +172,28 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
     // MARK: - Private
 
     private static func reduce(
-        state: RemovalState,
+        state: State,
         action: RemovalAction
-    ) -> RemovalState? {
+    ) -> State? {
         var state = state
 
         switch action {
         case let .removeButtonTapped(item):
-            let identifier = item.paymentMethod.identifier
             guard state.itemPendingConfirmation == nil,
-                  !state.identifiersBeingRemoved.contains(identifier) else {
+                  !state.isRemoving(item) else {
                 return nil
             }
 
             state.itemPendingConfirmation = item
-            state.removalError = nil
+            state.clearRemovalState(for: item)
         case let .removeConfirmButtonTapped(item):
-            let identifier = item.paymentMethod.identifier
-            guard state.itemPendingConfirmation?.paymentMethod.identifier == identifier,
-                  state.identifiersBeingRemoved.insert(identifier).inserted else {
+            guard state.isPendingConfirmation(for: item),
+                  state.isIdle(item) else {
                 return nil
             }
 
             state.itemPendingConfirmation = nil
+            state.setRemovalState(.removing, for: item)
         case .removeCancelButtonTapped:
             guard state.itemPendingConfirmation != nil else {
                 return nil
@@ -206,15 +201,17 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
 
             state.itemPendingConfirmation = nil
         case let .removalSucceeded(identifier):
-            guard state.identifiersBeingRemoved.remove(identifier) != nil else {
-                return nil
-            }
-        case let .removalFailed(identifier):
-            guard state.identifiersBeingRemoved.remove(identifier) != nil else {
+            guard state.isRemoving(identifier) else {
                 return nil
             }
 
-            state.removalError = .unsuccessful
+            state.clearRemovalState(for: identifier)
+        case let .removalFailed(identifier):
+            guard state.isRemoving(identifier) else {
+                return nil
+            }
+
+            state.setRemovalState(.failed, for: identifier)
         }
 
         return state
@@ -222,11 +219,16 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
 
     @discardableResult
     private func send(_ action: RemovalAction) -> Bool {
-        guard let state = Self.reduce(state: removalState, action: action) else {
+        guard let newState = Self.reduce(state: state, action: action) else {
             return false
         }
 
-        removalState = state
+        guard newState.isValid else {
+            assertionFailure("Reducer produced an invalid removal state")
+            return false
+        }
+
+        state = newState
         return true
     }
 
@@ -240,5 +242,92 @@ internal final class StoredPaymentMethodManagementViewModel: ObservableObject {
 
             return StoredPaymentMethodManagementSection(kind: section.kind, items: remainingItems)
         }
+    }
+}
+
+private extension StoredPaymentMethodManagementViewModel.State {
+
+    typealias StoredPaymentMethodId = StoredPaymentMethodManagementViewModel.StoredPaymentMethodId
+    typealias ItemRemovalState = StoredPaymentMethodManagementViewModel.ItemRemovalState
+
+    var identifiersBeingRemoved: Set<StoredPaymentMethodId> {
+        Set(removalStatesByIdentifier.compactMap { identifier, removalState in
+            removalState.isRemoving ? identifier : nil
+        })
+    }
+
+    var removalError: StoredPaymentMethodRemovalError? {
+        removalStatesByIdentifier.values.contains(where: \.isFailed) ? .unsuccessful : nil
+    }
+
+    var isRemoving: Bool {
+        removalStatesByIdentifier.values.contains(where: \.isRemoving)
+    }
+
+    var isValid: Bool {
+        guard let itemPendingConfirmation else {
+            return true
+        }
+
+        return isIdle(itemPendingConfirmation)
+    }
+
+    func removalState(for identifier: StoredPaymentMethodId) -> ItemRemovalState? {
+        removalStatesByIdentifier[identifier]
+    }
+
+    func removalState(for item: StoredPaymentMethodManagementItem) -> ItemRemovalState? {
+        removalState(for: item.paymentMethod.identifier)
+    }
+
+    func isIdle(_ item: StoredPaymentMethodManagementItem) -> Bool {
+        removalState(for: item) == nil
+    }
+
+    func isRemoving(_ identifier: StoredPaymentMethodId) -> Bool {
+        removalState(for: identifier)?.isRemoving == true
+    }
+
+    func isRemoving(_ item: StoredPaymentMethodManagementItem) -> Bool {
+        isRemoving(item.paymentMethod.identifier)
+    }
+
+    func isPendingConfirmation(for item: StoredPaymentMethodManagementItem) -> Bool {
+        itemPendingConfirmation?.paymentMethod.identifier == item.paymentMethod.identifier
+    }
+
+    mutating func setRemovalState(_ removalState: ItemRemovalState, for identifier: StoredPaymentMethodId) {
+        removalStatesByIdentifier[identifier] = removalState
+    }
+
+    mutating func setRemovalState(_ removalState: ItemRemovalState, for item: StoredPaymentMethodManagementItem) {
+        setRemovalState(removalState, for: item.paymentMethod.identifier)
+    }
+
+    mutating func clearRemovalState(for identifier: StoredPaymentMethodId) {
+        removalStatesByIdentifier[identifier] = nil
+    }
+
+    mutating func clearRemovalState(for item: StoredPaymentMethodManagementItem) {
+        clearRemovalState(for: item.paymentMethod.identifier)
+    }
+}
+
+private extension StoredPaymentMethodManagementViewModel.ItemRemovalState {
+
+    var isRemoving: Bool {
+        if case .removing = self {
+            return true
+        }
+
+        return false
+    }
+
+    var isFailed: Bool {
+        if case .failed = self {
+            return true
+        }
+
+        return false
     }
 }

--- a/AdyenDropIn/Modules/StoredPaymentMethodManagement/Views/StoredPaymentMethodManagementListView.swift
+++ b/AdyenDropIn/Modules/StoredPaymentMethodManagement/Views/StoredPaymentMethodManagementListView.swift
@@ -40,7 +40,7 @@ internal struct StoredPaymentMethodManagementListView: View {
                     identifiersBeingRemoved: viewModel.identifiersBeingRemoved,
                     removeButtonTitle: viewModel.removeButtonTitle,
                     theme: theme,
-                    onRemove: viewModel.requestRemoval
+                    onRemove: viewModel.onRemoveButtonTap
                 )
             }
         }

--- a/AdyenDropIn/Modules/StoredPaymentMethodManagement/Views/StoredPaymentMethodManagementView.swift
+++ b/AdyenDropIn/Modules/StoredPaymentMethodManagement/Views/StoredPaymentMethodManagementView.swift
@@ -75,10 +75,10 @@ internal struct StoredPaymentMethodManagementView: View {
             theme: theme,
             onRemove: {
                 Task {
-                    await viewModel.confirmRemoval()
+                    await viewModel.onRemoveConfirmButtonTap(item)
                 }
             },
-            onCancel: viewModel.dismissRemovalConfirmation
+            onCancel: viewModel.onRemoveCancelButtonTap
         )
         .presentationDetents([.height(Constants.removalConfirmationHeight)])
         .presentationDragIndicator(.hidden)
@@ -86,10 +86,10 @@ internal struct StoredPaymentMethodManagementView: View {
 
     private var removalConfirmationItem: Binding<StoredPaymentMethodManagementItem?> {
         Binding(
-            get: { viewModel.itemToRemove },
+            get: { viewModel.itemPendingConfirmation },
             set: { item in
                 if item == nil {
-                    viewModel.dismissRemovalConfirmation()
+                    viewModel.onRemoveCancelButtonTap()
                 }
             }
         )

--- a/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodManagementAssemblerTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodManagementAssemblerTests.swift
@@ -121,14 +121,23 @@ struct StoredPaymentMethodManagementAssemblerTests {
 
         hostingController.viewWillAppear(false)
         #expect(!navigationController.navigationBar.isUserInteractionEnabled)
+        #expect(navigationController.navigationBar.tintColor != originalTintColor)
+        #expect(navigationController.interactivePopGestureRecognizer?.isEnabled == false)
+
+        hostingController.viewWillDisappear(false)
+
+        navigationController.navigationBar.isUserInteractionEnabled = false
+        navigationController.navigationBar.tintColor = .systemOrange
+        navigationController.interactivePopGestureRecognizer?.isEnabled = false
 
         let continuation = try #require(removalContinuation)
         continuation.resume()
         await removal.value
 
-        #expect(navigationController.navigationBar.isUserInteractionEnabled)
-        #expect(navigationController.navigationBar.tintColor == originalTintColor)
-        #expect(navigationController.interactivePopGestureRecognizer?.isEnabled == true)
+        #expect(!navigationController.navigationBar.isUserInteractionEnabled)
+        #expect(navigationController.navigationBar.tintColor == .systemOrange)
+        #expect(navigationController.interactivePopGestureRecognizer?.isEnabled == false)
+
     }
 
     private func storedPaymentMethod() -> StoredPaymentMethodMock {

--- a/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodManagementAssemblerTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodManagementAssemblerTests.swift
@@ -105,8 +105,8 @@ struct StoredPaymentMethodManagementAssemblerTests {
         hostingController.viewWillAppear(false)
         let item = try #require(hostingController.viewModel.sections.first?.items.first)
 
-        hostingController.viewModel.requestRemoval(of: item)
-        let removal = Task { await hostingController.viewModel.confirmRemoval() }
+        hostingController.viewModel.onRemoveButtonTap(item)
+        let removal = Task { await hostingController.viewModel.onRemoveConfirmButtonTap(item) }
         await Task.yield()
 
         #expect(!navigationController.navigationBar.isUserInteractionEnabled)

--- a/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodManagementViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodManagementViewModelTests.swift
@@ -131,7 +131,7 @@ struct StoredPaymentMethodManagementViewModelTests {
     }
 
     @Test
-    func removeButtonTap_afterMultipleFailures_clearsOnlySelectedItemError() async throws {
+    func openingAndCancellingConfirmation_preserveError() async throws {
         let firstPaymentMethod = storedPaymentMethod(identifier: "first-stored-payment-method-id")
         let secondPaymentMethod = storedPaymentMethod(identifier: "second-stored-payment-method-id")
         let sut = makeSUT(
@@ -157,9 +157,7 @@ struct StoredPaymentMethodManagementViewModelTests {
         sut.onRemoveButtonTap(firstItem)
         #expect(sut.removalError == .unsuccessful)
         sut.onRemoveCancelButtonTap()
-
-        sut.onRemoveButtonTap(secondItem)
-        #expect(sut.removalError == nil)
+        #expect(sut.removalError == .unsuccessful)
     }
 
     @Test
@@ -184,10 +182,19 @@ struct StoredPaymentMethodManagementViewModelTests {
     }
 
     @Test
-    func removeAndCancelButtonTaps_afterFailure_clearError() async throws {
+    func retryingRemoval_clearsError() async throws {
+        var removalCallsCount = 0
+        var retryContinuation: CheckedContinuation<Void, Never>?
         let sut = makeSUT(
             capability: StoredPaymentMethodManagementCapability { _ in
-                throw StoredPaymentMethodRemovalError.unsuccessful
+                removalCallsCount += 1
+                if removalCallsCount == 1 {
+                    throw StoredPaymentMethodRemovalError.unsuccessful
+                }
+
+                await withCheckedContinuation { continuation in
+                    retryContinuation = continuation
+                }
             }
         )
         let item = try #require(sut.sections.first?.items.first)
@@ -196,10 +203,15 @@ struct StoredPaymentMethodManagementViewModelTests {
         #expect(sut.removalError == .unsuccessful)
 
         sut.onRemoveButtonTap(item)
-        #expect(sut.removalError == nil)
+        let retry = Task { await sut.onRemoveConfirmButtonTap(item) }
+        await Task.yield()
 
-        sut.onRemoveCancelButtonTap()
         #expect(sut.removalError == nil)
+        #expect(sut.isRemoving(item))
+        let continuation = try #require(retryContinuation)
+        continuation.resume()
+
+        await retry.value
     }
 
     @Test

--- a/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodManagementViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodManagementViewModelTests.swift
@@ -12,19 +12,19 @@ import Testing
 struct StoredPaymentMethodManagementViewModelTests {
 
     @Test
-    func requestAndDismissRemoval_updatesItemPendingRemoval() throws {
+    func removeAndCancelButtonTaps_updateItemPendingConfirmation() throws {
         let sut = makeSUT()
         let item = try #require(sut.sections.first?.items.first)
 
-        sut.requestRemoval(of: item)
-        #expect(sut.itemToRemove?.paymentMethod.identifier == item.paymentMethod.identifier)
+        sut.onRemoveButtonTap(item)
+        #expect(sut.itemPendingConfirmation?.paymentMethod.identifier == item.paymentMethod.identifier)
 
-        sut.dismissRemovalConfirmation()
-        #expect(sut.itemToRemove == nil)
+        sut.onRemoveCancelButtonTap()
+        #expect(sut.itemPendingConfirmation == nil)
     }
 
     @Test
-    func confirmRemoval_afterSuccess_removesItemAndNotifiesRouter() async throws {
+    func removeConfirmButtonTap_afterSuccess_removesItemAndNotifiesRouter() async throws {
         var removalCallsCount = 0
         var observedRemovingState = false
         weak var weakSUT: StoredPaymentMethodManagementViewModel?
@@ -33,29 +33,61 @@ struct StoredPaymentMethodManagementViewModelTests {
             capability: StoredPaymentMethodManagementCapability { paymentMethod in
                 removalCallsCount += 1
                 observedRemovingState = weakSUT?.identifiersBeingRemoved.contains(paymentMethod.identifier) == true
-                await weakSUT?.confirmRemoval()
             }
         )
         weakSUT = sut
         sut.router = router
         let item = try #require(sut.sections.first?.items.first)
-        sut.requestRemoval(of: item)
+        sut.onRemoveButtonTap(item)
 
-        await sut.confirmRemoval()
+        await sut.onRemoveConfirmButtonTap(item)
 
         #expect(removalCallsCount == 1)
         #expect(observedRemovingState)
         #expect(sut.sections.isEmpty)
-        #expect(sut.itemToRemove == nil)
+        #expect(sut.itemPendingConfirmation == nil)
         #expect(!sut.isRemoving)
         #expect(router.removedPaymentMethods.last?.identifier == item.paymentMethod.identifier)
     }
 
     @Test
-    func confirmRemoval_whileAnotherRemovalIsInProgress_tracksBothItems() async throws {
+    func removeActions_whileSameItemIsRemoving_startOneRemoval() async throws {
+        var removalContinuation: CheckedContinuation<Void, Never>?
+        var removalCallsCount = 0
+        let sut = makeSUT(
+            capability: StoredPaymentMethodManagementCapability { _ in
+                removalCallsCount += 1
+                await withCheckedContinuation { continuation in
+                    removalContinuation = continuation
+                }
+            }
+        )
+        let item = try #require(sut.sections.first?.items.first)
+        sut.onRemoveButtonTap(item)
+        let removal = Task { await sut.onRemoveConfirmButtonTap(item) }
+        await Task.yield()
+
+        sut.onRemoveButtonTap(item)
+        await sut.onRemoveConfirmButtonTap(item)
+
+        #expect(removalCallsCount == 1)
+        #expect(sut.itemPendingConfirmation == nil)
+        #expect(sut.isRemoving(item))
+
+        let continuation = try #require(removalContinuation)
+        continuation.resume()
+        await removal.value
+
+        #expect(sut.sections.isEmpty)
+        #expect(!sut.isRemoving)
+    }
+
+    @Test
+    func concurrentRemovals_whenFirstFailsAndSecondSucceeds_trackItemsAndPreserveError() async throws {
         var removalContinuations = [String: CheckedContinuation<Void, any Error>]()
         let firstPaymentMethod = storedPaymentMethod(identifier: "first-stored-payment-method-id")
         let secondPaymentMethod = storedPaymentMethod(identifier: "second-stored-payment-method-id")
+        let router = StoredPaymentMethodManagementRoutingMock()
         let sut = makeSUT(
             paymentMethods: [firstPaymentMethod, secondPaymentMethod],
             capability: StoredPaymentMethodManagementCapability { paymentMethod in
@@ -64,87 +96,95 @@ struct StoredPaymentMethodManagementViewModelTests {
                 }
             }
         )
+        sut.router = router
         let items = sut.sections.flatMap(\.items)
         let firstItem = try #require(items.first { $0.paymentMethod.identifier == firstPaymentMethod.identifier })
         let secondItem = try #require(items.first { $0.paymentMethod.identifier == secondPaymentMethod.identifier })
 
-        sut.requestRemoval(of: firstItem)
-        let firstRemoval = Task { await sut.confirmRemoval() }
+        sut.onRemoveButtonTap(firstItem)
+        let firstRemoval = Task { await sut.onRemoveConfirmButtonTap(firstItem) }
         await Task.yield()
-
-        #expect(sut.identifiersBeingRemoved == [firstPaymentMethod.identifier])
-        sut.requestRemoval(of: firstItem)
-        #expect(sut.itemToRemove == nil)
-
-        sut.requestRemoval(of: secondItem)
-        let secondRemoval = Task { await sut.confirmRemoval() }
+        sut.onRemoveButtonTap(secondItem)
+        let secondRemoval = Task { await sut.onRemoveConfirmButtonTap(secondItem) }
         await Task.yield()
 
         #expect(sut.identifiersBeingRemoved == [firstPaymentMethod.identifier, secondPaymentMethod.identifier])
 
         let pendingFirstRemoval = removalContinuations.removeValue(forKey: firstPaymentMethod.identifier)
         let firstContinuation = try #require(pendingFirstRemoval)
-        firstContinuation.resume()
+        firstContinuation.resume(throwing: StoredPaymentMethodRemovalError.unsuccessful)
         await firstRemoval.value
 
         #expect(!sut.isRemoving(firstItem))
         #expect(sut.isRemoving(secondItem))
+        #expect(sut.removalError == .unsuccessful)
 
         let pendingSecondRemoval = removalContinuations.removeValue(forKey: secondPaymentMethod.identifier)
         let secondContinuation = try #require(pendingSecondRemoval)
         secondContinuation.resume()
         await secondRemoval.value
 
-        #expect(sut.sections.isEmpty)
         #expect(!sut.isRemoving)
+        #expect(sut.removalError == .unsuccessful)
+        #expect(sut.sections.flatMap(\.items).map(\.paymentMethod.identifier) == [firstPaymentMethod.identifier])
+        #expect(router.removedPaymentMethods.map(\.identifier) == [secondPaymentMethod.identifier])
     }
 
     @Test
-    func confirmRemoval_whenCapabilityThrows_preservesItemAndShowsError() async throws {
+    func removeConfirmButtonTap_whenCapabilityThrows_preservesItemAndError() async throws {
+        let sut = makeSUT(
+            capability: StoredPaymentMethodManagementCapability { _ in
+                throw StoredPaymentMethodRemovalError.unavailable
+            }
+        )
+        let item = try #require(sut.sections.first?.items.first)
+        sut.onRemoveButtonTap(item)
+
+        await sut.onRemoveConfirmButtonTap(item)
+
+        #expect(sut.sections.first?.items.count == 1)
+        #expect(sut.itemPendingConfirmation == nil)
+        #expect(!sut.isRemoving)
+        #expect(sut.removalError == .unsuccessful)
+
+        sut.onRemoveCancelButtonTap()
+        #expect(sut.removalError == .unsuccessful)
+    }
+
+    @Test
+    func removeAndCancelButtonTaps_afterFailure_clearError() async throws {
         let sut = makeSUT(
             capability: StoredPaymentMethodManagementCapability { _ in
                 throw StoredPaymentMethodRemovalError.unsuccessful
             }
         )
         let item = try #require(sut.sections.first?.items.first)
-        sut.requestRemoval(of: item)
-
-        await sut.confirmRemoval()
-
-        #expect(sut.sections.first?.items.count == 1)
-        #expect(sut.itemToRemove == nil)
-        #expect(!sut.isRemoving)
+        sut.onRemoveButtonTap(item)
+        await sut.onRemoveConfirmButtonTap(item)
         #expect(sut.removalError == .unsuccessful)
+
+        sut.onRemoveButtonTap(item)
+        #expect(sut.removalError == nil)
+
+        sut.onRemoveCancelButtonTap()
+        #expect(sut.removalError == nil)
     }
 
     @Test
-    func confirmRemoval_afterFailureThenSuccess_clearsErrorWhenRetryStarts() async throws {
-        var removalAttemptCount = 0
-        var observedRetryError: StoredPaymentMethodRemovalError?
-        weak var weakSUT: StoredPaymentMethodManagementViewModel?
+    func removeConfirmButtonTap_fromIdle_doesNotCallCapability() async throws {
+        var removalCallsCount = 0
         let sut = makeSUT(
             capability: StoredPaymentMethodManagementCapability { _ in
-                removalAttemptCount += 1
-
-                if removalAttemptCount == 1 {
-                    throw StoredPaymentMethodRemovalError.unsuccessful
-                }
-
-                observedRetryError = weakSUT?.removalError
+                removalCallsCount += 1
             }
         )
-        weakSUT = sut
         let item = try #require(sut.sections.first?.items.first)
-        sut.requestRemoval(of: item)
-        await sut.confirmRemoval()
-        #expect(sut.removalError == .unsuccessful)
 
-        sut.requestRemoval(of: item)
-        #expect(sut.removalError == .unsuccessful)
-        await sut.confirmRemoval()
+        await sut.onRemoveConfirmButtonTap(item)
 
-        #expect(observedRetryError == nil)
-        #expect(sut.removalError == nil)
+        #expect(removalCallsCount == 0)
+        #expect(sut.itemPendingConfirmation == nil)
+        #expect(!sut.isRemoving)
     }
 
     @Test

--- a/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodManagementViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/StoredPaymentMethodManagementViewModelTests.swift
@@ -131,6 +131,38 @@ struct StoredPaymentMethodManagementViewModelTests {
     }
 
     @Test
+    func removeButtonTap_afterMultipleFailures_clearsOnlySelectedItemError() async throws {
+        let firstPaymentMethod = storedPaymentMethod(identifier: "first-stored-payment-method-id")
+        let secondPaymentMethod = storedPaymentMethod(identifier: "second-stored-payment-method-id")
+        let sut = makeSUT(
+            paymentMethods: [firstPaymentMethod, secondPaymentMethod],
+            capability: StoredPaymentMethodManagementCapability { _ in
+                throw StoredPaymentMethodRemovalError.unsuccessful
+            }
+        )
+        let items = sut.sections.flatMap(\.items)
+        let firstItem = try #require(items.first { $0.paymentMethod.identifier == firstPaymentMethod.identifier })
+        let secondItem = try #require(items.first { $0.paymentMethod.identifier == secondPaymentMethod.identifier })
+
+        sut.onRemoveButtonTap(firstItem)
+        await sut.onRemoveConfirmButtonTap(firstItem)
+        sut.onRemoveButtonTap(secondItem)
+        #expect(sut.removalError == .unsuccessful)
+        await sut.onRemoveConfirmButtonTap(secondItem)
+        #expect(!sut.isRemoving(firstItem))
+        #expect(!sut.isRemoving(secondItem))
+        #expect(sut.identifiersBeingRemoved.isEmpty)
+        #expect(sut.sections.flatMap(\.items).count == 2)
+
+        sut.onRemoveButtonTap(firstItem)
+        #expect(sut.removalError == .unsuccessful)
+        sut.onRemoveCancelButtonTap()
+
+        sut.onRemoveButtonTap(secondItem)
+        #expect(sut.removalError == nil)
+    }
+
+    @Test
     func removeConfirmButtonTap_whenCapabilityThrows_preservesItemAndError() async throws {
         let sut = makeSUT(
             capability: StoredPaymentMethodManagementCapability { _ in


### PR DESCRIPTION
## Summary

- Models screen coordination as one private `State` value.
- Models each row with an `ItemRemovalState` enum: `.removing`, `.failed`, or absent for idle.
- Routes UI intents and async results through a pure `State + Action -> State?` reducer.
- Preserves the concurrent per-row removal behavior introduced by #2687.
- Binds confirmation to the item rendered by the sheet and qualifies completions by identifier.
- Derives the global error banner, row loading state, and UIKit navigation lock from the same source of truth.

This PR is part of stack #2691 and is stacked directly on #2687. Review the six-file diff against `chore/stored-pm-removal-updates` rather than `develop`.

## Why

#2687 allows several stored payment methods to be removed concurrently. That introduces two levels of state:

- screen state: at most one item awaiting confirmation;
- item state: each row is independently idle, removing, or failed.

The reducer keeps the transition rules in one place. It rejects duplicate, mismatched, stale, and invalid actions without publishing an unchanged state.

This is intentionally a screen-local pilot. It adds no shared framework or dependency. The goal is to evaluate whether this pattern is readable enough to guide future SwiftUI screens before adopting it more broadly.

## State model

The root `State` contains:

- `itemPendingConfirmation`;
- `[StoredPaymentMethodId: ItemRemovalState]`.

`ItemRemovalState` is mutually exclusive:

- `.removing`;
- `.failed`;
- absence from the dictionary means idle.

State helper methods encapsulate dictionary access so the reducer reads in domain terms: `isIdle`, `isRemoving`, `isPendingConfirmation`, `setRemovalState`, and `clearRemovalState`.

The existing global error banner is a view-model projection: it is visible when any item has failed. Retrying one item clears only that item's failure, so errors belonging to other rows remain represented.

`sections` remains outside the reducer because it is screen content rather than transient removal coordination. It changes only after the reducer accepts a successful completion.

## Concurrency guarantees

- Different rows can remove concurrently.
- The same identifier cannot start twice.
- Only the item currently shown by the sheet can be confirmed.
- A row cannot be removing and failed simultaneously.
- Completing one identifier does not alter another row's state.
- Retrying one failed row does not clear failures belonging to other rows.
- Section mutation and router notification happen only after an accepted success.
- Navigation remains locked until no removals are active.

## Review focus

- Does the reducer make valid transitions easier to understand than distributed property mutations?
- Does the screen-state struct plus per-item enum represent the domain clearly?
- Are the helper APIs readable and appropriately scoped?
- Is this a useful pilot for future SwiftUI state management without introducing a framework prematurely?

## Ticket

COSDK-1430

## Test plan

- [x] Single successful removal updates sections and notifies the router.
- [x] Duplicate actions for an in-flight row start one capability call.
- [x] Two rows can remain in flight concurrently.
- [x] Failure of one row does not affect another row's loading state.
- [x] A later success preserves an earlier concurrent error.
- [x] Multiple row failures remain independent; retry clears only the selected row.
- [x] Navigation locks during removal and restores its original state afterward.
- [x] Focused view-model and assembler suites pass: 14 tests.
- [x] SwiftFormat, SwiftLint, and `git diff --check` pass.
