### PR TITLE
[2/2] DropIn - Generic Payment Method tests

### DIFF
--- a/AdyenDropIn/Modules/GenericPaymentMethod/GenericPaymentMethodAssembler.swift
+++ b/AdyenDropIn/Modules/GenericPaymentMethod/GenericPaymentMethodAssembler.swift
@@ -8,6 +8,7 @@ import AdyenUI
 import Foundation
 import SwiftUI
 
+// sourcery:AutoMockable
 @MainActor
 internal protocol GenericPaymentMethodAssemblerProtocol {
     func resolveGenericPaymentMethodRouter(

--- a/AdyenDropIn/Modules/GenericPaymentMethod/GenericPaymentMethodRouter.swift
+++ b/AdyenDropIn/Modules/GenericPaymentMethod/GenericPaymentMethodRouter.swift
@@ -6,11 +6,13 @@
 
 import Foundation
 
+// sourcery:AutoMockable
 @MainActor
 internal protocol GenericPaymentMethodRouterListener: AnyObject {
     func didDismissGenericPaymentMethod()
 }
 
+// sourcery:AutoMockable
 internal protocol GenericPaymentMethodRouting: AnyObject {
     func present(actionViewController: UIViewController, onCancel: (() -> Void)?)
     func dismiss()

--- a/Tests/GeneratedMocks/AutoMockable.generated.swift
+++ b/Tests/GeneratedMocks/AutoMockable.generated.swift
@@ -1,9 +1,3 @@
-//
-// Copyright (c) 2025 Adyen N.V.
-//
-// This file is open source and available under the MIT license. See the LICENSE file for more info.
-//
-
 // Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable line_length
@@ -11,26 +5,50 @@
 
 import Foundation
 #if os(iOS) || os(tvOS) || os(watchOS)
-    import UIKit
+import UIKit
 #elseif os(OSX)
-    import AppKit
+import AppKit
 #endif
 
+
 @testable import Adyen
-@testable import AdyenCard
 @testable import AdyenCheckout
 @testable import AdyenDropIn
+@testable import AdyenCard
 @testable import AdyenUI
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 class ActionPresenterMock: ActionPresenter {
 
-    // MARK: - present
+
+
+
+    //MARK: - present
 
     var presentActionViewControllerCallsCount = 0
     var presentActionViewControllerCalled: Bool {
-        presentActionViewControllerCallsCount > 0
+        return presentActionViewControllerCallsCount > 0
     }
-
     var presentActionViewControllerReceivedActionViewController: UIViewController?
     var presentActionViewControllerReceivedInvocations: [UIViewController] = []
     var presentActionViewControllerClosure: ((UIViewController) -> Void)?
@@ -42,13 +60,12 @@ class ActionPresenterMock: ActionPresenter {
         presentActionViewControllerClosure?(actionViewController)
     }
 
-    // MARK: - didCancel
+    //MARK: - didCancel
 
     var didCancelActionComponentCallsCount = 0
     var didCancelActionComponentCalled: Bool {
-        didCancelActionComponentCallsCount > 0
+        return didCancelActionComponentCallsCount > 0
     }
-
     var didCancelActionComponentReceivedActionComponent: ActionComponent?
     var didCancelActionComponentReceivedInvocations: [ActionComponent] = []
     var didCancelActionComponentClosure: ((ActionComponent) -> Void)?
@@ -61,20 +78,19 @@ class ActionPresenterMock: ActionPresenter {
     }
 
 }
-
 public class AnyEventAnalyticsProviderMock: AnyEventAnalyticsProvider {
 
     public init() {}
 
     public var checkoutAttemptId: String?
 
-    // MARK: - add
+
+    //MARK: - add
 
     public var addInfoCallsCount = 0
     public var addInfoCalled: Bool {
-        addInfoCallsCount > 0
+        return addInfoCallsCount > 0
     }
-
     public var addInfoReceivedInfo: AnalyticsEventInfo?
     public var addInfoReceivedInvocations: [AnalyticsEventInfo] = []
     public var addInfoClosure: ((AnalyticsEventInfo) -> Void)?
@@ -86,13 +102,12 @@ public class AnyEventAnalyticsProviderMock: AnyEventAnalyticsProvider {
         addInfoClosure?(info)
     }
 
-    // MARK: - add
+    //MARK: - add
 
     public var addLogCallsCount = 0
     public var addLogCalled: Bool {
-        addLogCallsCount > 0
+        return addLogCallsCount > 0
     }
-
     public var addLogReceivedLog: AnalyticsEventLog?
     public var addLogReceivedInvocations: [AnalyticsEventLog] = []
     public var addLogClosure: ((AnalyticsEventLog) -> Void)?
@@ -104,13 +119,12 @@ public class AnyEventAnalyticsProviderMock: AnyEventAnalyticsProvider {
         addLogClosure?(log)
     }
 
-    // MARK: - add
+    //MARK: - add
 
     public var addErrorCallsCount = 0
     public var addErrorCalled: Bool {
-        addErrorCallsCount > 0
+        return addErrorCallsCount > 0
     }
-
     public var addErrorReceivedError: AnalyticsEventError?
     public var addErrorReceivedInvocations: [AnalyticsEventError] = []
     public var addErrorClosure: ((AnalyticsEventError) -> Void)?
@@ -123,16 +137,17 @@ public class AnyEventAnalyticsProviderMock: AnyEventAnalyticsProvider {
     }
 
 }
-
 class ComponentContainerAssemblerProtocolMock: ComponentContainerAssemblerProtocol {
 
-    // MARK: - resolveComponentContainerRouter
+
+
+
+    //MARK: - resolveComponentContainerRouter
 
     var resolveComponentContainerRouterForListenerCallsCount = 0
     var resolveComponentContainerRouterForListenerCalled: Bool {
-        resolveComponentContainerRouterForListenerCallsCount > 0
+        return resolveComponentContainerRouterForListenerCallsCount > 0
     }
-
     var resolveComponentContainerRouterForListenerReceivedArguments: (component: PresentablePaymentComponent, listener: ComponentContainerRouterListener)?
     var resolveComponentContainerRouterForListenerReceivedInvocations: [(component: PresentablePaymentComponent, listener: ComponentContainerRouterListener)] = []
     var resolveComponentContainerRouterForListenerReturnValue: Router!
@@ -142,7 +157,7 @@ class ComponentContainerAssemblerProtocolMock: ComponentContainerAssemblerProtoc
         resolveComponentContainerRouterForListenerCallsCount += 1
         resolveComponentContainerRouterForListenerReceivedArguments = (component: component, listener: listener)
         resolveComponentContainerRouterForListenerReceivedInvocations.append((component: component, listener: listener))
-        if let resolveComponentContainerRouterForListenerClosure {
+        if let resolveComponentContainerRouterForListenerClosure = resolveComponentContainerRouterForListenerClosure {
             return resolveComponentContainerRouterForListenerClosure(component, listener)
         } else {
             return resolveComponentContainerRouterForListenerReturnValue
@@ -150,16 +165,17 @@ class ComponentContainerAssemblerProtocolMock: ComponentContainerAssemblerProtoc
     }
 
 }
-
 class ComponentContainerRouterListenerMock: ComponentContainerRouterListener {
 
-    // MARK: - didDismissComponentContainer
+
+
+
+    //MARK: - didDismissComponentContainer
 
     var didDismissComponentContainerCompletionCallsCount = 0
     var didDismissComponentContainerCompletionCalled: Bool {
-        didDismissComponentContainerCompletionCallsCount > 0
+        return didDismissComponentContainerCompletionCallsCount > 0
     }
-
     var didDismissComponentContainerCompletionClosure: (((() -> Void)?) -> Void)?
 
     func didDismissComponentContainer(completion: (() -> Void)?) {
@@ -168,16 +184,17 @@ class ComponentContainerRouterListenerMock: ComponentContainerRouterListener {
     }
 
 }
-
 class ComponentContainerRoutingMock: ComponentContainerRouting {
 
-    // MARK: - present
+
+
+
+    //MARK: - present
 
     var presentPaymentComponentCallsCount = 0
     var presentPaymentComponentCalled: Bool {
-        presentPaymentComponentCallsCount > 0
+        return presentPaymentComponentCallsCount > 0
     }
-
     var presentPaymentComponentReceivedPaymentComponent: PresentablePaymentComponent?
     var presentPaymentComponentReceivedInvocations: [PresentablePaymentComponent] = []
     var presentPaymentComponentClosure: ((PresentablePaymentComponent) -> Void)?
@@ -189,13 +206,12 @@ class ComponentContainerRoutingMock: ComponentContainerRouting {
         presentPaymentComponentClosure?(paymentComponent)
     }
 
-    // MARK: - present
+    //MARK: - present
 
     var presentActionViewControllerOnCancelCallsCount = 0
     var presentActionViewControllerOnCancelCalled: Bool {
-        presentActionViewControllerOnCancelCallsCount > 0
+        return presentActionViewControllerOnCancelCallsCount > 0
     }
-
     var presentActionViewControllerOnCancelClosure: ((UIViewController, (() -> Void)?) -> Void)?
 
     func present(actionViewController: UIViewController, onCancel: (() -> Void)?) {
@@ -203,13 +219,12 @@ class ComponentContainerRoutingMock: ComponentContainerRouting {
         presentActionViewControllerOnCancelClosure?(actionViewController, onCancel)
     }
 
-    // MARK: - dismiss
+    //MARK: - dismiss
 
     var dismissCompletionCallsCount = 0
     var dismissCompletionCalled: Bool {
-        dismissCompletionCallsCount > 0
+        return dismissCompletionCallsCount > 0
     }
-
     var dismissCompletionClosure: (((() -> Void)?) -> Void)?
 
     func dismiss(completion: (() -> Void)?) {
@@ -218,23 +233,22 @@ class ComponentContainerRoutingMock: ComponentContainerRouting {
     }
 
 }
-
 class ComponentContainerViewModelProtocolMock: ComponentContainerViewModelProtocol {
 
+
     var componentViewController: UIViewController {
-        get { underlyingComponentViewController }
+        get { return underlyingComponentViewController }
         set(value) { underlyingComponentViewController = value }
     }
-
     var underlyingComponentViewController: UIViewController!
 
-    // MARK: - cancel
+
+    //MARK: - cancel
 
     var cancelCallsCount = 0
     var cancelCalled: Bool {
-        cancelCallsCount > 0
+        return cancelCallsCount > 0
     }
-
     var cancelClosure: (() -> Void)?
 
     func cancel() {
@@ -243,16 +257,17 @@ class ComponentContainerViewModelProtocolMock: ComponentContainerViewModelProtoc
     }
 
 }
-
 class DropInFlowManagingMock: DropInFlowManaging {
 
-    // MARK: - submit
+
+
+
+    //MARK: - submit
 
     var submitFromActionPresenterCallsCount = 0
     var submitFromActionPresenterCalled: Bool {
-        submitFromActionPresenterCallsCount > 0
+        return submitFromActionPresenterCallsCount > 0
     }
-
     var submitFromActionPresenterReceivedArguments: (data: PaymentComponentData, component: PaymentComponent, actionPresenter: ActionPresenter)?
     var submitFromActionPresenterReceivedInvocations: [(data: PaymentComponentData, component: PaymentComponent, actionPresenter: ActionPresenter)] = []
     var submitFromActionPresenterClosure: ((PaymentComponentData, PaymentComponent, ActionPresenter) -> Void)?
@@ -264,13 +279,12 @@ class DropInFlowManagingMock: DropInFlowManaging {
         submitFromActionPresenterClosure?(data, component, actionPresenter)
     }
 
-    // MARK: - fail
+    //MARK: - fail
 
     var failWithFromCallsCount = 0
     var failWithFromCalled: Bool {
-        failWithFromCallsCount > 0
+        return failWithFromCallsCount > 0
     }
-
     var failWithFromReceivedArguments: (error: Error, component: PaymentComponent)?
     var failWithFromReceivedInvocations: [(error: Error, component: PaymentComponent)] = []
     var failWithFromClosure: ((Error, PaymentComponent) -> Void)?
@@ -282,13 +296,12 @@ class DropInFlowManagingMock: DropInFlowManaging {
         failWithFromClosure?(error, component)
     }
 
-    // MARK: - cancel
+    //MARK: - cancel
 
     var cancelComponentCallsCount = 0
     var cancelComponentCalled: Bool {
-        cancelComponentCallsCount > 0
+        return cancelComponentCallsCount > 0
     }
-
     var cancelComponentReceivedComponent: PaymentComponent?
     var cancelComponentReceivedInvocations: [PaymentComponent] = []
     var cancelComponentClosure: ((PaymentComponent) -> Void)?
@@ -300,13 +313,12 @@ class DropInFlowManagingMock: DropInFlowManaging {
         cancelComponentClosure?(component)
     }
 
-    // MARK: - handle
+    //MARK: - handle
 
     var handleActionCallsCount = 0
     var handleActionCalled: Bool {
-        handleActionCallsCount > 0
+        return handleActionCallsCount > 0
     }
-
     var handleActionReceivedAction: Action?
     var handleActionReceivedInvocations: [Action] = []
     var handleActionClosure: ((Action) -> Void)?
@@ -319,16 +331,96 @@ class DropInFlowManagingMock: DropInFlowManaging {
     }
 
 }
+class GenericPaymentMethodAssemblerProtocolMock: GenericPaymentMethodAssemblerProtocol {
 
+
+
+
+    //MARK: - resolveGenericPaymentMethodRouter
+
+    var resolveGenericPaymentMethodRouterForListenerCallsCount = 0
+    var resolveGenericPaymentMethodRouterForListenerCalled: Bool {
+        return resolveGenericPaymentMethodRouterForListenerCallsCount > 0
+    }
+    var resolveGenericPaymentMethodRouterForListenerReceivedArguments: (component: PaymentComponent, listener: GenericPaymentMethodRouterListener)?
+    var resolveGenericPaymentMethodRouterForListenerReceivedInvocations: [(component: PaymentComponent, listener: GenericPaymentMethodRouterListener)] = []
+    var resolveGenericPaymentMethodRouterForListenerReturnValue: Router!
+    var resolveGenericPaymentMethodRouterForListenerClosure: ((PaymentComponent, GenericPaymentMethodRouterListener) -> Router)?
+
+    func resolveGenericPaymentMethodRouter(for component: PaymentComponent, listener: GenericPaymentMethodRouterListener) -> Router {
+        resolveGenericPaymentMethodRouterForListenerCallsCount += 1
+        resolveGenericPaymentMethodRouterForListenerReceivedArguments = (component: component, listener: listener)
+        resolveGenericPaymentMethodRouterForListenerReceivedInvocations.append((component: component, listener: listener))
+        if let resolveGenericPaymentMethodRouterForListenerClosure = resolveGenericPaymentMethodRouterForListenerClosure {
+            return resolveGenericPaymentMethodRouterForListenerClosure(component, listener)
+        } else {
+            return resolveGenericPaymentMethodRouterForListenerReturnValue
+        }
+    }
+
+}
+class GenericPaymentMethodRouterListenerMock: GenericPaymentMethodRouterListener {
+
+
+
+
+    //MARK: - didDismissGenericPaymentMethod
+
+    var didDismissGenericPaymentMethodCallsCount = 0
+    var didDismissGenericPaymentMethodCalled: Bool {
+        return didDismissGenericPaymentMethodCallsCount > 0
+    }
+    var didDismissGenericPaymentMethodClosure: (() -> Void)?
+
+    func didDismissGenericPaymentMethod() {
+        didDismissGenericPaymentMethodCallsCount += 1
+        didDismissGenericPaymentMethodClosure?()
+    }
+
+}
+class GenericPaymentMethodRoutingMock: GenericPaymentMethodRouting {
+
+
+
+
+    //MARK: - present
+
+    var presentActionViewControllerOnCancelCallsCount = 0
+    var presentActionViewControllerOnCancelCalled: Bool {
+        return presentActionViewControllerOnCancelCallsCount > 0
+    }
+    var presentActionViewControllerOnCancelClosure: ((UIViewController, (() -> Void)?) -> Void)?
+
+    func present(actionViewController: UIViewController, onCancel: (() -> Void)?) {
+        presentActionViewControllerOnCancelCallsCount += 1
+        presentActionViewControllerOnCancelClosure?(actionViewController, onCancel)
+    }
+
+    //MARK: - dismiss
+
+    var dismissCallsCount = 0
+    var dismissCalled: Bool {
+        return dismissCallsCount > 0
+    }
+    var dismissClosure: (() -> Void)?
+
+    func dismiss() {
+        dismissCallsCount += 1
+        dismissClosure?()
+    }
+
+}
 class PaymentMethodListAssemblerProtocolMock: PaymentMethodListAssemblerProtocol {
 
-    // MARK: - resolvePaymentMethodListRouter
+
+
+
+    //MARK: - resolvePaymentMethodListRouter
 
     var resolvePaymentMethodListRouterDelegateCallsCount = 0
     var resolvePaymentMethodListRouterDelegateCalled: Bool {
-        resolvePaymentMethodListRouterDelegateCallsCount > 0
+        return resolvePaymentMethodListRouterDelegateCallsCount > 0
     }
-
     var resolvePaymentMethodListRouterDelegateReceivedDelegate: PaymentMethodListRouterListener?
     var resolvePaymentMethodListRouterDelegateReceivedInvocations: [PaymentMethodListRouterListener?] = []
     var resolvePaymentMethodListRouterDelegateReturnValue: Router!
@@ -338,7 +430,7 @@ class PaymentMethodListAssemblerProtocolMock: PaymentMethodListAssemblerProtocol
         resolvePaymentMethodListRouterDelegateCallsCount += 1
         resolvePaymentMethodListRouterDelegateReceivedDelegate = delegate
         resolvePaymentMethodListRouterDelegateReceivedInvocations.append(delegate)
-        if let resolvePaymentMethodListRouterDelegateClosure {
+        if let resolvePaymentMethodListRouterDelegateClosure = resolvePaymentMethodListRouterDelegateClosure {
             return resolvePaymentMethodListRouterDelegateClosure(delegate)
         } else {
             return resolvePaymentMethodListRouterDelegateReturnValue
@@ -346,16 +438,17 @@ class PaymentMethodListAssemblerProtocolMock: PaymentMethodListAssemblerProtocol
     }
 
 }
-
 class PaymentMethodListRouterListenerMock: PaymentMethodListRouterListener {
 
-    // MARK: - didDismissPaymentMethodList
+
+
+
+    //MARK: - didDismissPaymentMethodList
 
     var didDismissPaymentMethodListCompletionCallsCount = 0
     var didDismissPaymentMethodListCompletionCalled: Bool {
-        didDismissPaymentMethodListCompletionCallsCount > 0
+        return didDismissPaymentMethodListCompletionCallsCount > 0
     }
-
     var didDismissPaymentMethodListCompletionClosure: (((() -> Void)?) -> Void)?
 
     func didDismissPaymentMethodList(completion: (() -> Void)?) {
@@ -364,16 +457,17 @@ class PaymentMethodListRouterListenerMock: PaymentMethodListRouterListener {
     }
 
 }
-
 class PaymentMethodListRoutingMock: PaymentMethodListRouting {
 
-    // MARK: - present
+
+
+
+    //MARK: - present
 
     var presentComponentCallsCount = 0
     var presentComponentCalled: Bool {
-        presentComponentCallsCount > 0
+        return presentComponentCallsCount > 0
     }
-
     var presentComponentReceivedComponent: PaymentComponent?
     var presentComponentReceivedInvocations: [PaymentComponent] = []
     var presentComponentClosure: ((PaymentComponent) -> Void)?
@@ -385,13 +479,12 @@ class PaymentMethodListRoutingMock: PaymentMethodListRouting {
         presentComponentClosure?(component)
     }
 
-    // MARK: - present
+    //MARK: - present
 
     var presentViewControllerCallsCount = 0
     var presentViewControllerCalled: Bool {
-        presentViewControllerCallsCount > 0
+        return presentViewControllerCallsCount > 0
     }
-
     var presentViewControllerReceivedViewController: UIViewController?
     var presentViewControllerReceivedInvocations: [UIViewController] = []
     var presentViewControllerClosure: ((UIViewController) -> Void)?
@@ -403,13 +496,12 @@ class PaymentMethodListRoutingMock: PaymentMethodListRouting {
         presentViewControllerClosure?(viewController)
     }
 
-    // MARK: - present
+    //MARK: - present
 
     var presentActionViewControllerOnCancelCallsCount = 0
     var presentActionViewControllerOnCancelCalled: Bool {
-        presentActionViewControllerOnCancelCallsCount > 0
+        return presentActionViewControllerOnCancelCallsCount > 0
     }
-
     var presentActionViewControllerOnCancelClosure: ((UIViewController, (() -> Void)?) -> Void)?
 
     func present(actionViewController: UIViewController, onCancel: (() -> Void)?) {
@@ -417,13 +509,12 @@ class PaymentMethodListRoutingMock: PaymentMethodListRouting {
         presentActionViewControllerOnCancelClosure?(actionViewController, onCancel)
     }
 
-    // MARK: - presentStoredPaymentMethodManagement
+    //MARK: - presentStoredPaymentMethodManagement
 
     var presentStoredPaymentMethodManagementCallsCount = 0
     var presentStoredPaymentMethodManagementCalled: Bool {
-        presentStoredPaymentMethodManagementCallsCount > 0
+        return presentStoredPaymentMethodManagementCallsCount > 0
     }
-
     var presentStoredPaymentMethodManagementClosure: (() -> Void)?
 
     func presentStoredPaymentMethodManagement() {
@@ -431,13 +522,12 @@ class PaymentMethodListRoutingMock: PaymentMethodListRouting {
         presentStoredPaymentMethodManagementClosure?()
     }
 
-    // MARK: - dismiss
+    //MARK: - dismiss
 
     var dismissCompletionCallsCount = 0
     var dismissCompletionCalled: Bool {
-        dismissCompletionCallsCount > 0
+        return dismissCompletionCallsCount > 0
     }
-
     var dismissCompletionClosure: (((() -> Void)?) -> Void)?
 
     func dismiss(completion: (() -> Void)?) {
@@ -446,60 +536,53 @@ class PaymentMethodListRoutingMock: PaymentMethodListRouting {
     }
 
 }
-
 class PaymentMethodListViewModelProtocolMock: PaymentMethodListViewModelProtocol {
 
+
     var context: AdyenContext {
-        get { underlyingContext }
+        get { return underlyingContext }
         set(value) { underlyingContext = value }
     }
-
     var underlyingContext: AdyenContext!
     var title: String {
-        get { underlyingTitle }
+        get { return underlyingTitle }
         set(value) { underlyingTitle = value }
     }
-
     var underlyingTitle: String!
     var paymentMethodSections: [PaymentMethodsSection] = []
     var statePublisher: Published<PaymentMethodListState>.Publisher {
-        get { underlyingStatePublisher }
+        get { return underlyingStatePublisher }
         set(value) { underlyingStatePublisher = value }
     }
-
     var underlyingStatePublisher: Published<PaymentMethodListState>.Publisher!
     var theme: CheckoutTheme {
-        get { underlyingTheme }
+        get { return underlyingTheme }
         set(value) { underlyingTheme = value }
     }
-
     var underlyingTheme: CheckoutTheme!
     var formattedAmount: String {
-        get { underlyingFormattedAmount }
+        get { return underlyingFormattedAmount }
         set(value) { underlyingFormattedAmount = value }
     }
-
     var underlyingFormattedAmount: String!
     var subtitle: String {
-        get { underlyingSubtitle }
+        get { return underlyingSubtitle }
         set(value) { underlyingSubtitle = value }
     }
-
     var underlyingSubtitle: String!
     var applePayButtonState: PaymentMethodListHeaderViewModel.ApplePayButtonState {
-        get { underlyingApplePayButtonState }
+        get { return underlyingApplePayButtonState }
         set(value) { underlyingApplePayButtonState = value }
     }
-
     var underlyingApplePayButtonState: PaymentMethodListHeaderViewModel.ApplePayButtonState!
 
-    // MARK: - cancel
+
+    //MARK: - cancel
 
     var cancelCallsCount = 0
     var cancelCalled: Bool {
-        cancelCallsCount > 0
+        return cancelCallsCount > 0
     }
-
     var cancelClosure: (() -> Void)?
 
     func cancel() {
@@ -507,13 +590,12 @@ class PaymentMethodListViewModelProtocolMock: PaymentMethodListViewModelProtocol
         cancelClosure?()
     }
 
-    // MARK: - didLoad
+    //MARK: - didLoad
 
     var didLoadCallsCount = 0
     var didLoadCalled: Bool {
-        didLoadCallsCount > 0
+        return didLoadCallsCount > 0
     }
-
     var didLoadClosure: (() -> Void)?
 
     func didLoad() {
@@ -522,16 +604,17 @@ class PaymentMethodListViewModelProtocolMock: PaymentMethodListViewModelProtocol
     }
 
 }
-
 class PreselectedPaymentMethodAssemblerProtocolMock: PreselectedPaymentMethodAssemblerProtocol {
 
-    // MARK: - resolvePreselectedPaymentMethodRouter
+
+
+
+    //MARK: - resolvePreselectedPaymentMethodRouter
 
     var resolvePreselectedPaymentMethodRouterDelegateComponentTitleCallsCount = 0
     var resolvePreselectedPaymentMethodRouterDelegateComponentTitleCalled: Bool {
-        resolvePreselectedPaymentMethodRouterDelegateComponentTitleCallsCount > 0
+        return resolvePreselectedPaymentMethodRouterDelegateComponentTitleCallsCount > 0
     }
-
     var resolvePreselectedPaymentMethodRouterDelegateComponentTitleReceivedArguments: (delegate: PreselectedPaymentMethodRouterListener?, component: PaymentComponent, title: String)?
     var resolvePreselectedPaymentMethodRouterDelegateComponentTitleReceivedInvocations: [(delegate: PreselectedPaymentMethodRouterListener?, component: PaymentComponent, title: String)] = []
     var resolvePreselectedPaymentMethodRouterDelegateComponentTitleReturnValue: Router!
@@ -541,7 +624,7 @@ class PreselectedPaymentMethodAssemblerProtocolMock: PreselectedPaymentMethodAss
         resolvePreselectedPaymentMethodRouterDelegateComponentTitleCallsCount += 1
         resolvePreselectedPaymentMethodRouterDelegateComponentTitleReceivedArguments = (delegate: delegate, component: component, title: title)
         resolvePreselectedPaymentMethodRouterDelegateComponentTitleReceivedInvocations.append((delegate: delegate, component: component, title: title))
-        if let resolvePreselectedPaymentMethodRouterDelegateComponentTitleClosure {
+        if let resolvePreselectedPaymentMethodRouterDelegateComponentTitleClosure = resolvePreselectedPaymentMethodRouterDelegateComponentTitleClosure {
             return resolvePreselectedPaymentMethodRouterDelegateComponentTitleClosure(delegate, component, title)
         } else {
             return resolvePreselectedPaymentMethodRouterDelegateComponentTitleReturnValue
@@ -549,16 +632,17 @@ class PreselectedPaymentMethodAssemblerProtocolMock: PreselectedPaymentMethodAss
     }
 
 }
-
 class PreselectedPaymentMethodRoutingMock: PreselectedPaymentMethodRouting {
 
-    // MARK: - presentPaymentMethodList
+
+
+
+    //MARK: - presentPaymentMethodList
 
     var presentPaymentMethodListCallsCount = 0
     var presentPaymentMethodListCalled: Bool {
-        presentPaymentMethodListCallsCount > 0
+        return presentPaymentMethodListCallsCount > 0
     }
-
     var presentPaymentMethodListClosure: (() -> Void)?
 
     func presentPaymentMethodList() {
@@ -566,13 +650,12 @@ class PreselectedPaymentMethodRoutingMock: PreselectedPaymentMethodRouting {
         presentPaymentMethodListClosure?()
     }
 
-    // MARK: - present
+    //MARK: - present
 
     var presentComponentCallsCount = 0
     var presentComponentCalled: Bool {
-        presentComponentCallsCount > 0
+        return presentComponentCallsCount > 0
     }
-
     var presentComponentReceivedComponent: PaymentComponent?
     var presentComponentReceivedInvocations: [PaymentComponent] = []
     var presentComponentClosure: ((PaymentComponent) -> Void)?
@@ -584,13 +667,12 @@ class PreselectedPaymentMethodRoutingMock: PreselectedPaymentMethodRouting {
         presentComponentClosure?(component)
     }
 
-    // MARK: - present
+    //MARK: - present
 
     var presentActionViewControllerOnCancelCallsCount = 0
     var presentActionViewControllerOnCancelCalled: Bool {
-        presentActionViewControllerOnCancelCallsCount > 0
+        return presentActionViewControllerOnCancelCallsCount > 0
     }
-
     var presentActionViewControllerOnCancelClosure: ((UIViewController, (() -> Void)?) -> Void)?
 
     func present(actionViewController: UIViewController, onCancel: (() -> Void)?) {
@@ -598,13 +680,12 @@ class PreselectedPaymentMethodRoutingMock: PreselectedPaymentMethodRouting {
         presentActionViewControllerOnCancelClosure?(actionViewController, onCancel)
     }
 
-    // MARK: - dismiss
+    //MARK: - dismiss
 
     var dismissCompletionCallsCount = 0
     var dismissCompletionCalled: Bool {
-        dismissCompletionCallsCount > 0
+        return dismissCompletionCallsCount > 0
     }
-
     var dismissCompletionClosure: (((() -> Void)?) -> Void)?
 
     func dismiss(completion: (() -> Void)?) {
@@ -613,60 +694,53 @@ class PreselectedPaymentMethodRoutingMock: PreselectedPaymentMethodRouting {
     }
 
 }
-
 class StoredCardInputViewModelProtocolMock: StoredCardInputViewModelProtocol {
 
+
     var cardImageItem: CardImageItem {
-        get { underlyingCardImageItem }
+        get { return underlyingCardImageItem }
         set(value) { underlyingCardImageItem = value }
     }
-
     var underlyingCardImageItem: CardImageItem!
     var titleText: String {
-        get { underlyingTitleText }
+        get { return underlyingTitleText }
         set(value) { underlyingTitleText = value }
     }
-
     var underlyingTitleText: String!
     var subtitleText: NSAttributedString {
-        get { underlyingSubtitleText }
+        get { return underlyingSubtitleText }
         set(value) { underlyingSubtitleText = value }
     }
-
     var underlyingSubtitleText: NSAttributedString!
     var securityCodeItem: FormCardSecurityCodeItem {
-        get { underlyingSecurityCodeItem }
+        get { return underlyingSecurityCodeItem }
         set(value) { underlyingSecurityCodeItem = value }
     }
-
     var underlyingSecurityCodeItem: FormCardSecurityCodeItem!
     var submitButtonTitle: String {
-        get { underlyingSubmitButtonTitle }
+        get { return underlyingSubmitButtonTitle }
         set(value) { underlyingSubmitButtonTitle = value }
     }
-
     var underlyingSubmitButtonTitle: String!
     var theme: CheckoutTheme {
-        get { underlyingTheme }
+        get { return underlyingTheme }
         set(value) { underlyingTheme = value }
     }
-
     var underlyingTheme: CheckoutTheme!
     var onSecurityCodeValidationRequested: VoidCompletion?
     var inProgressPublisher: Published<Bool>.Publisher {
-        get { underlyingInProgressPublisher }
+        get { return underlyingInProgressPublisher }
         set(value) { underlyingInProgressPublisher = value }
     }
-
     var underlyingInProgressPublisher: Published<Bool>.Publisher!
 
-    // MARK: - submit
+
+    //MARK: - submit
 
     var submitCallsCount = 0
     var submitCalled: Bool {
-        submitCallsCount > 0
+        return submitCallsCount > 0
     }
-
     var submitClosure: (() async -> Void)?
 
     @MainActor
@@ -675,13 +749,12 @@ class StoredCardInputViewModelProtocolMock: StoredCardInputViewModelProtocol {
         await submitClosure?()
     }
 
-    // MARK: - viewDidDisappear
+    //MARK: - viewDidDisappear
 
     var viewDidDisappearCallsCount = 0
     var viewDidDisappearCalled: Bool {
-        viewDidDisappearCallsCount > 0
+        return viewDidDisappearCallsCount > 0
     }
-
     var viewDidDisappearClosure: (() -> Void)?
 
     @MainActor
@@ -690,13 +763,12 @@ class StoredCardInputViewModelProtocolMock: StoredCardInputViewModelProtocol {
         viewDidDisappearClosure?()
     }
 
-    // MARK: - viewDidLoad
+    //MARK: - viewDidLoad
 
     var viewDidLoadCallsCount = 0
     var viewDidLoadCalled: Bool {
-        viewDidLoadCallsCount > 0
+        return viewDidLoadCallsCount > 0
     }
-
     var viewDidLoadClosure: (() -> Void)?
 
     func viewDidLoad() {

--- a/Tests/IntegrationTests/DropIn Tests/GenericPaymentMethod/GenericPaymentMethodRouterTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/GenericPaymentMethod/GenericPaymentMethodRouterTests.swift
@@ -1,0 +1,78 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@testable import AdyenDropIn
+import Testing
+import UIKit
+
+@MainActor
+struct GenericPaymentMethodRouterTests {
+
+    // MARK: - Tests
+
+    @Test
+    func rootViewController_returnsInjectedViewController() {
+        // Given
+        let viewController = UIViewController()
+        let sut = makeSUT(viewController: viewController)
+
+        // Then
+        #expect(sut.rootViewController === viewController)
+    }
+
+    @Test
+    func present_shouldPresentActionViewControllerModally() {
+        // Given
+        let viewControllerSpy = ViewControllerSpy()
+        let sut = makeSUT(viewController: viewControllerSpy)
+        let actionViewController = UIViewController()
+
+        // When
+        sut.present(actionViewController: actionViewController, onCancel: nil)
+
+        // Then
+        #expect(viewControllerSpy.presentedViewControllerCaptured != nil)
+    }
+
+    @Test
+    func dismiss_shouldPopViewControllerAndNotifyListener() {
+        // Given
+        let viewController = UIViewController()
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        navigationController.pushViewController(viewController, animated: false)
+        let listener = GenericPaymentMethodRouterListenerMock()
+        let sut = makeSUT(viewController: viewController, listener: listener)
+
+        // When
+        sut.dismiss()
+
+        // Then
+        #expect(listener.didDismissGenericPaymentMethodCallsCount == 1)
+    }
+
+    // MARK: - Spy
+
+    private class ViewControllerSpy: UIViewController {
+        var presentedViewControllerCaptured: UIViewController?
+
+        override func present(_ viewControllerToPresent: UIViewController, animated: Bool, completion: (() -> Void)? = nil) {
+            presentedViewControllerCaptured = viewControllerToPresent
+            completion?()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT(
+        viewController: UIViewController? = nil,
+        listener: GenericPaymentMethodRouterListener? = nil
+    ) -> GenericPaymentMethodRouter {
+        GenericPaymentMethodRouter(
+            viewController: viewController ?? UIViewController(),
+            listener: listener ?? GenericPaymentMethodRouterListenerMock()
+        )
+    }
+}

--- a/Tests/IntegrationTests/DropIn Tests/GenericPaymentMethod/GenericPaymentMethodViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/GenericPaymentMethod/GenericPaymentMethodViewModelTests.swift
@@ -1,0 +1,192 @@
+//
+// Copyright (c) 2026 Adyen N.V.
+//
+// This file is open source and available under the MIT license. See the LICENSE file for more info.
+//
+
+@testable import Adyen
+@testable import AdyenActions
+@testable import AdyenDropIn
+import Testing
+import UIKit
+
+@MainActor
+struct GenericPaymentMethodViewModelTests {
+
+    // MARK: - Tests
+
+    @Test
+    func title_shouldReturnPaymentMethodName() {
+        // Given
+        let (sut, _, _, _) = makeSUT(paymentMethodName: "MB WAY")
+
+        // Then
+        #expect(sut.title == "MB WAY")
+    }
+
+    @Test
+    func paymentMethodLogoURL_shouldUsePaymentMethodTypeAsLogoName() {
+        // Given
+        let (sut, paymentComponentMock, _, _) = makeSUT()
+
+        // When
+        let logoURL = sut.paymentMethodLogoURL
+
+        // Then
+        let expectedURL = LogoURLProvider(environment: Dummy.apiContext.environment)
+            .logoURL(withName: paymentComponentMock.paymentMethod.type.rawValue)
+        #expect(logoURL == expectedURL)
+    }
+
+    @Test
+    func startPayment_shouldSetLoadingStateAndCallPerformSubmit() {
+        // Given
+        let (sut, paymentComponentMock, _, _) = makeSUT()
+        paymentComponentMock.shouldCallDelegateOnSubmit = false
+
+        // When
+        sut.startPayment()
+
+        // Then
+        #expect(sut.state == .loading)
+        #expect(paymentComponentMock.submitCallsCount == 1)
+    }
+
+    @Test
+    func dismiss_shouldCallRouterDismiss() {
+        // Given
+        let (sut, _, _, routerMock) = makeSUT()
+
+        // When
+        sut.dismiss()
+
+        // Then
+        #expect(routerMock.dismissCallsCount == 1)
+    }
+
+    @Test
+    func didSubmit_shouldCallDropInFlowManagerSubmit() {
+        // Given
+        let (sut, paymentComponentMock, dropInFlowManagerMock, _) = makeSUT()
+        let data = PaymentComponentData(
+            paymentMethodDetails: GenericPaymentDetails(type: paymentComponentMock.paymentMethod.type),
+            order: nil
+        )
+
+        // When
+        sut.didSubmit(data, from: paymentComponentMock)
+
+        // Then
+        #expect(dropInFlowManagerMock.submitFromActionPresenterCallsCount == 1)
+    }
+
+    @Test
+    func didFail_shouldCallDropInFlowManagerFailAndResetStateToIdle() {
+        // Given
+        let (sut, paymentComponentMock, dropInFlowManagerMock, _) = makeSUT()
+        paymentComponentMock.shouldCallDelegateOnSubmit = false
+        sut.startPayment()
+        #expect(sut.state == .loading)
+
+        // When
+        sut.didFail(with: ErrorMock(errorDescription: "Payment component's error"), from: paymentComponentMock)
+
+        // Then
+        #expect(dropInFlowManagerMock.failWithFromCallsCount == 1)
+        #expect(sut.state == .idle)
+    }
+
+    @Test
+    func presentActionViewController_shouldCallRouterPresent() {
+        // Given
+        let (sut, _, _, routerMock) = makeSUT()
+        let actionViewController = UIViewController()
+
+        // When
+        sut.present(actionViewController: actionViewController)
+
+        // Then
+        #expect(routerMock.presentActionViewControllerOnCancelCallsCount == 1)
+    }
+
+    @Test
+    func presentActionViewController_whenCancelled_shouldResetStateToIdle() {
+        // Given
+        let (sut, paymentComponentMock, _, routerMock) = makeSUT()
+        paymentComponentMock.shouldCallDelegateOnSubmit = false
+        sut.startPayment()
+        let actionViewController = UIViewController()
+
+        routerMock.presentActionViewControllerOnCancelClosure = { _, onCancel in
+            onCancel?()
+        }
+
+        // When
+        sut.present(actionViewController: actionViewController)
+
+        // Then
+        #expect(sut.state == .idle)
+    }
+
+    @Test
+    func didCancel_shouldResetStateToIdle() {
+        // Given
+        let (sut, paymentComponentMock, _, _) = makeSUT()
+        paymentComponentMock.shouldCallDelegateOnSubmit = false
+        sut.startPayment()
+
+        let contextMock = AdyenContext(
+            apiContext: Dummy.apiContext,
+            amount: .init(value: 100, currencyCode: "EUR"),
+            publicKey: Dummy.publicKey,
+            analyticsProvider: AnalyticsProviderMock()
+        )
+        let redirectComponent = RedirectComponent(context: contextMock)
+
+        // When
+        sut.didCancel(actionComponent: redirectComponent)
+
+        // Then
+        #expect(sut.state == .idle)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSUT(
+        paymentMethodName: String = "Generic Payment Method"
+    ) -> (
+        sut: GenericPaymentMethodViewModel,
+        paymentComponentMock: PaymentComponentMock,
+        dropInFlowManagerMock: DropInFlowManagingMock,
+        routerMock: GenericPaymentMethodRoutingMock
+    ) {
+        let paymentMethodMock = PaymentMethodMock(type: .other("genericPaymentMethod"), name: paymentMethodName)
+        let paymentComponentMock = PaymentComponentMock(paymentMethod: paymentMethodMock)
+        let dropInFlowManagerMock = DropInFlowManagingMock()
+
+        let sut = GenericPaymentMethodViewModel(
+            component: paymentComponentMock,
+            dropInFlowManager: dropInFlowManagerMock,
+            logoUrlProvider: LogoURLProvider(environment: Dummy.apiContext.environment),
+            localizationParameters: LocalizationParameters()
+        )
+
+        let routerMock = GenericPaymentMethodRoutingMock()
+        sut.router = routerMock
+
+        return (sut, paymentComponentMock, dropInFlowManagerMock, routerMock)
+    }
+}
+
+// MARK: - GenericPaymentMethodViewModel.State Test Helpers
+
+extension GenericPaymentMethodViewModel.State: Equatable {
+
+    static func == (lhs: GenericPaymentMethodViewModel.State, rhs: GenericPaymentMethodViewModel.State) -> Bool {
+        switch (lhs, rhs) {
+        case (.idle, .idle): true
+        case (.loading, .loading): true
+        default: false
+        }
+    }
+}

--- a/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListRouterTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListRouterTests.swift
@@ -278,24 +278,28 @@ struct PaymentMethodListRouterTests {
     }
 
     @Test
-    func presentComponent_givenInitiableComponent_shouldNotPresentAnything() {
+    func presentComponent_givenGenericComponent_shouldPushGenericPaymentMethod() {
         // Given
         let navigationControllerSpy = NavigationControllerSpy()
+        let genericPaymentMethodRouter = RouterMock()
+        let genericPaymentMethodAssemblerSpy = GenericPaymentMethodAssemblerSpy(router: genericPaymentMethodRouter)
         let componentContainerAssemblerMock = makeComponentContainerAssembler()
         let sut = makeSUT(
             navigationController: navigationControllerSpy,
-            componentContainerAssembler: componentContainerAssemblerMock
+            componentContainerAssembler: componentContainerAssemblerMock,
+            genericPaymentMethodAssembler: genericPaymentMethodAssemblerSpy
         )
-        let initiablePaymentComponent = makeInitiablePaymentComponentMock()
+        let genericPaymentComponent = makeGenericPaymentComponentMock()
 
         // When
-        sut.present(component: initiablePaymentComponent)
+        sut.present(component: genericPaymentComponent)
 
-        // Then - initiable components are not presented by the router
-        #expect(navigationControllerSpy.pushViewControllerCallsCount == 0)
-        #expect(navigationControllerSpy.presentCallsCount == 0)
+        // Then - generic components are pushed via the generic payment method flow
+        #expect(genericPaymentMethodAssemblerSpy.resolveCallsCount == 1)
+        #expect(navigationControllerSpy.pushViewControllerCallsCount == 1)
+        #expect(navigationControllerSpy.capturedPushedViewController === genericPaymentMethodRouter.rootViewController)
         #expect(componentContainerAssemblerMock.resolveComponentContainerRouterForListenerCallsCount == 0)
-        #expect(sut.childRouter == nil)
+        #expect(sut.childRouter === genericPaymentMethodRouter)
     }
 
     @Test
@@ -320,12 +324,15 @@ struct PaymentMethodListRouterTests {
         navigationController: NavigationControllerSpy = NavigationControllerSpy(),
         listener: PaymentMethodListRouterListenerMock? = nil,
         componentContainerAssembler: ComponentContainerAssemblerProtocolMock? = nil,
+        genericPaymentMethodAssembler: GenericPaymentMethodAssemblerProtocol? = nil,
         storedPaymentMethodManagementAssembler: StoredPaymentMethodManagementAssemblerProtocol? = nil,
         supportsStoredPaymentMethodManagement: Bool = true,
         onStoredPaymentMethodRemoved: @escaping (any StoredPaymentMethod) -> Void = { _ in }
     ) -> PaymentMethodListRouter {
         viewController.setNavigationController(navigationController)
         let componentContainerAssembler = componentContainerAssembler ?? makeComponentContainerAssembler()
+        let genericPaymentMethodAssembler = genericPaymentMethodAssembler
+            ?? GenericPaymentMethodAssemblerSpy(router: RouterMock())
         let storedPaymentMethodManagementAssembler = storedPaymentMethodManagementAssembler
             ?? StoredPaymentMethodManagementAssemblerSpy(router: RouterMock())
         let storedPaymentMethodManagementCapability = supportsStoredPaymentMethodManagement
@@ -337,6 +344,7 @@ struct PaymentMethodListRouterTests {
             navigationController: navigationController,
             listener: listener,
             componentContainerAssembler: componentContainerAssembler,
+            genericPaymentMethodAssembler: genericPaymentMethodAssembler,
             storedPaymentMethodManagementAssembler: storedPaymentMethodManagementAssembler,
             storedPaymentMethodManagementCapability: storedPaymentMethodManagementCapability,
             storedPaymentMethodsProvider: { [] },
@@ -374,7 +382,7 @@ struct PaymentMethodListRouterTests {
         )
     }
 
-    private func makeInitiablePaymentComponentMock() -> PaymentComponentMock {
+    private func makeGenericPaymentComponentMock() -> PaymentComponentMock {
         let paymentMethodMock = PaymentMethodMock(type: .applePay, name: "Apple Pay")
         return PaymentComponentMock(paymentMethod: paymentMethodMock)
     }
@@ -394,6 +402,25 @@ private final class StoredPaymentMethodManagementAssemblerSpy: StoredPaymentMeth
         paymentMethods: [any StoredPaymentMethod],
         capability: StoredPaymentMethodManagementCapability,
         listener: StoredPaymentMethodManagementListener
+    ) -> Router {
+        resolveCallsCount += 1
+        return router
+    }
+}
+
+@MainActor
+private final class GenericPaymentMethodAssemblerSpy: GenericPaymentMethodAssemblerProtocol {
+
+    private let router: Router
+    private(set) var resolveCallsCount = 0
+
+    init(router: Router) {
+        self.router = router
+    }
+
+    func resolveGenericPaymentMethodRouter(
+        for component: PaymentComponent,
+        listener: GenericPaymentMethodRouterListener
     ) -> Router {
         resolveCallsCount += 1
         return router

--- a/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewControllerTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewControllerTests.swift
@@ -121,51 +121,6 @@ struct PaymentMethodListViewControllerTests {
     }
 
     @Test
-    func stateIdle_shouldHideLoadingOverlay() async {
-        // Given
-        let (sut, viewModelMock) = makeSUT()
-        sut.loadViewIfNeeded()
-
-        let logoURLProvider = LogoURLProvider(environment: Dummy.apiContext.environment)
-        let item = PaymentMethodItem(
-            title: "Test Item",
-            logoURLProvider: logoURLProvider,
-            theme: .init()
-        )
-        let section = PaymentMethodSection(items: [item], theme: .init())
-        viewModelMock.setState(.loaded(sections: [section]))
-        await Task.yield()
-
-        // First show loading overlay
-        viewModelMock.setState(.loading)
-        await Task.yield()
-
-        // When
-        viewModelMock.setState(.idle)
-        await Task.yield()
-
-        // Then - loading overlay should be hidden (alpha = 0)
-        let loadingOverlay: UIView? = sut.view.findView(by: ".loadingOverlay")
-        #expect(loadingOverlay?.alpha == 0, "Loading overlay should be hidden (alpha = 0) in idle state")
-    }
-
-    @Test
-    func stateLoading_shouldShowLoadingOverlay() async {
-        // Given
-        let (sut, viewModelMock) = makeSUT()
-        sut.loadViewIfNeeded()
-
-        // When
-        viewModelMock.setState(.loading)
-        await Task.yield()
-
-        // Then - loading overlay should be visible (alpha = 1)
-        let loadingOverlay: UIView? = sut.view.findView(by: ".loadingOverlay")
-        #expect(loadingOverlay != nil, "Loading overlay should be present")
-        #expect(loadingOverlay?.alpha == 1, "Loading overlay should be visible (alpha = 1) in loading state")
-    }
-
-    @Test
     func viewDidLoad_shouldApplyThemeBackgroundColor() {
         // Given
         let (sut, _) = makeSUT()

--- a/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewModelTests.swift
+++ b/Tests/IntegrationTests/DropIn Tests/PaymentMethodList/PaymentMethodListViewModelTests.swift
@@ -573,7 +573,6 @@ extension PaymentMethodListState: Equatable {
     public static func == (lhs: PaymentMethodListState, rhs: PaymentMethodListState) -> Bool {
         switch (lhs, rhs) {
         case (.idle, .idle): true
-        case (.loading, .loading): true
         case (.loaded, .loaded): true
         default: false
         }


### PR DESCRIPTION
## Summary
Fixes tests that broke after recent `PaymentMethodList`/`GenericPaymentMethod` refactors (removal of the loading overlay and the switch from `.initiable` to `.generic` component handling), and adds unit test coverage for the `GenericPaymentMethod` module's view model and router.

## Technical Information
- `PaymentMethodListViewModelTests.swift`: removed the stale `.loading` case from the `PaymentMethodListState: Equatable` test helper (that case no longer exists on `PaymentMethodListState`).
- `PaymentMethodListViewControllerTests.swift`: removed `stateIdle_shouldHideLoadingOverlay` / `stateLoading_shouldShowLoadingOverlay`, which tested the loading overlay UI removed in a previous commit.
- `PaymentMethodListRouterTests.swift`: added a `GenericPaymentMethodAssemblerSpy` and wired the new `genericPaymentMethodAssembler` router dependency into `makeSUT`; replaced the outdated `presentComponent_givenInitiableComponent_shouldNotPresentAnything` test with `presentComponent_givenGenericComponent_shouldPushGenericPaymentMethod`, reflecting that `.generic` components are now routed to the generic payment method flow instead of being no-ops.
- `GenericPaymentMethodAssembler.swift` / `GenericPaymentMethodRouter.swift`: annotated `GenericPaymentMethodAssemblerProtocol`, `GenericPaymentMethodRouterListener`, and `GenericPaymentMethodRouting` with `// sourcery:AutoMockable` and regenerated `Tests/GeneratedMocks/AutoMockable.generated.swift`.
- Added `Tests/IntegrationTests/DropIn Tests/GenericPaymentMethod/GenericPaymentMethodViewModelTests.swift` and `GenericPaymentMethodRouterTests.swift`, covering title/logo URL resolution, `startPayment`/`dismiss`, `PaymentComponentDelegate` (`didSubmit`/`didFail`) and `ActionPresenter` (`present`/`didCancel`) behavior on the view model, and root view controller / action presentation / dismissal on the router.

## Ticket
<ticket>
CO-237
</ticket>

## Checklist
- [x] Tested changes locally
- [x] Added/updated unit tests
- [ ] Verified against acceptance criteria
- [ ] Aligned public API changes with other platforms (if applicable)