### PR TITLE
Add the injected payment component builder to dropin

### DIFF
--- a/AdyenCheckout/Component/CheckoutComponentBuilder.swift
+++ b/AdyenCheckout/Component/CheckoutComponentBuilder.swift
@@ -107,6 +107,30 @@ internal enum CheckoutComponentBuilder {
         }
     }
 
+    /// Builds a component for a type-erased regular or stored payment method.
+    @MainActor
+    internal static func build(
+        forAnyPaymentMethod paymentMethod: PaymentMethod,
+        configuration: CheckoutConfiguration,
+        sessionConfiguration: SessionComponentConfiguration? = nil,
+        context: AdyenContext
+    ) throws -> PaymentComponent {
+        if let storedPaymentMethod = paymentMethod as? any StoredPaymentMethod {
+            return build(
+                for: storedPaymentMethod,
+                configuration: configuration,
+                context: context
+            )
+        }
+
+        return try build(
+            for: paymentMethod,
+            configuration: configuration,
+            sessionConfiguration: sessionConfiguration,
+            context: context
+        )
+    }
+
     /// Creates a component using the provided factory for standard payment methods.
     ///
     /// This works for all components whose configurations conform to

--- a/AdyenDropIn/DropInComponent.swift
+++ b/AdyenDropIn/DropInComponent.swift
@@ -52,7 +52,8 @@ package final class DropInComponent: NSObject,
             configuration: configuration,
             dropInFlowManager: dropInFlowManager,
             partialPaymentDelegate: partialPaymentDelegate,
-            storedPaymentMethodManagementCapability: storedPaymentMethodManagementCapability
+            storedPaymentMethodManagementCapability: storedPaymentMethodManagementCapability,
+            paymentComponentBuilder: paymentComponentBuilder
         )
         return dropInAssembler.resolveDropInRouter()
     }()
@@ -68,6 +69,7 @@ package final class DropInComponent: NSObject,
     internal var configuration: DropInConfiguration
 
     private let actionComponentConfiguration: CheckoutActionComponent.Configuration
+    private let paymentComponentBuilder: DropInPaymentComponentBuilder?
 
     internal var paymentInProgress: Bool = false
 
@@ -89,6 +91,7 @@ package final class DropInComponent: NSObject,
     ///   - context: The context object for this component.
     ///   - configuration: Drop-in behavior and checkout-wide presentation configuration.
     ///   - actionComponentConfiguration: The resolved configuration for action handling.
+    ///   - paymentComponentBuilder: The payment component builder to handle component creation.
     ///   - title: Name of the application. To be displayed on a first payment page.
     ///            If no external value provided, the Main Bundle's name would be used.
     package init(
@@ -96,11 +99,13 @@ package final class DropInComponent: NSObject,
         context: AdyenContext,
         configuration: DropInConfiguration = .init(),
         actionComponentConfiguration: CheckoutActionComponent.Configuration = .init(),
+        paymentComponentBuilder: DropInPaymentComponentBuilder? = nil,
         title: String? = nil
     ) {
         self.title = title ?? Bundle.main.displayName
         self.configuration = configuration
         self.actionComponentConfiguration = actionComponentConfiguration
+        self.paymentComponentBuilder = paymentComponentBuilder
         self.context = context
         self.paymentMethods = paymentMethods
 
@@ -211,7 +216,8 @@ package final class DropInComponent: NSObject,
             configuration: configuration,
             partialPaymentEnabled: partialPaymentDelegate != nil,
             order: order,
-            presentationDelegate: self
+            presentationDelegate: self,
+            paymentComponentBuilder: paymentComponentBuilder
         )
     }
 

--- a/AdyenDropIn/Modules/Root/DropInAssembler.swift
+++ b/AdyenDropIn/Modules/Root/DropInAssembler.swift
@@ -35,7 +35,8 @@ internal struct DropInAssembler {
         configuration: DropInConfiguration,
         dropInFlowManager: DropInFlowManaging,
         partialPaymentDelegate: PartialPaymentDelegate?,
-        storedPaymentMethodManagementCapability: StoredPaymentMethodManagementCapability?
+        storedPaymentMethodManagementCapability: StoredPaymentMethodManagementCapability?,
+        paymentComponentBuilder: DropInPaymentComponentBuilder?
     ) {
         self.title = title
         self.paymentMethods = paymentMethods
@@ -50,7 +51,8 @@ internal struct DropInAssembler {
             configuration: configuration,
             partialPaymentEnabled: false, // TODO: - Set partial payment flow
             order: nil,
-            presentationDelegate: nil
+            presentationDelegate: nil,
+            paymentComponentBuilder: paymentComponentBuilder
         )
     }
 

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -21,6 +21,9 @@ import Adyen
 #endif
 import Foundation
 
