### PR TITLE
Expose payment method lists on PaymentCheckout

### DIFF
--- a/AdyenCheckout/Flows/PaymentCheckout.swift
+++ b/AdyenCheckout/Flows/PaymentCheckout.swift
@@ -15,8 +15,13 @@ import Foundation
 public class PaymentCheckout: BaseCheckout {
 
     /// The payment methods available for this checkout flow.
-    public var paymentMethods: PaymentMethods? {
-        core.paymentMethods
+    public var paymentMethods: [PaymentMethod] {
+        core.paymentMethods?.regular ?? []
+    }
+
+    /// The stored payment methods available for this checkout flow.
+    public var storedPaymentMethods: [StoredPaymentMethod] {
+        core.paymentMethods?.stored ?? []
     }
 
     /// Creates a payment component for the specified payment method type.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -123,6 +123,17 @@ let checkout = try await Checkout.setup(
 
 `callPayments(with:)` should return `SubmitResult`, and `callDetails(with:)` should return `AdditionalDetailsResult`.
 
+#### Available payment methods
+
+`SessionCheckout` and `AdvancedCheckout` expose non-optional regular and stored payment-method arrays:
+
+```swift
+let paymentMethods = checkout.paymentMethods
+let storedPaymentMethods = checkout.storedPaymentMethods
+```
+
+These replace the interim `checkout.paymentMethods?.regular` and `checkout.paymentMethods?.stored` access paths. Missing payment-method data is represented by an empty array.
+
 #### Summary
 
 - `Checkout.setup(...)` replaces `AdyenSession.initialize(...)` for the new public v6 flows.

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ In v6 you present each payment method individually with `createPaymentComponent(
 let component = try checkout.createPaymentComponent(for: .scheme)
 
 // A stored payment method.
-guard let storedCard = checkout.paymentMethods?.stored
+guard let storedCard = checkout.storedPaymentMethods
     .compactMap({ $0 as? StoredCardPaymentMethod })
     .first else { return }
 

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -90,7 +90,10 @@ final class CheckoutTests: XCTestCase {
             provider: mockProvider
         )
         
-        XCTAssertNotNil(checkout.paymentMethods)
+        XCTAssertEqual(checkout.paymentMethods.map(\.name), paymentMethods.regular.map(\.name))
+        XCTAssertEqual(checkout.storedPaymentMethods.map(\.identifier), paymentMethods.stored.map(\.identifier))
+        XCTAssertEqual(typeIdentifiers(for: checkout.paymentMethods), typeIdentifiers(for: paymentMethods.regular))
+        XCTAssertEqual(typeIdentifiers(for: checkout.storedPaymentMethods), typeIdentifiers(for: paymentMethods.stored))
         XCTAssertNotNil(checkout.session)
         XCTAssertTrue(checkout.session === expectedSession)
         XCTAssertEqual(checkout.session?.state.identifier, "test_session_id")
@@ -130,8 +133,26 @@ final class CheckoutTests: XCTestCase {
         )
 
         XCTAssertNil(checkout.session)
-        XCTAssertNotNil(checkout.paymentMethods)
+        XCTAssertEqual(checkout.paymentMethods.map(\.name), paymentMethods.regular.map(\.name))
+        XCTAssertEqual(checkout.storedPaymentMethods.map(\.identifier), paymentMethods.stored.map(\.identifier))
+        XCTAssertEqual(typeIdentifiers(for: checkout.paymentMethods), typeIdentifiers(for: paymentMethods.regular))
+        XCTAssertEqual(typeIdentifiers(for: checkout.storedPaymentMethods), typeIdentifiers(for: paymentMethods.stored))
         XCTAssertTrue(mockProvider.setupPaymentMethodsCalled)
+    }
+
+    func testSetupWithPaymentMethods_whenCoreHasNoPaymentMethods_returnsEmptyLists() async throws {
+        let expectedCheckout = makeAdvancedCheckoutCore()
+        mockProvider.setupWithPaymentMethodsResult = .success(expectedCheckout)
+
+        let checkout = try await Checkout.setup(
+            with: paymentMethods,
+            configuration: configuration,
+            presentationDelegate: nil,
+            provider: mockProvider
+        )
+
+        XCTAssertTrue(checkout.paymentMethods.isEmpty)
+        XCTAssertTrue(checkout.storedPaymentMethods.isEmpty)
     }
 
     func testSetupWithPaymentMethods_Failure() async {
@@ -746,6 +767,10 @@ final class CheckoutTests: XCTestCase {
 
         // Then
         XCTAssertFalse(result)
+    }
+
+    private func typeIdentifiers(for values: [some Any]) -> [ObjectIdentifier] {
+        values.map { value in ObjectIdentifier(type(of: value)) }
     }
 
     private func makeSessionCheckoutCore(

--- a/guides/v6/card.md
+++ b/guides/v6/card.md
@@ -91,7 +91,7 @@ let configuration = try CheckoutConfiguration(
 If your checkout flow returns stored payment methods, first select a stored card explicitly:
 
 ```swift
-guard let storedCard = checkout.paymentMethods?.stored
+guard let storedCard = checkout.storedPaymentMethods
     .compactMap({ $0 as? StoredCardPaymentMethod })
     .first else { return }
 


### PR DESCRIPTION
# Summary
**What:** Exposes non-optional regular and stored payment-method arrays directly from `PaymentCheckout`. `SessionCheckout` and `AdvancedCheckout` inherit both properties, while `ActionOnlyCheckout` remains unchanged.

**Why:** Aligns the merchant-facing iOS checkout API with the Android payment-method list accessors introduced in [Adyen/adyen-android#2972](https://github.com/Adyen/adyen-android/pull/2972).

This intentionally replaces the interim `PaymentCheckout.paymentMethods: PaymentMethods?` aggregate with `paymentMethods: [PaymentMethod]` and adds `storedPaymentMethods: [StoredPaymentMethod]`.

## Technical Information

- Maps `paymentMethods` to `core.paymentMethods?.regular ?? []`.
- Maps `storedPaymentMethods` to `core.paymentMethods?.stored ?? []`.
- Preserves response ordering and concrete payment-method types.
- Keeps `CheckoutCore`, `PaymentMethods`, Sessions decoding, and ActionOnly behavior unchanged.
- Updates README, v6 card guidance, and migration documentation.

## Verification

- `CheckoutTests`: 36 passed.
- Full `UnitTests` scheme: 359 XCTest tests passed (1 skipped) plus 27 Swift Testing cases passed.
- Targeted SwiftFormat validation passed for both modified Swift files.
- SwiftLint completed with baseline warnings only and no serious violations.
- `AdyenTwint` simulator build passed.
- Standalone `AdyenCheckout` scheme remains blocked locally by the existing missing `AdyenDropIn` → `AdyenTwint` / `TwintSDK` dependency edge; the UnitTests build compiles the changed AdyenCheckout code successfully.

## Release Notes

<changed>
- `PaymentCheckout` now exposes regular and stored payment methods through the non-optional `paymentMethods` and `storedPaymentMethods` arrays.
</changed>

## Ticket
<ticket>
COSDK-1490
</ticket>

## Checklist
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms ([Android PR #2972](https://github.com/Adyen/adyen-android/pull/2972))