### PR TITLE
fix: Always complete session checkout without session result

### DIFF
--- a/AdyenCheckout/Callbacks/CheckoutResultCallbackStore.swift
+++ b/AdyenCheckout/Callbacks/CheckoutResultCallbackStore.swift
@@ -22,11 +22,12 @@ package final class SessionCheckoutCallbackStore: CheckoutResultCallbackStore {
     package var onFailure: CheckoutFailureHandler?
 
     package func handleCompletion(resultCode: CheckoutResultCode, sessionId: String?, sessionResult: String?) {
-        guard let sessionId, let sessionResult else {
-            AdyenAssertion.assertionFailure(message: "Session completion called without sessionId or sessionResult.")
-            return
+        if sessionId == nil {
+            AdyenAssertion.assertionFailure(message: "Session completion called without a sessionId.")
+        } else if sessionResult == nil, resultCode != .cancelled, resultCode != .error {
+            AdyenAssertion.assertionFailure(message: "Session completion called without a sessionResult.")
         }
-        onComplete?(SessionCheckoutResult(resultCode: resultCode, sessionId: sessionId, sessionResult: sessionResult))
+        onComplete?(SessionCheckoutResult(resultCode: resultCode, sessionId: sessionId ?? "", sessionResult: sessionResult ?? ""))
     }
 }
 

--- a/Tests/UnitTests/AdyenCheckout/CheckoutResultCallbackStoreTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutResultCallbackStoreTests.swift
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@_spi(AdyenInternal) @testable import Adyen
+@testable import AdyenCheckout
+import XCTest
+
+/// Tests that ``SessionCheckoutCallbackStore/handleCompletion(resultCode:sessionId:sessionResult:)``
+/// always notifies the merchant's `onComplete` handler, even when `sessionResult` is legitimately
+/// unavailable (e.g. the shopper cancels, or checkout errors, before any `/payments` or
+/// `/payments/details` call completes).
+@MainActor
+final class CheckoutResultCallbackStoreTests: XCTestCase {
+
+    override func tearDown() {
+        AdyenAssertion.listener = nil
+        super.tearDown()
+    }
+
+    func test_handleCompletion_withSessionIdAndSessionResult_shouldCallOnCompleteWithBothValues() {
+        let sut = SessionCheckoutCallbackStore()
+        let onCompleteExpectation = expectation(description: "onComplete called")
+
+        sut.onComplete = { result in
+            XCTAssertEqual(result.resultCode, .authorised)
+            XCTAssertEqual(result.sessionId, "session_id")
+            XCTAssertEqual(result.sessionResult, "session_result")
+            onCompleteExpectation.fulfill()
+        }
+
+        sut.handleCompletion(resultCode: .authorised, sessionId: "session_id", sessionResult: "session_result")
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_handleCompletion_withCancelledResultCodeAndMissingSessionResult_shouldCallOnCompleteWithEmptySessionResultAndNotAssert() {
+        let sut = SessionCheckoutCallbackStore()
+        let onCompleteExpectation = expectation(description: "onComplete called")
+        AdyenAssertion.listener = { message in
+            XCTFail("Assertion should not fire for a cancelled result with no sessionResult: \(message)")
+        }
+
+        sut.onComplete = { result in
+            XCTAssertEqual(result.resultCode, .cancelled)
+            XCTAssertEqual(result.sessionId, "session_id")
+            XCTAssertEqual(result.sessionResult, "")
+            onCompleteExpectation.fulfill()
+        }
+
+        sut.handleCompletion(resultCode: .cancelled, sessionId: "session_id", sessionResult: nil)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_handleCompletion_withErrorResultCodeAndMissingSessionResult_shouldCallOnCompleteWithEmptySessionResultAndNotAssert() {
+        let sut = SessionCheckoutCallbackStore()
+        let onCompleteExpectation = expectation(description: "onComplete called")
+        AdyenAssertion.listener = { message in
+            XCTFail("Assertion should not fire for an error result with no sessionResult: \(message)")
+        }
+
+        sut.onComplete = { result in
+            XCTAssertEqual(result.resultCode, .error)
+            XCTAssertEqual(result.sessionId, "session_id")
+            XCTAssertEqual(result.sessionResult, "")
+            onCompleteExpectation.fulfill()
+        }
+
+        sut.handleCompletion(resultCode: .error, sessionId: "session_id", sessionResult: nil)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_handleCompletion_withAuthorisedResultCodeAndMissingSessionResult_shouldCallOnCompleteAndAssert() {
+        let sut = SessionCheckoutCallbackStore()
+        let onCompleteExpectation = expectation(description: "onComplete called")
+        let assertionExpectation = expectation(description: "assertion fired")
+        AdyenAssertion.listener = { message in
+            XCTAssertEqual(message, "Session completion called without a sessionResult.")
+            assertionExpectation.fulfill()
+        }
+
+        sut.onComplete = { result in
+            XCTAssertEqual(result.resultCode, .authorised)
+            XCTAssertEqual(result.sessionId, "session_id")
+            XCTAssertEqual(result.sessionResult, "")
+            onCompleteExpectation.fulfill()
+        }
+
+        sut.handleCompletion(resultCode: .authorised, sessionId: "session_id", sessionResult: nil)
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_handleCompletion_withMissingSessionId_shouldCallOnCompleteWithEmptySessionIdAndAssert() {
+        let sut = SessionCheckoutCallbackStore()
+        let onCompleteExpectation = expectation(description: "onComplete called")
+        let assertionExpectation = expectation(description: "assertion fired")
+        AdyenAssertion.listener = { message in
+            XCTAssertEqual(message, "Session completion called without a sessionId.")
+            assertionExpectation.fulfill()
+        }
+
+        sut.onComplete = { result in
+            XCTAssertEqual(result.resultCode, .authorised)
+            XCTAssertEqual(result.sessionId, "")
+            XCTAssertEqual(result.sessionResult, "session_result")
+            onCompleteExpectation.fulfill()
+        }
+
+        sut.handleCompletion(resultCode: .authorised, sessionId: nil, sessionResult: "session_result")
+
+        waitForExpectations(timeout: 1)
+    }
+}

--- a/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
+++ b/Tests/UnitTests/AdyenCheckout/CheckoutTests.swift
@@ -739,6 +739,30 @@ final class CheckoutTests: XCTestCase {
         XCTAssertFalse(onFailureCalled)
     }
 
+    // MARK: - session completion callback
+
+    func test_didComplete_withCancelledResultCodeAndNoPriorSessionCall_shouldCallOnCompleteWithEmptySessionResult() async throws {
+        // A shopper backing out before any `/payments` or `/payments/details` call ever
+        // completed leaves `session.state.sessionResult` at its initial `nil` value. That is
+        // an expected case for `.cancelled` (and `.error`) and must still notify `onComplete`.
+        let callbackStore = SessionCheckoutCallbackStore()
+        let onCompleteExpectation = expectation(description: "onComplete called")
+        let blik = try XCTUnwrap(paymentMethods.paymentMethod(ofType: BLIKPaymentMethod.self))
+        let session = makeSessionMock()
+        session.state.resultCode = .cancelled
+        callbackStore.onComplete = { result in
+            XCTAssertEqual(result.resultCode, .cancelled)
+            XCTAssertEqual(result.sessionId, "test_session_id")
+            XCTAssertEqual(result.sessionResult, "")
+            onCompleteExpectation.fulfill()
+        }
+        let sut = makeSessionCheckoutCore(session: session, callbackStore: callbackStore)
+        sut.pendingPaymentComponent = PaymentComponentMock(paymentMethod: blik)
+
+        sut.didComplete(from: ActionComponentMock())
+        await fulfillment(of: [onCompleteExpectation], timeout: 1)
+    }
+
     // MARK: - handleReturn
 
     func test_handleReturn_withRegisteredHandler_returnsTrue() throws {


### PR DESCRIPTION
# Summary

Fixed session checkout completion so `onComplete` is invoked even when `sessionResult` is unavailable. Missing session results now default to an empty string, while unexpected missing values retain assertion diagnostics.

## Release Notes

<fixed>
- Fixed session checkout completion callbacks not being invoked when a session result was unavailable.
</fixed>

## Technical Information

`SessionCheckoutCallbackStore` now always creates `SessionCheckoutResult`. Missing `sessionResult` is expected for `.cancelled` and `.error`; other missing values still trigger an assertion without suppressing the merchant callback.


## Ticket

<ticket>
COSDK-1532
</ticket>

## Checklist

- [x] Tested changes locally
- [x] Added/updated unit tests
- [x] Verified against acceptance criteria
- [x] Aligned public API changes with other platforms (if applicable)