+package typealias DropInPaymentComponentBuilder =
+    @MainActor (_ paymentMethod: PaymentMethod) throws -> PaymentComponent
+
 @MainActor
 internal protocol ComponentManaging {
     var sections: [PaymentMethodsSection] { get }
@@ -28,7 +31,7 @@ internal protocol ComponentManaging {
     func removeStoredPaymentMethod(withIdentifier identifier: String)
 }
 
-// TODO: - The ComponentManager should use the factories that Eren introduced in components.
+// TODO: Remove the legacy construction path when the injected builder becomes required in next PR.
 @MainActor
 internal final class ComponentManager: ComponentManaging {
 
@@ -40,6 +43,8 @@ internal final class ComponentManager: ComponentManaging {
     internal let order: PartialPaymentOrder?
     internal let partialPaymentEnabled: Bool
     internal weak var presentationDelegate: PresentationDelegate?
+
+    private let paymentComponentBuilder: DropInPaymentComponentBuilder?
 
     private var localizationParameters: LocalizationParameters? {
         configuration.resolvedLocalizationParameters
@@ -57,7 +62,8 @@ internal final class ComponentManager: ComponentManaging {
         configuration: DropInConfiguration,
         partialPaymentEnabled: Bool = true,
         order: PartialPaymentOrder?,
-        presentationDelegate: PresentationDelegate?
+        presentationDelegate: PresentationDelegate?,
+        paymentComponentBuilder: DropInPaymentComponentBuilder? = nil
     ) {
         self.paymentMethods = paymentMethods
         self.context = context
@@ -65,6 +71,7 @@ internal final class ComponentManager: ComponentManaging {
         self.partialPaymentEnabled = partialPaymentEnabled
         self.order = order
         self.presentationDelegate = presentationDelegate
+        self.paymentComponentBuilder = paymentComponentBuilder
 
         updateContextAmountIfNeeded()
     }
@@ -96,16 +103,18 @@ internal final class ComponentManager: ComponentManaging {
             return nil
         }
 
-        let component: PaymentComponent? = {
-            if let buildable = paymentMethod as? any PaymentComponentBuildable {
-                buildable.buildComponent(using: self)
-            } else {
-                build(paymentMethod: paymentMethod)
-            }
-        }()
+        let component: PaymentComponent? = if let paymentComponentBuilder {
+            try? paymentComponentBuilder(paymentMethod)
+        } else if let buildable = paymentMethod as? any PaymentComponentBuildable {
+            buildable.buildComponent(using: self)
+        } else {
+            build(paymentMethod: paymentMethod)
+        }
         guard var paymentComponent = component else { return nil }
+        // TODO: Preserve the order assignment until partial payments have a dedicated design.
         paymentComponent.order = order
 
+        // TODO: To be removed with the same updates on the builder next PR
         if var localizableComponent = paymentComponent as? Localizable {
             localizableComponent.localizationParameters = localizationParameters
         }

--- a/AdyenDropIn/Utilities/ComponentManager.swift
+++ b/AdyenDropIn/Utilities/ComponentManager.swift
@@ -103,12 +103,19 @@ internal final class ComponentManager: ComponentManaging {
             return nil
         }
 
-        let component: PaymentComponent? = if let paymentComponentBuilder {
-            try? paymentComponentBuilder(paymentMethod)
+        let component: PaymentComponent?
+        if let paymentComponentBuilder {
+            do {
+                component = try paymentComponentBuilder(paymentMethod)
+            } catch {
+                // TODO: Store these errors if we need to track them.
+                adyenPrint("Failed to build component for \(paymentMethod.type.rawValue):", error)
+                component = nil
+            }
         } else if let buildable = paymentMethod as? any PaymentComponentBuildable {
-            buildable.buildComponent(using: self)
+            component = buildable.buildComponent(using: self)
         } else {
-            build(paymentMethod: paymentMethod)
+            component = build(paymentMethod: paymentMethod)
         }
         guard var paymentComponent = component else { return nil }
         // TODO: Preserve the order assignment until partial payments have a dedicated design.

--- a/AdyenUI/CheckoutConfiguration/CheckoutConfigurable.swift
+++ b/AdyenUI/CheckoutConfiguration/CheckoutConfigurable.swift
@@ -32,7 +32,7 @@ package protocol CheckoutComponentConfiguration: CheckoutConfigurable {
 
 package extension CheckoutConfigurable {
 
-    // TODO: add descriptions
+    // TODO: remove this, components don't support setting this individually
     // having this function here instead of re writing it for all configurations
     // prevents duplication, but the returned value will be seen as CheckoutConfigurable
     // after calling this function, as opposed to actual type

--- a/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutComponentBuilderTests.swift
@@ -484,6 +484,38 @@ final class CheckoutComponentBuilderTests: XCTestCase {
         XCTAssertEqual(blikComponent.configuration.localizationParameters, localizationParameters)
     }
 
+    // MARK: - Runtime Dispatch Tests
+
+    func test_buildForAnyPaymentMethod_withRegularMethod_shouldUseRegularBuilder() throws {
+        // Given
+        let paymentMethod: any PaymentMethod = try XCTUnwrap(createCardPaymentMethod())
+
+        // When
+        let component = try CheckoutComponentBuilder.build(
+            forAnyPaymentMethod: paymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+
+        // Then
+        XCTAssertTrue(component is CardComponent)
+    }
+
+    func test_buildForAnyPaymentMethod_withStoredMethod_shouldUseStoredBuilder() throws {
+        // Given
+        let paymentMethod: any PaymentMethod = try XCTUnwrap(createStoredCardPaymentMethod())
+
+        // When
+        let component = try CheckoutComponentBuilder.build(
+            forAnyPaymentMethod: paymentMethod,
+            configuration: checkoutConfiguration,
+            context: context
+        )
+
+        // Then
+        XCTAssertTrue(component is StoredCardComponent)
+    }
+
     // MARK: - Stored Payment Method Tests
     
     func test_build_withStoredCardPaymentMethod_returnsStoredCardComponent() throws {

--- a/Tests/UnitTests/AdyenDropIn/ComponentManagerTests.swift
+++ b/Tests/UnitTests/AdyenDropIn/ComponentManagerTests.swift
@@ -6,6 +6,7 @@
 
 @_spi(AdyenInternal) @testable import Adyen
 @testable import AdyenCard
+@testable import AdyenCheckout
 @testable import AdyenComponents
 @testable import AdyenDropIn
 #if canImport(AdyenTwint)
@@ -250,6 +251,134 @@ class ComponentManagerTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(paymentComponent as? StoredPaymentMethodComponent)
+    }
+
+    func test_buildComponent_withInjectedBuilder_shouldInvokeBuilder() throws {
+        // Given
+        let paymentMethod = try XCTUnwrap(paymentMethods.regular.first)
+        var receivedPaymentMethod: (any PaymentMethod)?
+        let sut = ComponentManager(
+            paymentMethods: PaymentMethods(regular: [], stored: []),
+            context: context,
+            configuration: configuration,
+            order: nil,
+            presentationDelegate: presentationDelegate,
+            paymentComponentBuilder: { paymentMethod in
+                receivedPaymentMethod = paymentMethod
+                return GenericPaymentComponent(
+                    paymentMethod: paymentMethod,
+                    context: self.context,
+                    order: nil
+                )
+            }
+        )
+
+        // When
+        let component = sut.buildComponent(for: paymentMethod)
+
+        // Then
+        XCTAssertNotNil(component)
+        XCTAssertEqual(receivedPaymentMethod?.type, paymentMethod.type)
+    }
+
+    func test_buildComponent_whenInjectedBuilderThrowsCheckoutError_shouldReturnNil() throws {
+        // Given
+        let paymentMethod = try XCTUnwrap(paymentMethods.regular.first)
+        let sut: ComponentManaging = ComponentManager(
+            paymentMethods: PaymentMethods(regular: [], stored: []),
+            context: context,
+            configuration: configuration,
+            order: nil,
+            presentationDelegate: presentationDelegate,
+            paymentComponentBuilder: { _ in
+                throw CheckoutError(
+                    code: .paymentMethodFailure,
+                    message: "Expected test error"
+                )
+            }
+        )
+
+        // When
+        let component = sut.buildComponent(for: paymentMethod)
+
+        // Then
+        XCTAssertNil(component)
+    }
+
+    func test_buildComponent_withCheckoutBuilder_shouldMatchLegacyComponentTypes() throws {
+        // Given
+        let checkoutConfiguration = CheckoutConfiguration(
+            apiContext: Dummy.apiContext,
+            amount: Dummy.amount,
+            analyticsApiContext: nil,
+            analyticsConfiguration: .init()
+        )
+        let legacyManager = ComponentManager(
+            paymentMethods: PaymentMethods(regular: [], stored: []),
+            context: context,
+            configuration: configuration,
+            order: nil,
+            presentationDelegate: presentationDelegate
+        )
+        let injectedManager = ComponentManager(
+            paymentMethods: PaymentMethods(regular: [], stored: []),
+            context: context,
+            configuration: configuration,
+            order: nil,
+            presentationDelegate: presentationDelegate,
+            paymentComponentBuilder: { paymentMethod in
+                try CheckoutComponentBuilder.build(
+                    forAnyPaymentMethod: paymentMethod,
+                    configuration: checkoutConfiguration,
+                    context: self.context
+                )
+            }
+        )
+        let regularMethods: [any PaymentMethod] = try [
+            XCTUnwrap(paymentMethods.regular.first { $0 is CardPaymentMethod }),
+            XCTUnwrap(paymentMethods.regular.first { $0 is ACHDirectDebitPaymentMethod }),
+            XCTUnwrap(paymentMethods.regular.first { $0 is BLIKPaymentMethod }),
+            XCTUnwrap(paymentMethods.regular.first { $0 is GenericPaymentMethod })
+        ]
+        let storedMethods: [any PaymentMethod] = try [
+            XCTUnwrap(paymentMethods.stored.first { $0 is StoredCardPaymentMethod }),
+            XCTUnwrap(paymentMethods.stored.first { $0 is StoredPayPalPaymentMethod })
+        ]
+
+        // When / Then
+        for paymentMethod in regularMethods + storedMethods {
+            let legacyComponent = try XCTUnwrap(legacyManager.buildComponent(for: paymentMethod))
+            let injectedComponent = try XCTUnwrap(injectedManager.buildComponent(for: paymentMethod))
+            XCTAssertTrue(
+                type(of: legacyComponent) == type(of: injectedComponent),
+                "Expected matching component types for \(paymentMethod.type.rawValue)"
+            )
+        }
+    }
+
+    func test_sections_withoutInjectedBuilder_shouldPreserveMethodSetAndOrdering() throws {
+        // Given
+        let sut = ComponentManager(
+            paymentMethods: paymentMethods,
+            context: context,
+            configuration: configuration,
+            order: nil,
+            presentationDelegate: presentationDelegate
+        )
+
+        // When
+        let storedSection = try XCTUnwrap(sut.sections.first { $0.kind == .stored })
+        let regularSection = try XCTUnwrap(sut.sections.first { $0.kind == .regular })
+
+        // Then
+        XCTAssertEqual(
+            storedSection.paymentMethods.map(\.name),
+            sut.visibleStoredPaymentMethods.map(\.name)
+        )
+        XCTAssertEqual(
+            regularSection.paymentMethods.map(\.name),
+            paymentMethods.regular.map(\.name)
+        )
     }
 
     func testOrderInjection() {


### PR DESCRIPTION
# Summary [Required]
DropIn will migrate to using the new CheckoutComponentBuilder but it can't depend on it as it's higher module. Instead Dropin will receive a closure injected that will in turn be filled by Checkout owned CheckoutComponentBuilder to populate the dropin components.

## Ticket [Optional]
<ticket>
COSDK-1520
</ticket>

## Checklist [Required]
<!-- Mark completed items with an [x] -->
- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)
